### PR TITLE
Reliability: clear stale gateway metadata on redeploy

### DIFF
--- a/backend-api/__tests__/agents.test.js
+++ b/backend-api/__tests__/agents.test.js
@@ -300,6 +300,11 @@ describe("POST /agents/:id/redeploy", () => {
 
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ success: true, status: "queued" });
+    expect(mockDb.query).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("gateway_host_port = NULL, gateway_token = NULL"),
+      ["a-warning"]
+    );
     expect(mockAddDeploymentJob).toHaveBeenCalledWith(expect.objectContaining({
       id: "a-warning",
       name: "Warning Agent",

--- a/backend-api/routes/agents.js
+++ b/backend-api/routes/agents.js
@@ -371,7 +371,7 @@ router.post("/:id/redeploy", async (req, res) => {
     }
 
     await db.query(
-      "UPDATE agents SET status = 'queued', container_id = NULL, host = NULL WHERE id = $1",
+      "UPDATE agents SET status = 'queued', container_id = NULL, host = NULL, gateway_host_port = NULL, gateway_token = NULL WHERE id = $1",
       [agent.id]
     );
 


### PR DESCRIPTION
## Summary
- clear stale `gateway_host_port` and `gateway_token` when an agent is re-queued for redeploy
- keep control-plane state deterministic across warning/error/stopped recovery paths
- add backend coverage for the redeploy cleanup query

## Validation
- `npx jest __tests__/agents.test.js --runInBand`
- `npm test` (backend-api)

## Scope
Bounded provisioning determinism fix only. No live deploy.