### PR TITLE
feat(integrations): migrate gitlab and bitbucket to provider strategy

### DIFF
--- a/backend-api/__tests__/providers/bitbucketProvider.test.ts
+++ b/backend-api/__tests__/providers/bitbucketProvider.test.ts
@@ -1,0 +1,88 @@
+// @ts-nocheck
+const { bitbucketProvider } = require("../../integrations/providers/bitbucket");
+
+function makeDeps(fetchImpl) {
+  return {
+    fetch: fetchImpl,
+    assertSafeUrl: async (u) => u,
+    encrypt: (s) => `enc(${s})`,
+    decrypt: (s) => `dec(${s})`,
+    ensureEncryptionConfigured: jest.fn(),
+    db: { query: jest.fn() },
+  };
+}
+
+describe("bitbucketProvider", () => {
+  it("identifies as bitbucket / basic", () => {
+    expect(bitbucketProvider.id).toBe("bitbucket");
+    expect(bitbucketProvider.authType).toBe("basic");
+  });
+
+  it("sends a Basic auth header built from username + app password", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ username: "alice", display_name: "Alice" }),
+    });
+    const expected = "Basic " + Buffer.from("alice:apppass").toString("base64");
+    const result = await bitbucketProvider.test(
+      {
+        row: { provider: "bitbucket" },
+        token: "apppass",
+        config: { username: "alice" },
+      },
+      makeDeps(fetchImpl),
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.bitbucket.org/2.0/user",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: expected }),
+      }),
+    );
+    expect(result).toEqual({ success: true, message: "Connected as alice" });
+  });
+
+  it("falls back to display_name when username is absent in response", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ display_name: "Alice Wonderland" }),
+    });
+    const result = await bitbucketProvider.test(
+      { row: { provider: "bitbucket" }, token: "p", config: { username: "alice" } },
+      makeDeps(fetchImpl),
+    );
+    expect(result.message).toBe("Connected as Alice Wonderland");
+  });
+
+  it("returns success=false when username is not configured", async () => {
+    const fetchImpl = jest.fn();
+    const result = await bitbucketProvider.test(
+      { row: { provider: "bitbucket" }, token: "p", config: {} },
+      makeDeps(fetchImpl),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Bitbucket username not configured");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("returns success=false on 401", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: false, status: 401 });
+    const result = await bitbucketProvider.test(
+      { row: { provider: "bitbucket" }, token: "bad", config: { username: "alice" } },
+      makeDeps(fetchImpl),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Bitbucket API returned 401");
+  });
+
+  it("maps username, app password, and workspace to env vars", () => {
+    const env = bitbucketProvider.mapToEnv({
+      row: { provider: "bitbucket" },
+      token: null,
+      config: { username: "alice", workspace: "acme-eng" },
+    });
+    expect(env).toEqual({
+      primary: "BITBUCKET_APP_PASSWORD",
+      config: { username: "BITBUCKET_USERNAME", workspace: "BITBUCKET_WORKSPACE" },
+    });
+  });
+});

