### PR TITLE
Reliability: cover blocked gateway asset proxy

### DIFF
--- a/backend-api/__tests__/controlPlane.test.js
+++ b/backend-api/__tests__/controlPlane.test.js
@@ -181,4 +181,21 @@ describe("gateway control-plane embed", () => {
     expect(res.status).toBe(404);
     expect(global.fetch).not.toHaveBeenCalled();
   });
+
+  it("rejects asset proxy access for error agents so failed control-plane state stays closed", async () => {
+    mockDb.query.mockResolvedValueOnce({
+      rows: [{
+        host: "10.0.0.10",
+        gateway_host_port: 19123,
+        status: "error",
+      }],
+    });
+
+    const res = await request(app)
+      .get("/agents/agent-1/gateway/assets/app.js")
+      .set("Host", "nora.test");
+
+    expect(res.status).toBe(404);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- add control-plane regression coverage for blocked asset proxy access on failed agents
- mirror the existing blocked embed-path coverage so route/embed/asset policy stays aligned

## Validation
- `npx jest __tests__/controlPlane.test.js --runInBand`
- `npm test` (backend-api)

## Scope
Bounded QA/CI coverage follow-up only. No live deploy.