### PR TITLE
Reliability: preserve warning status during reconciliation

### DIFF
--- a/backend-api/__tests__/agentStatus.test.js
+++ b/backend-api/__tests__/agentStatus.test.js
@@ -1,0 +1,21 @@
+const { reconcileAgentStatus } = require("../agentStatus");
+
+describe("reconcileAgentStatus", () => {
+  it("preserves warning when the container is still running", () => {
+    expect(reconcileAgentStatus("warning", true)).toBe("warning");
+  });
+
+  it("downgrades warning to stopped when the container is no longer running", () => {
+    expect(reconcileAgentStatus("warning", false)).toBe("stopped");
+  });
+
+  it("promotes stopped and error agents back to running when the container is live", () => {
+    expect(reconcileAgentStatus("stopped", true)).toBe("running");
+    expect(reconcileAgentStatus("error", true)).toBe("running");
+  });
+
+  it("leaves queued and deploying agents untouched", () => {
+    expect(reconcileAgentStatus("queued", true)).toBe("queued");
+    expect(reconcileAgentStatus("deploying", false)).toBe("deploying");
+  });
+});

--- a/backend-api/__tests__/agents.test.js
+++ b/backend-api/__tests__/agents.test.js
@@ -121,7 +121,7 @@ describe("GET /agents", () => {
 });
 
 describe("GET /agents/:id", () => {
-  it("preserves warning status without forcing live reconciliation", async () => {
+  it("preserves warning status when the container is still live", async () => {
     mockDb.query.mockResolvedValueOnce({
       rows: [{
         id: "a-warning",
@@ -136,6 +136,32 @@ describe("GET /agents/:id", () => {
 
     expect(res.status).toBe(200);
     expect(res.body).toHaveProperty("status", "warning");
+  });
+
+  it("reconciles warning agents to stopped when the container is no longer live", async () => {
+    const containerManager = require("../containerManager");
+    containerManager.status.mockResolvedValueOnce({ running: false });
+    mockDb.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: "a-warning-down",
+          name: "Warning Down Agent",
+          status: "warning",
+          user_id: "user-1",
+          container_id: "container-warning-down",
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{
+          id: "a-warning-down",
+          status: "stopped",
+        }],
+      });
+
+    const res = await auth(request(app).get("/agents/a-warning-down"));
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("status", "stopped");
   });
 
   it("reconciles stopped agents back to running when the container is live", async () => {

--- a/backend-api/agentStatus.js
+++ b/backend-api/agentStatus.js
@@ -1,0 +1,19 @@
+function reconcileAgentStatus(currentStatus, liveRunning) {
+  if (currentStatus === "queued" || currentStatus === "deploying") {
+    return currentStatus;
+  }
+
+  if (liveRunning) {
+    if (currentStatus === "warning") return "warning";
+    if (currentStatus === "stopped" || currentStatus === "error") return "running";
+    return currentStatus;
+  }
+
+  if (["running", "warning", "error"].includes(currentStatus)) {
+    return "stopped";
+  }
+
+  return currentStatus;
+}
+
+module.exports = { reconcileAgentStatus };

--- a/backend-api/routes/agents.js
+++ b/backend-api/routes/agents.js
@@ -5,6 +5,7 @@ const billing = require("../billing");
 const scheduler = require("../scheduler");
 const containerManager = require("../containerManager");
 const monitoring = require("../monitoring");
+const { reconcileAgentStatus } = require("../agentStatus");
 const { OPENCLAW_GATEWAY_PORT } = require("../../agent-runtime/lib/contracts");
 const { asyncHandler } = require("../middleware/errorHandler");
 
@@ -27,14 +28,15 @@ router.get("/:id", asyncHandler(async (req, res) => {
 
   const agent = result.rows[0];
 
-  // Live status reconciliation — check actual container state
-  if (agent.container_id && (agent.status === "running" || agent.status === "error" || agent.status === "stopped")) {
+  // Live status reconciliation — check actual container state while preserving
+  // warning as a first-class degraded state until the container actually stops.
+  if (agent.container_id && ["running", "warning", "error", "stopped"].includes(agent.status)) {
     try {
       const live = await containerManager.status(agent);
-      const liveStatus = live.running ? "running" : "stopped";
-      if (liveStatus !== agent.status && agent.status !== "queued" && agent.status !== "deploying") {
-        await db.query("UPDATE agents SET status = $1 WHERE id = $2", [liveStatus, agent.id]);
-        agent.status = liveStatus;
+      const reconciledStatus = reconcileAgentStatus(agent.status, Boolean(live.running));
+      if (reconciledStatus !== agent.status) {
+        await db.query("UPDATE agents SET status = $1 WHERE id = $2", [reconciledStatus, agent.id]);
+        agent.status = reconciledStatus;
       }
     } catch {
       // Can't reach container runtime — leave DB status as-is

--- a/backend-api/server.js
+++ b/backend-api/server.js
@@ -14,6 +14,7 @@ const { getBootstrapAdminSeedConfig } = require("./bootstrapAdmin");
 const { authenticateToken } = require("./middleware/auth");
 const { correlationId, errorHandler } = require("./middleware/errorHandler");
 const { createGatewayRouter, attachGatewayWS } = require("./gatewayProxy");
+const { reconcileAgentStatus } = require("./agentStatus");
 const { OPENCLAW_GATEWAY_PORT } = require("../agent-runtime/lib/contracts");
 
 // ─── JWT Secret ───────────────────────────────────────────────────
@@ -467,14 +468,15 @@ if (require.main === module) {
         for (const agent of agents.rows) {
           try {
             const info = await docker.getContainer(agent.container_id).inspect();
-            const liveStatus = info.State?.Running ? "running" : "stopped";
-            if (liveStatus !== agent.status && agent.status !== "queued" && agent.status !== "deploying") {
-              await db.query("UPDATE agents SET status = $1 WHERE id = $2", [liveStatus, agent.id]);
+            const reconciledStatus = reconcileAgentStatus(agent.status, Boolean(info.State?.Running));
+            if (reconciledStatus !== agent.status) {
+              await db.query("UPDATE agents SET status = $1 WHERE id = $2", [reconciledStatus, agent.id]);
             }
           } catch (e) {
-            // Container removed or unreachable — mark as stopped if it was running
-            if (agent.status === "running" || agent.status === "warning") {
-              await db.query("UPDATE agents SET status = 'stopped' WHERE id = $1", [agent.id]);
+            // Container removed or unreachable — mark any previously live/degraded agent as stopped.
+            const reconciledStatus = reconcileAgentStatus(agent.status, false);
+            if (reconciledStatus !== agent.status) {
+              await db.query("UPDATE agents SET status = $1 WHERE id = $2", [reconciledStatus, agent.id]);
             }
           }
         }


### PR DESCRIPTION
## Summary
- centralize agent status reconciliation rules
- preserve `warning` while the container is still live
- transition `warning` to `stopped` only when the container is actually down
- apply the same logic to API reads and background reconciliation
- add regression coverage for warning-state health signaling

## Validation
- `npx jest __tests__/agentStatus.test.js __tests__/agents.test.js --runInBand`
- `npm test` (backend-api)

## Scope
Bounded reliability/health-signaling fix only. No live deploy.