### PR TITLE
security: lock bootstrap admin seed policy

### DIFF
--- a/backend-api/__tests__/bootstrapAdmin.test.js
+++ b/backend-api/__tests__/bootstrapAdmin.test.js
@@ -1,0 +1,35 @@
+const { getBootstrapAdminSeedConfig } = require("../bootstrapAdmin");
+
+describe("bootstrap admin policy", () => {
+  it("rejects missing bootstrap credentials", () => {
+    expect(getBootstrapAdminSeedConfig({ adminEmail: "", adminPassword: "" })).toMatchObject({
+      shouldSeed: false,
+      reason: "missing_credentials",
+    });
+  });
+
+  it("rejects short bootstrap passwords", () => {
+    expect(getBootstrapAdminSeedConfig({ adminEmail: "admin@example.com", adminPassword: "shortpass" })).toMatchObject({
+      shouldSeed: false,
+      reason: "password_too_short",
+      email: "admin@example.com",
+    });
+  });
+
+  it("rejects the legacy default bootstrap password", () => {
+    expect(getBootstrapAdminSeedConfig({ adminEmail: "admin@example.com", adminPassword: "admin123" })).toMatchObject({
+      shouldSeed: false,
+      reason: "default_password_forbidden",
+      email: "admin@example.com",
+    });
+  });
+
+  it("accepts explicit secure bootstrap credentials and trims the email", () => {
+    expect(getBootstrapAdminSeedConfig({ adminEmail: "  admin@example.com ", adminPassword: "supersecure12" })).toEqual({
+      shouldSeed: true,
+      email: "admin@example.com",
+      password: "supersecure12",
+      reason: "ok",
+    });
+  });
+});

--- a/backend-api/bootstrapAdmin.js
+++ b/backend-api/bootstrapAdmin.js
@@ -1,0 +1,39 @@
+function getBootstrapAdminSeedConfig({ adminEmail, adminPassword }) {
+  const normalizedEmail = typeof adminEmail === "string" ? adminEmail.trim() : "";
+  const password = typeof adminPassword === "string" ? adminPassword : "";
+
+  if (!normalizedEmail || !password) {
+    return {
+      shouldSeed: false,
+      email: normalizedEmail,
+      reason: "missing_credentials",
+    };
+  }
+
+  if (password === "admin123") {
+    return {
+      shouldSeed: false,
+      email: normalizedEmail,
+      reason: "default_password_forbidden",
+    };
+  }
+
+  if (password.length < 12) {
+    return {
+      shouldSeed: false,
+      email: normalizedEmail,
+      reason: "password_too_short",
+    };
+  }
+
+  return {
+    shouldSeed: true,
+    email: normalizedEmail,
+    password,
+    reason: "ok",
+  };
+}
+
+module.exports = {
+  getBootstrapAdminSeedConfig,
+};

--- a/backend-api/server.js
+++ b/backend-api/server.js
@@ -10,6 +10,7 @@ const channels = require("./channels");
 const marketplace = require("./marketplace");
 const integrations = require("./integrations");
 const snapshots = require("./snapshots");
+const { getBootstrapAdminSeedConfig } = require("./bootstrapAdmin");
 const { authenticateToken } = require("./middleware/auth");
 const { correlationId, errorHandler } = require("./middleware/errorHandler");
 const { createGatewayRouter, attachGatewayWS } = require("./gatewayProxy");
@@ -373,21 +374,21 @@ if (require.main === module) {
     try {
       const { rows } = await db.query("SELECT id FROM users LIMIT 1");
       if (rows.length === 0) {
-        const adminEmail = (process.env.DEFAULT_ADMIN_EMAIL || "").trim();
-        const adminPass = process.env.DEFAULT_ADMIN_PASSWORD || "";
-        const hasExplicitBootstrapCreds = Boolean(adminEmail) && Boolean(adminPass);
-        const hasSecureBootstrapPassword = adminPass.length >= 12 && adminPass !== "admin123";
+        const bootstrapAdmin = getBootstrapAdminSeedConfig({
+          adminEmail: process.env.DEFAULT_ADMIN_EMAIL,
+          adminPassword: process.env.DEFAULT_ADMIN_PASSWORD,
+        });
 
-        if (!hasExplicitBootstrapCreds || !hasSecureBootstrapPassword) {
+        if (!bootstrapAdmin.shouldSeed) {
           console.warn("Skipping bootstrap admin seed: set explicit DEFAULT_ADMIN_EMAIL and a non-default DEFAULT_ADMIN_PASSWORD with at least 12 characters.");
         } else {
           const bcrypt = require("bcryptjs");
-          const hash = await bcrypt.hash(adminPass, 10);
+          const hash = await bcrypt.hash(bootstrapAdmin.password, 10);
           await db.query(
             "INSERT INTO users(email, password_hash, role, name) VALUES($1, $2, 'admin', 'Admin') ON CONFLICT DO NOTHING",
-            [adminEmail, hash]
+            [bootstrapAdmin.email, hash]
           );
-          console.log(`Bootstrap admin account created: ${adminEmail}`);
+          console.log(`Bootstrap admin account created: ${bootstrapAdmin.email}`);
         }
       }
     } catch (e) { console.error("Failed to seed admin account:", e.message); }


### PR DESCRIPTION
## Summary\n- extract bootstrap admin seed policy into a small helper\n- add regression tests covering missing creds, short passwords, legacy default password rejection, and secure explicit bootstrap creds\n- route backend startup seeding through the helper so the policy is test-locked\n\n## Validation\n- npm test -- --runInBand __tests__/bootstrapAdmin.test.js __tests__/auth.test.js\n