### PR TITLE
security: require server oauth flag in nextauth

### DIFF
--- a/frontend-marketing/pages/api/auth/[...nextauth].js
+++ b/frontend-marketing/pages/api/auth/[...nextauth].js
@@ -5,7 +5,7 @@ import GithubProvider from "next-auth/providers/github";
 
 // Backend API base — inside Docker this resolves to the backend service
 const API_INTERNAL = process.env.API_INTERNAL_URL || "http://backend-api:4000";
-const OAUTH_LOGIN_ENABLED = process.env.OAUTH_LOGIN_ENABLED === "true" || process.env.NEXT_PUBLIC_OAUTH_LOGIN_ENABLED === "true";
+const OAUTH_LOGIN_ENABLED = process.env.OAUTH_LOGIN_ENABLED === "true";
 
 export const authOptions = {
   providers: [
@@ -63,6 +63,12 @@ export const authOptions = {
   ],
 
   callbacks: {
+    async signIn({ account }) {
+      if (account?.provider && account.provider !== "credentials" && !OAUTH_LOGIN_ENABLED) {
+        return "/login?error=OAuthDisabled";
+      }
+      return true;
+    },
     async jwt({ token, user, account, profile }) {
       // On initial sign-in
       if (account && user) {


### PR DESCRIPTION
## Summary
- make the server-side NextAuth route depend only on `OAUTH_LOGIN_ENABLED`
- stop the server auth handler from being activated by the public `NEXT_PUBLIC_OAUTH_LOGIN_ENABLED` flag
- add a server-side sign-in guard that redirects OAuth attempts back to `/login` when OAuth is disabled

## Validation
- `grep` confirmed `frontend-marketing/pages/api/auth/[...nextauth].js` no longer references `NEXT_PUBLIC_OAUTH_LOGIN_ENABLED`
- `node --check frontend-marketing/pages/api/auth/[...nextauth].js`
- `git diff --check`
- local `npm --prefix frontend-marketing run build` could not run in this worktree because the `next` binary is unavailable here; CI will perform the real build/check path
