### PR TITLE
docs: strengthen OSS monetization proof pack

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,13 +17,13 @@
   ·
   <a href="https://nora.solomontsao.com">Hosted eval / managed PaaS</a>
   ·
-  <a href="https://nora.solomontsao.com/pricing">Pricing / rollout help / enterprise</a>
+  <a href="https://nora.solomontsao.com/pricing">Deployment / support / enterprise paths</a>
   ·
   <a href="https://github.com/solomon2773/nora/discussions">Rollout help / paid support</a>
   ·
-  <a href="https://raw.githubusercontent.com/solomon2773/nora/master/setup.sh">Install script (bash)</a>
+  <a href="https://storage.solomontsao.com/setup.sh">Install script (bash)</a>
   ·
-  <a href="https://raw.githubusercontent.com/solomon2773/nora/master/setup.ps1">Install script (PowerShell)</a>
+  <a href="https://storage.solomontsao.com/setup.ps1">Install script (PowerShell)</a>
   ·
   <a href="#open-source-proof-pack">Open-source proof pack</a>
   ·
@@ -57,6 +57,18 @@ Nora gives technical teams a single place to:
 - monitor operator activity and runtime workflows
 
 The core value proposition is simple: **if you care about infrastructure, observability, repeatable operations, and a trustworthy operator surface, Nora helps you get to a usable control plane faster.**
+
+## Positioning pillars
+
+Nora should be easy to describe in one pass:
+
+- **Security built in** — the product should feel trustworthy for real operator environments, not like an afterthought wrapper around secrets and infrastructure.
+- **Easy to use** — teams should be able to reach first proof quickly: install, create an operator account, add one provider, deploy one runtime, and validate the workflow.
+- **Expandable** — the product should support a clean path from today's best-supported runtime to broader runtime adapters over time.
+- **Self-hostable** — the repo, install scripts, and Docker Compose flow should remain a credible trust path.
+- **Enterprise-capable** — Nora should make sense from single-host evaluation through Proxmox, private cloud / on-prem, and AWS/Azure/GCP rollout footprints.
+
+That combination is the durable positioning: not a toy dashboard, not a vague AI shell, and not a permanently single-runtime wrapper.
 
 ## Open source means open source
 
