### PR TITLE
feat(integrations): migrate communication providers (discord/telegram/teams/email/twilio/sendgrid)

### DIFF
--- a/backend-api/__tests__/providers/discordProvider.test.ts
+++ b/backend-api/__tests__/providers/discordProvider.test.ts
@@ -1,0 +1,55 @@
+// @ts-nocheck
+const { discordProvider } = require("../../integrations/providers/discord");
+
+function deps(fetchImpl) {
+  return {
+    fetch: fetchImpl,
+    assertSafeUrl: async (u) => u,
+    encrypt: (s) => s,
+    decrypt: (s) => s,
+    ensureEncryptionConfigured: jest.fn(),
+    db: { query: jest.fn() },
+  };
+}
+
+describe("discordProvider", () => {
+  it("uses the `Bot <token>` Authorization header", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ username: "norabot" }),
+    });
+    const result = await discordProvider.test(
+      { row: { provider: "discord" }, token: "tok", config: {} },
+      deps(fetchImpl),
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://discord.com/api/v10/users/@me",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bot tok" }),
+      }),
+    );
+    expect(result).toEqual({ success: true, message: "Connected as norabot" });
+  });
+
+  it("returns success=false on 401", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: false, status: 401 });
+    const result = await discordProvider.test(
+      { row: {}, token: "bad", config: {} },
+      deps(fetchImpl),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Discord API returned 401");
+  });
+
+  it("emits DISCORD_GUILD_ID when guild_id is configured", () => {
+    const env = discordProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { guild_id: "123456789" },
+    });
+    expect(env).toEqual({
+      primary: "DISCORD_TOKEN",
+      config: { guild_id: "DISCORD_GUILD_ID" },
+    });
+  });
+});

--- a/backend-api/__tests__/providers/emailProvider.test.ts
+++ b/backend-api/__tests__/providers/emailProvider.test.ts
@@ -1,0 +1,68 @@
+// @ts-nocheck
+const { emailProvider } = require("../../integrations/providers/email");
+
+const deps = {
+  fetch: jest.fn(),
+  assertSafeUrl: async (u) => u,
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+};
+
+const goodConfig = {
+  smtp_host: "smtp.gmail.com",
+  smtp_port: 587,
+  smtp_user: "alice@example.com",
+  from_address: "alice@example.com",
+};
+
+describe("emailProvider", () => {
+  it("identifies as email / credentials", () => {
+    expect(emailProvider.id).toBe("email");
+    expect(emailProvider.authType).toBe("credentials");
+  });
+
+  it("accepts a complete config without making any network calls", async () => {
+    const result = await emailProvider.test({ row: {}, token: "secret", config: goodConfig }, deps);
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("smtp.gmail.com:587");
+    expect(deps.fetch).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["smtp_host", { ...goodConfig, smtp_host: "" }, "host"],
+    ["smtp_port", { ...goodConfig, smtp_port: 0 }, "port"],
+    ["smtp_user", { ...goodConfig, smtp_user: "" }, "username"],
+    ["from_address", { ...goodConfig, from_address: "" }, "From address"],
+  ])("rejects when %s is empty", async (_, cfg, expected) => {
+    const result = await emailProvider.test({ row: {}, token: "secret", config: cfg }, deps);
+    expect(result.success).toBe(false);
+    expect(result.error.toLowerCase()).toContain(expected.toLowerCase());
+  });
+
+  it("rejects RFC1918 / loopback hosts", async () => {
+    const cfg = { ...goodConfig, smtp_host: "127.0.0.1" };
+    const result = await emailProvider.test({ row: {}, token: "s", config: cfg }, deps);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("RFC1918");
+  });
+
+  it("rejects malformed from_address", async () => {
+    const cfg = { ...goodConfig, from_address: "not-an-email" };
+    const result = await emailProvider.test({ row: {}, token: "s", config: cfg }, deps);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("not a valid email");
+  });
+
+  it("emits SMTP_PASS as primary and the host/port/user/from envs", () => {
+    const env = emailProvider.mapToEnv({ row: {}, token: null, config: goodConfig });
+    expect(env.primary).toBe("SMTP_PASS");
+    expect(env.config).toEqual({
+      smtp_host: "SMTP_HOST",
+      smtp_port: "SMTP_PORT",
+      smtp_user: "SMTP_USER",
+      from_address: "SMTP_FROM_ADDRESS",
+    });
+  });
+});

--- a/backend-api/__tests__/providers/sendgridProvider.test.ts
+++ b/backend-api/__tests__/providers/sendgridProvider.test.ts
@@ -1,0 +1,52 @@
+// @ts-nocheck
+const { sendgridProvider } = require("../../integrations/providers/sendgrid");
+
+function deps(fetchImpl) {
+  return {
+    fetch: fetchImpl,
+    assertSafeUrl: async (u) => u,
+    encrypt: (s) => s,
+    decrypt: (s) => s,
+    ensureEncryptionConfigured: jest.fn(),
+    db: { query: jest.fn() },
+  };
+}
+
+describe("sendgridProvider", () => {
+  it("calls /v3/user/profile with a Bearer token", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: true });
+    const result = await sendgridProvider.test(
+      { row: {}, token: "SG.x", config: {} },
+      deps(fetchImpl),
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.sendgrid.com/v3/user/profile",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer SG.x" }),
+      }),
+    );
+    expect(result).toEqual({ success: true, message: "API key validated" });
+  });
+
+  it("returns success=false on 401", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: false, status: 401 });
+    const result = await sendgridProvider.test(
+      { row: {}, token: "bad", config: {} },
+      deps(fetchImpl),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("SendGrid API returned 401");
+  });
+
+  it("emits SENDGRID_API_KEY + from_email when configured", () => {
+    const env = sendgridProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { from_email: "alice@example.com" },
+    });
+    expect(env).toEqual({
+      primary: "SENDGRID_API_KEY",
+      config: { from_email: "SENDGRID_FROM_EMAIL" },
+    });
+  });
+});

