### PR TITLE
feat(integrations): migrate devops providers (jenkins/circleci/vercel/terraform/docker-hub/kubernetes)

### DIFF
--- a/backend-api/__tests__/providers/circleciProvider.test.ts
+++ b/backend-api/__tests__/providers/circleciProvider.test.ts
@@ -1,0 +1,65 @@
+// @ts-nocheck
+const { circleciProvider } = require("../../integrations/providers/circleci");
+
+function deps(fetchImpl) {
+  return {
+    fetch: fetchImpl,
+    assertSafeUrl: async (u) => u,
+    encrypt: (s) => s,
+    decrypt: (s) => s,
+    ensureEncryptionConfigured: jest.fn(),
+    db: { query: jest.fn() },
+  };
+}
+
+describe("circleciProvider", () => {
+  it("identifies as circleci / api_key", () => {
+    expect(circleciProvider.id).toBe("circleci");
+    expect(circleciProvider.authType).toBe("api_key");
+  });
+
+  it("hits /api/v2/me with the Circle-Token header", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ name: "Alice", login: "alice" }),
+    });
+    const result = await circleciProvider.test(
+      { row: { provider: "circleci" }, token: "tok", config: {} },
+      deps(fetchImpl),
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://circleci.com/api/v2/me",
+      expect.objectContaining({ headers: expect.objectContaining({ "Circle-Token": "tok" }) }),
+    );
+    expect(result).toEqual({ success: true, message: "Connected as Alice" });
+  });
+
+  it("falls back to login when name is absent", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ login: "alice" }),
+    });
+    const result = await circleciProvider.test(
+      { row: { provider: "circleci" }, token: "tok", config: {} },
+      deps(fetchImpl),
+    );
+    expect(result.message).toBe("Connected as alice");
+  });
+
+  it("returns success=false on 401", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: false, status: 401 });
+    const result = await circleciProvider.test(
+      { row: { provider: "circleci" }, token: "bad", config: {} },
+      deps(fetchImpl),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("CircleCI API returned 401");
+  });
+
+  it("emits CIRCLE_TOKEN as primary", () => {
+    expect(circleciProvider.mapToEnv({ row: {}, token: null, config: {} })).toEqual({
+      primary: "CIRCLE_TOKEN",
+      config: {},
+    });
+  });
+});

--- a/backend-api/__tests__/providers/dockerHubProvider.test.ts
+++ b/backend-api/__tests__/providers/dockerHubProvider.test.ts
@@ -1,0 +1,59 @@
+// @ts-nocheck
+const { dockerHubProvider } = require("../../integrations/providers/dockerHub");
+
+function deps(fetchImpl) {
+  return {
+    fetch: fetchImpl,
+    assertSafeUrl: async (u) => u,
+    encrypt: (s) => s,
+    decrypt: (s) => s,
+    ensureEncryptionConfigured: jest.fn(),
+    db: { query: jest.fn() },
+  };
+}
+
+describe("dockerHubProvider", () => {
+  it("identifies as docker-hub / credentials", () => {
+    expect(dockerHubProvider.id).toBe("docker-hub");
+    expect(dockerHubProvider.authType).toBe("credentials");
+  });
+
+  it("POSTs username + password to /v2/users/login", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: true });
+    const result = await dockerHubProvider.test(
+      { row: {}, token: "tok", config: { username: "alice" } },
+      deps(fetchImpl),
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://hub.docker.com/v2/users/login",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ username: "alice", password: "tok" }),
+      }),
+    );
+    expect(result).toEqual({ success: true, message: "Connected as alice" });
+  });
+
+  it("returns success=false when username is missing", async () => {
+    const fetchImpl = jest.fn();
+    const result = await dockerHubProvider.test(
+      { row: {}, token: "tok", config: {} },
+      deps(fetchImpl),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Docker Hub username not configured");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("emits DOCKER_HUB_TOKEN + DOCKER_HUB_USERNAME", () => {
+    const env = dockerHubProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { username: "alice" },
+    });
+    expect(env).toEqual({
+      primary: "DOCKER_HUB_TOKEN",
+      config: { username: "DOCKER_HUB_USERNAME" },
+    });
+  });
+});

--- a/backend-api/__tests__/providers/jenkinsProvider.test.ts
+++ b/backend-api/__tests__/providers/jenkinsProvider.test.ts
@@ -1,0 +1,70 @@
+// @ts-nocheck
+const { jenkinsProvider } = require("../../integrations/providers/jenkins");
+
+function deps(fetchImpl, assertSafeUrlImpl) {
+  return {
+    fetch: fetchImpl,
+    assertSafeUrl: assertSafeUrlImpl || (async (u) => u),
+    encrypt: (s) => s,
+    decrypt: (s) => s,
+    ensureEncryptionConfigured: jest.fn(),
+    db: { query: jest.fn() },
+  };
+}
+
+describe("jenkinsProvider", () => {
+  it("identifies as jenkins / credentials", () => {
+    expect(jenkinsProvider.id).toBe("jenkins");
+    expect(jenkinsProvider.authType).toBe("credentials");
+  });
+
+  it("uses HTTP Basic and validates the URL through assertSafeUrl", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: true });
+    const assertSafeUrl = jest.fn(async (u) => u);
+    const result = await jenkinsProvider.test(
+      {
+        row: { provider: "jenkins" },
+        token: "tok",
+        config: { url: "https://jenkins.example.com", username: "alice" },
+      },
+      deps(fetchImpl, assertSafeUrl),
+    );
+    expect(assertSafeUrl).toHaveBeenCalledWith("https://jenkins.example.com", "Jenkins URL");
+    const expectedAuth = "Basic " + Buffer.from("alice:tok").toString("base64");
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://jenkins.example.com/api/json",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: expectedAuth }),
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("returns success=false when URL or username missing", async () => {
+    const fetchImpl = jest.fn();
+    let result = await jenkinsProvider.test(
+      { row: {}, token: "t", config: { username: "alice" } },
+      deps(fetchImpl),
+    );
+    expect(result.error).toContain("Jenkins URL not configured");
+
+    result = await jenkinsProvider.test(
+      { row: {}, token: "t", config: { url: "https://j.example.com" } },
+      deps(fetchImpl),
+    );
+    expect(result.error).toContain("Jenkins username not configured");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("emits the JENKINS_* env vars from config", () => {
+    const env = jenkinsProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { url: "https://j.example.com", username: "alice" },
+    });
+    expect(env).toEqual({
+      primary: "JENKINS_TOKEN",
+      config: { url: "JENKINS_URL", username: "JENKINS_USERNAME" },
+    });
+  });
+});

