### PR TITLE
Improve agent auth sync reliability with gateway health polling

### DIFF
--- a/backend-api/authSync.js
+++ b/backend-api/authSync.js
@@ -8,19 +8,33 @@ const llmProviders = require('./llmProviders');
 
 const LLM_ENV_VARS = new Set(llmProviders.PROVIDERS.map(p => p.envVar));
 
-const PROVIDER_MODEL_DEFAULTS = {
-  anthropic: 'claude-sonnet-4-5',
-  openai:    'gpt-5.4',
-  google:    'gemini-3-flash-preview',
-  groq:      'llama-3.3-70b-versatile',
-  mistral:   'mistral-large-latest',
-  deepseek:  'deepseek-chat',
-  cohere:    'command-r-plus',
-  xai:       'grok-2',
-  nvidia:    'nvidia/nemotron-3-super-120b-a12b',
-  moonshot:  'kimi-k2.5',
-  zai:       'glm-5',
-};
+/**
+ * Poll the agent's gateway health endpoint until it returns 200 OK
+ * or the maximum retries are reached.
+ */
+async function waitForGateway(container, maxRetries = 15, intervalMs = 1000) {
+  for (let i = 0; i < maxRetries; i++) {
+    try {
+      const healthExec = await container.exec({
+        Cmd: ['curl', '-sf', 'http://localhost:18789/health'],
+        AttachStdout: true,
+        AttachStderr: true,
+      });
+      const stream = await healthExec.start({});
+      const exitCode = await new Promise((resolve) => {
+        stream.on('end', async () => {
+          const { ExitCode } = await healthExec.inspect();
+          resolve(ExitCode);
+        });
+      });
+      if (exitCode === 0) return true;
+    } catch (e) {
+      // ignore and retry
+    }
+    await new Promise(r => setTimeout(r, intervalMs));
+  }
+  return false;
+}
 
 /**
  * Build auth-profiles.json content for a specific agent.
@@ -86,20 +100,24 @@ async function writeAuthToContainer(docker, containerId, authProfiles, defaultPr
   } catch { /* container may already be restarting */ }
 
   // 3. After restart, set the default model (runs in the fresh gateway).
-  //    Wait briefly for the gateway to re-initialize before issuing CLI commands.
+  //    Wait for the gateway to re-initialize before issuing CLI commands.
   if (defaultProvider) {
-    const modelId = defaultProvider.model || PROVIDER_MODEL_DEFAULTS[defaultProvider.provider];
+    const modelId = defaultProvider.model || llmProviders.MODEL_DEFAULTS[defaultProvider.provider];
     if (modelId) {
       const fullModel = modelId.includes('/') ? modelId : `${defaultProvider.provider}/${modelId}`;
-      await new Promise(r => setTimeout(r, 8000));
-      try {
-        const modelExec = await container.exec({
-          Cmd: ['openclaw', 'models', 'set', fullModel],
-          AttachStdout: true,
-          AttachStderr: true,
-        });
-        await modelExec.start({});
-      } catch { /* non-critical */ }
+      const isUp = await waitForGateway(container);
+      if (isUp) {
+        try {
+          const modelExec = await container.exec({
+            Cmd: ['openclaw', 'models', 'set', fullModel],
+            AttachStdout: true,
+            AttachStderr: true,
+          });
+          await modelExec.start({});
+        } catch { /* non-critical */ }
+      } else {
+        console.warn(`[authSync] Gateway did not come up in time for agent ${containerId} - skipped model set`);
+      }
     }
   }
 }

--- a/backend-api/llmProviders.js
+++ b/backend-api/llmProviders.js
@@ -26,6 +26,20 @@ const PROVIDERS = [
   { id: "nvidia", name: "NVIDIA", envVar: "NVIDIA_API_KEY", endpoint: "https://integrate.api.nvidia.com/v1", models: ["nvidia/nemotron-3-super-120b-a12b", "nvidia/llama-3.1-nemotron-ultra-253b-v1", "nvidia/llama-3.3-nemotron-super-49b-v1.5", "nvidia/nemotron-3-nano-30b-a3b"] },
 ];
 
+const MODEL_DEFAULTS = {
+  anthropic: 'claude-sonnet-4-5',
+  openai:    'gpt-5.4',
+  google:    'gemini-3-flash-preview',
+  groq:      'llama-3.3-70b-versatile',
+  mistral:   'mistral-large-latest',
+  deepseek:  'deepseek-chat',
+  cohere:    'command-r-plus',
+  xai:       'grok-2',
+  nvidia:    'nvidia/nemotron-3-super-120b-a12b',
+  moonshot:  'kimi-k2.5',
+  zai:       'glm-5',
+};
+
 function getAvailableProviders() {
   return PROVIDERS.map(({ id, name, models }) => ({ id, name, models }));
 }
@@ -175,4 +189,5 @@ module.exports = {
   getProviderKeys,
   buildAuthProfiles,
   PROVIDERS,
+  MODEL_DEFAULTS,
 };


### PR DESCRIPTION
Summary

This PR improves the reliability of syncing LLM provider credentials to running agents.

Previously, the system relied on a fixed 8‑second delay before setting the default model after restarting the OpenClaw gateway. This caused race conditions and unnecessary delays.

This update replaces the static delay with health‑based readiness detection.

---

Changes
Gateway health polling
Added:

waitForGateway()


This polls:

http://localhost:18789/health


inside the container until the gateway is ready.

Result:
• faster sync when gateway starts quickly
• prevents failures if startup is slower than 8s

---

Centralized model defaults
Moved default model mappings from:

authSync.js


to:


llmProviders.js


New export:

MODEL_DEFAULTS


This avoids duplicated configuration and keeps provider definitions centralized.

---

Benefits
• Removes fragile timing assumptions
• Faster agent startup
• Cleaner provider configuration structure
• More reliable auth sync across container restarts

---

Testing
Verified by:

Adding a provider key
Triggering syncAuthToUserAgents
Observing container restart
Confirming model applied correctly after gateway health becomes ready