--- a/backend-api/__tests__/providers/teamsProvider.test.ts
+++ b/backend-api/__tests__/providers/teamsProvider.test.ts
@@ -1,0 +1,70 @@
+// @ts-nocheck
+const { teamsProvider } = require("../../integrations/providers/teams");
+
+const deps = {
+  fetch: jest.fn(),
+  assertSafeUrl: async (u) => u,
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+};
+
+describe("teamsProvider", () => {
+  it("identifies as teams / webhook", () => {
+    expect(teamsProvider.id).toBe("teams");
+    expect(teamsProvider.authType).toBe("webhook");
+  });
+
+  it("accepts a valid Microsoft webhook URL without sending a message", async () => {
+    const result = await teamsProvider.test(
+      {
+        row: {},
+        token: null,
+        config: {
+          webhook_url: "https://acme.webhook.office.com/webhookb2/abc/IncomingWebhook/xyz",
+        },
+      },
+      deps,
+    );
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("not verified");
+    expect(deps.fetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects empty URL", async () => {
+    const result = await teamsProvider.test({ row: {}, token: null, config: {} }, deps);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("not configured");
+  });
+
+  it("rejects non-https URLs", async () => {
+    const result = await teamsProvider.test(
+      { row: {}, token: null, config: { webhook_url: "http://acme.webhook.office.com/x" } },
+      deps,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("https");
+  });
+
+  it("rejects URLs that don't look like Microsoft webhook hosts", async () => {
+    const result = await teamsProvider.test(
+      { row: {}, token: null, config: { webhook_url: "https://evil.com/x" } },
+      deps,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Microsoft webhook");
+  });
+
+  it("emits TEAMS_WEBHOOK_URL with no primary token", () => {
+    const env = teamsProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { webhook_url: "https://x.webhook.office.com/x" },
+    });
+    expect(env).toEqual({
+      primary: null,
+      config: { webhook_url: "TEAMS_WEBHOOK_URL" },
+    });
+  });
+});

--- a/backend-api/__tests__/providers/telegramProvider.test.ts
+++ b/backend-api/__tests__/providers/telegramProvider.test.ts
@@ -1,0 +1,66 @@
+// @ts-nocheck
+const { telegramProvider } = require("../../integrations/providers/telegram");
+
+function deps(fetchImpl) {
+  return {
+    fetch: fetchImpl,
+    assertSafeUrl: async (u) => u,
+    encrypt: (s) => s,
+    decrypt: (s) => s,
+    ensureEncryptionConfigured: jest.fn(),
+    db: { query: jest.fn() },
+  };
+}
+
+describe("telegramProvider", () => {
+  it("validates the token format before calling the API", async () => {
+    const fetchImpl = jest.fn();
+    const result = await telegramProvider.test(
+      { row: {}, token: "not-a-valid-token", config: {} },
+      deps(fetchImpl),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Invalid Telegram bot token format");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("calls /getMe with the bot token in the URL path", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: true, result: { username: "norabot" } }),
+    });
+    const result = await telegramProvider.test(
+      { row: {}, token: "123456789:ABCdef-XYZ_abc", config: {} },
+      deps(fetchImpl),
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.telegram.org/bot123456789:ABCdef-XYZ_abc/getMe",
+    );
+    expect(result).toEqual({ success: true, message: "Connected as @norabot" });
+  });
+
+  it("surfaces Telegram's own description when ok=false", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ ok: false, description: "Unauthorized" }),
+    });
+    const result = await telegramProvider.test(
+      { row: {}, token: "123:abc", config: {} },
+      deps(fetchImpl),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Unauthorized");
+  });
+
+  it("emits TELEGRAM_BOT_TOKEN as primary and operator id when configured", () => {
+    const env = telegramProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { operator_user_id: "987654" },
+    });
+    expect(env).toEqual({
+      primary: "TELEGRAM_BOT_TOKEN",
+      config: { operator_user_id: "OPERATOR_TELEGRAM_ID" },
+    });
+  });
+});

--- a/backend-api/__tests__/providers/twilioProvider.test.ts
+++ b/backend-api/__tests__/providers/twilioProvider.test.ts
@@ -1,0 +1,59 @@
+// @ts-nocheck
+const { twilioProvider } = require("../../integrations/providers/twilio");
+
+function deps(fetchImpl) {
+  return {
+    fetch: fetchImpl,
+    assertSafeUrl: async (u) => u,
+    encrypt: (s) => s,
+    decrypt: (s) => s,
+    ensureEncryptionConfigured: jest.fn(),
+    db: { query: jest.fn() },
+  };
+}
+
+describe("twilioProvider", () => {
+  it("identifies as twilio / credentials", () => {
+    expect(twilioProvider.id).toBe("twilio");
+    expect(twilioProvider.authType).toBe("credentials");
+  });
+
+  it("calls /Accounts/<sid>.json with HTTP Basic auth", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: true });
+    const result = await twilioProvider.test(
+      { row: {}, token: "tok", config: { account_sid: "AC123" } },
+      deps(fetchImpl),
+    );
+    const expected = "Basic " + Buffer.from("AC123:tok").toString("base64");
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.twilio.com/2010-04-01/Accounts/AC123.json",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: expected }),
+      }),
+    );
+    expect(result).toEqual({ success: true, message: "Connected to Twilio" });
+  });
+
+  it("rejects missing SID", async () => {
+    const fetchImpl = jest.fn();
+    const result = await twilioProvider.test(
+      { row: {}, token: "tok", config: {} },
+      deps(fetchImpl),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Account SID");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("emits TWILIO_AUTH_TOKEN + sid + phone_number when configured", () => {
+    const env = twilioProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { account_sid: "AC123", phone_number: "+15555550123" },
+    });
+    expect(env).toEqual({
+      primary: "TWILIO_AUTH_TOKEN",
+      config: { account_sid: "TWILIO_ACCOUNT_SID", phone_number: "TWILIO_PHONE_NUMBER" },
+    });
+  });
+});

--- a/backend-api/integrations/catalog/catalog.json
+++ b/backend-api/integrations/catalog/catalog.json
@@ -238,7 +238,18 @@
       { "key": "bot_token", "label": "Bot Token", "type": "password", "required": true },
       { "key": "guild_id", "label": "Server (Guild) ID", "type": "text", "required": false }
     ],
