### PR TITLE
Reliability: block stopped gateway embed

### DIFF
--- a/backend-api/__tests__/controlPlane.test.js
+++ b/backend-api/__tests__/controlPlane.test.js
@@ -164,6 +164,24 @@ describe("gateway control-plane embed", () => {
     );
   });
 
+  it("rejects embed for stopped agents so stale control-plane state stays closed", async () => {
+    mockDb.query.mockResolvedValueOnce({
+      rows: [{
+        host: "10.0.0.10",
+        gateway_token: "gateway-password",
+        gateway_host_port: 19123,
+        status: "stopped",
+      }],
+    });
+
+    const res = await request(app)
+      .get(`/agents/agent-1/gateway/embed?token=${encodeURIComponent(token)}`)
+      .set("Host", "nora.test");
+
+    expect(res.status).toBe(404);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
   it("rejects embed for error agents so failed control-plane state stays closed", async () => {
     mockDb.query.mockResolvedValueOnce({
       rows: [{


### PR DESCRIPTION
## Summary
- add control-plane regression coverage for blocked embed access on stopped agents
- complete the embed-path mirror for warning vs stopped/error gateway availability policy

## Validation
- `npx jest __tests__/controlPlane.test.js --runInBand`
- `npm test` (backend-api)

## Scope
Bounded QA/CI coverage follow-up only. No live deploy.