### PR TITLE
fix(setup): correct PowerShell secret generation and broaden .env ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,9 +12,10 @@ coverage/
 *.swp
 
 # Local environment files
-.env
-.env.local
-.env.*.local
+.env*
+!.env.example
+!.env.test
+!e2e/.env.real.example
 e2e/.env.real
 docker-compose.override.yml
 nginx.public.conf

--- a/setup.ps1
+++ b/setup.ps1
@@ -406,10 +406,15 @@ function Start-NoraComposeStack {
 # ── Helper: generate random hex ─────────────────────────────
 
 function New-HexSecret {
-    param([int]$Bytes = 32)
-    $bytes = New-Object byte[] $Bytes
-    [System.Security.Cryptography.RandomNumberGenerator]::Fill($bytes)
-    return ($bytes | ForEach-Object { $_.ToString("x2") }) -join ''
+    param([Alias("Bytes")][int]$ByteCount = 32)
+    $secretBytes = [byte[]]::new($ByteCount)
+    $rng = [System.Security.Cryptography.RandomNumberGenerator]::Create()
+    try {
+        $rng.GetBytes($secretBytes)
+    } finally {
+        $rng.Dispose()
+    }
+    return ($secretBytes | ForEach-Object { $_.ToString("x2") }) -join ''
 }
 
 # ── Helper: refresh PATH from registry ─────────────────────


### PR DESCRIPTION
## Summary

Migrated from #156 by @mrn55. Two salvageable fixes — the third (PowerShell 7 version check) was already added to master separately.

- **`setup.ps1` / `New-HexSecret`** — PowerShell variable names are case-insensitive, so the `$Bytes` parameter and `$bytes` local collided and broke secret generation on PS7. Rename the local to `$secretBytes` and the parameter to `$ByteCount` with a `-Bytes` alias so existing call sites (`New-HexSecret -Bytes 24` at line 914) keep working.
- **`.gitignore`** — broaden `.env` ignore to cover the `.env.backup-YYYYMMDD-HHMMSSZ` files that `setup.ps1`/`setup.sh` generate, with explicit allowlist for the three tracked templates (`.env.example`, `.env.test`, `e2e/.env.real.example`).

Verified `git ls-files | grep '\.env'` still surfaces all three tracked templates after the change.

## Test plan

- [ ] Run `setup.ps1` on PowerShell 7 — confirm secrets generate without the case-collision error
- [ ] Confirm `git status` does not surface `.env.backup-*` after a setup run
- [ ] Confirm tracked `.env.example`, `.env.test`, `e2e/.env.real.example` still show in `git ls-files`

🤖 Generated with [Claude Code](https://claude.com/claude-code)