-    "capabilities": ["read", "write", "webhook"]
+    "capabilities": ["read", "write", "webhook"],
+    "credentialsUrl": "https://discord.com/developers/applications",
+    "setupGuide": {
+      "steps": [
+        "Open the Discord Developer Portal and click New Application.",
+        "In the left nav, open Bot, then click Reset Token to generate a bot token (copy it once).",
+        "Under OAuth2 → URL Generator, pick the bot scope and the permissions your agent needs, then visit the generated URL to invite the bot to your server.",
+        "Right-click your server in Discord → Copy Server ID (enable Developer Mode in User Settings if you don't see it). Paste it into the Server (Guild) ID field."
+      ],
+      "scopes": ["bot", "applications.commands"]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "telegram",
@@ -251,7 +262,17 @@
       { "key": "bot_token", "label": "Bot Token", "type": "password", "required": true },
       { "key": "operator_user_id", "label": "Operator User ID", "type": "text", "required": false }
     ],
-    "capabilities": ["read", "write", "webhook"]
+    "capabilities": ["read", "write", "webhook"],
+    "credentialsUrl": "https://t.me/BotFather",
+    "setupGuide": {
+      "steps": [
+        "Open Telegram and start a chat with @BotFather.",
+        "Send /newbot, give your bot a name and a username ending in 'bot'.",
+        "BotFather replies with an HTTP API token in the form <id>:<secret> — copy it.",
+        "(Optional) Send a message to your bot, then call https://api.telegram.org/bot<token>/getUpdates to find your numeric user ID and paste it into the Operator User ID field."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "teams",
@@ -263,7 +284,17 @@
     "configFields": [
       { "key": "webhook_url", "label": "Incoming Webhook URL", "type": "url", "required": true }
     ],
-    "capabilities": ["write"]
+    "capabilities": ["write"],
+    "credentialsUrl": "https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook",
+    "setupGuide": {
+      "steps": [
+        "In Teams, go to the channel where messages should appear.",
+        "Click ⋯ next to the channel name → Manage channel → Connectors.",
+        "Find Incoming Webhook, click Add, give it a name, and click Create.",
+        "Copy the generated webhook URL and paste it into Nora."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "email",
@@ -279,7 +310,16 @@
       { "key": "smtp_pass", "label": "Password", "type": "password", "required": true },
       { "key": "from_address", "label": "From Address", "type": "email", "required": true }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://nodemailer.com/smtp/",
+    "setupGuide": {
+      "steps": [
+        "Pick an SMTP relay — most providers (SendGrid, Mailgun, AWS SES, your Google Workspace, your own Postfix) expose SMTP credentials in their console.",
+        "Get the SMTP host, port (usually 587 with STARTTLS or 465 with implicit TLS), username, and password.",
+        "The from_address must be an email the relay will accept as the sender — for shared relays this often has to match a verified domain or sender."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "openai",
@@ -1046,7 +1086,16 @@
       { "key": "auth_token", "label": "Auth Token", "type": "password", "required": true },
       { "key": "phone_number", "label": "From Number", "type": "text", "required": false }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://console.twilio.com/",
+    "setupGuide": {
+      "steps": [
+        "Sign in to the Twilio Console.",
+        "Copy your Account SID and Auth Token from the dashboard's Account Info panel.",
+        "(Optional) Buy or assign a phone number under Phone Numbers → Manage → Active numbers and paste it as the From Number."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "sendgrid",
@@ -1059,7 +1108,17 @@
       { "key": "api_key", "label": "API Key", "type": "password", "required": true },
       { "key": "from_email", "label": "From Email", "type": "email", "required": false }
     ],
-    "capabilities": ["write"]
+    "capabilities": ["write"],
+    "credentialsUrl": "https://app.sendgrid.com/settings/api_keys",
+    "setupGuide": {
+      "steps": [
+        "Sign in to SendGrid and open Settings → API Keys.",
+        "Click Create API Key, choose Full Access (or Restricted with Mail Send) and copy the key.",
+        "(Optional) Verify a sender at Settings → Sender Authentication and paste the email into the From Email field."
+      ],
+      "scopes": ["mail.send"]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "terraform",

--- a/backend-api/integrations/index.ts
+++ b/backend-api/integrations/index.ts
@@ -49,6 +49,12 @@ export { terraformProvider } from "./providers/terraform";
 export { jenkinsProvider } from "./providers/jenkins";
 export { dockerHubProvider } from "./providers/dockerHub";
 export { kubernetesProvider } from "./providers/kubernetes";
+export { discordProvider } from "./providers/discord";
+export { telegramProvider } from "./providers/telegram";
+export { teamsProvider } from "./providers/teams";
+export { emailProvider } from "./providers/email";
+export { twilioProvider } from "./providers/twilio";
+export { sendgridProvider } from "./providers/sendgrid";
 
 // The orchestration service is the recommended import for callers that
 // need the high-level operations (connect, list, test, sync, env-vars).

--- a/backend-api/integrations/providers/discord.ts
+++ b/backend-api/integrations/providers/discord.ts
@@ -1,0 +1,36 @@
+// Discord provider — bot tokens via the standard `Authorization: Bot <token>`
+// header. The connectivity test hits /users/@me which Discord supports for
+// bot tokens (returns the bot user, not the server's owner).
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const discordProvider: Provider = {
+  id: "discord",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const res = await deps.fetch("https://discord.com/api/v10/users/@me", {
+        headers: { Authorization: `Bot ${ctx.token ?? ""}` },
+      });
+      if (!res.ok) throw new Error(`Discord API returned ${res.status}`);
+      const data: any = await res.json();
+      return { success: true, message: `Connected as ${data.username}` };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.guild_id) configEnv.guild_id = "DISCORD_GUILD_ID";
+    return { primary: "DISCORD_TOKEN", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/email.ts
+++ b/backend-api/integrations/providers/email.ts
@@ -1,0 +1,61 @@
+// Email (SMTP) provider — credentials authType.
+//
+// SMTP connectivity is hard to verify from the control plane: sending a
+// real message would deliver, and most providers gate STARTTLS behind a
+// full handshake we don't want to recreate without nodemailer. test()
+// instead validates that the required fields are present and that the
+// host looks reachable (FQDN, not RFC1918). The agent runtime sends real
+// messages via SMTP_* env vars.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+} from "../types/provider";
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const PRIVATE_HOST_RE = /^(127\.|10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.|localhost$|0\.0\.0\.0$)/;
+
+export const emailProvider: Provider = {
+  id: "email",
+  authType: "credentials",
+
+  async test(ctx: DecryptedIntegration): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      const host = String(config.smtp_host || "").trim();
+      const port = Number(config.smtp_port);
+      const user = String(config.smtp_user || "").trim();
+      const fromAddress = String(config.from_address || "").trim();
+      if (!host) throw new Error("SMTP host is required");
+      if (!port || port < 1 || port > 65535)
+        throw new Error("SMTP port must be between 1 and 65535");
+      if (!user) throw new Error("SMTP username is required");
+      if (!ctx.token) throw new Error("SMTP password is required");
+      if (!fromAddress) throw new Error("From address is required");
+      if (!EMAIL_RE.test(fromAddress)) throw new Error("From address is not a valid email");
+      if (PRIVATE_HOST_RE.test(host)) {
+        throw new Error(
+          "SMTP host must be reachable from Nora — RFC1918 / loopback hosts are rejected",
+        );
+      }
+      return {
+        success: true,
+        message: `SMTP credentials stored — connectivity not verified from control plane (${host}:${port})`,
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.smtp_host) configEnv.smtp_host = "SMTP_HOST";
+    if (config.smtp_port !== undefined) configEnv.smtp_port = "SMTP_PORT";
+    if (config.smtp_user) configEnv.smtp_user = "SMTP_USER";
+    if (config.from_address) configEnv.from_address = "SMTP_FROM_ADDRESS";
+    return { primary: "SMTP_PASS", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/legacy/connectivityTests.ts
+++ b/backend-api/integrations/providers/legacy/connectivityTests.ts
@@ -44,14 +44,7 @@ function buildConnectivityTests(integration, token, deps) {
 
   return {
     // gitlab → migrated to providers/gitlab.ts
-    discord: async () => {
-      const res = await fetch("https://discord.com/api/v10/users/@me", {
-        headers: { Authorization: `Bot ${token}` },
-      });
-      if (!res.ok) throw new Error(`Discord API returned ${res.status}`);
-      const data = await res.json();
-      return { success: true, message: `Connected as ${data.username}` };
-    },
+    // discord → migrated to providers/discord.ts
     notion: async () => {
       const res = await fetch("https://api.notion.com/v1/users/me", {
         headers: { Authorization: `Bearer ${token}`, "Notion-Version": "2022-06-28" },
@@ -74,13 +67,7 @@ function buildConnectivityTests(integration, token, deps) {
       if (!res.ok) throw new Error(`Sentry API returned ${res.status}`);
       return { success: true, message: "Authenticated successfully" };
     },
-    sendgrid: async () => {
-      const res = await fetch("https://api.sendgrid.com/v3/user/profile", {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (!res.ok) throw new Error(`SendGrid API returned ${res.status}`);
-      return { success: true, message: "API key validated" };
-    },
+    // sendgrid → migrated to providers/sendgrid.ts
     openai: async () => {
       const res = await fetch("https://api.openai.com/v1/models", {
         headers: { Authorization: `Bearer ${token}` },
@@ -309,30 +296,8 @@ function buildConnectivityTests(integration, token, deps) {
       const data = await res.json();
       return { success: true, message: `Connected as ${data.name?.display_name || "verified"}` };
     },
-    twilio: async () => {
-      const config =
-        typeof integration.config === "string"
-          ? JSON.parse(integration.config)
-          : integration.config || {};
-      const sid = config.account_sid;
-      if (!sid) throw new Error("Twilio Account SID not configured");
-      const res = await fetch(`https://api.twilio.com/2010-04-01/Accounts/${sid}.json`, {
-        headers: { Authorization: `Basic ${Buffer.from(`${sid}:${token}`).toString("base64")}` },
-      });
-      if (!res.ok) throw new Error(`Twilio API returned ${res.status}`);
-      return { success: true, message: "Connected to Twilio" };
-    },
-    telegram: async () => {
-      const botToken = String(token || "").trim();
-      if (!/^\d+:[A-Za-z0-9_-]+$/.test(botToken)) {
-        throw new Error("Invalid Telegram bot token format");
-      }
-      const res = await fetch(`https://api.telegram.org/bot${botToken}/getMe`);
-      if (!res.ok) throw new Error(`Telegram API returned ${res.status}`);
-      const data = await res.json();
-      if (!data.ok) throw new Error(`Telegram: ${data.description || "validation failed"}`);
-      return { success: true, message: `Connected as @${data.result?.username || "bot"}` };
-    },
+    // twilio → migrated to providers/twilio.ts
+    // telegram → migrated to providers/telegram.ts
     shopify: async () => {
       const config =
         typeof integration.config === "string"

--- a/backend-api/integrations/providers/legacy/envMaps.ts
+++ b/backend-api/integrations/providers/legacy/envMaps.ts
@@ -14,12 +14,12 @@ const INTEGRATION_ENV_MAP = {
   // github → migrated to providers/github.ts
   // gitlab → migrated to providers/gitlab.ts
   // slack → migrated to providers/slack.ts
-  discord: "DISCORD_TOKEN",
+  // discord → migrated to providers/discord.ts
   notion: "NOTION_TOKEN",
   // linear → migrated to providers/linear.ts
   datadog: "DD_API_KEY",
   sentry: "SENTRY_AUTH_TOKEN",
-  sendgrid: "SENDGRID_API_KEY",
+  // sendgrid → migrated to providers/sendgrid.ts
   openai: "OPENAI_API_KEY",
   anthropic: "ANTHROPIC_API_KEY",
   airtable: "AIRTABLE_API_KEY",
@@ -33,8 +33,8 @@ const INTEGRATION_ENV_MAP = {
   // terraform → migrated to providers/terraform.ts
   pagerduty: "PAGERDUTY_TOKEN",
   dropbox: "DROPBOX_ACCESS_TOKEN",
-  twilio: "TWILIO_AUTH_TOKEN",
-  telegram: "TELEGRAM_BOT_TOKEN",
+  // twilio → migrated to providers/twilio.ts
+  // telegram → migrated to providers/telegram.ts
   shopify: "SHOPIFY_ACCESS_TOKEN",
   // linkedin → migrated to providers/linkedin.ts
   instagram: "INSTAGRAM_ACCESS_TOKEN",
@@ -72,7 +72,7 @@ const INTEGRATION_ENV_MAP = {
   // Vector DBs
   weaviate: "WEAVIATE_API_KEY",
   // Communication
-  email: "SMTP_PASS",
+  // email → migrated to providers/email.ts
   // Automation webhooks have no token; webhook_url is in INTEGRATION_CONFIG_ENV_MAP.
 };
 
@@ -88,16 +88,12 @@ const INTEGRATION_CONFIG_ENV_MAP = {
   // linear.team_id → providers/linear.ts
   // Communication
   // slack.default_channel → providers/slack.ts
-  "discord.guild_id": "DISCORD_GUILD_ID",
-  "teams.webhook_url": "TEAMS_WEBHOOK_URL",
-  "email.smtp_host": "SMTP_HOST",
-  "email.smtp_port": "SMTP_PORT",
-  "email.smtp_user": "SMTP_USER",
-  "email.from_address": "SMTP_FROM_ADDRESS",
-  "twilio.account_sid": "TWILIO_ACCOUNT_SID",
-  "twilio.phone_number": "TWILIO_PHONE_NUMBER",
+  // discord.guild_id → providers/discord.ts
+  // teams.webhook_url → providers/teams.ts
+  // email.* → providers/email.ts
+  // twilio.account_sid/phone_number → providers/twilio.ts
   "sendgrid.from_email": "SENDGRID_FROM_EMAIL",
-  "telegram.operator_user_id": "OPERATOR_TELEGRAM_ID",
+  // telegram.operator_user_id → providers/telegram.ts
   // AI / ML
   "openai.org_id": "OPENAI_ORG_ID",
   "huggingface.model_id": "HF_DEFAULT_MODEL",

--- a/backend-api/integrations/providers/sendgrid.ts
+++ b/backend-api/integrations/providers/sendgrid.ts
@@ -1,0 +1,36 @@
+// SendGrid provider — Bearer token, GET /v3/user/profile validates the
+// API key. SendGrid keys can be scoped (Mail Send only, Full Access, etc.)
+// — /user/profile is in the default scope of every key, so it's a safe
+// validation endpoint.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const sendgridProvider: Provider = {
+  id: "sendgrid",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const res = await deps.fetch("https://api.sendgrid.com/v3/user/profile", {
+        headers: { Authorization: `Bearer ${ctx.token ?? ""}` },
+      });
+      if (!res.ok) throw new Error(`SendGrid API returned ${res.status}`);
+      return { success: true, message: "API key validated" };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.from_email) configEnv.from_email = "SENDGRID_FROM_EMAIL";
+    return { primary: "SENDGRID_API_KEY", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/teams.ts
+++ b/backend-api/integrations/providers/teams.ts
@@ -1,0 +1,56 @@
+// Microsoft Teams (incoming webhooks) provider — webhook authType.
+//
+// Teams incoming webhooks are write-only and don't expose a verification
+// endpoint. We can't safely send a real test message (it would deliver
+// to the channel), so test() validates that the URL is well-formed and
+// hits the documented webhook host pattern. The agent sends messages
+// via POST to TEAMS_WEBHOOK_URL — connectivity is verified there.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+} from "../types/provider";
+
+export const teamsProvider: Provider = {
+  id: "teams",
+  authType: "webhook",
+
+  async test(ctx: DecryptedIntegration): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      const url = String(config.webhook_url || "").trim();
+      if (!url) throw new Error("Teams webhook URL not configured");
+      let parsed: URL;
+      try {
+        parsed = new URL(url);
+      } catch {
+        throw new Error("Teams webhook URL is not a valid URL");
+      }
+      if (parsed.protocol !== "https:") {
+        throw new Error("Teams webhook URL must use https://");
+      }
+      const validHost =
+        /\.webhook\.office\.com$/.test(parsed.hostname) ||
+        /\.outlook\.office\.com$/.test(parsed.hostname) ||
+        /^outlook\.office\.com$/.test(parsed.hostname);
+      if (!validHost) {
+        throw new Error("Teams webhook URL host doesn't look like a Microsoft webhook endpoint");
+      }
+      return {
+        success: true,
+        message: "Webhook URL stored — message delivery not verified from control plane",
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.webhook_url) configEnv.webhook_url = "TEAMS_WEBHOOK_URL";
+    return { primary: null, config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/telegram.ts
+++ b/backend-api/integrations/providers/telegram.ts
@@ -1,0 +1,45 @@
+// Telegram bot provider — tokens follow the format <bot_id>:<secret>.
+// The connectivity test calls getMe via the Bot API and reads the bot's
+// username. The token format check guards against operators pasting their
+// own user API key by mistake.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+const TELEGRAM_TOKEN_RE = /^\d+:[A-Za-z0-9_-]+$/;
+
+export const telegramProvider: Provider = {
+  id: "telegram",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const botToken = String(ctx.token || "").trim();
+      if (!TELEGRAM_TOKEN_RE.test(botToken)) {
+        throw new Error("Invalid Telegram bot token format");
+      }
+      const res = await deps.fetch(`https://api.telegram.org/bot${botToken}/getMe`);
+      if (!res.ok) throw new Error(`Telegram API returned ${res.status}`);
+      const data: any = await res.json();
+      if (!data.ok) throw new Error(`Telegram: ${data.description || "validation failed"}`);
+      return {
+        success: true,
+        message: `Connected as @${data.result?.username || "bot"}`,
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.operator_user_id) configEnv.operator_user_id = "OPERATOR_TELEGRAM_ID";
+    return { primary: "TELEGRAM_BOT_TOKEN", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/twilio.ts
+++ b/backend-api/integrations/providers/twilio.ts
@@ -1,0 +1,40 @@
+// Twilio provider — Account SID + Auth Token, HTTP Basic auth.
+// The connectivity test reads the account record by SID, which Twilio
+// considers a free admin call and returns 401 if the credentials are wrong.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const twilioProvider: Provider = {
+  id: "twilio",
+  authType: "credentials",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      const sid = String(config.account_sid || "").trim();
+      if (!sid) throw new Error("Twilio Account SID not configured");
+      const credentials = Buffer.from(`${sid}:${ctx.token ?? ""}`).toString("base64");
+      const res = await deps.fetch(`https://api.twilio.com/2010-04-01/Accounts/${sid}.json`, {
+        headers: { Authorization: `Basic ${credentials}` },
+      });
+      if (!res.ok) throw new Error(`Twilio API returned ${res.status}`);
+      return { success: true, message: "Connected to Twilio" };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.account_sid) configEnv.account_sid = "TWILIO_ACCOUNT_SID";
+    if (config.phone_number) configEnv.phone_number = "TWILIO_PHONE_NUMBER";
+    return { primary: "TWILIO_AUTH_TOKEN", config: configEnv };
+  },
+};

--- a/backend-api/integrations/services/integrationsService.ts
+++ b/backend-api/integrations/services/integrationsService.ts
@@ -37,6 +37,12 @@ const { terraformProvider } = require("../providers/terraform");
 const { jenkinsProvider } = require("../providers/jenkins");
 const { dockerHubProvider } = require("../providers/dockerHub");
 const { kubernetesProvider } = require("../providers/kubernetes");
+const { discordProvider } = require("../providers/discord");
+const { telegramProvider } = require("../providers/telegram");
+const { teamsProvider } = require("../providers/teams");
+const { emailProvider } = require("../providers/email");
+const { twilioProvider } = require("../providers/twilio");
+const { sendgridProvider } = require("../providers/sendgrid");
 
 const repo = createIntegrationsRepository(db);
 const secretCrypto = createSecretEncryption({
@@ -78,6 +84,12 @@ const providerRegistry = createProviderRegistry((providerId) =>
   jenkinsProvider,
   dockerHubProvider,
   kubernetesProvider,
+  discordProvider,
+  telegramProvider,
+  teamsProvider,
+  emailProvider,
+  twilioProvider,
+  sendgridProvider,
 ].forEach((p) => providerRegistry.register(p));
 
 // Resolve fetch at call time so test mocks reassigning `global.fetch`

--- a/docs/guides/integrations/discord.mdx
+++ b/docs/guides/integrations/discord.mdx
@@ -1,0 +1,68 @@
+# Discord
+
+> Where to register a Discord bot, which scopes its token needs, and how to connect it to Nora.
+
+Discord integrations let your agents read messages, post replies, and manage channels via the bot API. Nora authenticates with a bot token — issued from the Discord Developer Portal.
+
+## Where to apply for credentials
+
+Bot tokens come from the Developer Portal:
+
+<Card
+  title="Discord Developer Portal"
+  href="https://discord.com/developers/applications"
+  icon="key"
+  arrow
+>
+  https://discord.com/developers/applications
+</Card>
+
+## Required scopes
+
+When inviting the bot via OAuth2, select:
+
+- **`bot`** — required for any bot-mode operation.
+- **`applications.commands`** — required if you want the bot to register slash commands.
+
+Plus the per-channel **bot permissions** the agent needs (Read Messages, Send Messages, Manage Channels, etc.).
+
+## Connect in Nora
+
+<Steps>
+  <Step title="Create the application">
+    Open the Developer Portal, click **New Application**, give it a name. In the left nav, open **Bot**, click **Reset Token**, and copy the bot token (you only see it once).
+  </Step>
+
+<Step title="Invite the bot to your server">
+  In the left nav, open **OAuth2 → URL Generator**. Tick `bot` and `applications.commands` under
+  scopes, then tick the per-channel permissions you need under Bot Permissions. Visit the URL it
+  generates, pick your server, and authorize.
+</Step>
+
+<Step title="Copy the server (guild) ID">
+  Right-click your server in Discord → **Copy Server ID**. (You may need to enable **Developer
+  Mode** under User Settings → Advanced first.)
+</Step>
+
+  <Step title="Connect in Nora">
+    From the agent's **Integrations** tab, find **Discord**, paste the bot token and the server ID, and click **Connect**. Nora calls `GET /users/@me` with the bot token to verify it.
+  </Step>
+</Steps>
+
+## Verify the connection
+
+The **Test** button calls `/users/@me`. The bot user's display name is reported back. Common failures:
+
+- **401 Unauthorized** — token revoked. Reset it in the Developer Portal.
+- **403 Forbidden** — token belongs to an application that hasn't been added to any server.
+
+## MCP server
+
+No official Discord MCP server today.
+
+## Environment variables Nora injects
+
+| Variable           | Source                  |
+| ------------------ | ----------------------- |
+| `DISCORD_TOKEN`    | Bot Token field         |
+| `DISCORD_GUILD_ID` | Server (Guild) ID field |

--- a/docs/guides/integrations/email.mdx
+++ b/docs/guides/integrations/email.mdx
@@ -1,0 +1,62 @@
+# Email (SMTP)
+
+> Where to get SMTP credentials and how to connect them to Nora.
+
+Email integrations let your agents send messages via any SMTP relay — your own Postfix server, Google Workspace SMTP, AWS SES, Mailgun, SendGrid (via SMTP), Mailtrap, etc. Nora stores the credentials encrypted and the agent runtime sends mail through the configured relay.
+
+## Where to apply for credentials
+
+Pick whichever SMTP provider you already have an account with:
+
+| Provider              | SMTP host                           | Where to get credentials                                                                |
+| --------------------- | ----------------------------------- | --------------------------------------------------------------------------------------- |
+| Google Workspace      | `smtp.gmail.com`                    | [Create an app password](https://myaccount.google.com/apppasswords)                     |
+| AWS SES               | `email-smtp.<region>.amazonaws.com` | [SES SMTP credentials](https://docs.aws.amazon.com/ses/latest/dg/smtp-credentials.html) |
+| Mailgun               | `smtp.mailgun.org`                  | [Mailgun domain dashboard](https://app.mailgun.com/)                                    |
+| SendGrid (SMTP)       | `smtp.sendgrid.net`                 | [SendGrid API Keys](https://app.sendgrid.com/settings/api_keys) — username is `apikey`  |
+| Postmark              | `smtp.postmarkapp.com`              | [Postmark Servers](https://account.postmarkapp.com/)                                    |
+| Self-hosted (Postfix) | your hostname                       | `/etc/postfix/main.cf`                                                                  |
+
+For Google Workspace and other 2FA-protected accounts, use an **app password** — not your account password.
+
+## Connect in Nora
+
+<Steps>
+  <Step title="Open the Email (SMTP) integration">
+    From an agent's detail page, open the **Integrations** tab and find **Email (SMTP)**.
+  </Step>
+
+<Step title="Fill in the SMTP fields">
+  | Field | Example | | -------------- | -------------------------------- | | SMTP Host |
+  `smtp.gmail.com` | | SMTP Port | `587` (STARTTLS) or `465` (TLS) | | Username | `you@example.com`
+  or `apikey` | | Password | the app password / API secret | | From Address | `you@example.com` |
+</Step>
+
+  <Step title="Connect">
+    Click **Connect**. Nora validates the field shapes (port range, email format, public-host check) and stores the credentials encrypted. **It does not perform an SMTP handshake** from the control plane — that happens in the agent runtime.
+  </Step>
+</Steps>
+
+## Verify the connection
+
+The **Test** button runs the same structural validation. End-to-end verification happens when your agent sends its first message; failures usually surface as `EAUTH`, `ECONNREFUSED`, or `ETIMEOUT` in the agent logs.
+
+<Note>
+  Nora rejects RFC1918 / loopback SMTP hosts (e.g. `127.0.0.1`, `10.x.x.x`) as a defense-in-depth
+  measure. If you really do want to relay through localhost, the agent's container needs network
+  access to that host — set up an SSH tunnel or VPN at the runtime layer.
+</Note>
+
+## MCP server
+
+No MCP server — SMTP isn't a query API.
+
+## Environment variables Nora injects
+
+| Variable            | Source             |
+| ------------------- | ------------------ |
+| `SMTP_PASS`         | Password field     |
+| `SMTP_HOST`         | SMTP Host field    |
+| `SMTP_PORT`         | SMTP Port field    |
+| `SMTP_USER`         | Username field     |
+| `SMTP_FROM_ADDRESS` | From Address field |

--- a/docs/guides/integrations/sendgrid.mdx
+++ b/docs/guides/integrations/sendgrid.mdx
@@ -1,0 +1,68 @@
+# SendGrid
+
+> Where to issue a SendGrid API key, which scope it needs, and how to connect it to Nora.
+
+SendGrid integrations let your agents send transactional and marketing email via the SendGrid v3 API. Nora authenticates with a Bearer API key.
+
+## Where to apply for credentials
+
+API keys are issued from your SendGrid account settings:
+
+<Card
+  title="SendGrid — API Keys"
+  href="https://app.sendgrid.com/settings/api_keys"
+  icon="send"
+  arrow
+>
+  https://app.sendgrid.com/settings/api_keys
+</Card>
+
+## Required scope
+
+Pick the smallest scope that covers your agent's behavior:
+
+| API Key permission    | When to use                                                                |
+| --------------------- | -------------------------------------------------------------------------- |
+| **Full Access**       | Agent reads stats, manages templates, sends mail (development convenience) |
+| **Restricted Access** | Production. Tick **Mail Send** at minimum.                                 |
+
+The `/v3/user/profile` endpoint Nora uses for connectivity testing is in the default scope of every key — so even a Mail-Send-only key passes the test.
+
+## Connect in Nora
+
+<Steps>
+  <Step title="Open the SendGrid integration">
+    From an agent's detail page, open the **Integrations** tab and find **SendGrid**.
+  </Step>
+
+<Step title="Paste the API key">
+  Paste the API key (starts with `SG.`) into the **API Key** field.
+</Step>
+
+<Step title="(Optional) Verify a sender">
+  For Mail Send, your **From Email** must be verified at **Settings → Sender Authentication**.
+  SendGrid rejects unverified senders. Paste the verified address into the **From Email** field.
+</Step>
+
+  <Step title="Connect">
+    Click **Connect**. Nora calls `GET https://api.sendgrid.com/v3/user/profile` with the API key.
+  </Step>
+</Steps>
+
+## Verify the connection
+
+The **Test** button calls the same `/v3/user/profile`. Common failures:
+
+- **401 Unauthorized** — key revoked or you copied the wrong value (note: SendGrid shows the key only once at creation; if you've lost it, generate a new one).
+- **403 Forbidden** — the key is restricted and lacks the User: Read scope. This shouldn't happen with default scopes; if it does, regenerate.
+
+## MCP server
+
+No official SendGrid MCP server today.
+
+## Environment variables Nora injects
+
+| Variable              | Source              |
+| --------------------- | ------------------- |
+| `SENDGRID_API_KEY`    | API Key field       |
+| `SENDGRID_FROM_EMAIL` | From Email (if set) |

--- a/docs/guides/integrations/teams.mdx
+++ b/docs/guides/integrations/teams.mdx
@@ -1,0 +1,59 @@
+# Microsoft Teams
+
+> How to set up an Incoming Webhook in Microsoft Teams and connect it to Nora.
+
+Teams integrations are write-only: Nora posts notifications and messages into a Teams channel via an Incoming Webhook URL. There's no return channel — the webhook can't read messages.
+
+## Where to apply for credentials
+
+The webhook is created from inside Teams — there's no developer portal:
+
+<Card
+  title="Add an Incoming Webhook to a Teams channel"
+  href="https://learn.microsoft.com/en-us/microsoftteams/platform/webhooks-and-connectors/how-to/add-incoming-webhook"
+  icon="message-square"
+  arrow
+>
+  Microsoft Learn — Add an Incoming Webhook
+</Card>
+
+## Connect in Nora
+
+<Steps>
+  <Step title="Open the channel's connectors">
+    In Teams, navigate to the channel where messages should appear. Click the **⋯** next to the channel name → **Manage channel** → **Connectors**.
+  </Step>
+
+<Step title="Add Incoming Webhook">
+  Find **Incoming Webhook** in the list, click **Add**. Give it a name (e.g. "Nora notifications")
+  and optionally upload an icon, then click **Create**.
+</Step>
+
+<Step title="Copy the webhook URL">
+  Teams generates a URL on `webhook.office.com`. Copy it — Microsoft only shows it once.
+</Step>
+
+  <Step title="Connect in Nora">
+    Paste the URL into Nora and click **Connect**. Nora validates that the URL is well-formed and points at a Microsoft webhook host, then stores it. **It does not send a test message** — that would deliver to the channel.
+  </Step>
+</Steps>
+
+## Verify the connection
+
+The **Test** button repeats the structural validation — it does not send a test message. To verify end-to-end, deploy your agent and trigger a notification.
+
+## Limitations
+
+- **Send-only.** Teams webhooks can't read messages or list channels. For two-way agent integrations, set up a Bot via the Microsoft Bot Framework instead.
+- **Per-channel.** Each webhook is bound to one channel. To post into multiple channels, create multiple integrations or use one with the channel ID encoded into your message routing.
+- **Microsoft is sunsetting Office 365 Connectors.** Plan to migrate to Power Automate / Workflows when Microsoft retires the legacy webhook URLs.
+
+## MCP server
+
+No MCP server — webhook integrations don't have a query surface.
+
+## Environment variables Nora injects
+
+| Variable            | Source               |
+| ------------------- | -------------------- |
+| `TEAMS_WEBHOOK_URL` | Incoming Webhook URL |

--- a/docs/guides/integrations/telegram.mdx
+++ b/docs/guides/integrations/telegram.mdx
@@ -1,0 +1,51 @@
+# Telegram
+
+> How to register a Telegram bot with BotFather and connect it to Nora.
+
+Telegram integrations let your agents send and receive messages via the [Bot API](https://core.telegram.org/bots/api). Nora authenticates with a bot token of the form `<bot_id>:<secret>`.
+
+## Where to apply for credentials
+
+Telegram doesn't have a developer console — bots are registered through a chatbot called **BotFather**:
+
+<Card title="@BotFather on Telegram" href="https://t.me/BotFather" icon="send" arrow>
+  https://t.me/BotFather
+</Card>
+
+## Connect in Nora
+
+<Steps>
+  <Step title="Talk to BotFather">
+    Open Telegram, search for `@BotFather`, and start a chat. Send `/newbot`, give your bot a name and a unique username ending in `bot` (e.g. `my_nora_bot`).
+  </Step>
+
+<Step title="Copy the token">
+  BotFather replies with an HTTP API token like `123456789:AAEbz...`. Copy it.
+</Step>
+
+  <Step title="(Optional) Find your operator user ID">
+    Send a message to your bot from your personal Telegram account, then visit `https://api.telegram.org/bot<token>/getUpdates`. Your `from.id` is the numeric user ID. Paste it into the **Operator User ID** field if your agent needs to know who's allowed to issue commands.
+  </Step>
+
+  <Step title="Connect in Nora">
+    Paste the token into Nora and click **Connect**. Nora calls `GET https://api.telegram.org/bot<token>/getMe` to verify the bot, then surfaces the bot's `@username`.
+  </Step>
+</Steps>
+
+## Verify the connection
+
+The **Test** button calls `getMe`. Common failures:
+
+- **`Invalid Telegram bot token format`** — the token doesn't match `<digits>:<id>`. Make sure you pasted the bot token, not a bare chat token or a webhook secret.
+- **401 Unauthorized** — the token was revoked. Send `/revoke` to BotFather and create a new one.
+
+## MCP server
+
+No official Telegram MCP server today. Community packages exist but aren't stable.
+
+## Environment variables Nora injects
+
+| Variable                    | Source                 |
+| --------------------------- | ---------------------- |
+| `TELEGRAM_BOT_TOKEN`        | Bot Token field        |
+| `OPERATOR_TELEGRAM_ID` | Operator User ID field |

--- a/docs/guides/integrations/twilio.mdx
+++ b/docs/guides/integrations/twilio.mdx
@@ -1,0 +1,59 @@
+# Twilio
+
+> Where to find your Twilio Account SID + Auth Token, and how to connect them to Nora.
+
+Twilio integrations let your agents send SMS, place voice calls, and message via WhatsApp / Programmable Messaging. Nora authenticates with HTTP Basic using your Account SID as the username and Auth Token as the password.
+
+## Where to apply for credentials
+
+Both values live on the Twilio Console dashboard:
+
+<Card title="Twilio Console" href="https://console.twilio.com/" icon="phone" arrow>
+  https://console.twilio.com/
+</Card>
+
+The dashboard shows the **Account SID** in plain text and reveals the **Auth Token** when you click the show/hide toggle. Copy both.
+
+## Connect in Nora
+
+<Steps>
+  <Step title="Open the Twilio integration">
+    From an agent's detail page, open the **Integrations** tab and find **Twilio**.
+  </Step>
+
+<Step title="Paste SID and Auth Token">
+  Paste the **Account SID** into its field and the **Auth Token** as the secret.
+</Step>
+
+<Step title="(Optional) Set the From number">
+  If your agent will send SMS, paste a Twilio phone number you've already provisioned (Phone Numbers
+  → Manage → Active numbers) into the **From Number** field.
+</Step>
+
+  <Step title="Connect">
+    Click **Connect**. Nora calls `GET https://api.twilio.com/2010-04-01/Accounts/<sid>.json` with HTTP Basic to verify the credentials. The card shows "Connected to Twilio" on success.
+  </Step>
+</Steps>
+
+## Verify the connection
+
+The **Test** button hits the same `/Accounts/<sid>.json` endpoint. Common failures:
+
+- **401 Unauthorized** — wrong SID or Auth Token. Note that **rotating the auth token** in the Twilio console invalidates the existing one immediately.
+- **404 Not Found** — wrong SID; double-check you copied the full string starting with `AC`.
+
+## API key alternative
+
+For production agents, prefer **API Keys** (Account → API keys & tokens → Create API key) over the Auth Token — they're scoped and revocable independently. Nora's current integration uses the Account SID + Auth Token shape; API key support can be added by setting a non-default username in the underlying basic-auth header.
+
+## MCP server
+
+There's a [twilio-labs/mcp](https://github.com/twilio-labs/mcp) project. It uses the same Account SID + Auth Token, so the env vars Nora injects work as input.
+
+## Environment variables Nora injects
+
+| Variable              | Source               |
+| --------------------- | -------------------- |
+| `TWILIO_AUTH_TOKEN`   | Auth Token field     |
+| `TWILIO_ACCOUNT_SID`  | Account SID field    |
+| `TWILIO_PHONE_NUMBER` | From Number (if set) |


### PR DESCRIPTION
## Summary

- Move 6 communication providers off the legacy switch onto strategy files: `discord`, `telegram`, `teams`, `email` (SMTP), `twilio`, `sendgrid`.
- Discord, Telegram, Twilio, SendGrid all hit live verification endpoints. Teams (webhook) and Email (SMTP) validate structure only — they can't safely call out from the control plane.
- Telegram preserves the legacy `OPERATOR_TELEGRAM_ID` env var name to avoid breaking deployed agents (initial provider draft used `TELEGRAM_OPERATOR_USER_ID`; reverted after `__tests__/integrations.test.ts` flagged it).
- Catalog `credentialsUrl` + `setupGuide` populated for all six. Per-provider docs cover where to apply for credentials, the connect flow, and limitations (e.g. Teams' send-only nature, Microsoft sunsetting Office 365 Connectors).

## Test plan

- [x] `npx prettier --write` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 693/693 passing (was 664; +29 tests across the six new files plus the env-name regression catch in `integrations.test.ts`)
- [ ] Manual dashboard pass per provider once merged