### PR TITLE
Reliability: honor gateway host in gateway URL endpoint

### DIFF
--- a/backend-api/__tests__/agents.test.js
+++ b/backend-api/__tests__/agents.test.js
@@ -189,6 +189,32 @@ describe("GET /agents/:id", () => {
   });
 });
 
+describe("GET /agents/:id/gateway-url", () => {
+  it("uses GATEWAY_HOST when returning a published gateway url", async () => {
+    process.env.GATEWAY_HOST = "gateway.external";
+    mockDb.query.mockResolvedValueOnce({
+      rows: [{
+        id: "a-gateway",
+        container_id: "container-gateway",
+        gateway_token: "gateway-token",
+        gateway_host_port: 19123,
+        user_id: "user-1",
+      }],
+    });
+
+    const res = await auth(request(app).get("/agents/a-gateway/gateway-url"));
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      url: "http://gateway.external:19123",
+      port: 19123,
+      token: "gateway-token",
+    });
+
+    delete process.env.GATEWAY_HOST;
+  });
+});
+
 describe("POST /agents/deploy", () => {
   it("rejects unauthenticated request", async () => {
     const res = await request(app).post("/agents/deploy").send({});

--- a/backend-api/routes/agents.js
+++ b/backend-api/routes/agents.js
@@ -111,8 +111,9 @@ router.get("/:id/gateway-url", asyncHandler(async (req, res) => {
 
   if (!hostPort) return res.status(409).json({ error: "Gateway port not published" });
 
+  const gatewayHost = process.env.GATEWAY_HOST || "localhost";
   res.json({
-    url: `http://localhost:${hostPort}`,
+    url: `http://${gatewayHost}:${hostPort}`,
     port: parseInt(hostPort),
     token: agent.gateway_token,
   });


### PR DESCRIPTION
## Summary
- make `GET /agents/:id/gateway-url` honor `GATEWAY_HOST` instead of hardcoding localhost
- align the control-plane URL endpoint with the published gateway host behavior already covered in readiness checks
- add backend regression coverage for the returned URL

## Validation
- `npx jest __tests__/agents.test.js --runInBand`
- `npm test` (backend-api)

## Scope
Bounded control-plane reliability fix only. No live deploy.