### PR TITLE
security: stop returning integration access tokens

### DIFF
--- a/backend-api/__tests__/integrations.test.js
+++ b/backend-api/__tests__/integrations.test.js
@@ -1,0 +1,57 @@
+const mockDb = { query: jest.fn() };
+const mockEncrypt = jest.fn((value) => `enc(${value})`);
+const mockDecrypt = jest.fn((value) => `dec(${value})`);
+const mockEnsureEncryptionConfigured = jest.fn();
+
+jest.mock("../db", () => mockDb);
+jest.mock("../crypto", () => ({
+  encrypt: mockEncrypt,
+  decrypt: mockDecrypt,
+  ensureEncryptionConfigured: mockEnsureEncryptionConfigured,
+}));
+
+const integrations = require("../integrations");
+
+describe("integration secret handling", () => {
+  beforeEach(() => {
+    mockDb.query.mockReset();
+    mockEncrypt.mockClear();
+    mockDecrypt.mockClear();
+    mockEnsureEncryptionConfigured.mockClear();
+  });
+
+  it("redacts sensitive config and does not return access_token after create", async () => {
+    mockDb.query.mockResolvedValueOnce({
+      rows: [{
+        id: "int-1",
+        agent_id: "agent-1",
+        provider: "github",
+        catalog_id: "github",
+        access_token: "enc(secret-token)",
+        config: '{"api_key":"enc(config-secret)","base_url":"https://api.github.com"}',
+        status: "active",
+      }],
+    });
+
+    const result = await integrations.connectIntegration("agent-1", "github", "secret-token", {
+      api_key: "config-secret",
+      base_url: "https://api.github.com",
+    });
+
+    expect(mockEnsureEncryptionConfigured).toHaveBeenCalledWith("Integration credential storage");
+    expect(mockEncrypt).toHaveBeenCalledWith("secret-token");
+    expect(mockEncrypt).toHaveBeenCalledWith("config-secret");
+    expect(result).toMatchObject({
+      id: "int-1",
+      agent_id: "agent-1",
+      provider: "github",
+      catalog_id: "github",
+      status: "active",
+      config: {
+        api_key: "[REDACTED]",
+        base_url: "https://api.github.com",
+      },
+    });
+    expect(result).not.toHaveProperty("access_token");
+  });
+});

--- a/backend-api/integrations.js
+++ b/backend-api/integrations.js
@@ -386,8 +386,9 @@ async function connectIntegration(agentId, provider, token, config = {}) {
     "INSERT INTO integrations(agent_id, provider, catalog_id, access_token, config) VALUES($1, $2, $3, $4, $5) RETURNING *",
     [agentId, provider, provider, encryptedToken, JSON.stringify(securedConfig)]
   );
+  const { access_token, ...safeRow } = result.rows[0] || {};
   return {
-    ...result.rows[0],
+    ...safeRow,
     config: redactSensitiveConfig(provider, securedConfig),
   };
 }


### PR DESCRIPTION
## Summary
- remove access_token from the create-integration response payload
- keep sensitive config values redacted in the same response
- add regression coverage for the create path so encrypted tokens cannot leak back to the client

## Validation
- npm test -- --runInBand __tests__/integrations.test.js
