### PR TITLE
Reliability: include readiness detail in warning metadata

### DIFF
--- a/backend-api/__tests__/readinessWarning.test.js
+++ b/backend-api/__tests__/readinessWarning.test.js
@@ -1,4 +1,4 @@
-const { buildReadinessWarningDetail } = require("../../workers/provisioner/readinessWarning");
+const { buildReadinessWarningDetail, buildReadinessWarningMetadata } = require("../../workers/provisioner/readinessWarning");
 
 describe("buildReadinessWarningDetail", () => {
   it("formats a runtime-only readiness warning", () => {
@@ -52,5 +52,29 @@ describe("buildReadinessWarningDetail", () => {
 
   it("falls back to a generic message when readiness is malformed", () => {
     expect(buildReadinessWarningDetail({})).toBe("readiness checks failed");
+  });
+});
+
+describe("buildReadinessWarningMetadata", () => {
+  it("includes a flattened warning detail alongside the raw readiness payload", () => {
+    const readiness = {
+      runtime: {
+        ok: false,
+        url: "http://agent.internal:9090/health",
+        error: "timeout after 5000ms",
+      },
+      gateway: { ok: true },
+    };
+
+    expect(buildReadinessWarningMetadata({
+      agentId: "agent-123",
+      host: "agent.internal",
+      readiness,
+    })).toEqual({
+      agentId: "agent-123",
+      host: "agent.internal",
+      detail: "runtime unavailable at http://agent.internal:9090/health (timeout after 5000ms)",
+      readiness,
+    });
   });
 });

--- a/workers/provisioner/readinessWarning.js
+++ b/workers/provisioner/readinessWarning.js
@@ -16,4 +16,13 @@ function buildReadinessWarningDetail(readiness) {
   return problems.join('; ') || 'readiness checks failed';
 }
 
-module.exports = { buildReadinessWarningDetail };
+function buildReadinessWarningMetadata({ agentId, host, readiness }) {
+  return {
+    agentId,
+    host,
+    detail: buildReadinessWarningDetail(readiness),
+    readiness,
+  };
+}
+
+module.exports = { buildReadinessWarningDetail, buildReadinessWarningMetadata };

--- a/workers/provisioner/worker.js
+++ b/workers/provisioner/worker.js
@@ -3,7 +3,7 @@ const IORedis = require('ioredis');
 const { Pool } = require('pg');
 const { agentRuntimeUrl } = require('../../agent-runtime/lib/contracts');
 const { waitForAgentReadiness } = require('./healthChecks');
-const { buildReadinessWarningDetail } = require('./readinessWarning');
+const { buildReadinessWarningDetail, buildReadinessWarningMetadata } = require('./readinessWarning');
 
 // ── Connections ──────────────────────────────────────────
 const connection = new IORedis({
@@ -390,7 +390,7 @@ const worker = new Worker('deployments', async (job) => {
       await db.query("UPDATE deployments SET status = 'warning' WHERE agent_id = $1", [id]);
       await db.query(
         "INSERT INTO events(type, message, metadata) VALUES($1, $2, $3)",
-        ['agent_runtime_warning', `Agent "${name}" deployed with readiness warning: ${detail}`, JSON.stringify({ agentId: id, host, readiness })]
+        ['agent_runtime_warning', `Agent "${name}" deployed with readiness warning: ${detail}`, JSON.stringify(buildReadinessWarningMetadata({ agentId: id, host, readiness }))]
       );
     }
 


### PR DESCRIPTION
## Summary
- include flattened readiness warning detail directly in warning event metadata
- keep degraded deploy events easier to search without parsing nested readiness blobs
- add regression coverage for warning metadata construction

## Validation
- `npx jest __tests__/readinessWarning.test.js --runInBand`
- `npm test` (backend-api)

## Scope
Bounded provisioning observability fix only. No live deploy.