--- a/backend-api/__tests__/providers/gitlabProvider.test.ts
+++ b/backend-api/__tests__/providers/gitlabProvider.test.ts
@@ -1,0 +1,78 @@
+// @ts-nocheck
+const { gitlabProvider } = require("../../integrations/providers/gitlab");
+
+function makeDeps(fetchImpl, assertSafeUrlImpl) {
+  return {
+    fetch: fetchImpl,
+    assertSafeUrl: assertSafeUrlImpl || (async (u) => u),
+    encrypt: (s) => `enc(${s})`,
+    decrypt: (s) => `dec(${s})`,
+    ensureEncryptionConfigured: jest.fn(),
+    db: { query: jest.fn() },
+  };
+}
+
+describe("gitlabProvider", () => {
+  it("identifies as gitlab / api_key", () => {
+    expect(gitlabProvider.id).toBe("gitlab");
+    expect(gitlabProvider.authType).toBe("api_key");
+  });
+
+  it("hits gitlab.com by default and reports the username", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ username: "alice" }),
+    });
+    const result = await gitlabProvider.test(
+      { row: { provider: "gitlab" }, token: "glpat_x", config: {} },
+      makeDeps(fetchImpl),
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://gitlab.com/api/v4/user",
+      expect.objectContaining({
+        headers: expect.objectContaining({ "PRIVATE-TOKEN": "glpat_x" }),
+      }),
+    );
+    expect(result).toEqual({ success: true, message: "Connected as alice" });
+  });
+
+  it("uses a self-hosted base URL when configured", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ username: "bob" }),
+    });
+    const assertSafeUrl = jest.fn(async (u) => u);
+    await gitlabProvider.test(
+      {
+        row: { provider: "gitlab" },
+        token: "t",
+        config: { base_url: "https://gitlab.example.com" },
+      },
+      makeDeps(fetchImpl, assertSafeUrl),
+    );
+    expect(assertSafeUrl).toHaveBeenCalledWith("https://gitlab.example.com", "GitLab base URL");
+    expect(fetchImpl.mock.calls[0][0]).toBe("https://gitlab.example.com/api/v4/user");
+  });
+
+  it("returns success=false on 401", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: false, status: 401 });
+    const result = await gitlabProvider.test(
+      { row: { provider: "gitlab" }, token: "bad", config: {} },
+      makeDeps(fetchImpl),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("GitLab API returned 401");
+  });
+
+  it("emits GITLAB_TOKEN and GITLAB_BASE_URL when configured", () => {
+    const env = gitlabProvider.mapToEnv({
+      row: { provider: "gitlab" },
+      token: null,
+      config: { base_url: "https://gitlab.example.com" },
+    });
+    expect(env).toEqual({
+      primary: "GITLAB_TOKEN",
+      config: { base_url: "GITLAB_BASE_URL" },
+    });
+  });
+});

--- a/backend-api/integrations/catalog/catalog.json
+++ b/backend-api/integrations/catalog/catalog.json
@@ -136,7 +136,24 @@
       },
       { "key": "group", "label": "Group/Namespace", "type": "text", "required": false }
     ],
