### PR TITLE
Reliability: lock readiness warning message formatting

### DIFF
--- a/backend-api/__tests__/readinessWarning.test.js
+++ b/backend-api/__tests__/readinessWarning.test.js
@@ -1,0 +1,56 @@
+const { buildReadinessWarningDetail } = require("../../workers/provisioner/readinessWarning");
+
+describe("buildReadinessWarningDetail", () => {
+  it("formats a runtime-only readiness warning", () => {
+    const detail = buildReadinessWarningDetail({
+      runtime: {
+        ok: false,
+        url: "http://agent.internal:9090/health",
+        error: "timeout after 5000ms",
+      },
+      gateway: { ok: true },
+    });
+
+    expect(detail).toBe(
+      "runtime unavailable at http://agent.internal:9090/health (timeout after 5000ms)"
+    );
+  });
+
+  it("formats a gateway-only readiness warning", () => {
+    const detail = buildReadinessWarningDetail({
+      runtime: { ok: true },
+      gateway: {
+        ok: false,
+        url: "http://host.docker.internal:18789/",
+        status: 502,
+      },
+    });
+
+    expect(detail).toBe(
+      "gateway unavailable at http://host.docker.internal:18789/ (502)"
+    );
+  });
+
+  it("formats combined runtime and gateway readiness warnings", () => {
+    const detail = buildReadinessWarningDetail({
+      runtime: {
+        ok: false,
+        url: "http://agent.internal:9090/health",
+        error: "connection refused",
+      },
+      gateway: {
+        ok: false,
+        url: "http://host.docker.internal:19123/",
+        error: "timeout after 5000ms",
+      },
+    });
+
+    expect(detail).toBe(
+      "runtime unavailable at http://agent.internal:9090/health (connection refused); gateway unavailable at http://host.docker.internal:19123/ (timeout after 5000ms)"
+    );
+  });
+
+  it("falls back to a generic message when readiness is malformed", () => {
+    expect(buildReadinessWarningDetail({})).toBe("readiness checks failed");
+  });
+});

--- a/workers/provisioner/readinessWarning.js
+++ b/workers/provisioner/readinessWarning.js
@@ -1,0 +1,19 @@
+function buildReadinessWarningDetail(readiness) {
+  const problems = [];
+
+  if (readiness?.runtime && !readiness.runtime.ok) {
+    problems.push(
+      `runtime unavailable at ${readiness.runtime.url} (${readiness.runtime.error || readiness.runtime.status || 'unreachable'})`
+    );
+  }
+
+  if (readiness?.gateway && !readiness.gateway.ok) {
+    problems.push(
+      `gateway unavailable at ${readiness.gateway.url} (${readiness.gateway.error || readiness.gateway.status || 'unreachable'})`
+    );
+  }
+
+  return problems.join('; ') || 'readiness checks failed';
+}
+
+module.exports = { buildReadinessWarningDetail };

--- a/workers/provisioner/worker.js
+++ b/workers/provisioner/worker.js
@@ -3,6 +3,7 @@ const IORedis = require('ioredis');
 const { Pool } = require('pg');
 const { agentRuntimeUrl } = require('../../agent-runtime/lib/contracts');
 const { waitForAgentReadiness } = require('./healthChecks');
+const { buildReadinessWarningDetail } = require('./readinessWarning');
 
 // ── Connections ──────────────────────────────────────────
 const connection = new IORedis({
@@ -383,14 +384,7 @@ const worker = new Worker('deployments', async (job) => {
       gatewayPort,
     });
     if (!readiness.ok) {
-      const problems = [];
-      if (!readiness.runtime.ok) {
-        problems.push(`runtime unavailable at ${readiness.runtime.url} (${readiness.runtime.error || readiness.runtime.status || 'unreachable'})`);
-      }
-      if (!readiness.gateway.ok) {
-        problems.push(`gateway unavailable at ${readiness.gateway.url} (${readiness.gateway.error || readiness.gateway.status || 'unreachable'})`);
-      }
-      const detail = problems.join('; ');
+      const detail = buildReadinessWarningDetail(readiness);
       console.warn(`[provisioner] Readiness check failed for agent ${id}: ${detail}`);
       await db.query("UPDATE agents SET status = 'warning' WHERE id = $1", [id]);
       await db.query("UPDATE deployments SET status = 'warning' WHERE agent_id = $1", [id]);


### PR DESCRIPTION
## Summary
- centralize readiness warning detail generation for degraded deploys
- keep runtime/gateway warning messages deterministic for event/log emission
- add regression coverage for runtime-only, gateway-only, combined, and malformed readiness payloads

## Validation
- `npx jest __tests__/readinessWarning.test.js __tests__/provisioning.test.js --runInBand`
- `npm test` (backend-api)

## Scope
Bounded provisioning observability/coverage fix only. No live deploy.