### PR TITLE
security: scope monitoring events to owned agents

### DIFF
--- a/backend-api/__tests__/monitoringRoutes.test.js
+++ b/backend-api/__tests__/monitoringRoutes.test.js
@@ -1,0 +1,73 @@
+const express = require("express");
+const request = require("supertest");
+
+const mockDb = { query: jest.fn() };
+const mockMonitoring = {
+  getMetrics: jest.fn(),
+  getRecentEvents: jest.fn(),
+};
+const mockMetrics = {
+  getAgentMetrics: jest.fn(),
+  getAgentSummary: jest.fn(),
+  getAgentCost: jest.fn(),
+};
+const mockOwnership = {
+  findOwnedAgent: jest.fn(),
+  requireOwnedAgent: jest.fn(() => (req, res, next) => next()),
+};
+
+jest.mock("../db", () => mockDb);
+jest.mock("../monitoring", () => mockMonitoring);
+jest.mock("../metrics", () => mockMetrics);
+jest.mock("../middleware/ownership", () => mockOwnership);
+
+const router = require("../routes/monitoring");
+
+describe("monitoring route ownership", () => {
+  let app;
+
+  beforeEach(() => {
+    mockDb.query.mockReset();
+    mockMonitoring.getMetrics.mockReset();
+    mockMonitoring.getRecentEvents.mockReset();
+    mockOwnership.findOwnedAgent.mockReset();
+
+    app = express();
+    app.use(express.json());
+    app.use((req, res, next) => {
+      req.user = { id: "user-1", role: "user" };
+      next();
+    });
+    app.use(router);
+  });
+
+  it("scopes generic monitoring events to the current user's agents", async () => {
+    mockDb.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: "evt-1",
+          type: "deployment",
+          message: "Deployed agent-1",
+          metadata: { agentId: "agent-1" },
+        },
+      ],
+    });
+
+    const res = await request(app).get("/monitoring/events?limit=10");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([
+      {
+        id: "evt-1",
+        type: "deployment",
+        message: "Deployed agent-1",
+        metadata: { agentId: "agent-1" },
+      },
+    ]);
+    expect(mockMonitoring.getRecentEvents).not.toHaveBeenCalled();
+    expect(mockDb.query).toHaveBeenCalledWith(
+      expect.stringContaining("SELECT id::text FROM agents WHERE user_id = $1"),
+      ["user-1", 10]
+    );
+  });
+});

--- a/backend-api/routes/monitoring.js
+++ b/backend-api/routes/monitoring.js
@@ -17,16 +17,27 @@ router.get("/monitoring/metrics", asyncHandler(async (req, res) => {
 
 router.get("/monitoring/events", asyncHandler(async (req, res) => {
   const { agentId, limit } = req.query;
+  const parsedLimit = parseInt(limit) || 50;
   if (agentId) {
     const agent = await findOwnedAgent(agentId, req.user.id);
     if (!agent) return res.status(404).json({ error: "Agent not found" });
     const result = await db.query(
       "SELECT * FROM events WHERE metadata->>'agentId' = $1 ORDER BY created_at DESC LIMIT $2",
-      [agentId, parseInt(limit) || 20]
+      [agentId, parsedLimit]
     );
     return res.json(result.rows);
   }
-  res.json(await monitoring.getRecentEvents(parseInt(limit) || 50));
+  const result = await db.query(
+    `SELECT e.*
+       FROM events e
+      WHERE e.metadata->>'agentId' IN (
+        SELECT id::text FROM agents WHERE user_id = $1
+      )
+      ORDER BY e.created_at DESC
+      LIMIT $2`,
+    [req.user.id, parsedLimit]
+  );
+  res.json(result.rows);
 }));
 
 router.get("/monitoring/performance", asyncHandler(async (req, res) => {


### PR DESCRIPTION
## Summary
- stop returning platform-wide monitoring events to any authenticated user
- scope the generic /monitoring/events feed to the caller's owned agents
- add a route-level regression test for the owned-agent event filter

## Validation
- npm test -- --runInBand __tests__/monitoringRoutes.test.js