@@ -149,7 +161,7 @@ Use [nora.solomontsao.com](https://nora.solomontsao.com) and [signup](https://no
 
 ### 4. Enterprise / custom deployment
 
-Use [pricing](https://nora.solomontsao.com/pricing) when you need scoped help around deployment footprint, infrastructure ownership, rollout depth, or larger-team requirements.
+Use [deployment paths](https://nora.solomontsao.com/pricing) when you need scoped help around deployment footprint, infrastructure ownership, rollout depth, or larger-team requirements.
 
 See [Commercial paths](docs/COMMERCIAL_PATHS.md) for the full public-path positioning guide.
 
@@ -159,18 +171,31 @@ Nora should ask people to trust the product itself, the install path, and the op
 
 Use these resources when you need to prove that the repo is real and usable:
 
+- [Repo proof pack](docs/PROOF_PACK.md) — the public proof map for installability, operator workflow, screenshot evidence, and paid-path credibility
 - [Open-source implementation proof](docs/IMPLEMENTATION_PROOF.md) — code-backed evidence for self-hosting, operator flows, proof assets, and runtime direction
 - [Adoption checklist](docs/ADOPTION_CHECKLIST.md) — practical paths for self-hosting, Apache 2.0 commercial use, rollout help, hosted evaluation, and runtime expansion
 - [Open-source usage guide](docs/OPEN_SOURCE_USAGE.md) — Apache 2.0 usage rights and public repo framing
 - [Commercial paths](docs/COMMERCIAL_PATHS.md) — self-hosted OSS, rollout help / paid support, managed PaaS, and enterprise/custom entry points
 - [Deployment footprints](docs/DEPLOYMENT_FOOTPRINTS.md) — how Nora should scale from single-host through Proxmox, private cloud, and AWS/Azure/GCP
-- [README screenshot plan](docs/README_SCREENSHOT_PLAN.md)
-- [Marketing proof asset plan](docs/MARKETING_PROOF_ASSET_PLAN.md)
+- [Runtime direction guide](docs/RUNTIME_DIRECTION.md) — how to describe Nora as OpenClaw-first today while keeping the product future-runtime-friendly
 - [Operator screenshot capture script](e2e/scripts/capture-operator-screenshots.mjs) — regenerates the operator screenshots from a local self-hosted stack
 
 ## Screenshots
 
 The repo now includes real operator-side screenshots alongside the marketing and OSS-proof images. They show Nora as a working self-hosted control plane, with OpenClaw as the current best-supported runtime example rather than the forever-only frame.
+
+## What each proof asset demonstrates
+
+| Proof asset | What it demonstrates |
+|---|---|
+| `proof-landing-open-source-funnel.png` | Nora leads with an OSS-first trust path rather than a sales-first gate |
+| `proof-usage-rights-apache.png` | Apache 2.0 commercial-use rights and path clarity are visible publicly |
+| `proof-signup-operator-account.png` | A real operator account entry flow exists |
+| `proof-operator-dashboard.png` | Nora has a working operator overview beyond marketing copy |
+| `proof-operator-fleet.png` | Operators can manage and validate multiple runtimes |
+| `proof-operator-deploy-flow.png` | The first runtime deployment flow is concrete and inspectable |
+| `proof-operator-agent-detail.png` | Ongoing operations include validation, logs, and terminal surfaces |
+| `proof-operator-settings-provider-setup.png` | Provider setup is part of the current product path |
 
 ### Landing and OSS proof
 
@@ -223,6 +248,8 @@ Nora should be described as:
 
 That framing is more durable than treating Nora as a permanently single-runtime dashboard or centering the repo around sales packaging.
 
+See [Runtime direction guide](docs/RUNTIME_DIRECTION.md) for the durable wording and guardrails behind that positioning.
+
 ## Quick Start
 
 ### Prerequisites
@@ -237,13 +264,13 @@ That framing is more durable than treating Nora as a permanently single-runtime 
 **macOS / Linux / WSL2**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/solomon2773/nora/master/setup.sh | bash
+curl -fsSL https://storage.solomontsao.com/setup.sh | bash
 ```
 
 **Windows (PowerShell)**
 
 ```powershell
-iwr -useb https://raw.githubusercontent.com/solomon2773/nora/master/setup.ps1 | iex
+iwr -useb https://storage.solomontsao.com/setup.ps1 | iex
 ```
 
 The installer will:
@@ -257,7 +284,7 @@ The installer will:
 7. start the Nora stack
 8. take you to the dashboard so you can deploy the first agent
 
-The public install links intentionally use `raw.githubusercontent.com` so the setup path stays aligned with the open-source repo and current trust model.
+The public install links intentionally use `storage.solomontsao.com` as the canonical installer host while keeping the open-source repo and install docs as the primary trust anchor.
 
 ### Manual setup
 
@@ -387,7 +414,7 @@ Track agent health, queue state, logs, metrics, and runtime activity.
 
 ### Core components
 
-- `frontend-marketing/` — landing, login, signup, pricing/deployment-path page
+- `frontend-marketing/` — landing, login, signup, and deployment/support-path page
 - `frontend-dashboard/` — operator dashboard for agents and settings
 - `backend-api/` — APIs, auth, key management, provisioning, monitoring
 - `admin-dashboard/` — admin/operator surfaces

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -47,7 +47,7 @@ Best fit:
 
 Use the public deployment paths when self-hosting is not the preferred first step.
 
-- [Pricing / deployment paths](https://nora.solomontsao.com/pricing)
+- [Deployment / support paths](https://nora.solomontsao.com/pricing)
 - [Hosted evaluation signup](https://nora.solomontsao.com/signup)
 
 Best fit:
@@ -73,4 +73,4 @@ Do **not** post secrets, API keys, `.env` files, or private credentials in Issue
 If you are unsure where to start:
 - choose [Install guide](docs/INSTALL.md) if you want to self-host
 - choose [GitHub Discussions](https://github.com/solomon2773/nora/discussions) if you want rollout help or paid support
-- choose [pricing](https://nora.solomontsao.com/pricing) or [signup](https://nora.solomontsao.com/signup) if you want a hosted, managed, or custom-deployment path
+- choose [deployment paths](https://nora.solomontsao.com/pricing) or [signup](https://nora.solomontsao.com/signup) if you want a hosted, managed, or custom-deployment path

--- a/docs/ADOPTION_CHECKLIST.md
+++ b/docs/ADOPTION_CHECKLIST.md
@@ -41,6 +41,13 @@ Use this checklist to evaluate Nora from an OSS-first point of view.
 - [ ] Are security, identity, networking, or compliance constraints known?
 - [ ] Is the first proof milestone concrete enough to scope?
 
+## Positioning checklist
+
+- [ ] Does the public story clearly describe Nora as an open-source AI agent orchestration control panel?
+- [ ] Are the five pillars obvious: security built in, easy to use, expandable, self-hostable, and enterprise-capable?
+- [ ] Is enterprise-capable grounded in deployment footprint reality rather than vague packaging language?
+- [ ] Can someone understand the path from single-host evaluation to Proxmox, private cloud / on-prem, and AWS/Azure/GCP?
+
 ## Runtime-direction checklist
 
 - [ ] Are they starting with OpenClaw as the best-supported runtime today?
@@ -51,9 +58,10 @@ Use this checklist to evaluate Nora from an OSS-first point of view.
 ## Supporting docs
 
 - `README.md`
+- `docs/PROOF_PACK.md`
 - `docs/INSTALL.md`
 - `docs/COMMERCIAL_PATHS.md`
 - `docs/DEPLOYMENT_FOOTPRINTS.md`
+- `docs/RUNTIME_DIRECTION.md`
 - `docs/OPEN_SOURCE_USAGE.md`
 - `docs/IMPLEMENTATION_PROOF.md`
-- `docs/README_SCREENSHOT_PLAN.md`

--- a/docs/COMMERCIAL_PATHS.md
+++ b/docs/COMMERCIAL_PATHS.md
@@ -23,8 +23,8 @@ Start here:
 - Repo: `https://github.com/solomon2773/nora`
 - Quick start: `README.md#quick-start`
 - Install guide: `docs/INSTALL.md`
-- Bash install: `https://raw.githubusercontent.com/solomon2773/nora/master/setup.sh`
-- PowerShell install: `https://raw.githubusercontent.com/solomon2773/nora/master/setup.ps1`
+- Bash install: `https://storage.solomontsao.com/setup.sh`
+- PowerShell install: `https://storage.solomontsao.com/setup.ps1`
 
 Best fit:
 
@@ -59,7 +59,7 @@ Current public entry points:
 
 - Hosted app: `https://nora.solomontsao.com`
 - Hosted signup: `https://nora.solomontsao.com/signup`
-- Pricing / deployment paths page: `https://nora.solomontsao.com/pricing`
+- Deployment / support paths page: `https://nora.solomontsao.com/pricing`
 
 Best fit:
 
@@ -74,7 +74,7 @@ Best for teams that expect larger-team requirements, more complex infrastructure
 
 Current public entry point:
 
-- Pricing / deployment paths page: `https://nora.solomontsao.com/pricing`
+- Deployment / support paths page: `https://nora.solomontsao.com/pricing`
 
 Best fit:
 
@@ -90,10 +90,10 @@ Best fit:
 |---|---|---|---|
 | Self-hosted open source | `README#Quick Start` + install docs | Team wants full infra control and transparent proof | Account → provider key → first runtime on their own stack |
 | Rollout help / paid support | GitHub Discussions | Team wants faster rollout without giving up self-hosting | Scoped help around setup, onboarding, and first-value delivery |
-| Hosted evaluation / managed PaaS | Signup + pricing page | Team wants less ops overhead for the first evaluation | Faster evaluation start, then managed-path qualification |
-| Enterprise / custom deployment | Pricing page | Team needs a more tailored environment or rollout scope | Deployment footprint, requirements, and commercial scoping |
+| Hosted evaluation / managed PaaS | Signup + deployment-path page | Team wants less ops overhead for the first evaluation | Faster evaluation start, then managed-path qualification |
+| Enterprise / custom deployment | Deployment-path page | Team needs a more tailored environment or rollout scope | Deployment footprint, requirements, and commercial scoping |
 
-## How pricing should be framed today
+## How public commercial scoping should be framed today
 
 Nora does **not** need the repo to lead with invented fixed-plan sales language.
 
@@ -101,9 +101,9 @@ Instead, public messaging should make these points clear:
 
 1. which path to choose — self-hosted, rollout help / paid support, hosted evaluation / managed PaaS, or enterprise/custom
 2. what changes scope — infra ownership, rollout depth, support level, deployment complexity, and operator requirements
-3. what the next step is — install docs, GitHub Discussions, hosted signup, or pricing-page qualification
+3. what the next step is — install docs, GitHub Discussions, hosted signup, or deployment-path qualification
 
-A short honest pricing summary is:
+A short honest public scoping summary is:
 
 - **Self-hosted OSS:** free under Apache 2.0
 - **Rollout help / paid support:** scoped based on setup and support needs
@@ -139,7 +139,7 @@ Whether the conversation starts in GitHub Discussions or after hosted signup, it
 
 ## Domain consistency rules
 
-- Use the GitHub repo and install scripts as the trust anchor for self-hosted evaluation.
+- Use the GitHub repo plus the canonical public installer URLs as the trust anchor for self-hosted evaluation.
 - Use `nora.solomontsao.com` for the live app, signup flow, and deployment/commercial path packaging.
 - Use GitHub Discussions as the current public rollout-help and paid-support intake.
 - Avoid mixing repo-native install CTAs with copy that implies unsupported deployment promises.

--- a/docs/IMPLEMENTATION_PROOF.md
+++ b/docs/IMPLEMENTATION_PROOF.md
@@ -9,10 +9,10 @@ This document lists which parts of Nora's OSS story are backed by code or public
 | **Self-hosted install path** | Nora ships repo-native install flows for Bash and PowerShell plus Docker Compose setup. | `setup.sh`, `setup.ps1`, `docker-compose.yml`, `.env.example`, `README.md` | The open-source path is real, not a placeholder. |
 | **Operator account flow** | The app includes login and signup surfaces plus backend auth endpoints. | `frontend-marketing/pages/login.js`, `frontend-marketing/pages/signup.js`, `backend-api/server.js` | The product has a real operator entry path, not just a landing page. |
 | **Agent operations UI** | Nora includes dashboard, deploy, logs, settings, terminal, sessions, tools, and runtime-management surfaces. | `frontend-dashboard/pages/*`, `frontend-dashboard/components/*`, `frontend-dashboard/components/agents/openclaw/*` | The repo contains a real operator product rather than a brochure-only front end. |
-| **Demo-flow proof assets** | The repo already includes operator screenshots and capture scripts for landing, signup, dashboard, deploy flow, agent detail, and provider setup. | `docs/assets/*`, `docs/README_SCREENSHOT_PLAN.md`, `e2e/scripts/capture-operator-screenshots.mjs`, `e2e/scripts/capture-marketing-proof.mjs` | Evaluators can inspect concrete UI proof before any managed conversation. |
-| **Deployment-path clarity** | Public docs now distinguish self-hosted OSS, rollout help, and hosted/custom deployment paths without inventing fixed plans. | `docs/COMMERCIAL_PATHS.md`, `docs/INSTALL.md`, `SUPPORT.md`, `frontend-marketing/pages/pricing.js` | The paid path is credible because it is scoped clearly, not because the repo hides the OSS route. |
+| **Demo-flow proof assets** | The repo already includes operator screenshots and capture scripts for landing, signup, dashboard, deploy flow, agent detail, and provider setup. | `docs/assets/*`, `e2e/scripts/capture-operator-screenshots.mjs`, `e2e/scripts/capture-marketing-proof.mjs` | Evaluators can inspect concrete UI proof before any managed conversation. |
+| **Commercial-path clarity** | Public docs now distinguish self-hosted OSS, rollout help, and hosted/custom deployment paths without inventing fixed plans. | `docs/COMMERCIAL_PATHS.md`, `docs/INSTALL.md`, `SUPPORT.md`, `frontend-marketing/pages/pricing.js` | The non-DIY path is credible because it is scoped clearly, not because the repo hides the OSS route. |
 | **Deployment footprint direction** | Nora is documented as starting with single-host proof while staying credible for Proxmox, private cloud/on-prem, and AWS/Azure/GCP growth. | `README.md`, `docs/DEPLOYMENT_FOOTPRINTS.md`, `docs/OPEN_SOURCE_USAGE.md`, `frontend-marketing/pages/pricing.js` | This makes the enterprise-capable story concrete without claiming unsupported deployment automation. |
-| **Runtime direction** | OpenClaw is the strongest supported runtime today, while product language and docs stay open to future runtime integrations. | `README.md`, `frontend-marketing/pages/index.js`, `frontend-marketing/pages/pricing.js`, `docs/DEPLOYMENT_FOOTPRINTS.md` | This keeps the current proof honest without turning Nora into a permanently single-runtime story. |
+| **Runtime direction** | OpenClaw is the strongest supported runtime today, while product language and docs stay open to future runtime integrations. | `README.md`, `frontend-marketing/pages/index.js`, `frontend-marketing/pages/pricing.js`, `docs/DEPLOYMENT_FOOTPRINTS.md`, `docs/RUNTIME_DIRECTION.md` | This keeps the current proof honest without turning Nora into a permanently single-runtime story. |
 | **Commercial use by anyone** | The repo is licensed under Apache 2.0 and the supporting docs explain the allowed usage model. | `LICENSE`, `docs/OPEN_SOURCE_USAGE.md`, `frontend-marketing/pages/pricing.js` | Operators can self-host, modify, and use Nora commercially under the Apache 2.0 terms. |
 
 ## What the repo should prove first
@@ -20,7 +20,7 @@ This document lists which parts of Nora's OSS story are backed by code or public
 1. **Installability** — someone can get Nora running from the repo
 2. **Operator workflow** — someone can create an account, add a provider, and deploy a runtime
 3. **Control-plane value** — chat, logs, terminal, sessions, tools, and monitoring work from one surface
-4. **Paid-path credibility** — the repo makes it obvious when to self-host, when to ask for rollout help, and when a hosted/custom path makes sense
+4. **Commercial-path clarity** — the repo makes it obvious when to self-host, when to ask for rollout help, and when a hosted/custom path makes sense
 5. **Runtime honesty** — OpenClaw is strongest today without being framed as the permanent only-runtime future
 
 ## Concrete proof assets for the monetization path
@@ -28,9 +28,11 @@ This document lists which parts of Nora's OSS story are backed by code or public
 If a buyer or operator asks why the non-DIY path should be trusted, these are the public assets that should answer most of that question:
 
 - `README.md`
+- `docs/PROOF_PACK.md`
 - `docs/INSTALL.md`
 - `docs/COMMERCIAL_PATHS.md`
 - `docs/DEPLOYMENT_FOOTPRINTS.md`
+- `docs/RUNTIME_DIRECTION.md`
 - `docs/OPEN_SOURCE_USAGE.md`
 - `docs/ADOPTION_CHECKLIST.md`
 - `docs/assets/proof-landing-open-source-funnel.png`

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -21,13 +21,13 @@ If those steps work cleanly, Nora has already proven the core self-hosted value.
 **macOS / Linux / WSL2**
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/solomon2773/nora/master/setup.sh | bash
+curl -fsSL https://storage.solomontsao.com/setup.sh | bash
 ```
 
 **Windows (PowerShell)**
 
 ```powershell
-iwr -useb https://raw.githubusercontent.com/solomon2773/nora/master/setup.ps1 | iex
+iwr -useb https://storage.solomontsao.com/setup.ps1 | iex
 ```
 
 Use this path if you want Nora to:
@@ -79,7 +79,7 @@ Open the agent detail page and confirm:
 | You want to keep self-hosting and just need the docs | [README Quick Start](../README.md#quick-start) |
 | You hit a bug or broken instruction | [GitHub Issues](https://github.com/solomon2773/nora/issues) |
 | You want rollout help or paid support without giving up self-hosting | [GitHub Discussions](https://github.com/solomon2773/nora/discussions) |
-| You do not want a pure DIY path anymore | [Pricing / deployment paths](https://nora.solomontsao.com/pricing) |
+| You do not want a pure DIY path anymore | [Deployment / support paths](https://nora.solomontsao.com/pricing) |
 | You want a hosted evaluation, managed PaaS, or custom deployment conversation | [Hosted evaluation signup](https://nora.solomontsao.com/signup) |
 
 ## Upgrade paths from self-hosted evaluation

--- a/docs/OPEN_SOURCE_USAGE.md
+++ b/docs/OPEN_SOURCE_USAGE.md
@@ -55,6 +55,7 @@ Public-facing docs and pages should emphasize:
 - repo-native install scripts and Docker Compose setup
 - operator workflows like signup, deploy, chat, logs, terminal, and settings
 - screenshot proof from the real product
+- the core positioning pillars: security built in, easy to use, expandable, self-hostable, and enterprise-capable
 - enterprise-capable self-hosting in the practical operator sense
 - a clear deployment continuum from single-host to Proxmox, private cloud, and AWS/Azure/GCP
 - OpenClaw as the best-supported example today
@@ -80,10 +81,11 @@ A short public answer is:
 Use these repo-native proof resources when you need to show the OSS story clearly:
 
 - `README.md`
+- `docs/PROOF_PACK.md`
 - `docs/IMPLEMENTATION_PROOF.md`
 - `docs/ADOPTION_CHECKLIST.md`
 - `docs/DEPLOYMENT_FOOTPRINTS.md`
-- `docs/README_SCREENSHOT_PLAN.md`
+- `docs/RUNTIME_DIRECTION.md`
 - `docs/assets/proof-landing-open-source-funnel.png`
 - `docs/assets/proof-usage-rights-apache.png`
 - `docs/assets/proof-signup-operator-account.png`
@@ -97,4 +99,5 @@ The README should make these points obvious:
 - self-hosting is the primary trust path
 - OpenClaw is the strongest runtime example today
 - Nora should stay open to broader runtime integration over time
+- the core positioning pillars should be obvious: security built in, easy to use, expandable, self-hostable, and enterprise-capable
 - screenshots should prove operator reality, not just marketing polish

--- a/docs/PROOF_PACK.md
+++ b/docs/PROOF_PACK.md
@@ -1,0 +1,94 @@
+# Nora Repo Proof Pack
+
+Use this document when someone asks a simple question:
+
+> Why should we trust the paid path if Nora is open source?
+
+The answer should come from the repo first.
+
+Nora should earn trust through:
+
+- the self-hosted install path
+- the real operator workflow
+- concrete screenshots and demo-flow assets
+- clear path comparison between OSS, rollout help, hosted evaluation, and enterprise/custom deployment
+- honest scoping language that does not outrun the current product
+
+## What someone should be able to prove before any commercial conversation
+
+| What they want to verify | Public proof in repo today | Where to look | What a credible outcome looks like |
+|---|---|---|---|
+| Nora is really self-hostable | Setup scripts, Docker Compose, env template, install docs | `setup.sh`, `setup.ps1`, `docker-compose.yml`, `.env.example`, `README.md`, `docs/INSTALL.md` | They can see a real install path that does not depend on a sales-led setup |
+| The operator entry flow is real | Login and signup surfaces plus backend auth | `frontend-marketing/pages/login.js`, `frontend-marketing/pages/signup.js`, `backend-api/server.js`, `docs/assets/proof-signup-operator-account.png` | They can picture how an operator account is created and enters the product |
+| Nora is more than a landing page | Dashboard, deploy, agent, logs, settings, terminal, and runtime-management surfaces | `frontend-dashboard/pages/*`, `frontend-dashboard/components/*`, `docs/assets/proof-operator-dashboard.png`, `docs/assets/proof-operator-fleet.png`, `docs/assets/proof-operator-agent-detail.png` | They can tell the repo contains a real control plane |
+| The first demo flow is concrete | Deploy-flow and provider-setup screenshots plus capture scripts | `docs/assets/proof-operator-deploy-flow.png`, `docs/assets/proof-operator-settings-provider-setup.png`, `e2e/scripts/capture-operator-screenshots.mjs`, `e2e/scripts/capture-marketing-proof.mjs` | They can see the path from account -> provider -> runtime -> validation |
+| The non-DIY path is honest | Public docs clearly separate self-hosted OSS, rollout help, hosted eval, and enterprise/custom scope | `docs/COMMERCIAL_PATHS.md`, `SUPPORT.md`, `frontend-marketing/pages/pricing.js`, `docs/ADOPTION_CHECKLIST.md` | They can tell what changes when they want help, hosting, or a larger deployment footprint |
+| Nora is commercially usable as OSS | Apache 2.0 license and public usage docs | `LICENSE`, `docs/OPEN_SOURCE_USAGE.md`, `docs/assets/proof-usage-rights-apache.png` | They understand they can self-host and use Nora commercially under the license terms |
+| Nora is OpenClaw-first today without being boxed in forever | Runtime-direction guidance and repo/product copy | `README.md`, `docs/RUNTIME_DIRECTION.md`, `frontend-marketing/pages/index.js`, `frontend-marketing/pages/pricing.js` | They understand the fastest current proof path without mistaking direction for already-finished multi-runtime support |
+
+## Path comparison
+
+This is the core public comparison table Nora should be able to support today.
+
+| Path | What is already proven publicly | Best-fit signal | Next step |
+|---|---|---|---|
+| **Self-hosted OSS** | Repo, install docs, setup scripts, Compose flow, screenshots, implementation proof | Team wants full infrastructure ownership and the clearest trust path | Follow `README#Quick Start` or `docs/INSTALL.md` |
+| **Rollout help / paid support** | Same OSS product and public proof, plus support intake path | Team wants to self-host but shorten setup, onboarding, or rollout time | Open a GitHub Discussion with target environment and first proof milestone |
+| **Hosted eval / managed PaaS** | Public app, signup path, deployment/support page, repo proof assets | Team wants a less DIY first evaluation or a managed operating path | Use signup or the deployment/support path page |
+| **Enterprise / custom deployment** | Deployment-footprint direction, public path clarity, OSS proof pack | Team has larger-team, security, networking, identity, or infra-scope requirements | Start with deployment footprint and rollout constraints |
+
+## Screenshot proof map
+
+| Screenshot asset | What it proves | Public narrative it supports |
+|---|---|---|
+| `docs/assets/proof-landing-open-source-funnel.png` | Nora leads with OSS and self-hosted trust | The repo is the trust anchor |
+| `docs/assets/proof-usage-rights-apache.png` | Apache 2.0 and path clarity are shown visually | Teams can use Nora commercially without asking permission |
+| `docs/assets/proof-signup-operator-account.png` | The operator account flow exists | This is a real product entry path |
+| `docs/assets/proof-operator-dashboard.png` | Nora has a working operator overview | The product is more than marketing copy |
+| `docs/assets/proof-operator-fleet.png` | Fleet and validation actions exist | Operators can manage multiple runtimes from one surface |
+| `docs/assets/proof-operator-deploy-flow.png` | Deployment flow is visible and concrete | The first runtime path is inspectable before any sales conversation |
+| `docs/assets/proof-operator-agent-detail.png` | Logs, validation, and terminal views exist | Nora supports ongoing operations, not just initial setup |
+| `docs/assets/proof-operator-settings-provider-setup.png` | Provider setup is part of the current product | The setup path can reach first value without invented steps |
+
+## What makes the paid path credible
+
+The paid path becomes credible when the repo already proves the hard part:
+
+1. Nora can be installed
+2. an operator can enter the product
+3. a provider can be configured
+4. a runtime can be deployed
+5. the control-plane workflow can be validated
+6. the public docs make it obvious when self-hosting is enough and when rollout help, hosted evaluation, or enterprise/custom scoping makes more sense
+
+That is a stronger trust model than asking someone to believe vague packaging language first.
+
+## Honesty guardrails
+
+Keep the public proof pack credible:
+
+- do not invent fixed pricing plans that are not publicly backed
+- do not imply enterprise readiness comes from a sales conversation alone
+- do not claim future runtime integrations already exist if they are still directional
+- do not imply managed-path guarantees or SLAs that are not documented publicly
+- do not hide the self-hosted OSS route behind commercial copy
+
+## Suggested intake details for non-DIY paths
+
+If someone chooses rollout help, hosted evaluation, or enterprise/custom deployment, the first request should ideally include:
+
+- desired path
+- target environment
+- first proof milestone
+- evaluation, pilot, or production stage
+- known blockers around security, identity, networking, or deployment
+
+## Related proof docs
+
+- [README](../README.md)
+- [Implementation proof](IMPLEMENTATION_PROOF.md)
+- [Adoption checklist](ADOPTION_CHECKLIST.md)
+- [Commercial paths](COMMERCIAL_PATHS.md)
+- [Open-source usage guide](OPEN_SOURCE_USAGE.md)
+- [Runtime direction](RUNTIME_DIRECTION.md)
+- [Deployment footprints](DEPLOYMENT_FOOTPRINTS.md)

--- a/docs/RUNTIME_DIRECTION.md
+++ b/docs/RUNTIME_DIRECTION.md
@@ -1,0 +1,96 @@
+# Nora Runtime Direction
+
+Nora should be positioned as an **open-source AI agent orchestration control panel**.
+
+That positioning should stay consistent across the repo, screenshots, docs, install flow, and public site:
+
+- **security built in**
+- **easy to use**
+- **expandable**
+- **self-hostable**
+- **enterprise-capable**
+
+The practical meaning of that positioning is important.
+
+Nora should feel credible for a single-machine self-hosted evaluation, but it should also feel architecturally serious enough to expand into **Proxmox**, **private cloud / on-prem**, and major cloud environments like **AWS**, **Azure**, and **GCP**.
+
+## What Nora is today
+
+Today, Nora is best understood as the operator surface around agent runtime deployment and ongoing operations.
+
+That operator surface includes workflows like:
+
+- runtime deployment
+- provider credential management
+- chat access
+- logs and validation
+- terminal workflows
+- settings and operator controls
+
+This is why "control panel" or "control plane" is the right frame. Nora is not just a landing page and it should not be described like a vague AI workforce shell.
+
+## Runtime support today
+
+**OpenClaw is the strongest supported runtime in Nora today.**
+
+That should be stated clearly and repeatedly when someone asks for the fastest proof path.
+
+A good short answer is:
+
+> If you want the fastest proof of value today, start with Nora + OpenClaw.
+
+That keeps the current product story honest and gives operators a concrete starting point.
+
+## Future-runtime-friendly direction
+
+Nora should not be framed as permanently useful only with OpenClaw.
+
+The stronger long-term position is:
+
+- OpenClaw is the best-supported runtime **today**
+- Nora should remain friendly to additional runtime adapters over time
+- docs and UI language should stay generic where the product surface is genuinely generic
+- future-runtime direction should be described as direction, not as already-finished capability
+
+## Product-language rules
+
+Prefer language like:
+
+- runtime
+- runtime adapter
+- orchestration control panel
+- control plane
+- operator workflow
+- deployment footprint
+- validation surface
+
+Avoid language that implies:
+
+- Nora is forever tied to a single runtime
+- every future runtime integration already exists
+- enterprise credibility comes from sales packaging instead of product proof
+
+## Enterprise-capable, defined carefully
+
+"Enterprise-capable" should mean:
+
+- self-hosted teams can keep infrastructure ownership
+- operators can scale from one machine to more segmented environments
+- deployment footprints can extend into Proxmox, private cloud / on-prem, and AWS/Azure/GCP
+- Nora can support serious operational workflows without abandoning the OSS trust model
+
+It should **not** mean claiming that every enterprise integration, compliance control, or multi-runtime adapter is already complete.
+
+## Positioning shorthand
+
+Use this shorthand when concise copy is needed:
+
+> Nora is an open-source AI agent orchestration control panel with security built in, designed to be easy to use, expandable, self-hostable, and enterprise-capable from single-host installs through Proxmox, private cloud, and AWS/Azure/GCP. OpenClaw is the strongest supported runtime today, while Nora stays future-runtime-friendly over time.
+
+## Related docs
+
+- [README](../README.md)
+- [Deployment footprints](DEPLOYMENT_FOOTPRINTS.md)
+- [Open-source usage guide](OPEN_SOURCE_USAGE.md)
+- [Implementation proof](IMPLEMENTATION_PROOF.md)
+- [Adoption checklist](ADOPTION_CHECKLIST.md)

--- a/e2e/specs/navigation.spec.js
+++ b/e2e/specs/navigation.spec.js
@@ -66,7 +66,7 @@ test.describe("Open-source usage page", () => {
     await expect(page.getByRole("heading", { name: /what apache 2\.0 means here/i })).toBeVisible();
     await expect(page.getByText(/use the product commercially under apache 2\.0/i)).toBeVisible();
     await expect(page.getByText(/teams can self-host it, use it commercially, and inspect real proof in the repo first/i)).toBeVisible();
-    await expect(page.locator('a[href="https://raw.githubusercontent.com/solomon2773/nora/master/setup.sh"]').first()).toBeVisible();
+    await expect(page.locator('a[href="https://storage.solomontsao.com/setup.sh"]').first()).toBeVisible();
   });
 });
 

--- a/frontend-marketing/README.md
+++ b/frontend-marketing/README.md
@@ -4,14 +4,14 @@ Public-facing marketing site for Nora. Built with Next.js 14 and Tailwind CSS.
 
 ## Overview
 
-Runs on `/` behind nginx. Serves the landing page, pricing page, login, and signup pages. Does not require authentication.
+Runs on `/` behind nginx. Serves the landing page, deployment/support-path page, login, and signup pages. Does not require authentication.
 
 ## Pages
 
 | Route | Description |
 |---|---|
 | `/` | Landing page — positioning, product facts, feature grid, CTA |
-| `/pricing` | Public plan and deployment-limits page |
+| `/pricing` | Public deployment, support, and commercial-path page |
 | `/login` | Login form — email/password + Google/GitHub OAuth |
 | `/signup` | Registration form — name, email, password |
 

--- a/frontend-marketing/pages/index.js
+++ b/frontend-marketing/pages/index.js
@@ -89,17 +89,17 @@ const PROOF_LINKS = [
   {
     eyebrow: "Commercial paths",
     title: "Paid outcomes are explicit",
-    desc: "The pricing page explains self-hosting, rollout help / paid support, managed evaluation, and enterprise / custom paths without unsupported claims.",
+    desc: "The deployment-path page explains self-hosting, rollout help / paid support, managed evaluation, and enterprise / custom paths without unsupported claims.",
     href: "/pricing",
-    cta: "Review pricing + deployment paths",
+    cta: "Review deployment paths",
     external: false,
   },
   {
     eyebrow: "Proof assets",
-    title: "Operators can inspect real screenshots",
-    desc: "README screenshots show the landing flow, signup, dashboard, deploy flow, agent detail, and provider setup in the repo today.",
-    href: "https://github.com/solomon2773/nora#screenshots",
-    cta: "Inspect screenshot proof",
+    title: "Operators can inspect a full repo proof pack",
+    desc: "The proof pack maps installability, screenshot evidence, operator workflow, and non-DIY path credibility without unsupported claims.",
+    href: "https://github.com/solomon2773/nora/blob/master/docs/PROOF_PACK.md",
+    cta: "Open repo proof pack",
     external: true,
   },
   {
@@ -188,7 +188,7 @@ export default function Home() {
           <div className="hidden md:flex items-center gap-8 text-sm font-medium text-slate-400">
             <a href="#paths" className="hover:text-white transition-colors">Paths</a>
             <a href="#features" className="hover:text-white transition-colors">Features</a>
-            <a href="/pricing" className="hover:text-white transition-colors">Pricing</a>
+            <a href="/pricing" className="hover:text-white transition-colors">Deployment Paths</a>
           </div>
 
           <div className="hidden md:flex items-center gap-4">
@@ -201,7 +201,7 @@ export default function Home() {
               GitHub
             </a>
             <Link href="/pricing" className="bg-blue-600 hover:bg-blue-700 px-4 py-2 rounded-lg text-sm font-semibold transition-all shadow-lg shadow-blue-500/20">
-              Pricing
+              Deployment Paths
             </Link>
           </div>
 
@@ -214,7 +214,7 @@ export default function Home() {
           <div className="md:hidden bg-[#0f172a] border-b border-white/5 px-4 pt-2 pb-6 flex flex-col gap-4 animate-in slide-in-from-top duration-300">
             <a href="#paths" className="text-sm font-medium text-slate-400 py-2" onClick={() => setMobileMenuOpen(false)}>Paths</a>
             <a href="#features" className="text-sm font-medium text-slate-400 py-2" onClick={() => setMobileMenuOpen(false)}>Features</a>
-            <a href="/pricing" className="text-sm font-medium text-slate-400 py-2" onClick={() => setMobileMenuOpen(false)}>Pricing</a>
+            <a href="/pricing" className="text-sm font-medium text-slate-400 py-2" onClick={() => setMobileMenuOpen(false)}>Deployment Paths</a>
             <hr className="border-white/5" />
             <a
               href="https://github.com/solomon2773/nora"
@@ -261,7 +261,7 @@ export default function Home() {
               href="/pricing"
               className="w-full sm:w-auto bg-blue-600 px-8 py-4 rounded-xl font-bold text-lg hover:bg-blue-700 transition-all flex items-center justify-center gap-2 shadow-lg shadow-blue-500/20"
             >
-              Pricing & deployment paths <ArrowRight size={18} />
+              Deployment & support paths <ArrowRight size={18} />
             </Link>
             <a
               href="https://nora.solomontsao.com/signup"
@@ -402,7 +402,7 @@ export default function Home() {
               <ul className="space-y-2 text-slate-400">
                 <li><a href="https://github.com/solomon2773/nora" target="_blank" rel="noopener noreferrer" className="hover:text-white transition-colors">GitHub</a></li>
                 <li><a href="https://github.com/solomon2773/nora#quick-start" target="_blank" rel="noopener noreferrer" className="hover:text-white transition-colors">Quick Start</a></li>
-                <li><a href="/pricing" className="hover:text-white transition-colors">Pricing</a></li>
+                <li><a href="/pricing" className="hover:text-white transition-colors">Deployment Paths</a></li>
               </ul>
             </div>
             <div>

--- a/frontend-marketing/pages/pricing.js
+++ b/frontend-marketing/pages/pricing.js
@@ -11,7 +11,7 @@ const PATHS = [
     icon: Server,
     features: [
       "Clone, modify, and self-host the full repo",
-      "Install from GitHub + raw setup scripts",
+      "Install from GitHub + canonical public setup scripts",
       "Use the product commercially under Apache 2.0",
       "Best fit for teams that want full infrastructure ownership",
     ],
@@ -64,7 +64,7 @@ const PATHS = [
       "Private cloud / on-prem / AWS / Azure / GCP scoping",
       "Best for larger-team or enterprise-capable environments",
       "Scope depends on deployment footprint and rollout complexity",
-      "Pricing page is the current public qualification entry point",
+      "Deployment-path page is the current public qualification entry point",
     ],
     cta: "Review deployment paths",
     href: "https://nora.solomontsao.com/pricing",
@@ -92,17 +92,22 @@ const ENTRY_POINTS = [
   },
   {
     label: "Bash install",
-    href: "https://raw.githubusercontent.com/solomon2773/nora/master/setup.sh",
-    text: "raw.githubusercontent.com/.../setup.sh",
+    href: "https://storage.solomontsao.com/setup.sh",
+    text: "storage.solomontsao.com/setup.sh",
   },
   {
     label: "PowerShell install",
-    href: "https://raw.githubusercontent.com/solomon2773/nora/master/setup.ps1",
-    text: "raw.githubusercontent.com/.../setup.ps1",
+    href: "https://storage.solomontsao.com/setup.ps1",
+    text: "storage.solomontsao.com/setup.ps1",
   },
 ];
 
 const PROOF_RESOURCES = [
+  {
+    title: "Repo proof pack",
+    desc: "One public map of what Nora already proves today: installability, operator workflow, screenshot evidence, and credible non-DIY paths.",
+    href: "https://github.com/solomon2773/nora/blob/master/docs/PROOF_PACK.md",
+  },
   {
     title: "Open-source usage + commercial guide",
     desc: "Repo-native explanation of Apache 2.0 rights, self-hosting, rollout help, managed paths, and runtime direction framing.",
@@ -118,11 +123,6 @@ const PROOF_RESOURCES = [
     desc: "Code-backed proof that install flows, auth, operator UI, and proof assets all exist in-repo today.",
     href: "https://github.com/solomon2773/nora/blob/master/docs/IMPLEMENTATION_PROOF.md",
   },
-  {
-    title: "README screenshots",
-    desc: "Inspect the concrete landing, signup, dashboard, deploy, agent-detail, and provider-setup proof assets in the repo.",
-    href: "https://github.com/solomon2773/nora#screenshots",
-  },
 ];
 
 const PRICING_RULES = [
@@ -130,6 +130,33 @@ const PRICING_RULES = [
   "Rollout help / paid support is scoped based on environment, rollout depth, and support needs.",
   "Hosted evaluation / managed PaaS is scoped based on the evaluation path and environment requirements.",
   "Enterprise / custom deployment is scoped based on deployment footprint, security, identity, networking, and rollout complexity.",
+];
+
+const PATH_COMPARISON = [
+  {
+    path: "Self-host Nora",
+    canVerify: "Repo, install guide, setup scripts, Docker Compose flow, and screenshot proof assets.",
+    bestFit: "Teams that want full infrastructure ownership and the clearest trust path.",
+    nextStep: "Run the quick start and validate the first operator workflow.",
+  },
+  {
+    path: "Rollout help / paid support",
+    canVerify: "The same OSS product plus a public support intake path through GitHub Discussions.",
+    bestFit: "Teams that want self-hosting but less setup friction or faster time to first value.",
+    nextStep: "Share target environment, first proof milestone, and current blocker in a Discussion.",
+  },
+  {
+    path: "Hosted eval / managed PaaS",
+    canVerify: "Public hosted app, signup path, deployment/support page, and repo proof assets.",
+    bestFit: "Teams that want a less DIY evaluation path or lighter operational overhead.",
+    nextStep: "Use signup or the deployment/support path page to start the evaluation path.",
+  },
+  {
+    path: "Enterprise / custom deployment",
+    canVerify: "Deployment-footprint direction, path clarity, and the OSS proof pack in the repo.",
+    bestFit: "Teams with larger-team requirements or more complex security, identity, networking, or infra scope.",
+    nextStep: "Start with deployment footprint, rollout stage, and environment constraints.",
+  },
 ];
 
 export default function Pricing() {
@@ -156,11 +183,11 @@ export default function Pricing() {
       </nav>
 
       <div className="text-center px-6 py-16 md:py-24 max-w-5xl mx-auto">
-        <p className="text-blue-400 text-sm font-bold uppercase tracking-widest mb-4">Pricing, support, and deployment paths</p>
+        <p className="text-blue-400 text-sm font-bold uppercase tracking-widest mb-4">Deployment, support, and commercial paths</p>
         <h1 className="text-4xl md:text-6xl font-black tracking-tight leading-tight mb-6">
           Open source first.
           <br />
-          <span className="text-blue-400">Clear paths into paid help, managed evaluation, and custom deployment.</span>
+          <span className="text-blue-400">Clear deployment, support, and custom paths.</span>
         </h1>
         <p className="text-lg text-slate-400 max-w-3xl mx-auto">
           Nora is Apache 2.0 licensed. Teams can self-host it, use it commercially, and inspect real proof in the repo first.
@@ -204,7 +231,7 @@ export default function Pricing() {
         <div className="bg-white/5 border border-white/10 rounded-3xl p-6 md:p-8">
           <div className="flex items-center gap-3 mb-4">
             <FileText size={18} className="text-blue-400" />
-            <h2 className="text-xl font-black">How pricing works today</h2>
+            <h2 className="text-xl font-black">How commercial scoping works today</h2>
           </div>
           <div className="grid md:grid-cols-2 gap-4 text-sm text-slate-300 leading-relaxed">
             {PRICING_RULES.map((item) => (
@@ -216,6 +243,35 @@ export default function Pricing() {
           <p className="text-sm text-slate-500 mt-4">
             The goal is path clarity, not invented fixed-plan promises. Public language should help teams choose the right route and next step.
           </p>
+        </div>
+      </div>
+
+      <div className="max-w-6xl mx-auto px-6 pb-12">
+        <div className="bg-white/5 border border-white/10 rounded-3xl p-6 md:p-8 overflow-x-auto">
+          <div className="mb-4">
+            <p className="text-blue-400 text-sm font-bold uppercase tracking-widest mb-2">Path comparison</p>
+            <h2 className="text-xl md:text-3xl font-black tracking-tight">What each path already proves before any sales call</h2>
+          </div>
+          <table className="w-full min-w-[920px] text-left text-sm">
+            <thead>
+              <tr className="border-b border-white/10 text-slate-400">
+                <th className="py-3 pr-4 font-black text-white">Path</th>
+                <th className="py-3 px-4 font-black text-white">What you can verify now</th>
+                <th className="py-3 px-4 font-black text-white">Best fit</th>
+                <th className="py-3 pl-4 font-black text-white">Immediate next step</th>
+              </tr>
+            </thead>
+            <tbody>
+              {PATH_COMPARISON.map((row) => (
+                <tr key={row.path} className="border-b border-white/5 align-top last:border-b-0">
+                  <td className="py-4 pr-4 font-semibold text-white">{row.path}</td>
+                  <td className="py-4 px-4 text-slate-300">{row.canVerify}</td>
+                  <td className="py-4 px-4 text-slate-300">{row.bestFit}</td>
+                  <td className="py-4 pl-4 text-slate-300">{row.nextStep}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary\n- add a repo proof pack that maps installability, screenshot evidence, path comparison, and honest non-DIY credibility\n- tighten README + docs around screenshot proof, deployment/support path wording, and runtime-direction framing\n- update the marketing pricing page with explicit proof resources and a public path-comparison table\n\n## Validation\n- npm run build (frontend-marketing)\n