### PR TITLE
Reliability: block stopped gateway asset proxy

### DIFF
--- a/backend-api/__tests__/controlPlane.test.js
+++ b/backend-api/__tests__/controlPlane.test.js
@@ -208,6 +208,23 @@ describe("gateway control-plane embed", () => {
     );
   });
 
+  it("rejects asset proxy access for stopped agents so stale control-plane state stays closed", async () => {
+    mockDb.query.mockResolvedValueOnce({
+      rows: [{
+        host: "10.0.0.10",
+        gateway_host_port: 19123,
+        status: "stopped",
+      }],
+    });
+
+    const res = await request(app)
+      .get("/agents/agent-1/gateway/assets/app.js")
+      .set("Host", "nora.test");
+
+    expect(res.status).toBe(404);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
   it("rejects asset proxy access for error agents so failed control-plane state stays closed", async () => {
     mockDb.query.mockResolvedValueOnce({
       rows: [{


### PR DESCRIPTION
## Summary
- add control-plane regression coverage for blocked asset proxy access on stopped agents
- complete the route/embed/asset policy mirror for warning vs stopped vs error states

## Validation
- `npx jest __tests__/controlPlane.test.js --runInBand`
- `npm test` (backend-api)

## Scope
Bounded QA/CI coverage follow-up only. No live deploy.