### PR TITLE
Fix/setup script compat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,10 @@ coverage/
 *.swp
 
 # Local environment files
-.env
-.env.local
-.env.*.local
+.env*
+!.env.example
+!.env.test
+!e2e/.env.real.example
 e2e/.env.real
 docker-compose.override.yml
 nginx.public.conf

--- a/setup.ps1
+++ b/setup.ps1
@@ -1,5 +1,7 @@
+#requires -Version 7.0
+
 # ============================================================
-# Nora — One-line installer & setup (Windows PowerShell)
+# Nora — One-line installer & setup (PowerShell 7+)
 # ============================================================
 # Usage:
 #   iwr -useb https://raw.githubusercontent.com/solomon2773/nora/master/setup.ps1 | iex
@@ -17,6 +19,14 @@ param(
     [switch]$Update,
     [switch]$CleanReinstall
 )
+
+if ($PSVersionTable.PSVersion.Major -lt 7) {
+    Write-Host "[error] Nora setup requires PowerShell 7 or newer." -ForegroundColor Red
+    Write-Host "        Install PowerShell 7, then run this script from pwsh:"
+    Write-Host "        pwsh"
+    Write-Host "        .\setup.ps1"
+    exit 1
+}
 
 $ErrorActionPreference = "Stop"
 

--- a/setup.ps1
+++ b/setup.ps1
@@ -151,10 +151,15 @@ function Start-NoraComposeStack {
 # ── Helper: generate random hex ─────────────────────────────
 
 function New-HexSecret {
-    param([int]$Bytes = 32)
-    $bytes = New-Object byte[] $Bytes
-    [System.Security.Cryptography.RandomNumberGenerator]::Fill($bytes)
-    return ($bytes | ForEach-Object { $_.ToString("x2") }) -join ''
+    param([Alias("Bytes")][int]$ByteCount = 32)
+    $secretBytes = [byte[]]::new($ByteCount)
+    $rng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+    try {
+        $rng.GetBytes($secretBytes)
+    } finally {
+        $rng.Dispose()
+    }
+    return ($secretBytes | ForEach-Object { $_.ToString("x2") }) -join ''
 }
 
 # ── Helper: refresh PATH from registry ─────────────────────


### PR DESCRIPTION
  ## Summary

  - Require PowerShell 7+ for `setup.ps1` so users fail fast instead of hitting Windows PowerShell 5 compatibility errors.
  - Fix setup secret generation by avoiding PowerShell’s case-insensitive `$Bytes` / `$bytes` variable collision.
  - Broaden `.env` ignore rules so generated `.env` backups are not shown as untracked files, while keeping tracked env templates available.

  ## Validation

  - Ran `setup.ps1` in PowerShell 7 through the Docker preflight and secret generation path.
  - Verified Windows PowerShell 5 exits immediately with the PowerShell 7 requirement.
  - Verified `.env` and `.env.backup-*` are ignored while `.env.example`, `.env.test`, and `e2e/.env.real.example` remain trackable.
  - Confirmed working tree was clean after commits.

  ## Release And Docs Checklist

  - [ ] Updated public architecture docs (`architecture.md`) if this PR changes architecture, deployment topology, component responsibilities, or major data flow.
  - [ ] If this is a release-prep PR, updated the `Reviewed for release:` marker in `architecture.md`.