--- a/backend-api/__tests__/providers/kubernetesProvider.test.ts
+++ b/backend-api/__tests__/providers/kubernetesProvider.test.ts
@@ -1,0 +1,76 @@
+// @ts-nocheck
+const { kubernetesProvider } = require("../../integrations/providers/kubernetes");
+
+function deps() {
+  return {
+    fetch: jest.fn(),
+    assertSafeUrl: async (u) => u,
+    encrypt: (s) => s,
+    decrypt: (s) => s,
+    ensureEncryptionConfigured: jest.fn(),
+    db: { query: jest.fn() },
+  };
+}
+
+describe("kubernetesProvider", () => {
+  it("identifies as kubernetes / credentials", () => {
+    expect(kubernetesProvider.id).toBe("kubernetes");
+    expect(kubernetesProvider.authType).toBe("credentials");
+  });
+
+  it("accepts well-formed YAML kubeconfigs without calling the API server", async () => {
+    const yamlConfig = `
+apiVersion: v1
+kind: Config
+clusters:
+  - name: my-cluster
+    cluster:
+      server: https://api.example.com
+`;
+    const d = deps();
+    const result = await kubernetesProvider.test(
+      { row: {}, token: null, config: { kubeconfig: yamlConfig } },
+      d,
+    );
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("connectivity not verified");
+    expect(d.fetch).not.toHaveBeenCalled();
+  });
+
+  it("accepts JSON kubeconfigs", async () => {
+    const json = JSON.stringify({ apiVersion: "v1", clusters: [{ name: "c" }] });
+    const result = await kubernetesProvider.test(
+      { row: {}, token: null, config: { kubeconfig: json } },
+      deps(),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects empty or malformed kubeconfigs", async () => {
+    let result = await kubernetesProvider.test(
+      { row: {}, token: null, config: { kubeconfig: "" } },
+      deps(),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Kubeconfig is required");
+
+    result = await kubernetesProvider.test(
+      { row: {}, token: null, config: { kubeconfig: "not yaml or json" } },
+      deps(),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("not valid YAML/JSON");
+  });
+
+  it("emits KUBECONFIG_CONTENTS / KUBECONFIG_CONTEXT (no primary token)", () => {
+    const env = kubernetesProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { kubeconfig: "yaml here", context: "prod" },
+    });
+    expect(env).toEqual({
+      primary: null,
+      config: { kubeconfig: "KUBECONFIG_CONTENTS", context: "KUBECONFIG_CONTEXT" },
+    });
+  });
+});

--- a/backend-api/__tests__/providers/terraformProvider.test.ts
+++ b/backend-api/__tests__/providers/terraformProvider.test.ts
@@ -1,0 +1,58 @@
+// @ts-nocheck
+const { terraformProvider } = require("../../integrations/providers/terraform");
+
+function deps(fetchImpl) {
+  return {
+    fetch: fetchImpl,
+    assertSafeUrl: async (u) => u,
+    encrypt: (s) => s,
+    decrypt: (s) => s,
+    ensureEncryptionConfigured: jest.fn(),
+    db: { query: jest.fn() },
+  };
+}
+
+describe("terraformProvider", () => {
+  it("calls /api/v2/account/details with the JSON:API content type", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: { attributes: { username: "alice" } } }),
+    });
+    const result = await terraformProvider.test(
+      { row: { provider: "terraform" }, token: "tfe_x", config: {} },
+      deps(fetchImpl),
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://app.terraform.io/api/v2/account/details",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer tfe_x",
+          "Content-Type": "application/vnd.api+json",
+        }),
+      }),
+    );
+    expect(result).toEqual({ success: true, message: "Connected as alice" });
+  });
+
+  it("returns success=false on 401", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: false, status: 401 });
+    const result = await terraformProvider.test(
+      { row: { provider: "terraform" }, token: "bad", config: {} },
+      deps(fetchImpl),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Terraform Cloud API returned 401");
+  });
+
+  it("emits TFE_ORGANIZATION when organization is configured", () => {
+    const env = terraformProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { organization: "acme" },
+    });
+    expect(env).toEqual({
+      primary: "TFE_TOKEN",
+      config: { organization: "TFE_ORGANIZATION" },
+    });
+  });
+});

--- a/backend-api/__tests__/providers/vercelProvider.test.ts
+++ b/backend-api/__tests__/providers/vercelProvider.test.ts
@@ -1,0 +1,55 @@
+// @ts-nocheck
+const { vercelProvider } = require("../../integrations/providers/vercel");
+
+function deps(fetchImpl) {
+  return {
+    fetch: fetchImpl,
+    assertSafeUrl: async (u) => u,
+    encrypt: (s) => s,
+    decrypt: (s) => s,
+    ensureEncryptionConfigured: jest.fn(),
+    db: { query: jest.fn() },
+  };
+}
+
+describe("vercelProvider", () => {
+  it("calls /v2/user with a Bearer token", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ user: { username: "alice" } }),
+    });
+    const result = await vercelProvider.test(
+      { row: { provider: "vercel" }, token: "v_x", config: {} },
+      deps(fetchImpl),
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.vercel.com/v2/user",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer v_x" }),
+      }),
+    );
+    expect(result).toEqual({ success: true, message: "Connected as alice" });
+  });
+
+  it("returns success=false on 401", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: false, status: 401 });
+    const result = await vercelProvider.test(
+      { row: { provider: "vercel" }, token: "bad", config: {} },
+      deps(fetchImpl),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Vercel API returned 401");
+  });
+
+  it("includes VERCEL_TEAM_ID when team_id is configured", () => {
+    const env = vercelProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { team_id: "team_xyz" },
+    });
+    expect(env).toEqual({
+      primary: "VERCEL_TOKEN",
+      config: { team_id: "VERCEL_TEAM_ID" },
+    });
+  });
+});

