### PR TITLE
Reliability: guard healthy readiness from warning writes

### DIFF
--- a/backend-api/__tests__/readinessWarning.test.js
+++ b/backend-api/__tests__/readinessWarning.test.js
@@ -1,4 +1,14 @@
-const { buildReadinessWarningDetail, buildReadinessWarningMetadata, buildReadinessWarningState, persistReadinessWarning } = require("../../workers/provisioner/readinessWarning");
+const { shouldPersistReadinessWarning, buildReadinessWarningDetail, buildReadinessWarningMetadata, buildReadinessWarningState, persistReadinessWarning } = require("../../workers/provisioner/readinessWarning");
+
+describe("shouldPersistReadinessWarning", () => {
+  it("returns true for degraded readiness", () => {
+    expect(shouldPersistReadinessWarning({ ok: false })).toBe(true);
+  });
+
+  it("returns false for healthy readiness", () => {
+    expect(shouldPersistReadinessWarning({ ok: true })).toBe(false);
+  });
+});
 
 describe("buildReadinessWarningDetail", () => {
   it("formats a runtime-only readiness warning", () => {
@@ -117,6 +127,20 @@ describe("buildReadinessWarningState", () => {
 });
 
 describe("persistReadinessWarning", () => {
+  it("returns null and performs no writes for healthy readiness", async () => {
+    const db = { query: jest.fn().mockResolvedValue({}) };
+
+    const result = await persistReadinessWarning(db, {
+      agentId: "agent-healthy",
+      name: "Healthy Nora",
+      host: "agent.internal",
+      readiness: { ok: true },
+    });
+
+    expect(result).toBeNull();
+    expect(db.query).not.toHaveBeenCalled();
+  });
+
   it("writes warning agent status, warning deployment status, and the runtime warning event in order", async () => {
     const db = { query: jest.fn().mockResolvedValue({}) };
     const readiness = {

--- a/workers/provisioner/readinessWarning.js
+++ b/workers/provisioner/readinessWarning.js
@@ -1,3 +1,7 @@
+function shouldPersistReadinessWarning(readiness) {
+  return !readiness?.ok;
+}
+
 function buildReadinessWarningDetail(readiness) {
   const problems = [];
 
@@ -39,6 +43,10 @@ function buildReadinessWarningState({ agentId, name, host, readiness }) {
 }
 
 async function persistReadinessWarning(db, { agentId, name, host, readiness }) {
+  if (!shouldPersistReadinessWarning(readiness)) {
+    return null;
+  }
+
   const warningState = buildReadinessWarningState({ agentId, name, host, readiness });
 
   await db.query(`UPDATE agents SET status = '${warningState.agentStatus}' WHERE id = $1`, [agentId]);
@@ -51,4 +59,4 @@ async function persistReadinessWarning(db, { agentId, name, host, readiness }) {
   return warningState;
 }
 
-module.exports = { buildReadinessWarningDetail, buildReadinessWarningMetadata, buildReadinessWarningState, persistReadinessWarning };
+module.exports = { shouldPersistReadinessWarning, buildReadinessWarningDetail, buildReadinessWarningMetadata, buildReadinessWarningState, persistReadinessWarning };


### PR DESCRIPTION
## Summary
- add an explicit healthy-readiness guard for warning persistence
- prevent false warning writes when readiness is healthy
- add regression coverage for the no-write path

## Validation
- `npx jest __tests__/readinessWarning.test.js --runInBand`
- `npm test` (backend-api)

## Scope
Bounded worker-level reliability guard only. No live deploy.