### PR TITLE
security: redact channel secrets in API responses

### DIFF
--- a/backend-api/__tests__/channels.test.js
+++ b/backend-api/__tests__/channels.test.js
@@ -1,0 +1,94 @@
+const mockDb = { query: jest.fn() };
+
+jest.mock("../db", () => mockDb);
+jest.mock("../../agent-runtime/lib/contracts", () => ({
+  agentRuntimeUrl: jest.fn(() => "http://runtime.test"),
+}));
+
+const channels = require("../channels");
+
+describe("channel secret redaction", () => {
+  beforeEach(() => {
+    mockDb.query.mockReset();
+  });
+
+  it("redacts password and secret-like fields when creating a channel", async () => {
+    mockDb.query.mockResolvedValueOnce({
+      rows: [{
+        id: "ch-1",
+        agent_id: "agent-1",
+        type: "telegram",
+        name: "Ops Telegram",
+        config: { bot_token: "123:secret", chat_id: "42" },
+        enabled: true,
+      }],
+    });
+
+    const result = await channels.createChannel("agent-1", "telegram", "Ops Telegram", {
+      bot_token: "123:secret",
+      chat_id: "42",
+    });
+
+    expect(result.config).toEqual({
+      bot_token: "[REDACTED]",
+      chat_id: "42",
+    });
+  });
+
+  it("redacts webhook and token fields when listing channels", async () => {
+    mockDb.query.mockResolvedValueOnce({
+      rows: [{
+        id: "ch-2",
+        agent_id: "agent-1",
+        type: "whatsapp",
+        name: "Ops WhatsApp",
+        config: {
+          phone_number_id: "pn_123",
+          access_token: "wa-secret",
+          verify_token: "verify-me",
+        },
+        enabled: true,
+      }],
+    });
+
+    const result = await channels.listChannels("agent-1");
+
+    expect(result).toHaveLength(1);
+    expect(result[0].config).toEqual({
+      phone_number_id: "pn_123",
+      access_token: "[REDACTED]",
+      verify_token: "[REDACTED]",
+    });
+  });
+
+  it("redacts webhook URLs and password fields when updating a channel", async () => {
+    mockDb.query.mockResolvedValueOnce({
+      rows: [{
+        id: "ch-3",
+        agent_id: "agent-1",
+        type: "slack",
+        name: "Ops Slack",
+        config: {
+          webhook_url: "https://hooks.slack.test/secret",
+          bot_token: "xoxb-secret",
+          channel: "#ops",
+        },
+        enabled: true,
+      }],
+    });
+
+    const result = await channels.updateChannel("ch-3", "agent-1", {
+      config: {
+        webhook_url: "https://hooks.slack.test/secret",
+        bot_token: "xoxb-secret",
+        channel: "#ops",
+      },
+    });
+
+    expect(result.config).toEqual({
+      webhook_url: "[REDACTED]",
+      bot_token: "[REDACTED]",
+      channel: "#ops",
+    });
+  });
+});

--- a/backend-api/channels/index.js
+++ b/backend-api/channels/index.js
@@ -6,6 +6,40 @@ const db = require("../db");
 const { agentRuntimeUrl } = require("../../agent-runtime/lib/contracts");
 const { getAdapter, listAdapterTypes } = require("./adapters");
 
+const REDACTED_SECRET = "[REDACTED]";
+const SECRET_CONFIG_KEY_RE = /(token|secret|password|webhook_url|smtp_pass|auth_token)/i;
+
+function parseConfig(config) {
+  return typeof config === "string" ? JSON.parse(config) : (config || {});
+}
+
+function redactChannelConfig(type, config = {}) {
+  const adapter = getAdapter(type);
+  const parsed = parseConfig(config);
+  const redacted = { ...parsed };
+  const passwordKeys = new Set(
+    (adapter.configFields || [])
+      .filter((field) => field?.type === "password")
+      .map((field) => field.key)
+  );
+
+  for (const key of Object.keys(redacted)) {
+    if ((passwordKeys.has(key) || SECRET_CONFIG_KEY_RE.test(key)) && redacted[key]) {
+      redacted[key] = REDACTED_SECRET;
+    }
+  }
+
+  return redacted;
+}
+
+function sanitizeChannel(channel) {
+  if (!channel) return channel;
+  return {
+    ...channel,
+    config: redactChannelConfig(channel.type, channel.config),
+  };
+}
+
 // ── Channel CRUD ─────────────────────────────────────────
 
 async function listChannels(agentId) {
@@ -13,7 +47,7 @@ async function listChannels(agentId) {
     "SELECT * FROM channels WHERE agent_id = $1 ORDER BY created_at DESC",
     [agentId]
   );
-  return result.rows;
+  return result.rows.map(sanitizeChannel);
 }
 
 async function createChannel(agentId, type, name, config = {}) {
@@ -23,7 +57,7 @@ async function createChannel(agentId, type, name, config = {}) {
     "INSERT INTO channels(agent_id, type, name, config) VALUES($1, $2, $3, $4) RETURNING *",
     [agentId, type, name, JSON.stringify(config)]
   );
-  return result.rows[0];
+  return sanitizeChannel(result.rows[0]);
 }
 
 async function updateChannel(channelId, agentId, updates) {
@@ -52,7 +86,7 @@ async function updateChannel(channelId, agentId, updates) {
     params
   );
   if (!result.rows[0]) throw new Error("Channel not found");
-  return result.rows[0];
+  return sanitizeChannel(result.rows[0]);
 }
 
 async function deleteChannel(channelId, agentId) {
@@ -181,4 +215,6 @@ module.exports = {
   testChannel,
   handleInboundWebhook,
   getChannelTypes,
+  redactChannelConfig,
+  sanitizeChannel,
 };


### PR DESCRIPTION
## Summary
- redact channel secret fields in create/list/update API responses
- use adapter password field metadata plus a secret-like key fallback for webhook/token/secret fields
- add regression coverage for create, list, and update channel response paths

## Validation
- npm test -- --runInBand __tests__/channels.test.js
