### PR TITLE
Reliability: cover published gateway host override

### DIFF
--- a/backend-api/__tests__/provisioning.test.js
+++ b/backend-api/__tests__/provisioning.test.js
@@ -109,6 +109,26 @@ describe("provisioning runtime/gateway contracts", () => {
     expect(fetchImpl.mock.calls[1][0]).toBe("http://host.docker.internal:19123/");
   });
 
+  it("uses GATEWAY_HOST for published control-plane ports when provided", async () => {
+    process.env.GATEWAY_HOST = "gateway.external";
+    const fetchImpl = jest
+      .fn()
+      .mockResolvedValueOnce({ status: 200 })
+      .mockResolvedValueOnce({ status: 403 });
+
+    const readiness = await waitForAgentReadiness(
+      { host: "agent.internal", gatewayHostPort: 19123 },
+      {
+        runtime: { attempts: 1, intervalMs: 1, timeoutMs: 1, fetchImpl },
+        gateway: { attempts: 1, intervalMs: 1, timeoutMs: 1, fetchImpl },
+      }
+    );
+
+    expect(readiness.ok).toBe(true);
+    expect(readiness.gateway.host).toBe("gateway.external");
+    expect(fetchImpl.mock.calls[1][0]).toBe("http://gateway.external:19123/");
+  });
+
   it("honors explicit runtime and gateway host overrides", async () => {
     const fetchImpl = jest
       .fn()


### PR DESCRIPTION
## Summary
- add provisioning regression coverage for published gateway host overrides
- verify `GATEWAY_HOST` is honored when the control-plane port is published
- keep runtime/gateway contract coverage explicit around `9090` and published gateway access

## Validation
- `npx jest __tests__/provisioning.test.js --runInBand`
- `npm test` (backend-api)

## Scope
Bounded QA/CI coverage follow-up only. No live deploy.