### PR TITLE
Reliability: clarify readiness timeout errors

### DIFF
--- a/backend-api/__tests__/provisioning.test.js
+++ b/backend-api/__tests__/provisioning.test.js
@@ -68,6 +68,28 @@ describe("provisioning runtime/gateway contracts", () => {
     clearTimeoutSpy.mockRestore();
   });
 
+  it("reports explicit timeout errors for readiness probes", async () => {
+    const fetchImpl = jest.fn().mockImplementationOnce(async (_url, { signal }) => {
+      return await new Promise((_, reject) => {
+        signal.addEventListener("abort", () => {
+          const err = new Error("This operation was aborted");
+          err.name = "AbortError";
+          reject(err);
+        }, { once: true });
+      });
+    });
+
+    const result = await waitForHttpReady("http://agent.internal:9090/health", {
+      attempts: 1,
+      intervalMs: 1,
+      timeoutMs: 5,
+      fetchImpl,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("timeout after 5ms");
+  });
+
   it("checks runtime on 9090 and gateway on the published control-plane port", async () => {
     const fetchImpl = jest
       .fn()

--- a/workers/provisioner/healthChecks.js
+++ b/workers/provisioner/healthChecks.js
@@ -29,7 +29,11 @@ async function waitForHttpReady(url, options = {}) {
       }
       lastError = new Error(`unexpected HTTP ${response.status}`);
     } catch (error) {
-      lastError = error;
+      if (controller.signal.aborted) {
+        lastError = new Error(`timeout after ${timeoutMs}ms`);
+      } else {
+        lastError = error;
+      }
     } finally {
       clearTimeout(timer);
     }


### PR DESCRIPTION
## Summary
- report explicit readiness probe timeout errors instead of generic abort messages
- improve provisioning health signaling for runtime/gateway checks
- add regression coverage for timeout formatting

## Validation
- `npx jest __tests__/provisioning.test.js --runInBand`
- `npm test` (backend-api)

## Scope
Bounded provisioning health-signaling fix only. No live deploy.