### PR TITLE
Reliability: recover warning-state deployments via redeploy

### DIFF
--- a/backend-api/__tests__/agents.test.js
+++ b/backend-api/__tests__/agents.test.js
@@ -209,6 +209,51 @@ describe("POST /agents/:id/stop", () => {
   });
 });
 
+describe("POST /agents/:id/redeploy", () => {
+  it("allows redeploy when an agent is in warning state", async () => {
+    mockDb.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: "a-warning",
+          name: "Warning Agent",
+          status: "warning",
+          sandbox_type: "standard",
+          vcpu: 2,
+          ram_mb: 2048,
+          disk_gb: 20,
+          container_name: "oclaw-agent-warning",
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const res = await auth(request(app).post("/agents/a-warning/redeploy"));
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true, status: "queued" });
+    expect(mockAddDeploymentJob).toHaveBeenCalledWith(expect.objectContaining({
+      id: "a-warning",
+      name: "Warning Agent",
+      userId: "user-1",
+      sandbox: "standard",
+      specs: { vcpu: 2, ram_mb: 2048, disk_gb: 20 },
+      container_name: "oclaw-agent-warning",
+    }));
+  });
+
+  it("rejects redeploy when the agent is still actively running", async () => {
+    mockDb.query.mockResolvedValueOnce({
+      rows: [{ id: "a-running", name: "Running Agent", status: "running" }],
+    });
+
+    const res = await auth(request(app).post("/agents/a-running/redeploy"));
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/warning, error, or stopped/i);
+    expect(mockAddDeploymentJob).not.toHaveBeenCalled();
+  });
+});
+
 describe("POST /agents/:id/delete", () => {
   it("deletes an agent", async () => {
     // db.query calls: SELECT agent, DELETE

--- a/backend-api/routes/agents.js
+++ b/backend-api/routes/agents.js
@@ -364,8 +364,8 @@ router.post("/:id/redeploy", async (req, res) => {
     );
     const agent = result.rows[0];
     if (!agent) return res.status(404).json({ error: "Agent not found" });
-    if (agent.status !== "error" && agent.status !== "stopped") {
-      return res.status(400).json({ error: "Agent must be in error or stopped state to redeploy" });
+    if (!["warning", "error", "stopped"].includes(agent.status)) {
+      return res.status(400).json({ error: "Agent must be in warning, error, or stopped state to redeploy" });
     }
 
     await db.query(

--- a/workers/provisioner/worker.js
+++ b/workers/provisioner/worker.js
@@ -393,6 +393,7 @@ const worker = new Worker('deployments', async (job) => {
       const detail = problems.join('; ');
       console.warn(`[provisioner] Readiness check failed for agent ${id}: ${detail}`);
       await db.query("UPDATE agents SET status = 'warning' WHERE id = $1", [id]);
+      await db.query("UPDATE deployments SET status = 'warning' WHERE agent_id = $1", [id]);
       await db.query(
         "INSERT INTO events(type, message, metadata) VALUES($1, $2, $3)",
         ['agent_runtime_warning', `Agent "${name}" deployed with readiness warning: ${detail}`, JSON.stringify({ agentId: id, host, readiness })]


### PR DESCRIPTION
## Summary
- mark degraded post-provision deployments as `warning` instead of hard-failing
- allow `warning` agents to be re-queued through `POST /agents/:id/redeploy`
- add backend coverage for warning-state redeploy behavior

## Validation
- `npx jest __tests__/agents.test.js --runInBand`
- `npm test` (backend-api)

## Scope
Bounded core reliability follow-up only. No live deploy.