--- a/backend-api/integrations/catalog/catalog.json
+++ b/backend-api/integrations/catalog/catalog.json
@@ -1072,7 +1072,16 @@
       { "key": "api_token", "label": "API Token", "type": "password", "required": true },
       { "key": "organization", "label": "Organization", "type": "text", "required": false }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://app.terraform.io/app/settings/tokens",
+    "setupGuide": {
+      "steps": [
+        "Sign in to Terraform Cloud and open User settings → Tokens.",
+        "Click Create an API token, name it (e.g. 'Nora'), and copy the value.",
+        "Paste the token into Nora and (optionally) enter your organization slug."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "jenkins",
@@ -1086,7 +1095,17 @@
       { "key": "username", "label": "Username", "type": "text", "required": true },
       { "key": "api_token", "label": "API Token", "type": "password", "required": true }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://www.jenkins.io/doc/book/managing/cli/#authentication",
+    "setupGuide": {
+      "steps": [
+        "Sign in to your Jenkins instance and click your username in the top-right.",
+        "Open Configure → API Token → Add new Token.",
+        "Copy the generated token and paste it into Nora alongside your Jenkins URL and username.",
+        "The Jenkins URL must be reachable from the Nora deployment (RFC1918 / loopback URLs are rejected)."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "circleci",
@@ -1098,7 +1117,17 @@
     "configFields": [
       { "key": "api_token", "label": "Personal API Token", "type": "password", "required": true }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://app.circleci.com/settings/user/tokens",
+    "setupGuide": {
+      "steps": [
+        "Sign in to CircleCI at app.circleci.com.",
+        "Open User settings → Personal API Tokens.",
+        "Click Create New Token, give it a name, and copy the value.",
+        "Paste the token into Nora."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "vercel",
@@ -1111,7 +1140,17 @@
       { "key": "api_token", "label": "API Token", "type": "password", "required": true },
       { "key": "team_id", "label": "Team ID", "type": "text", "required": false }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://vercel.com/account/tokens",
+    "setupGuide": {
+      "steps": [
+        "Sign in to Vercel and open Account Settings → Tokens.",
+        "Click Create, name the token, set an expiration, and pick the scope.",
+        "If you're managing a team's projects, copy the team ID from Team Settings → General.",
+        "Paste the token (and optional team ID) into Nora."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "sentry",
@@ -1252,7 +1291,17 @@
       { "key": "username", "label": "Username", "type": "text", "required": true },
       { "key": "access_token", "label": "Access Token", "type": "password", "required": true }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://hub.docker.com/settings/security",
+    "setupGuide": {
+      "steps": [
+        "Sign in to Docker Hub at hub.docker.com.",
+        "Open Account Settings → Security → Personal access tokens.",
+        "Click Generate new token, set the access (Read & Write or Read only), and copy the token.",
+        "Paste the token into Nora alongside your Docker Hub username."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "kubernetes",
@@ -1265,7 +1314,23 @@
       { "key": "kubeconfig", "label": "Kubeconfig (YAML)", "type": "textarea", "required": true },
       { "key": "context", "label": "Context Name", "type": "text", "required": false }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/",
+    "setupGuide": {
+      "steps": [
+        "Generate a kubeconfig for your cluster (cloud-provider console, kubeadm, k3s, etc.).",
+        "Make sure the context inside the kubeconfig points to the user/SA Nora should authenticate as.",
+        "Paste the full kubeconfig YAML into the textarea (it's encrypted at rest).",
+        "Optionally pin the active context by name — leave blank to use current-context from the file."
+      ]
+    },
+    "mcp": {
+      "available": true,
+      "transport": "stdio",
+      "npmPackage": "@kubernetes/mcp-server",
+      "docsUrl": "https://github.com/kubernetes/mcp-server",
+      "notes": "Community MCP server for Kubernetes. Reads KUBECONFIG from the environment."
+    }
   },
   {
     "id": "algolia",

--- a/backend-api/integrations/index.ts
+++ b/backend-api/integrations/index.ts
@@ -43,6 +43,12 @@ export { twitterProvider } from "./providers/twitter";
 export { linkedinProvider } from "./providers/linkedin";
 export { gitlabProvider } from "./providers/gitlab";
 export { bitbucketProvider } from "./providers/bitbucket";
+export { circleciProvider } from "./providers/circleci";
+export { vercelProvider } from "./providers/vercel";
+export { terraformProvider } from "./providers/terraform";
+export { jenkinsProvider } from "./providers/jenkins";
+export { dockerHubProvider } from "./providers/dockerHub";
+export { kubernetesProvider } from "./providers/kubernetes";
 
 // The orchestration service is the recommended import for callers that
 // need the high-level operations (connect, list, test, sync, env-vars).

--- a/backend-api/integrations/providers/circleci.ts
+++ b/backend-api/integrations/providers/circleci.ts
@@ -1,0 +1,34 @@
+// CircleCI provider — personal API token via the Circle-Token header.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const circleciProvider: Provider = {
+  id: "circleci",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const res = await deps.fetch("https://circleci.com/api/v2/me", {
+        headers: { "Circle-Token": ctx.token ?? "" },
+      });
+      if (!res.ok) throw new Error(`CircleCI API returned ${res.status}`);
+      const data: any = await res.json();
+      return {
+        success: true,
+        message: `Connected as ${data.name || data.login || "verified"}`,
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(): EnvMapping {
+    return { primary: "CIRCLE_TOKEN", config: {} };
+  },
+};

--- a/backend-api/integrations/providers/dockerHub.ts
+++ b/backend-api/integrations/providers/dockerHub.ts
@@ -1,0 +1,40 @@
+// Docker Hub provider — username + access token. Tested by hitting the
+// /v2/users/login endpoint, which Docker Hub provides specifically for
+// validating credentials without registering them as a session.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const dockerHubProvider: Provider = {
+  id: "docker-hub",
+  authType: "credentials",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      const username = config.username;
+      if (!username) throw new Error("Docker Hub username not configured");
+      const res = await deps.fetch("https://hub.docker.com/v2/users/login", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ username, password: ctx.token ?? "" }),
+      });
+      if (!res.ok) throw new Error(`Docker Hub API returned ${res.status}`);
+      return { success: true, message: `Connected as ${username}` };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.username) configEnv.username = "DOCKER_HUB_USERNAME";
+    return { primary: "DOCKER_HUB_TOKEN", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/jenkins.ts
+++ b/backend-api/integrations/providers/jenkins.ts
@@ -1,0 +1,44 @@
+// Jenkins provider — credentials shape (URL + username + API token).
+// Uses HTTP Basic against the customer's Jenkins host, validated through
+// assertSafeUrl to block RFC1918 / loopback URLs (the host has to be
+// reachable from the Nora deployment, but operators often try localhost).
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const jenkinsProvider: Provider = {
+  id: "jenkins",
+  authType: "credentials",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      const rawUrl = config.url;
+      const username = config.username;
+      if (!rawUrl) throw new Error("Jenkins URL not configured");
+      if (!username) throw new Error("Jenkins username not configured");
+      const url = await deps.assertSafeUrl(String(rawUrl), "Jenkins URL");
+      const credentials = Buffer.from(`${username}:${ctx.token ?? ""}`).toString("base64");
+      const res = await deps.fetch(`${url}/api/json`, {
+        headers: { Authorization: `Basic ${credentials}` },
+      });
+      if (!res.ok) throw new Error(`Jenkins API returned ${res.status}`);
+      return { success: true, message: "Connected to Jenkins" };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.url) configEnv.url = "JENKINS_URL";
+    if (config.username) configEnv.username = "JENKINS_USERNAME";
+    return { primary: "JENKINS_TOKEN", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/kubernetes.ts
+++ b/backend-api/integrations/providers/kubernetes.ts
@@ -1,0 +1,60 @@
+// Kubernetes provider — kubeconfig-based credential. The connectivity
+// test parses the kubeconfig to confirm it's well-formed YAML/JSON with a
+// `clusters` entry, but does not call the API server. The cluster is
+// usually behind a private network from the Nora control plane's
+// perspective; the agent runtime mounts the kubeconfig into a temp file
+// and runs `kubectl` from inside the agent container.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+function parseKubeconfig(raw: string): any {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  if (trimmed.startsWith("{")) {
+    try {
+      return JSON.parse(trimmed);
+    } catch {
+      return null;
+    }
+  }
+  // Minimal YAML probe — we don't depend on a YAML parser at the backend
+  // layer. Detect the top-level "clusters:" key as a smoke test; the
+  // runtime container parses the file with kubectl (which uses real YAML).
+  return /^\s*clusters\s*:/m.test(trimmed) ? { __probe: "yaml" } : null;
+}
+
+export const kubernetesProvider: Provider = {
+  id: "kubernetes",
+  authType: "credentials",
+
+  async test(ctx: DecryptedIntegration): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      const kubeconfig = String(config.kubeconfig || "").trim();
+      if (!kubeconfig) throw new Error("Kubeconfig is required");
+      const parsed = parseKubeconfig(kubeconfig);
+      if (!parsed) throw new Error("Kubeconfig is not valid YAML/JSON or has no clusters entry");
+      return {
+        success: true,
+        message: "Kubeconfig stored — cluster connectivity not verified from control plane",
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.kubeconfig) configEnv.kubeconfig = "KUBECONFIG_CONTENTS";
+    if (config.context) configEnv.context = "KUBECONFIG_CONTEXT";
+    // No primary token — kubeconfig is the credential, expressed via config envs.
+    return { primary: null, config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/legacy/connectivityTests.ts
+++ b/backend-api/integrations/providers/legacy/connectivityTests.ts
@@ -273,33 +273,9 @@ function buildConnectivityTests(integration, token, deps) {
       if (!res.ok) throw new Error(`Algolia API returned ${res.status}`);
       return { success: true, message: "Connected to Algolia" };
     },
-    vercel: async () => {
-      const res = await fetch("https://api.vercel.com/v2/user", {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (!res.ok) throw new Error(`Vercel API returned ${res.status}`);
-      const data = await res.json();
-      return { success: true, message: `Connected as ${data.user?.username || "verified"}` };
-    },
-    circleci: async () => {
-      const res = await fetch("https://circleci.com/api/v2/me", {
-        headers: { "Circle-Token": token },
-      });
-      if (!res.ok) throw new Error(`CircleCI API returned ${res.status}`);
-      const data = await res.json();
-      return { success: true, message: `Connected as ${data.name || data.login || "verified"}` };
-    },
-    terraform: async () => {
-      const res = await fetch("https://app.terraform.io/api/v2/account/details", {
-        headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/vnd.api+json" },
-      });
-      if (!res.ok) throw new Error(`Terraform Cloud API returned ${res.status}`);
-      const data = await res.json();
-      return {
-        success: true,
-        message: `Connected as ${data.data?.attributes?.username || "verified"}`,
-      };
-    },
+    // vercel → migrated to providers/vercel.ts
+    // circleci → migrated to providers/circleci.ts
+    // terraform → migrated to providers/terraform.ts
     grafana: async () => {
       const config =
         typeof integration.config === "string"
@@ -323,24 +299,7 @@ function buildConnectivityTests(integration, token, deps) {
       const data = await res.json();
       return { success: true, message: `Connected as ${data.user?.name || "verified"}` };
     },
-    jenkins: async () => {
-      const config =
-        typeof integration.config === "string"
-          ? JSON.parse(integration.config)
-          : integration.config || {};
-      const rawUrl = config.url;
-      const username = config.username;
-      if (!rawUrl) throw new Error("Jenkins URL not configured");
-      if (!username) throw new Error("Jenkins username not configured");
-      const url = await assertSafeUrl(rawUrl, "Jenkins URL");
-      const res = await fetch(`${url}/api/json`, {
-        headers: {
-          Authorization: `Basic ${Buffer.from(`${username}:${token}`).toString("base64")}`,
-        },
-      });
-      if (!res.ok) throw new Error(`Jenkins API returned ${res.status}`);
-      return { success: true, message: "Connected to Jenkins" };
-    },
+    // jenkins → migrated to providers/jenkins.ts
     dropbox: async () => {
       const res = await fetch("https://api.dropboxapi.com/2/users/get_current_account", {
         method: "POST",
@@ -434,21 +393,7 @@ function buildConnectivityTests(integration, token, deps) {
         message: `Connected as ${data.username || data.name || data.id || "verified"}`,
       };
     },
-    "docker-hub": async () => {
-      const config =
-        typeof integration.config === "string"
-          ? JSON.parse(integration.config)
-          : integration.config || {};
-      const username = config.username;
-      if (!username) throw new Error("Docker Hub username not configured");
-      const res = await fetch("https://hub.docker.com/v2/users/login", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ username, password: token }),
-      });
-      if (!res.ok) throw new Error(`Docker Hub API returned ${res.status}`);
-      return { success: true, message: `Connected as ${username}` };
-    },
+    // docker-hub → migrated to providers/dockerHub.ts
     salesforce: async () => {
       const config =
         typeof integration.config === "string"

--- a/backend-api/integrations/providers/legacy/envMaps.ts
+++ b/backend-api/integrations/providers/legacy/envMaps.ts
@@ -28,9 +28,9 @@ const INTEGRATION_ENV_MAP = {
   hubspot: "HUBSPOT_ACCESS_TOKEN",
   pipedrive: "PIPEDRIVE_API_KEY",
   pinecone: "PINECONE_API_KEY",
-  vercel: "VERCEL_TOKEN",
-  circleci: "CIRCLE_TOKEN",
-  terraform: "TFE_TOKEN",
+  // vercel → migrated to providers/vercel.ts
+  // circleci → migrated to providers/circleci.ts
+  // terraform → migrated to providers/terraform.ts
   pagerduty: "PAGERDUTY_TOKEN",
   dropbox: "DROPBOX_ACCESS_TOKEN",
   twilio: "TWILIO_AUTH_TOKEN",
@@ -45,11 +45,11 @@ const INTEGRATION_ENV_MAP = {
   clickup: "CLICKUP_API_KEY",
   monday: "MONDAY_API_KEY",
   zendesk: "ZENDESK_API_TOKEN",
-  "docker-hub": "DOCKER_HUB_TOKEN",
+  // docker-hub → migrated to providers/dockerHub.ts
   // bitbucket → migrated to providers/bitbucket.ts
   confluence: "CONFLUENCE_TOKEN",
   // jira → migrated to providers/jira.ts
-  jenkins: "JENKINS_TOKEN",
+  // jenkins → migrated to providers/jenkins.ts
   grafana: "GRAFANA_TOKEN",
   woocommerce: "WOOCOMMERCE_SECRET_KEY",
   trello: "TRELLO_TOKEN",

--- a/backend-api/integrations/providers/terraform.ts
+++ b/backend-api/integrations/providers/terraform.ts
@@ -1,0 +1,42 @@
+// Terraform Cloud / Enterprise provider — Bearer token against the
+// account details endpoint. Uses the JSON:API content type Terraform
+// requires for v2 API calls.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const terraformProvider: Provider = {
+  id: "terraform",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const res = await deps.fetch("https://app.terraform.io/api/v2/account/details", {
+        headers: {
+          Authorization: `Bearer ${ctx.token ?? ""}`,
+          "Content-Type": "application/vnd.api+json",
+        },
+      });
+      if (!res.ok) throw new Error(`Terraform Cloud API returned ${res.status}`);
+      const data: any = await res.json();
+      return {
+        success: true,
+        message: `Connected as ${data.data?.attributes?.username || "verified"}`,
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.organization) configEnv.organization = "TFE_ORGANIZATION";
+    return { primary: "TFE_TOKEN", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/vercel.ts
+++ b/backend-api/integrations/providers/vercel.ts
@@ -1,0 +1,37 @@
+// Vercel provider — Bearer token, optional team scoping via team_id.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const vercelProvider: Provider = {
+  id: "vercel",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const res = await deps.fetch("https://api.vercel.com/v2/user", {
+        headers: { Authorization: `Bearer ${ctx.token ?? ""}` },
+      });
+      if (!res.ok) throw new Error(`Vercel API returned ${res.status}`);
+      const data: any = await res.json();
+      return {
+        success: true,
+        message: `Connected as ${data.user?.username || "verified"}`,
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.team_id) configEnv.team_id = "VERCEL_TEAM_ID";
+    return { primary: "VERCEL_TOKEN", config: configEnv };
+  },
+};

--- a/backend-api/integrations/services/integrationsService.ts
+++ b/backend-api/integrations/services/integrationsService.ts
@@ -31,6 +31,12 @@ const { twitterProvider } = require("../providers/twitter");
 const { linkedinProvider } = require("../providers/linkedin");
 const { gitlabProvider } = require("../providers/gitlab");
 const { bitbucketProvider } = require("../providers/bitbucket");
+const { circleciProvider } = require("../providers/circleci");
+const { vercelProvider } = require("../providers/vercel");
+const { terraformProvider } = require("../providers/terraform");
+const { jenkinsProvider } = require("../providers/jenkins");
+const { dockerHubProvider } = require("../providers/dockerHub");
+const { kubernetesProvider } = require("../providers/kubernetes");
 
 const repo = createIntegrationsRepository(db);
 const secretCrypto = createSecretEncryption({
@@ -66,6 +72,12 @@ const providerRegistry = createProviderRegistry((providerId) =>
   linkedinProvider,
   gitlabProvider,
   bitbucketProvider,
+  circleciProvider,
+  vercelProvider,
+  terraformProvider,
+  jenkinsProvider,
+  dockerHubProvider,
+  kubernetesProvider,
 ].forEach((p) => providerRegistry.register(p));
 
 // Resolve fetch at call time so test mocks reassigning `global.fetch`

--- a/backend-api/integrations/types/provider.ts
+++ b/backend-api/integrations/types/provider.ts
@@ -26,7 +26,14 @@ export interface RefreshOutcome {
   refreshed: boolean;
 }
 
-export type ProviderAuthType = "api_key" | "oauth2" | "basic" | "webhook" | "custom";
+export type ProviderAuthType =
+  | "api_key"
+  | "oauth2"
+  | "basic"
+  | "webhook"
+  | "custom"
+  | "credentials"
+  | "service_account";
 
 export interface ProviderDeps {
   fetch: typeof fetch;

--- a/docs/guides/integrations/circleci.mdx
+++ b/docs/guides/integrations/circleci.mdx
@@ -1,0 +1,57 @@
+# CircleCI
+
+> Where to apply for a CircleCI personal API token, which permissions it carries, and how to connect it to Nora.
+
+CircleCI integrations let your agents trigger pipelines, read build status, and inspect workflow runs. Nora authenticates with a personal API token via the `Circle-Token` header — the same scheme `circleci` CLI uses.
+
+## Where to apply for credentials
+
+Personal API tokens are managed from your user settings:
+
+<Card
+  title="CircleCI Personal API Tokens"
+  href="https://app.circleci.com/settings/user/tokens"
+  icon="key"
+  arrow
+>
+  https://app.circleci.com/settings/user/tokens
+</Card>
+
+## Required permissions
+
+CircleCI personal tokens inherit the permissions of your user account — there are no separate scope checkboxes. If your CircleCI account can read the projects you want the agent to act on, the token can too.
+
+For org-owned projects, make sure your account is a member of the relevant organization.
+
+## Connect in Nora
+
+<Steps>
+  <Step title="Open the CircleCI integration">
+    From an agent's detail page, open the **Integrations** tab and find **CircleCI** in the catalog.
+  </Step>
+
+<Step title="Paste the token">
+  Paste the personal API token into the **Personal API Token** field.
+</Step>
+
+  <Step title="Connect">
+    Click **Connect**. Nora encrypts the token and immediately calls `GET https://circleci.com/api/v2/me` to verify it. On success, the card shows your CircleCI username.
+  </Step>
+</Steps>
+
+## Verify the connection
+
+The **Test** button calls `GET /api/v2/me`. Common failures:
+
+- **401 Unauthorized** — token revoked. Generate a new one from the same page.
+- **403 Forbidden** — token belongs to a user that no longer has access to the org.
+
+## MCP server
+
+No official MCP server. The token is exposed to the agent as `CIRCLE_TOKEN` so any community MCP server reading that env var works.
+
+## Environment variables Nora injects
+
+| Variable       | Source                   |
+| -------------- | ------------------------ |
+| `CIRCLE_TOKEN` | Personal API Token field |

--- a/docs/guides/integrations/docker-hub.mdx
+++ b/docs/guides/integrations/docker-hub.mdx
@@ -1,0 +1,64 @@
+# Docker Hub
+
+> Where to apply for a Docker Hub personal access token and how to connect it to Nora.
+
+Docker Hub integrations let your agents pull/push images, manage repositories, and inspect automated builds. Nora authenticates with your Docker Hub username plus a personal access token.
+
+## Where to apply for credentials
+
+Personal access tokens are issued from Account Settings:
+
+<Card
+  title="Docker Hub — Personal Access Tokens"
+  href="https://hub.docker.com/settings/security"
+  icon="box"
+  arrow
+>
+  https://hub.docker.com/settings/security
+</Card>
+
+## Token permissions
+
+When generating the token, choose one of:
+
+| Access scope         | Use when                                           |
+| -------------------- | -------------------------------------------------- |
+| **Read & Write**     | Agent pushes images or modifies repositories       |
+| **Read only**        | Agent only pulls / inspects                        |
+| **Public Repo Read** | Agent only pulls public images (no private access) |
+
+Nora doesn't enforce a minimum scope — it just calls `POST /v2/users/login` to verify the credentials.
+
+## Connect in Nora
+
+<Steps>
+  <Step title="Open the Docker Hub integration">
+    From an agent's detail page, open the **Integrations** tab and find **Docker Hub** in the catalog.
+  </Step>
+
+<Step title="Paste username and token">
+  Enter your Docker Hub **Username** (not your email) and paste the **Access Token**.
+</Step>
+
+  <Step title="Connect">
+    Click **Connect**. Nora encrypts the token and calls `POST https://hub.docker.com/v2/users/login` to verify the credentials.
+  </Step>
+</Steps>
+
+## Verify the connection
+
+The **Test** button calls the same `/v2/users/login`. Common failures:
+
+- **401 Unauthorized** — wrong username, wrong token, or token expired.
+- **`Docker Hub username not configured`** — Nora needs the username explicitly because the API expects it in the JSON body.
+
+## MCP server
+
+No official Docker Hub MCP server today.
+
+## Environment variables Nora injects
+
+| Variable              | Source             |
+| --------------------- | ------------------ |
+| `DOCKER_HUB_TOKEN`    | Access Token field |
+| `DOCKER_HUB_USERNAME` | Username field     |

--- a/docs/guides/integrations/jenkins.mdx
+++ b/docs/guides/integrations/jenkins.mdx
@@ -1,0 +1,59 @@
+# Jenkins
+
+> Where to issue a Jenkins API token, how to point Nora at your Jenkins host, and how to connect.
+
+Jenkins integrations let your agents trigger jobs, read build status, and inspect pipeline runs. Nora authenticates with HTTP Basic against your Jenkins host using your username plus an API token.
+
+## Where to apply for credentials
+
+API tokens are issued per-user from your Jenkins user profile:
+
+1. Sign in to your Jenkins instance (e.g. `https://jenkins.acme.io`).
+2. Click your username in the top-right.
+3. Open **Configure → API Token → Add new Token**.
+4. Name it (e.g. "Nora") and click **Generate**.
+
+Copy the token immediately — Jenkins shows it only once.
+
+<Note>
+  The Jenkins URL **must be reachable from where Nora is deployed.** Nora rejects RFC1918 / loopback
+  URLs (e.g. `http://localhost:8080`) to prevent SSRF, so a self-hosted Jenkins behind a private
+  network needs to be exposed (or Nora needs to live in the same network).
+</Note>
+
+## Connect in Nora
+
+<Steps>
+  <Step title="Open the Jenkins integration">
+    From an agent's detail page, open the **Integrations** tab and find **Jenkins** in the catalog.
+  </Step>
+
+<Step title="Paste URL, username, and API token">
+  - **Jenkins URL** — the origin of your Jenkins instance (no trailing slash, no `/api/json`
+  suffix). - **Username** — your Jenkins login name. - **API Token** — the token you generated.
+</Step>
+
+  <Step title="Connect">
+    Click **Connect**. Nora encrypts the token and calls `GET <url>/api/json` with HTTP Basic auth as a connectivity test. On success, the card confirms "Connected to Jenkins".
+  </Step>
+</Steps>
+
+## Verify the connection
+
+The **Test** button hits the same `/api/json` endpoint. Failures usually fall into:
+
+- **401 Unauthorized** — token revoked or username typo.
+- **403 Forbidden** — Jenkins's "anonymous read access" is off and the user lacks the `Overall/Read` permission.
+- **`getaddrinfo ENOTFOUND`** — the Jenkins URL isn't resolvable from where Nora runs.
+
+## MCP server
+
+No official Jenkins MCP server. The agent receives `JENKINS_URL`, `JENKINS_USERNAME`, and `JENKINS_TOKEN` env vars — community MCP servers can read those directly.
+
+## Environment variables Nora injects
+
+| Variable           | Source            |
+| ------------------ | ----------------- |
+| `JENKINS_TOKEN`    | API Token field   |
+| `JENKINS_URL`      | Jenkins URL field |
+| `JENKINS_USERNAME` | Username field    |

--- a/docs/guides/integrations/kubernetes.mdx
+++ b/docs/guides/integrations/kubernetes.mdx
@@ -1,0 +1,117 @@
+# Kubernetes
+
+> How to provide a kubeconfig so your agents can drive a Kubernetes cluster, and what Nora can and can't verify on the way in.
+
+Kubernetes integrations let your agents run `kubectl`, manage Deployments, watch Pods, and apply manifests. Nora stores the **full kubeconfig** as the credential — the runtime container writes it to a file and runs `kubectl` from there.
+
+## What's the credential?
+
+A kubeconfig is a YAML (or JSON) file that contains:
+
+- The cluster's API server URL + CA certificate.
+- The user/service-account credentials (client cert, bearer token, or exec plugin).
+- A list of contexts that pair clusters with users.
+
+Most operators already have one at `~/.kube/config`. For team agents, generate a **dedicated service account + kubeconfig** so the agent's permissions are scoped — see the canonical guide:
+
+<Card
+  title="Organizing access using kubeconfig files"
+  href="https://kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/"
+  icon="server"
+  arrow
+>
+  kubernetes.io/docs/concepts/configuration/organize-cluster-access-kubeconfig/
+</Card>
+
+## Building a least-privilege kubeconfig
+
+1. **Create a ServiceAccount** in the namespace your agent operates in:
+
+   ```bash
+   kubectl create serviceaccount nora-agent -n <namespace>
+   ```
+
+2. **Bind the role(s)** the agent actually needs:
+
+   ```bash
+   kubectl create rolebinding nora-agent-edit \
+     --clusterrole=edit --serviceaccount=<namespace>:nora-agent \
+     -n <namespace>
+   ```
+
+3. **Generate a token** (Kubernetes 1.24+):
+
+   ```bash
+   kubectl create token nora-agent -n <namespace> --duration=8760h
+   ```
+
+4. **Build a kubeconfig** with that token. The simplest form:
+
+   ```yaml
+   apiVersion: v1
+   kind: Config
+   clusters:
+     - name: my-cluster
+       cluster:
+         server: https://<api-server>:6443
+         certificate-authority-data: <base64 CA>
+   users:
+     - name: nora-agent
+       user:
+         token: <token from step 3>
+   contexts:
+     - name: nora
+       context:
+         cluster: my-cluster
+         user: nora-agent
+         namespace: <namespace>
+   current-context: nora
+   ```
+
+Paste that YAML into Nora's **Kubeconfig** textarea.
+
+## Connect in Nora
+
+<Steps>
+  <Step title="Open the Kubernetes integration">
+    From an agent's detail page, open the **Integrations** tab and find **Kubernetes** in the catalog.
+  </Step>
+
+<Step title="Paste the kubeconfig">
+  Paste the full kubeconfig YAML into the **Kubeconfig (YAML)** textarea. The value is encrypted at
+  rest.
+</Step>
+
+<Step title="(Optional) Pin a context">
+  If your kubeconfig has multiple contexts, set the **Context Name** field to pin which one the
+  agent uses. Leaving it blank uses the kubeconfig's `current-context`.
+</Step>
+
+  <Step title="Connect">
+    Click **Connect**. Nora validates that the YAML parses and contains a `clusters:` entry, but does **not** call the API server — most clusters aren't reachable from the Nora control plane (and that's fine; the agent runs the kubeconfig from inside its own container).
+  </Step>
+</Steps>
+
+## Verify the connection
+
+The **Test** button repeats the structural check (YAML/JSON parses, has `clusters`). The card reports "Kubeconfig stored — cluster connectivity not verified from control plane."
+
+To verify your agent can actually reach the cluster, deploy the agent and watch its logs as it makes its first `kubectl` call.
+
+## MCP server
+
+There's a community Kubernetes MCP server:
+
+- **Package:** `@kubernetes/mcp-server`
+- **Docs:** [github.com/kubernetes/mcp-server](https://github.com/kubernetes/mcp-server)
+
+It reads the kubeconfig from the standard `KUBECONFIG` env var. Nora doesn't auto-launch it — bring it up alongside your agent.
+
+## Environment variables Nora injects
+
+| Variable              | Source                |
+| --------------------- | --------------------- |
+| `KUBECONFIG_CONTENTS` | Kubeconfig field      |
+| `KUBECONFIG_CONTEXT`  | Context Name (if set) |
+
+The agent runtime writes `KUBECONFIG_CONTENTS` to a file at startup and points `KUBECONFIG` at that path.

--- a/docs/guides/integrations/terraform.mdx
+++ b/docs/guides/integrations/terraform.mdx
@@ -1,0 +1,54 @@
+# Terraform Cloud
+
+> Where to apply for a Terraform Cloud (HCP) API token and how to connect it to Nora.
+
+Terraform Cloud (now HCP Terraform) integrations let your agents read workspaces, queue runs, and inspect state versions. Nora authenticates with a user/team API token — Bearer auth with the JSON:API content type.
+
+## Where to apply for credentials
+
+User-level tokens come from your Terraform Cloud account settings:
+
+<Card
+  title="Terraform Cloud — Tokens"
+  href="https://app.terraform.io/app/settings/tokens"
+  icon="layers"
+  arrow
+>
+  https://app.terraform.io/app/settings/tokens
+</Card>
+
+For team-scoped permissions, use a **team token** (Settings → Teams → Choose team → API tokens) so the agent operates within a single team's permissions instead of the user's.
+
+## Connect in Nora
+
+<Steps>
+  <Step title="Open the Terraform integration">
+    From an agent's detail page, open the **Integrations** tab and find **Terraform** in the catalog.
+  </Step>
+
+<Step title="Paste the token">Paste the API token into the **API Token** field.</Step>
+
+<Step title="(Optional) Enter the organization">
+  Set the **Organization** field to the organization slug (e.g. `acme-eng`) so the agent doesn't
+  have to specify it on every call.
+</Step>
+
+  <Step title="Connect">
+    Click **Connect**. Nora encrypts the token and calls `GET https://app.terraform.io/api/v2/account/details` to verify it. The card shows your Terraform Cloud username on success.
+  </Step>
+</Steps>
+
+## Verify the connection
+
+The **Test** button calls `/api/v2/account/details`. Failures usually mean the token was revoked from the same page where it was issued.
+
+## MCP server
+
+There's no official Terraform MCP server published by HashiCorp yet. Community servers exist on npm — none have stabilized.
+
+## Environment variables Nora injects
+
+| Variable           | Source                |
+| ------------------ | --------------------- |
+| `TFE_TOKEN`        | API Token field       |
+| `TFE_ORGANIZATION` | Organization (if set) |

--- a/docs/guides/integrations/vercel.mdx
+++ b/docs/guides/integrations/vercel.mdx
@@ -1,0 +1,58 @@
+# Vercel
+
+> Where to apply for a Vercel API token, how to scope it, and how to connect it to Nora.
+
+Vercel integrations let your agents list and trigger deployments, manage domains, and read environment variables. Nora authenticates with a Bearer token issued from your Vercel account.
+
+## Where to apply for credentials
+
+API tokens are issued from your account settings:
+
+<Card title="Vercel API Tokens" href="https://vercel.com/account/tokens" icon="triangle" arrow>
+  https://vercel.com/account/tokens
+</Card>
+
+## Scope and team selection
+
+Vercel tokens scope to a **user account** by default. To act on a team's projects, you need to either:
+
+1. Generate the token from a team-admin user, or
+2. Set the **Team ID** field in Nora — Vercel API requests then include `?teamId=<id>` and the token is interpreted in the team's context.
+
+You can find the team ID under **Team Settings → General**.
+
+## Connect in Nora
+
+<Steps>
+  <Step title="Open the Vercel integration">
+    From an agent's detail page, open the **Integrations** tab and find **Vercel** in the catalog.
+  </Step>
+
+<Step title="Paste the token">Paste the Vercel API token into the **API Token** field.</Step>
+
+<Step title="(Optional) Enter the team ID">
+  For team-scoped operations, paste the team ID into the **Team ID** field.
+</Step>
+
+  <Step title="Connect">
+    Click **Connect**. Nora encrypts the token and immediately calls `GET https://api.vercel.com/v2/user` to verify it. On success, the card shows your Vercel username.
+  </Step>
+</Steps>
+
+## Verify the connection
+
+The **Test** button calls `GET /v2/user`. Common failures:
+
+- **403 Forbidden** — token expired or its scope was reduced after issue.
+- **400** with `forbidden` — team ID is invalid or the token doesn't belong to that team.
+
+## MCP server
+
+There's no official Vercel MCP server today. Track [vercel/mcp](https://github.com/vercel/mcp) (when it appears) — Nora's catalog will be updated.
+
+## Environment variables Nora injects
+
+| Variable         | Source                 |
+| ---------------- | ---------------------- |
+| `VERCEL_TOKEN`   | API Token field        |
+| `VERCEL_TEAM_ID` | Team ID field (if set) |


### PR DESCRIPTION
## Summary

- Move 6 devops providers off the legacy connectivity-test switch onto strategy files: `circleci`, `vercel`, `terraform`, `jenkins`, `docker-hub`, `kubernetes`.
- Extend `ProviderAuthType` with `credentials` and `service_account` so providers like Jenkins, Docker Hub, and Kubernetes can express their auth shape directly. (`service_account` lands here unused; the GCP/Firebase migration in a later PR will use it.)
- Populate `credentialsUrl` + `setupGuide` for all six in the catalog. Kubernetes also gets MCP metadata (community `@kubernetes/mcp-server` package).
- Per-provider docs pages added for all six, each documenting where to apply for credentials, scopes/permissions, the connect flow, and troubleshooting.
- Kubernetes connectivity test is intentionally structural (YAML/JSON parse + `clusters:` check) — most clusters aren't reachable from the Nora control plane. The agent runtime writes the kubeconfig to disk and runs `kubectl` from inside the agent container.

## Test plan

- [x] `npx prettier --write` clean on touched files
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 664/664 passing (was 640; +24 from the six new test files)
- [ ] Manual dashboard pass: connect each of the six on a real agent, hit Test, confirm the response shape