### PR TITLE
Reliability: cover gateway availability status helper

### DIFF
--- a/backend-api/__tests__/agentStatus.test.js
+++ b/backend-api/__tests__/agentStatus.test.js
@@ -1,4 +1,18 @@
-const { reconcileAgentStatus } = require("../agentStatus");
+const { isGatewayAvailableStatus, reconcileAgentStatus } = require("../agentStatus");
+
+describe("isGatewayAvailableStatus", () => {
+  it("allows running and warning states", () => {
+    expect(isGatewayAvailableStatus("running")).toBe(true);
+    expect(isGatewayAvailableStatus("warning")).toBe(true);
+  });
+
+  it("blocks stopped, error, queued, and deploying states", () => {
+    expect(isGatewayAvailableStatus("stopped")).toBe(false);
+    expect(isGatewayAvailableStatus("error")).toBe(false);
+    expect(isGatewayAvailableStatus("queued")).toBe(false);
+    expect(isGatewayAvailableStatus("deploying")).toBe(false);
+  });
+});
 
 describe("reconcileAgentStatus", () => {
   it("preserves warning when the container is still running", () => {


### PR DESCRIPTION
## Summary
- add direct unit coverage for the shared gateway availability status helper
- lock the single-source policy that allows `running|warning` and blocks non-live states

## Validation
- `npx jest __tests__/agentStatus.test.js --runInBand`
- `npm test` (backend-api)

## Scope
Bounded QA/CI coverage follow-up only. No live deploy.