### PR TITLE
test(e2e): update platform-journey deploy test for ClawHub flow

### DIFF
--- a/e2e/specs/platform-journey.spec.ts
+++ b/e2e/specs/platform-journey.spec.ts
@@ -118,6 +118,11 @@ test.describe("Complete platform journey", () => {
     await page.getByPlaceholder(/customer-support-operator/i).fill(primaryAgent.name);
 
     await Promise.all([
+      page.waitForURL(/\/clawhub$/, { waitUntil: "domcontentloaded" }),
+      page.getByRole("button", { name: /next: choose skills/i }).click(),
+    ]);
+
+    await Promise.all([
       page.waitForURL(/\/app\/agents\/[^/?#]+$/, {
         waitUntil: "domcontentloaded",
       }),


### PR DESCRIPTION
PR #151 changed the deploy flow to a two-step walk: /app/deploy routes to /clawhub for skill selection, and /clawhub is where the actual 'Deploy Agent & Open Validation' button fires POST /api/agents/deploy and redirects to /app/agents/:id.

The test still clicked the old single-page button and waited for the agent-detail URL, which timed out under the new flow. The admin-role failure on test 1 was a cascade: Playwright's serial retries re-ran the signup after test 2 failed, and the second signup no longer got role 'admin' because the first attempt had already seeded one.

Fix: add the intermediate /clawhub hop.

## Summary

- Describe the user-visible or maintainer-visible change.

## Validation

- List the commands, tests, or manual checks you ran.

## Release And Docs Checklist

- [ ] Updated public architecture docs (`architecture.md`) if this PR changes architecture, deployment topology, component responsibilities, or major data flow.
- [ ] If this is a release-prep PR, updated the `Reviewed for release:` marker in `architecture.md`.