-    "capabilities": ["read", "write", "webhook"]
+    "capabilities": ["read", "write", "webhook"],
+    "credentialsUrl": "https://gitlab.com/-/user_settings/personal_access_tokens",
+    "setupGuide": {
+      "steps": [
+        "Sign in to GitLab and open User Settings → Access Tokens.",
+        "Click Add new token, name it (e.g. 'Nora'), pick an expiry, and select scopes.",
+        "Copy the generated token (you won't see it again) and paste it into Nora.",
+        "For self-hosted GitLab, also fill in your instance URL (e.g. https://gitlab.example.com)."
+      ],
+      "scopes": ["api", "read_user", "read_repository", "write_repository"]
+    },
+    "mcp": {
+      "available": true,
+      "transport": "stdio",
+      "npmPackage": "@modelcontextprotocol/server-gitlab",
+      "docsUrl": "https://github.com/modelcontextprotocol/servers/tree/main/src/gitlab",
+      "notes": "Reference MCP server. Set GITLAB_PERSONAL_ACCESS_TOKEN and (optionally) GITLAB_API_URL for self-hosted."
+    }
   },
   {
     "id": "bitbucket",
@@ -144,13 +161,24 @@
     "icon": "bitbucket",
     "category": "developer-tools",
     "description": "Connect to Bitbucket Cloud repos, PRs, and pipelines",
-    "authType": "api_key",
+    "authType": "basic",
     "configFields": [
       { "key": "app_password", "label": "App Password", "type": "password", "required": true },
       { "key": "username", "label": "Username", "type": "text", "required": true },
       { "key": "workspace", "label": "Workspace", "type": "text", "required": false }
     ],
-    "capabilities": ["read", "write", "webhook"]
+    "capabilities": ["read", "write", "webhook"],
+    "credentialsUrl": "https://bitbucket.org/account/settings/app-passwords/",
+    "setupGuide": {
+      "steps": [
+        "Sign in to Bitbucket and open Personal settings → App passwords.",
+        "Click Create app password, name it, and select the permissions Nora needs.",
+        "Copy the generated app password (you won't see it again) and paste it into Nora.",
+        "Enter your Bitbucket username (not your email) so the basic-auth header can be built."
+      ],
+      "scopes": ["account:read", "repository:read", "repository:write", "pullrequest:write"]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "jira",

--- a/backend-api/integrations/index.ts
+++ b/backend-api/integrations/index.ts
@@ -41,6 +41,8 @@ export { linearProvider } from "./providers/linear";
 export { jiraProvider } from "./providers/jira";
 export { twitterProvider } from "./providers/twitter";
 export { linkedinProvider } from "./providers/linkedin";
+export { gitlabProvider } from "./providers/gitlab";
+export { bitbucketProvider } from "./providers/bitbucket";
 
 // The orchestration service is the recommended import for callers that
 // need the high-level operations (connect, list, test, sync, env-vars).

--- a/backend-api/integrations/providers/bitbucket.ts
+++ b/backend-api/integrations/providers/bitbucket.ts
@@ -1,0 +1,45 @@
+// Bitbucket Cloud provider — username + app password authenticated via
+// HTTP Basic. App passwords are scoped per-permission and can be created
+// from the user's account settings (the catalog credentialsUrl points
+// operators directly at the page).
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const bitbucketProvider: Provider = {
+  id: "bitbucket",
+  authType: "basic",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      const username = config.username;
+      if (!username) throw new Error("Bitbucket username not configured");
+      const credentials = Buffer.from(`${username}:${ctx.token ?? ""}`).toString("base64");
+      const res = await deps.fetch("https://api.bitbucket.org/2.0/user", {
+        headers: { Authorization: `Basic ${credentials}` },
+      });
+      if (!res.ok) throw new Error(`Bitbucket API returned ${res.status}`);
+      const data: any = await res.json();
+      return {
+        success: true,
+        message: `Connected as ${data.username || data.display_name}`,
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.username) configEnv.username = "BITBUCKET_USERNAME";
+    if (config.workspace) configEnv.workspace = "BITBUCKET_WORKSPACE";
+    return { primary: "BITBUCKET_APP_PASSWORD", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/gitlab.ts
+++ b/backend-api/integrations/providers/gitlab.ts
@@ -1,0 +1,39 @@
+// GitLab provider — supports gitlab.com and self-hosted GitLab via an
+// optional base URL. Uses a personal access token in the PRIVATE-TOKEN
+// header (GitLab's standard for PAT auth on the v4 API).
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const gitlabProvider: Provider = {
+  id: "gitlab",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      const rawBaseUrl = config.base_url || "https://gitlab.com";
+      const baseUrl = await deps.assertSafeUrl(String(rawBaseUrl), "GitLab base URL");
+      const res = await deps.fetch(`${baseUrl}/api/v4/user`, {
+        headers: { "PRIVATE-TOKEN": ctx.token ?? "" },
+      });
+      if (!res.ok) throw new Error(`GitLab API returned ${res.status}`);
+      const data: any = await res.json();
+      return { success: true, message: `Connected as ${data.username}` };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.base_url) configEnv.base_url = "GITLAB_BASE_URL";
+    return { primary: "GITLAB_TOKEN", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/legacy/connectivityTests.ts
+++ b/backend-api/integrations/providers/legacy/connectivityTests.ts
@@ -43,22 +43,7 @@ function buildConnectivityTests(integration, token, deps) {
   const { assertSafeUrl } = deps;
 
   return {
-    gitlab: async () => {
-      const config =
-        typeof integration.config === "string"
-          ? JSON.parse(integration.config)
-          : integration.config || {};
-      const baseUrl = await assertSafeUrl(
-        config.base_url || "https://gitlab.com",
-        "GitLab base URL",
-      );
-      const res = await fetch(`${baseUrl}/api/v4/user`, {
-        headers: { "PRIVATE-TOKEN": token },
-      });
-      if (!res.ok) throw new Error(`GitLab API returned ${res.status}`);
-      const data = await res.json();
-      return { success: true, message: `Connected as ${data.username}` };
-    },
+    // gitlab → migrated to providers/gitlab.ts
     discord: async () => {
       const res = await fetch("https://discord.com/api/v10/users/@me", {
         headers: { Authorization: `Bot ${token}` },
@@ -119,22 +104,7 @@ function buildConnectivityTests(integration, token, deps) {
       const data = await res.json();
       return { success: true, message: `Connected as ${data.name || data.fullname || "verified"}` };
     },
-    bitbucket: async () => {
-      const config =
-        typeof integration.config === "string"
-          ? JSON.parse(integration.config)
-          : integration.config || {};
-      const username = config.username;
-      if (!username) throw new Error("Bitbucket username not configured");
-      const res = await fetch("https://api.bitbucket.org/2.0/user", {
-        headers: {
-          Authorization: `Basic ${Buffer.from(`${username}:${token}`).toString("base64")}`,
-        },
-      });
-      if (!res.ok) throw new Error(`Bitbucket API returned ${res.status}`);
-      const data = await res.json();
-      return { success: true, message: `Connected as ${data.username || data.display_name}` };
-    },
+    // bitbucket → migrated to providers/bitbucket.ts
     airtable: async () => {
       const res = await fetch("https://api.airtable.com/v0/meta/whoami", {
         headers: { Authorization: `Bearer ${token}` },

--- a/backend-api/integrations/providers/legacy/envMaps.ts
+++ b/backend-api/integrations/providers/legacy/envMaps.ts
@@ -12,7 +12,7 @@ const llmProviders = require("../../../llmProviders");
 const INTEGRATION_ENV_MAP = {
   huggingface: "HF_TOKEN",
   // github → migrated to providers/github.ts
-  gitlab: "GITLAB_TOKEN",
+  // gitlab → migrated to providers/gitlab.ts
   // slack → migrated to providers/slack.ts
   discord: "DISCORD_TOKEN",
   notion: "NOTION_TOKEN",
@@ -46,7 +46,7 @@ const INTEGRATION_ENV_MAP = {
   monday: "MONDAY_API_KEY",
   zendesk: "ZENDESK_API_TOKEN",
   "docker-hub": "DOCKER_HUB_TOKEN",
-  bitbucket: "BITBUCKET_TOKEN",
+  // bitbucket → migrated to providers/bitbucket.ts
   confluence: "CONFLUENCE_TOKEN",
   // jira → migrated to providers/jira.ts
   jenkins: "JENKINS_TOKEN",
@@ -82,9 +82,8 @@ const INTEGRATION_ENV_MAP = {
 const INTEGRATION_CONFIG_ENV_MAP = {
   // Developer tools
   // github.org → providers/github.ts
-  "gitlab.base_url": "GITLAB_BASE_URL",
-  "bitbucket.username": "BITBUCKET_USERNAME",
-  "bitbucket.workspace": "BITBUCKET_WORKSPACE",
+  // gitlab.base_url → providers/gitlab.ts
+  // bitbucket.username/workspace → providers/bitbucket.ts
   // jira.email/site_url/project_key → providers/jira.ts
   // linear.team_id → providers/linear.ts
   // Communication

--- a/backend-api/integrations/services/integrationsService.ts
+++ b/backend-api/integrations/services/integrationsService.ts
@@ -29,6 +29,8 @@ const { linearProvider } = require("../providers/linear");
 const { jiraProvider } = require("../providers/jira");
 const { twitterProvider } = require("../providers/twitter");
 const { linkedinProvider } = require("../providers/linkedin");
+const { gitlabProvider } = require("../providers/gitlab");
+const { bitbucketProvider } = require("../providers/bitbucket");
 
 const repo = createIntegrationsRepository(db);
 const secretCrypto = createSecretEncryption({
@@ -62,6 +64,8 @@ const providerRegistry = createProviderRegistry((providerId) =>
   jiraProvider,
   twitterProvider,
   linkedinProvider,
+  gitlabProvider,
+  bitbucketProvider,
 ].forEach((p) => providerRegistry.register(p));
 
 // Resolve fetch at call time so test mocks reassigning `global.fetch`

--- a/docs/guides/integrations/bitbucket.mdx
+++ b/docs/guides/integrations/bitbucket.mdx
@@ -1,0 +1,81 @@
+# Bitbucket
+
+> Where to apply for a Bitbucket app password, which permissions it needs, and how to connect it to Nora.
+
+Bitbucket Cloud integrations let your agents read and write repositories, pull requests, and pipelines on bitbucket.org. Nora authenticates with HTTP Basic auth using your username plus an **app password** — Bitbucket's narrowly-scoped, revocable alternative to your account password.
+
+<Note>
+  This guide covers Bitbucket **Cloud** (bitbucket.org). Bitbucket Data Center / Server uses a
+  different auth mechanism (HTTP access tokens) and is not supported by this integration today.
+</Note>
+
+## Where to apply for credentials
+
+Bitbucket Cloud issues app passwords from your personal account settings:
+
+<Card
+  title="Bitbucket app passwords"
+  href="https://bitbucket.org/account/settings/app-passwords/"
+  icon="bitbucket"
+  arrow
+>
+  https://bitbucket.org/account/settings/app-passwords/
+</Card>
+
+You'll also need your Bitbucket **username** (not your email). Find it under **Personal settings → Bitbucket profile settings** if you don't remember it.
+
+## Required permissions
+
+When creating the app password, select these checkboxes:
+
+| Permission               | Why                                            |
+| ------------------------ | ---------------------------------------------- |
+| **Account: Read**        | Connectivity test — Nora calls `GET /2.0/user` |
+| **Repositories: Read**   | Read repos, branches, files                    |
+| **Repositories: Write**  | Push commits, create branches                  |
+| **Pull requests: Write** | Open and merge PRs                             |
+| **Pipelines: Read**      | List pipeline runs (if your agent inspects CI) |
+
+Pick only what your agent actually needs — app passwords scope tightly.
+
+## Connect in Nora
+
+<Steps>
+  <Step title="Open the Bitbucket integration">
+    From an agent's detail page, open the **Integrations** tab and find **Bitbucket** in the catalog.
+  </Step>
+
+<Step title="Paste username and app password">
+  Enter your Bitbucket **Username** and paste the generated **App Password** (you only see this
+  value once; copy it before closing the Bitbucket page).
+</Step>
+
+<Step title="(Optional) Enter your workspace">
+  Some agents need to know which workspace to default to. If your account belongs to multiple
+  Bitbucket workspaces, set the **Workspace** field to the slug — e.g. `acme-eng`.
+</Step>
+
+  <Step title="Connect">
+    Click **Connect**. Nora encrypts the app password with AES-256-GCM, stores it, and immediately calls `GET https://api.bitbucket.org/2.0/user` with HTTP Basic auth as a connectivity test. On success, the card shows your Bitbucket display name.
+  </Step>
+</Steps>
+
+## Verify the connection
+
+The **Test** button on the integration card calls the same `GET /2.0/user` endpoint. Common failures:
+
+- **401 Unauthorized** — wrong username, wrong app password, or app password was revoked.
+- **403 Forbidden** — the app password lacks **Account: Read**.
+- **`Bitbucket username not configured`** — Nora can't build the basic-auth header without a username; double-check the field.
+
+## MCP server
+
+There is no official Bitbucket MCP server at the time of writing. Community servers exist on npm — Nora's catalog will be updated when one stabilizes.
+
+## Environment variables Nora injects
+
+| Variable                 | Source                   |
+| ------------------------ | ------------------------ |
+| `BITBUCKET_APP_PASSWORD` | App Password field       |
+| `BITBUCKET_USERNAME`     | Username field           |
+| `BITBUCKET_WORKSPACE`    | Workspace field (if set) |

--- a/docs/guides/integrations/gitlab.mdx
+++ b/docs/guides/integrations/gitlab.mdx
@@ -1,0 +1,76 @@
+# GitLab
+
+> Where to apply for a GitLab personal access token, which scopes it needs, and how to connect it to Nora.
+
+GitLab integrations let your agents read repos, open merge requests, list pipelines, and act on issues. Nora authenticates with a personal access token (PAT) — the same kind GitLab issues for `git clone` over HTTPS — and supports both gitlab.com and self-hosted GitLab via an optional base URL.
+
+## Where to apply for credentials
+
+GitLab issues PATs from your user settings page:
+
+<Card
+  title="GitLab Personal Access Tokens"
+  href="https://gitlab.com/-/user_settings/personal_access_tokens"
+  icon="gitlab"
+  arrow
+>
+  https://gitlab.com/-/user_settings/personal_access_tokens
+</Card>
+
+For self-hosted GitLab, the same path works on your instance — replace `gitlab.com` with your hostname (e.g. `https://gitlab.example.com/-/user_settings/personal_access_tokens`).
+
+## Required scopes
+
+| Scope              | Why                                                                 |
+| ------------------ | ------------------------------------------------------------------- |
+| `api`              | Full read/write access (covers most agent workflows)                |
+| `read_user`        | Connectivity test — Nora calls `GET /user` to verify the credential |
+| `read_repository`  | Read-only repo operations (clones, file contents, branches)         |
+| `write_repository` | Push commits, branches, tags                                        |
+
+If your agent only reads (no writes), you can drop `api` and `write_repository` and use `read_api` instead.
+
+## Connect in Nora
+
+<Steps>
+  <Step title="Open the GitLab integration">
+    From an agent's detail page, open the **Integrations** tab and find **GitLab** in the catalog.
+  </Step>
+
+<Step title="Paste the token">Paste the PAT into the **Personal Access Token** field.</Step>
+
+<Step title="(Self-hosted only) Enter the GitLab URL">
+  For gitlab.com, leave the **GitLab URL** field blank — it defaults to `https://gitlab.com`. For
+  self-hosted, paste your instance origin (e.g. `https://gitlab.example.com`). Nora rejects RFC1918
+  / loopback URLs to prevent SSRF, so the host must be reachable from the Nora deployment.
+</Step>
+
+  <Step title="Connect">
+    Click **Connect**. Nora encrypts the token with AES-256-GCM, stores it, and immediately calls `GET <baseUrl>/api/v4/user` as a connectivity test. On success, the card shows your GitLab username.
+  </Step>
+</Steps>
+
+## Verify the connection
+
+The **Test** button on the integration card calls the same `GET /api/v4/user` endpoint and reports the username on success or the GitLab error message on failure. Common failures:
+
+- **401 Unauthorized** — token expired or revoked. Issue a new one.
+- **403 Forbidden** — token lacks the right scope (usually `api` or `read_user`).
+- **`getaddrinfo ENOTFOUND <host>`** — typo in the **GitLab URL** field, or your self-hosted instance isn't reachable from where Nora is deployed.
+
+## MCP server
+
+GitLab has a reference Model Context Protocol server published by the MCP project:
+
+- **Package:** `@modelcontextprotocol/server-gitlab`
+- **Docs:** [github.com/modelcontextprotocol/servers/tree/main/src/gitlab](https://github.com/modelcontextprotocol/servers/tree/main/src/gitlab)
+- **Env vars:** `GITLAB_PERSONAL_ACCESS_TOKEN`, optionally `GITLAB_API_URL` for self-hosted instances.
+
+Nora's runtime does not auto-launch this MCP server today — bring it up alongside your agent if you want MCP-style tool calls. The integration record itself injects `GITLAB_TOKEN` (and `GITLAB_BASE_URL` if set) into the agent container, so the MCP server picks them up automatically.
+
+## Environment variables Nora injects
+
+| Variable          | Source                      |
+| ----------------- | --------------------------- |
+| `GITLAB_TOKEN`    | Personal Access Token field |
+| `GITLAB_BASE_URL` | GitLab URL field (when set) |


### PR DESCRIPTION
## Summary

- Move GitLab and Bitbucket off the legacy connectivity-test switch onto first-class strategy files under `integrations/providers/`.
- Populate `credentialsUrl`, `setupGuide` (steps + scopes/permissions), and `mcp` metadata on both catalog entries so the dashboard modal can guide operators to the right developer console without forking the docs.
- Bitbucket's `authType` corrected from `api_key` to `basic` — the API has always required HTTP Basic with username + app password.
- Per-provider docs pages added under `docs/guides/integrations/` for GitLab and Bitbucket.
- Focused unit tests for each provider covering happy path, self-hosted URL (GitLab), missing username (Bitbucket), 401 failure, and `mapToEnv`.

## Test plan

- [x] `npx prettier --write` clean on touched files
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 640/640 passing (was 629; +11 from the two new test files)
- [ ] Manual dashboard pass: connect GitLab + Bitbucket on a real agent, click Test, confirm the username surfaces