### PR TITLE
Reliability: block stale gateway URLs for stopped agents

### DIFF
--- a/backend-api/__tests__/agents.test.js
+++ b/backend-api/__tests__/agents.test.js
@@ -199,6 +199,7 @@ describe("GET /agents/:id/gateway-url", () => {
         gateway_token: "gateway-token",
         gateway_host_port: 19123,
         user_id: "user-1",
+        status: "running",
       }],
     });
 
@@ -211,6 +212,23 @@ describe("GET /agents/:id/gateway-url", () => {
     });
 
     delete process.env.GATEWAY_HOST;
+  });
+
+  it("rejects gateway url lookups for stopped agents so stale ports are not exposed", async () => {
+    mockDb.query.mockResolvedValueOnce({
+      rows: [{
+        id: "a-stopped-gateway",
+        container_id: "container-gateway",
+        gateway_host_port: 19123,
+        user_id: "user-1",
+        status: "stopped",
+      }],
+    });
+
+    const res = await auth(request(app).get("/agents/a-stopped-gateway/gateway-url"));
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/only available while running/i);
   });
 });
 

--- a/backend-api/routes/agents.js
+++ b/backend-api/routes/agents.js
@@ -88,11 +88,14 @@ function parseInterval(pg) {
 // Get the gateway control UI URL (published host port for direct browser access)
 router.get("/:id/gateway-url", asyncHandler(async (req, res) => {
   const result = await db.query(
-    "SELECT id, container_id, gateway_token, gateway_host_port, user_id FROM agents WHERE id = $1 AND user_id = $2",
+    "SELECT id, container_id, gateway_token, gateway_host_port, user_id, status FROM agents WHERE id = $1 AND user_id = $2",
     [req.params.id, req.user.id]
   );
   const agent = result.rows[0];
   if (!agent) return res.status(404).json({ error: "Agent not found" });
+  if (!["running", "warning"].includes(agent.status)) {
+    return res.status(409).json({ error: "Agent gateway is only available while running" });
+  }
   if (!agent.container_id) return res.status(409).json({ error: "No container" });
 
   // Use stored host port if available, otherwise fall back to Docker inspect


### PR DESCRIPTION
## Summary
- only return gateway URLs for `running` or `warning` agents
- prevent stopped/error agents from surfacing stale published control-plane URLs
- add backend regression coverage for the stopped-agent rejection path

## Validation
- `npx jest __tests__/agents.test.js --runInBand`
- `npm test` (backend-api)

## Scope
Bounded control-plane correctness fix only. No live deploy.