### PR TITLE
feat(integrations): migrate data/storage/search providers (12 providers)

### DIFF
--- a/backend-api/__tests__/providers/algoliaProvider.test.ts
+++ b/backend-api/__tests__/providers/algoliaProvider.test.ts
@@ -1,0 +1,54 @@
+// @ts-nocheck
+const { algoliaProvider } = require("../../integrations/providers/algolia");
+
+function deps(fetchImpl) {
+  return {
+    fetch: fetchImpl,
+    assertSafeUrl: async (u) => u,
+    encrypt: (s) => s,
+    decrypt: (s) => s,
+    ensureEncryptionConfigured: jest.fn(),
+    db: { query: jest.fn() },
+  };
+}
+
+describe("algoliaProvider", () => {
+  it("hits /1/keys on the app's DSN endpoint with both auth headers", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: true });
+    const result = await algoliaProvider.test(
+      { row: {}, token: "admin_x", config: { app_id: "APP123" } },
+      deps(fetchImpl),
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://APP123-dsn.algolia.net/1/keys",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "X-Algolia-Application-Id": "APP123",
+          "X-Algolia-API-Key": "admin_x",
+        }),
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects when app_id missing", async () => {
+    const result = await algoliaProvider.test(
+      { row: {}, token: "admin_x", config: {} },
+      deps(jest.fn()),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Application ID");
+  });
+
+  it("emits ALGOLIA_* env vars", () => {
+    const env = algoliaProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { app_id: "APP123", index_name: "products" },
+    });
+    expect(env).toEqual({
+      primary: "ALGOLIA_API_KEY",
+      config: { app_id: "ALGOLIA_APP_ID", index_name: "ALGOLIA_INDEX" },
+    });
+  });
+});

--- a/backend-api/__tests__/providers/dropboxProvider.test.ts
+++ b/backend-api/__tests__/providers/dropboxProvider.test.ts
@@ -1,0 +1,51 @@
+// @ts-nocheck
+const { dropboxProvider } = require("../../integrations/providers/dropbox");
+
+function deps(fetchImpl) {
+  return {
+    fetch: fetchImpl,
+    assertSafeUrl: async (u) => u,
+    encrypt: (s) => s,
+    decrypt: (s) => s,
+    ensureEncryptionConfigured: jest.fn(),
+    db: { query: jest.fn() },
+  };
+}
+
+describe("dropboxProvider", () => {
+  it("POSTs /users/get_current_account with Bearer token", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ name: { display_name: "Alice" } }),
+    });
+    const result = await dropboxProvider.test(
+      { row: {}, token: "tok", config: {} },
+      deps(fetchImpl),
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.dropboxapi.com/2/users/get_current_account",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ Authorization: "Bearer tok" }),
+      }),
+    );
+    expect(result).toEqual({ success: true, message: "Connected as Alice" });
+  });
+
+  it("returns success=false on 401", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: false, status: 401 });
+    const result = await dropboxProvider.test(
+      { row: {}, token: "bad", config: {} },
+      deps(fetchImpl),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Dropbox API returned 401");
+  });
+
+  it("emits DROPBOX_ACCESS_TOKEN as primary", () => {
+    expect(dropboxProvider.mapToEnv({ row: {}, token: null, config: {} })).toEqual({
+      primary: "DROPBOX_ACCESS_TOKEN",
+      config: {},
+    });
+  });
+});

--- a/backend-api/__tests__/providers/elasticsearchProvider.test.ts
+++ b/backend-api/__tests__/providers/elasticsearchProvider.test.ts
@@ -1,0 +1,71 @@
+// @ts-nocheck
+const { elasticsearchProvider } = require("../../integrations/providers/elasticsearch");
+
+function deps(fetchImpl) {
+  return {
+    fetch: fetchImpl,
+    assertSafeUrl: async (u) => u,
+    encrypt: (s) => s,
+    decrypt: (s) => s,
+    ensureEncryptionConfigured: jest.fn(),
+    db: { query: jest.fn() },
+  };
+}
+
+describe("elasticsearchProvider", () => {
+  it("hits the node URL anonymously when no username configured", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ cluster_name: "prod" }),
+    });
+    const result = await elasticsearchProvider.test(
+      { row: {}, token: "", config: { node_url: "https://es.example.com" } },
+      deps(fetchImpl),
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://es.example.com",
+      expect.objectContaining({ headers: {} }),
+    );
+    expect(result.message).toContain('"prod"');
+  });
+
+  it("uses HTTP Basic when username is configured", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ cluster_name: "prod" }),
+    });
+    await elasticsearchProvider.test(
+      {
+        row: {},
+        token: "pw",
+        config: { node_url: "https://es.example.com", username: "elastic" },
+      },
+      deps(fetchImpl),
+    );
+    const expected = "Basic " + Buffer.from("elastic:pw").toString("base64");
+    expect(fetchImpl.mock.calls[0][1].headers.Authorization).toBe(expected);
+  });
+
+  it("rejects empty node_url", async () => {
+    const result = await elasticsearchProvider.test(
+      { row: {}, token: "", config: {} },
+      deps(jest.fn()),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("node URL");
+  });
+
+  it("emits ELASTICSEARCH_* env vars", () => {
+    const env = elasticsearchProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { node_url: "u", username: "elastic", index: "logs" },
+    });
+    expect(env.primary).toBe("ELASTICSEARCH_PASSWORD");
+    expect(env.config).toEqual({
+      node_url: "ELASTICSEARCH_URL",
+      username: "ELASTICSEARCH_USERNAME",
+      index: "ELASTICSEARCH_INDEX",
+    });
+  });
+});

--- a/backend-api/__tests__/providers/firebaseProvider.test.ts
+++ b/backend-api/__tests__/providers/firebaseProvider.test.ts
@@ -1,0 +1,66 @@
+// @ts-nocheck
+const { firebaseProvider } = require("../../integrations/providers/firebase");
+
+const deps = {
+  fetch: jest.fn(),
+  assertSafeUrl: async (u) => u,
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+};
+
+const validSa = JSON.stringify({
+  client_email: "agent@my-proj.iam.gserviceaccount.com",
+  private_key: "-----BEGIN PRIVATE KEY-----\nXXX\n-----END PRIVATE KEY-----\n",
+  project_id: "my-proj",
+});
+
+describe("firebaseProvider", () => {
+  it("identifies as firebase / service_account", () => {
+    expect(firebaseProvider.id).toBe("firebase");
+    expect(firebaseProvider.authType).toBe("service_account");
+  });
+
+  it("accepts a valid service account JSON without making network calls", async () => {
+    const result = await firebaseProvider.test(
+      { row: {}, token: null, config: { service_account_json: validSa } },
+      deps,
+    );
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("my-proj");
+    expect(deps.fetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed JSON", async () => {
+    const result = await firebaseProvider.test(
+      { row: {}, token: null, config: { service_account_json: "not json" } },
+      deps,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("not valid JSON");
+  });
+
+  it("rejects JSON missing required keys", async () => {
+    const result = await firebaseProvider.test(
+      {
+        row: {},
+        token: null,
+        config: { service_account_json: JSON.stringify({ client_email: "x" }) },
+      },
+      deps,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("missing required keys");
+  });
+
+  it("emits GOOGLE_APPLICATION_CREDENTIALS_JSON with no primary", () => {
+    const env = firebaseProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { service_account_json: validSa },
+    });
+    expect(env.primary).toBeNull();
+    expect(env.config).toEqual({ service_account_json: "GOOGLE_APPLICATION_CREDENTIALS_JSON" });
+  });
+});

--- a/backend-api/__tests__/providers/googleDriveProvider.test.ts
+++ b/backend-api/__tests__/providers/googleDriveProvider.test.ts
@@ -1,0 +1,52 @@
+// @ts-nocheck
+const { googleDriveProvider } = require("../../integrations/providers/googleDrive");
+
+const deps = {
+  fetch: jest.fn(),
+  assertSafeUrl: async (u) => u,
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+};
+
+const validSa = JSON.stringify({
+  client_email: "agent@p.iam.gserviceaccount.com",
+  private_key: "-----BEGIN PRIVATE KEY-----\nx\n-----END PRIVATE KEY-----\n",
+  project_id: "p",
+});
+
+describe("googleDriveProvider", () => {
+  it("identifies as google-drive / service_account", () => {
+    expect(googleDriveProvider.id).toBe("google-drive");
+    expect(googleDriveProvider.authType).toBe("service_account");
+  });
+
+  it("validates service account JSON structurally", async () => {
+    const result = await googleDriveProvider.test(
+      { row: {}, token: null, config: { service_account_json: validSa } },
+      deps,
+    );
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("agent@p.iam.gserviceaccount.com");
+  });
+
+  it("rejects bad JSON", async () => {
+    const result = await googleDriveProvider.test(
+      { row: {}, token: null, config: { service_account_json: "{}" } },
+      deps,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("missing required keys");
+  });
+
+  it("emits GOOGLE_APPLICATION_CREDENTIALS_JSON", () => {
+    const env = googleDriveProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { service_account_json: validSa },
+    });
+    expect(env.primary).toBeNull();
+    expect(env.config.service_account_json).toBe("GOOGLE_APPLICATION_CREDENTIALS_JSON");
+  });
+});

--- a/backend-api/__tests__/providers/mongodbProvider.test.ts
+++ b/backend-api/__tests__/providers/mongodbProvider.test.ts
@@ -1,0 +1,52 @@
+// @ts-nocheck
+const { mongodbProvider } = require("../../integrations/providers/mongodb");
+
+const deps = {
+  fetch: jest.fn(),
+  assertSafeUrl: async (u) => u,
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+};
+
+describe("mongodbProvider", () => {
+  it("accepts mongodb:// URIs", async () => {
+    const result = await mongodbProvider.test(
+      { row: {}, token: "mongodb://user:pass@db.example.com:27017/mydb", config: {} },
+      deps,
+    );
+    expect(result.success).toBe(true);
+    expect(deps.fetch).not.toHaveBeenCalled();
+  });
+
+  it("accepts mongodb+srv:// URIs", async () => {
+    const result = await mongodbProvider.test(
+      { row: {}, token: "mongodb+srv://user:pass@cluster0.example.mongodb.net/mydb", config: {} },
+      deps,
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects empty connection strings", async () => {
+    const result = await mongodbProvider.test({ row: {}, token: "", config: {} }, deps);
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("required");
+  });
+
+  it("rejects non-mongodb schemes", async () => {
+    const result = await mongodbProvider.test(
+      { row: {}, token: "https://example.com", config: {} },
+      deps,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("mongodb://");
+  });
+
+  it("emits MONGODB_URI as primary", () => {
+    expect(mongodbProvider.mapToEnv({ row: {}, token: null, config: {} })).toEqual({
+      primary: "MONGODB_URI",
+      config: {},
+    });
+  });
+});

--- a/backend-api/__tests__/providers/pineconeProvider.test.ts
+++ b/backend-api/__tests__/providers/pineconeProvider.test.ts
@@ -1,0 +1,40 @@
+// @ts-nocheck
+const { pineconeProvider } = require("../../integrations/providers/pinecone");
+
+function deps(fetchImpl) {
+  return {
+    fetch: fetchImpl,
+    assertSafeUrl: async (u) => u,
+    encrypt: (s) => s,
+    decrypt: (s) => s,
+    ensureEncryptionConfigured: jest.fn(),
+    db: { query: jest.fn() },
+  };
+}
+
+describe("pineconeProvider", () => {
+  it("hits /indexes with Api-Key header", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: true });
+    const result = await pineconeProvider.test(
+      { row: {}, token: "pc_x", config: {} },
+      deps(fetchImpl),
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.pinecone.io/indexes",
+      expect.objectContaining({ headers: { "Api-Key": "pc_x" } }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("emits PINECONE_API_KEY + environment + index_name", () => {
+    const env = pineconeProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { environment: "us-east-1-aws", index_name: "vectors" },
+    });
+    expect(env).toEqual({
+      primary: "PINECONE_API_KEY",
+      config: { environment: "PINECONE_ENVIRONMENT", index_name: "PINECONE_INDEX" },
+    });
+  });
+});

--- a/backend-api/__tests__/providers/postgresqlProvider.test.ts
+++ b/backend-api/__tests__/providers/postgresqlProvider.test.ts
@@ -1,0 +1,57 @@
+// @ts-nocheck
+const { postgresqlProvider } = require("../../integrations/providers/postgresql");
+
+const deps = {
+  fetch: jest.fn(),
+  assertSafeUrl: async (u) => u,
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+};
+
+describe("postgresqlProvider", () => {
+  it("identifies as postgresql / credentials", () => {
+    expect(postgresqlProvider.id).toBe("postgresql");
+    expect(postgresqlProvider.authType).toBe("credentials");
+  });
+
+  it("accepts a complete config without making any network calls", async () => {
+    const result = await postgresqlProvider.test(
+      {
+        row: {},
+        token: "secret",
+        config: { host: "db.example.com", port: 5432, database: "mydb", user: "alice" },
+      },
+      deps,
+    );
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("db.example.com:5432/mydb");
+    expect(deps.fetch).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["host", { port: 5432, database: "d", user: "u" }],
+    ["port", { host: "h", port: 0, database: "d", user: "u" }],
+    ["database", { host: "h", port: 5432, user: "u" }],
+    ["user", { host: "h", port: 5432, database: "d" }],
+  ])("rejects when %s is missing", async (_, cfg) => {
+    const result = await postgresqlProvider.test({ row: {}, token: "secret", config: cfg }, deps);
+    expect(result.success).toBe(false);
+  });
+
+  it("emits PG* env vars from config", () => {
+    const env = postgresqlProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { host: "h", port: 5432, database: "d", user: "u" },
+    });
+    expect(env.primary).toBe("PGPASSWORD");
+    expect(env.config).toEqual({
+      host: "PGHOST",
+      port: "PGPORT",
+      database: "PGDATABASE",
+      user: "PGUSER",
+    });
+  });
+});

--- a/backend-api/__tests__/providers/redisProvider.test.ts
+++ b/backend-api/__tests__/providers/redisProvider.test.ts
@@ -1,0 +1,41 @@
+// @ts-nocheck
+const { redisProvider } = require("../../integrations/providers/redis");
+
+const deps = {
+  fetch: jest.fn(),
+  assertSafeUrl: async (u) => u,
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+};
+
+describe("redisProvider", () => {
+  it("accepts host + port without password (no-auth dev cluster)", async () => {
+    const result = await redisProvider.test(
+      { row: {}, token: "", config: { host: "redis.example.com", port: 6379 } },
+      deps,
+    );
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("redis.example.com:6379");
+  });
+
+  it("rejects missing host or port", async () => {
+    let result = await redisProvider.test({ row: {}, token: "", config: { port: 6379 } }, deps);
+    expect(result.success).toBe(false);
+    result = await redisProvider.test({ row: {}, token: "", config: { host: "h" } }, deps);
+    expect(result.success).toBe(false);
+  });
+
+  it("emits REDIS_HOST/PORT/PASSWORD", () => {
+    const env = redisProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { host: "h", port: 6379 },
+    });
+    expect(env).toEqual({
+      primary: "REDIS_PASSWORD",
+      config: { host: "REDIS_HOST", port: "REDIS_PORT" },
+    });
+  });
+});

--- a/backend-api/__tests__/providers/s3Provider.test.ts
+++ b/backend-api/__tests__/providers/s3Provider.test.ts
@@ -1,0 +1,53 @@
+// @ts-nocheck
+const { s3Provider } = require("../../integrations/providers/s3");
+
+const deps = {
+  fetch: jest.fn(),
+  assertSafeUrl: async (u) => u,
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+};
+
+describe("s3Provider", () => {
+  it("identifies as s3 / credentials", () => {
+    expect(s3Provider.id).toBe("s3");
+    expect(s3Provider.authType).toBe("credentials");
+  });
+
+  it("accepts access key + secret without making network calls", async () => {
+    const result = await s3Provider.test(
+      {
+        row: {},
+        token: "secret",
+        config: { access_key_id: "AKIA...", region: "us-west-2", bucket_name: "my-bucket" },
+      },
+      deps,
+    );
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("my-bucket");
+    expect(deps.fetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects when access key or secret missing", async () => {
+    let result = await s3Provider.test({ row: {}, token: "secret", config: {} }, deps);
+    expect(result.success).toBe(false);
+    result = await s3Provider.test({ row: {}, token: "", config: { access_key_id: "AKIA" } }, deps);
+    expect(result.success).toBe(false);
+  });
+
+  it("emits AWS_* env vars", () => {
+    const env = s3Provider.mapToEnv({
+      row: {},
+      token: null,
+      config: { access_key_id: "AKIA", region: "us-west-2", bucket_name: "b" },
+    });
+    expect(env.primary).toBe("AWS_SECRET_ACCESS_KEY");
+    expect(env.config).toEqual({
+      access_key_id: "AWS_ACCESS_KEY_ID",
+      region: "AWS_REGION",
+      bucket_name: "S3_BUCKET",
+    });
+  });
+});

--- a/backend-api/__tests__/providers/supabaseProvider.test.ts
+++ b/backend-api/__tests__/providers/supabaseProvider.test.ts
@@ -1,0 +1,58 @@
+// @ts-nocheck
+const { supabaseProvider } = require("../../integrations/providers/supabase");
+
+function deps(fetchImpl) {
+  return {
+    fetch: fetchImpl,
+    assertSafeUrl: async (u) => u,
+    encrypt: (s) => s,
+    decrypt: (s) => s,
+    ensureEncryptionConfigured: jest.fn(),
+    db: { query: jest.fn() },
+  };
+}
+
+describe("supabaseProvider", () => {
+  it("hits /rest/v1/ with apikey + Bearer headers", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: true });
+    const result = await supabaseProvider.test(
+      {
+        row: {},
+        token: "key",
+        config: { url: "https://abc.supabase.co" },
+      },
+      deps(fetchImpl),
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://abc.supabase.co/rest/v1/",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          apikey: "key",
+          Authorization: "Bearer key",
+        }),
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects when project URL missing", async () => {
+    const result = await supabaseProvider.test(
+      { row: {}, token: "k", config: {} },
+      deps(jest.fn()),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("URL");
+  });
+
+  it("emits SUPABASE_URL + SUPABASE_SERVICE_ROLE_KEY", () => {
+    const env = supabaseProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { url: "https://abc.supabase.co" },
+    });
+    expect(env).toEqual({
+      primary: "SUPABASE_SERVICE_ROLE_KEY",
+      config: { url: "SUPABASE_URL" },
+    });
+  });
+});

--- a/backend-api/__tests__/providers/weaviateProvider.test.ts
+++ b/backend-api/__tests__/providers/weaviateProvider.test.ts
@@ -1,0 +1,67 @@
+// @ts-nocheck
+const { weaviateProvider } = require("../../integrations/providers/weaviate");
+
+function deps(fetchImpl) {
+  return {
+    fetch: fetchImpl,
+    assertSafeUrl: async (u) => u,
+    encrypt: (s) => s,
+    decrypt: (s) => s,
+    ensureEncryptionConfigured: jest.fn(),
+    db: { query: jest.fn() },
+  };
+}
+
+describe("weaviateProvider", () => {
+  it("hits /v1/meta with Bearer token when api_key is set", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: "1.24.1" }),
+    });
+    const result = await weaviateProvider.test(
+      {
+        row: {},
+        token: "wv_x",
+        config: { host: "https://cluster.weaviate.network" },
+      },
+      deps(fetchImpl),
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://cluster.weaviate.network/v1/meta",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer wv_x" }),
+      }),
+    );
+    expect(result.message).toContain("1.24.1");
+  });
+
+  it("anonymous when no api_key", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ version: "1.0" }),
+    });
+    await weaviateProvider.test(
+      { row: {}, token: "", config: { host: "https://c.weaviate.network" } },
+      deps(fetchImpl),
+    );
+    expect(fetchImpl.mock.calls[0][1].headers.Authorization).toBeUndefined();
+  });
+
+  it("rejects when host missing", async () => {
+    const result = await weaviateProvider.test({ row: {}, token: "", config: {} }, deps(jest.fn()));
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("cluster URL");
+  });
+
+  it("emits WEAVIATE_URL + WEAVIATE_API_KEY", () => {
+    const env = weaviateProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { host: "https://c.weaviate.network" },
+    });
+    expect(env).toEqual({
+      primary: "WEAVIATE_API_KEY",
+      config: { host: "WEAVIATE_URL" },
+    });
+  });
+});

--- a/backend-api/integrations/catalog/catalog.json
+++ b/backend-api/integrations/catalog/catalog.json
@@ -438,6 +438,21 @@
       { "key": "user", "label": "Username", "type": "text", "required": true },
       { "key": "password", "label": "Password", "type": "password", "required": true }
     ],
+    "credentialsUrl": "https://www.postgresql.org/docs/current/auth-password.html",
+    "setupGuide": {
+      "steps": [
+        "Provision a Postgres user with the privileges your agent needs (avoid using the superuser).",
+        "Get the host, port, database name, username, and password from your provider (RDS / Cloud SQL / Supabase / self-hosted).",
+        "The Postgres host must be reachable from the agent's network — Nora doesn't tunnel."
+      ]
+    },
+    "mcp": {
+      "available": true,
+      "transport": "stdio",
+      "npmPackage": "@modelcontextprotocol/server-postgres",
+      "docsUrl": "https://github.com/modelcontextprotocol/servers/tree/main/src/postgres",
+      "notes": "Reads connection details from a single POSTGRES_URL env var."
+    },
     "capabilities": ["read", "write"]
   },
   {
@@ -447,6 +462,15 @@
     "category": "data",
     "description": "Connect to MongoDB for document storage and querying",
     "authType": "credentials",
+    "credentialsUrl": "https://www.mongodb.com/docs/manual/reference/connection-string/",
+    "setupGuide": {
+      "steps": [
+        "From MongoDB Atlas (or your self-hosted setup), build a connection string of the form mongodb+srv://<user>:<pass>@<host>/<db>.",
+        "URL-encode any special characters in username/password.",
+        "Test it locally with mongosh or your driver before pasting."
+      ]
+    },
+    "mcp": { "available": false },
     "configFields": [
       {
         "key": "connection_string",
@@ -470,7 +494,16 @@
       { "key": "port", "label": "Port", "type": "number", "required": true },
       { "key": "password", "label": "Password", "type": "password", "required": false }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://redis.io/docs/latest/operate/oss_and_stack/management/security/acl/",
+    "setupGuide": {
+      "steps": [
+        "Get host and port from your Redis provider (Redis Cloud, ElastiCache, Upstash, self-hosted).",
+        "If your Redis uses ACL or requires-pass, supply the password.",
+        "For Redis Cloud / Upstash, use the rediss:// (TLS) endpoint and treat the AUTH password as the credential."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "datadog",
@@ -689,7 +722,23 @@
       },
       { "key": "folder_id", "label": "Default Folder ID", "type": "text", "required": false }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://console.cloud.google.com/iam-admin/serviceaccounts",
+    "setupGuide": {
+      "steps": [
+        "Open Google Cloud Console → IAM & Admin → Service Accounts.",
+        "Create a service account (or pick an existing one), then create a JSON key (Keys → Add Key → JSON).",
+        "Enable the Drive API for the project (APIs & Services → Library → Google Drive API).",
+        "Share the Drive folders the agent should access with the service account's client_email."
+      ]
+    },
+    "mcp": {
+      "available": true,
+      "transport": "stdio",
+      "npmPackage": "@modelcontextprotocol/server-gdrive",
+      "docsUrl": "https://github.com/modelcontextprotocol/servers/tree/main/src/gdrive",
+      "notes": "Reads GOOGLE_APPLICATION_CREDENTIALS pointing at the SA JSON file."
+    }
   },
   {
     "id": "dropbox",
@@ -701,7 +750,18 @@
     "configFields": [
       { "key": "access_token", "label": "Access Token", "type": "password", "required": true }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://www.dropbox.com/developers/apps",
+    "setupGuide": {
+      "steps": [
+        "Open the Dropbox App Console and click Create app.",
+        "Choose Scoped access, App folder or Full Dropbox, give it a name.",
+        "Under Permissions, tick the scopes your agent needs (files.content.read, files.content.write, etc.) and submit.",
+        "On the Settings tab, generate an OAuth 2 Access token (or use a refresh token + auth code flow for production)."
+      ],
+      "scopes": ["files.content.read", "files.content.write", "files.metadata.read"]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "s3",
@@ -721,7 +781,17 @@
       { "key": "bucket", "label": "Default Bucket", "type": "text", "required": false },
       { "key": "region", "label": "Region", "type": "text", "required": false }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://console.aws.amazon.com/iam/home?#/users",
+    "setupGuide": {
+      "steps": [
+        "In AWS Console → IAM, create a programmatic-access user (or use an existing one).",
+        "Attach a policy that grants the S3 actions your agent needs (e.g. AmazonS3ReadOnlyAccess, or a tighter custom policy).",
+        "Create an access key for the user and copy the Access Key ID + Secret Access Key.",
+        "Enter the default bucket and region your agent should target."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "stripe",
@@ -1014,7 +1084,16 @@
       { "key": "password", "label": "Password", "type": "password", "required": false },
       { "key": "index", "label": "Default Index", "type": "text", "required": false }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://www.elastic.co/guide/en/elasticsearch/reference/current/built-in-users.html",
+    "setupGuide": {
+      "steps": [
+        "Get the cluster's HTTPS endpoint (Elastic Cloud: Deployments → Endpoints; self-hosted: your nginx/ingress URL).",
+        "Create a dedicated user with the right roles (e.g. read for search-only agents, kibana_admin for management).",
+        "If your cluster has security disabled (dev), leave username/password blank — the test will hit the node anonymously."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "pinecone",
@@ -1028,7 +1107,16 @@
       { "key": "environment", "label": "Environment", "type": "text", "required": true },
       { "key": "index_name", "label": "Index Name", "type": "text", "required": false }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://app.pinecone.io/organizations/-/projects/-/keys",
+    "setupGuide": {
+      "steps": [
+        "Sign in to Pinecone at app.pinecone.io.",
+        "Open API Keys, click Create API Key, copy the value.",
+        "Note your environment (us-east-1-aws, gcp-starter, etc.) from the project home page."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "weaviate",
@@ -1041,7 +1129,16 @@
       { "key": "host", "label": "Cluster URL", "type": "url", "required": true },
       { "key": "api_key", "label": "API Key", "type": "password", "required": false }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://console.weaviate.cloud/dashboard",
+    "setupGuide": {
+      "steps": [
+        "Open Weaviate Cloud Console (or your self-hosted instance).",
+        "Copy the cluster URL (looks like https://your-cluster.weaviate.network).",
+        "If the cluster uses API-key auth, generate one in the cluster settings — leave blank for anonymous clusters."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "supabase",
@@ -1054,7 +1151,22 @@
       { "key": "url", "label": "Project URL", "type": "url", "required": true },
       { "key": "anon_key", "label": "Anon/Service Key", "type": "password", "required": true }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://app.supabase.com/project/_/settings/api",
+    "setupGuide": {
+      "steps": [
+        "Open your Supabase project's API settings.",
+        "Copy the Project URL (https://<ref>.supabase.co).",
+        "Copy the service_role key for full DB access, or the anon key for client-style access — paste whichever fits your agent's blast radius."
+      ]
+    },
+    "mcp": {
+      "available": true,
+      "transport": "stdio",
+      "npmPackage": "@supabase/mcp-server-supabase",
+      "docsUrl": "https://github.com/supabase-community/supabase-mcp",
+      "notes": "Official-track MCP server for Supabase by the community."
+    }
   },
   {
     "id": "firebase",
@@ -1072,7 +1184,17 @@
       },
       { "key": "database_url", "label": "Database URL", "type": "url", "required": false }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://console.firebase.google.com/",
+    "setupGuide": {
+      "steps": [
+        "Open Firebase Console → Project Settings → Service accounts.",
+        "Click Generate new private key — Firebase downloads a JSON file.",
+        "Paste the entire JSON contents into the Service Account JSON field.",
+        "(Realtime Database only) Copy the database URL from the Realtime Database tab."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "twilio",
@@ -1403,6 +1525,15 @@
       { "key": "admin_api_key", "label": "Admin API Key", "type": "password", "required": true },
       { "key": "index_name", "label": "Default Index", "type": "text", "required": false }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://dashboard.algolia.com/account/api-keys/all",
+    "setupGuide": {
+      "steps": [
+        "Open the Algolia dashboard → API Keys.",
+        "Copy the Application ID.",
+        "For full management access, use the Admin API Key. For read-only agents, generate a new key with Search-only ACLs and use that instead."
+      ]
+    },
+    "mcp": { "available": false }
   }
 ]

--- a/backend-api/integrations/index.ts
+++ b/backend-api/integrations/index.ts
@@ -55,6 +55,18 @@ export { teamsProvider } from "./providers/teams";
 export { emailProvider } from "./providers/email";
 export { twilioProvider } from "./providers/twilio";
 export { sendgridProvider } from "./providers/sendgrid";
+export { postgresqlProvider } from "./providers/postgresql";
+export { mongodbProvider } from "./providers/mongodb";
+export { redisProvider } from "./providers/redis";
+export { supabaseProvider } from "./providers/supabase";
+export { firebaseProvider } from "./providers/firebase";
+export { googleDriveProvider } from "./providers/googleDrive";
+export { dropboxProvider } from "./providers/dropbox";
+export { s3Provider } from "./providers/s3";
+export { elasticsearchProvider } from "./providers/elasticsearch";
+export { pineconeProvider } from "./providers/pinecone";
+export { weaviateProvider } from "./providers/weaviate";
+export { algoliaProvider } from "./providers/algolia";
 
 // The orchestration service is the recommended import for callers that
 // need the high-level operations (connect, list, test, sync, env-vars).

--- a/backend-api/integrations/providers/algolia.ts
+++ b/backend-api/integrations/providers/algolia.ts
@@ -1,0 +1,39 @@
+// Algolia provider — Application ID + Admin API key. The /1/keys endpoint
+// returns the list of API keys in the application; calling it confirms
+// both the app ID and the admin key are valid.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const algoliaProvider: Provider = {
+  id: "algolia",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      const appId = String(config.app_id || "").trim();
+      if (!appId) throw new Error("Algolia Application ID not configured");
+      const res = await deps.fetch(`https://${appId}-dsn.algolia.net/1/keys`, {
+        headers: { "X-Algolia-Application-Id": appId, "X-Algolia-API-Key": ctx.token ?? "" },
+      });
+      if (!res.ok) throw new Error(`Algolia API returned ${res.status}`);
+      return { success: true, message: "Connected to Algolia" };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.app_id) configEnv.app_id = "ALGOLIA_APP_ID";
+    if (config.index_name) configEnv.index_name = "ALGOLIA_INDEX";
+    return { primary: "ALGOLIA_API_KEY", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/dropbox.ts
+++ b/backend-api/integrations/providers/dropbox.ts
@@ -1,0 +1,36 @@
+// Dropbox provider — Bearer access token. POSTs the documented
+// /users/get_current_account endpoint to verify the token.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const dropboxProvider: Provider = {
+  id: "dropbox",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const res = await deps.fetch("https://api.dropboxapi.com/2/users/get_current_account", {
+        method: "POST",
+        headers: { Authorization: `Bearer ${ctx.token ?? ""}` },
+      });
+      if (!res.ok) throw new Error(`Dropbox API returned ${res.status}`);
+      const data: any = await res.json();
+      return {
+        success: true,
+        message: `Connected as ${data.name?.display_name || "verified"}`,
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(): EnvMapping {
+    return { primary: "DROPBOX_ACCESS_TOKEN", config: {} };
+  },
+};

--- a/backend-api/integrations/providers/elasticsearch.ts
+++ b/backend-api/integrations/providers/elasticsearch.ts
@@ -1,0 +1,47 @@
+// Elasticsearch provider — credentials shape, optional username (Basic
+// auth) or no auth at all (dev clusters). The connectivity test hits the
+// node URL and reads the cluster_name from Elasticsearch's root response.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const elasticsearchProvider: Provider = {
+  id: "elasticsearch",
+  authType: "credentials",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      const rawUrl = config.node_url;
+      if (!rawUrl) throw new Error("Elasticsearch node URL not configured");
+      const nodeUrl = await deps.assertSafeUrl(String(rawUrl), "Elasticsearch node URL");
+      const headers: Record<string, string> = {};
+      if (config.username) {
+        headers.Authorization = `Basic ${Buffer.from(`${config.username}:${ctx.token ?? ""}`).toString("base64")}`;
+      }
+      const res = await deps.fetch(nodeUrl, { headers });
+      if (!res.ok) throw new Error(`Elasticsearch returned ${res.status}`);
+      const data: any = await res.json();
+      return {
+        success: true,
+        message: `Connected to cluster "${data.cluster_name || "unknown"}"`,
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.node_url) configEnv.node_url = "ELASTICSEARCH_URL";
+    if (config.username) configEnv.username = "ELASTICSEARCH_USERNAME";
+    if (config.index) configEnv.index = "ELASTICSEARCH_INDEX";
+    return { primary: "ELASTICSEARCH_PASSWORD", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/firebase.ts
+++ b/backend-api/integrations/providers/firebase.ts
@@ -1,0 +1,52 @@
+// Firebase provider — service-account JSON. test() validates the JSON
+// parses and contains the keys Google's auth libraries expect
+// (client_email + private_key + project_id), without making any
+// network call.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+} from "../types/provider";
+
+const REQUIRED_SA_KEYS = ["client_email", "private_key", "project_id"] as const;
+
+export const firebaseProvider: Provider = {
+  id: "firebase",
+  authType: "service_account",
+
+  async test(ctx: DecryptedIntegration): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      const raw = String(config.service_account_json || "").trim();
+      if (!raw) throw new Error("Firebase service account JSON is required");
+      let parsed: any;
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        throw new Error("Firebase service account JSON is not valid JSON");
+      }
+      const missing = REQUIRED_SA_KEYS.filter((k) => !parsed[k]);
+      if (missing.length > 0) {
+        throw new Error(`Service account JSON is missing required keys: ${missing.join(", ")}`);
+      }
+      return {
+        success: true,
+        message: `Service account stored for project ${parsed.project_id}`,
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.service_account_json) {
+      configEnv.service_account_json = "GOOGLE_APPLICATION_CREDENTIALS_JSON";
+    }
+    if (config.project_id) configEnv.project_id = "FIREBASE_PROJECT_ID";
+    return { primary: null, config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/googleDrive.ts
+++ b/backend-api/integrations/providers/googleDrive.ts
@@ -1,0 +1,51 @@
+// Google Drive provider — service-account JSON. Same validation shape as
+// Firebase — the agent runtime drops the JSON onto disk and points
+// GOOGLE_APPLICATION_CREDENTIALS at it.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+} from "../types/provider";
+
+const REQUIRED_SA_KEYS = ["client_email", "private_key", "project_id"] as const;
+
+export const googleDriveProvider: Provider = {
+  id: "google-drive",
+  authType: "service_account",
+
+  async test(ctx: DecryptedIntegration): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      const raw = String(config.service_account_json || "").trim();
+      if (!raw) throw new Error("Google Drive service account JSON is required");
+      let parsed: any;
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        throw new Error("Service account JSON is not valid JSON");
+      }
+      const missing = REQUIRED_SA_KEYS.filter((k) => !parsed[k]);
+      if (missing.length > 0) {
+        throw new Error(`Service account JSON is missing required keys: ${missing.join(", ")}`);
+      }
+      return {
+        success: true,
+        message: `Service account stored (${parsed.client_email})`,
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.service_account_json) {
+      configEnv.service_account_json = "GOOGLE_APPLICATION_CREDENTIALS_JSON";
+    }
+    if (config.shared_drive_id) configEnv.shared_drive_id = "GOOGLE_DRIVE_SHARED_DRIVE_ID";
+    return { primary: null, config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/legacy/connectivityTests.ts
+++ b/backend-api/integrations/providers/legacy/connectivityTests.ts
@@ -169,20 +169,7 @@ function buildConnectivityTests(integration, token, deps) {
       const data = await res.json();
       return { success: true, message: `Connected (${data.account?.email || "verified"})` };
     },
-    supabase: async () => {
-      const config =
-        typeof integration.config === "string"
-          ? JSON.parse(integration.config)
-          : integration.config || {};
-      const rawUrl = config.url;
-      if (!rawUrl) throw new Error("Supabase project URL not configured");
-      const url = await assertSafeUrl(rawUrl, "Supabase URL");
-      const res = await fetch(`${url}/rest/v1/`, {
-        headers: { apikey: token, Authorization: `Bearer ${token}` },
-      });
-      if (!res.ok) throw new Error(`Supabase API returned ${res.status}`);
-      return { success: true, message: "Connected to Supabase" };
-    },
+    // supabase → migrated to providers/supabase.ts
     stripe: async () => {
       const res = await fetch("https://api.stripe.com/v1/balance", {
         headers: { Authorization: `Bearer ${token}` },
@@ -223,43 +210,9 @@ function buildConnectivityTests(integration, token, deps) {
       const data = await res.json();
       return { success: true, message: `Connected as ${data.user?.name || "verified"}` };
     },
-    elasticsearch: async () => {
-      const config =
-        typeof integration.config === "string"
-          ? JSON.parse(integration.config)
-          : integration.config || {};
-      const rawUrl = config.node_url;
-      if (!rawUrl) throw new Error("Elasticsearch node URL not configured");
-      const nodeUrl = await assertSafeUrl(rawUrl, "Elasticsearch node URL");
-      const headers = {};
-      if (config.username) {
-        headers.Authorization = `Basic ${Buffer.from(`${config.username}:${token}`).toString("base64")}`;
-      }
-      const res = await fetch(nodeUrl, { headers });
-      if (!res.ok) throw new Error(`Elasticsearch returned ${res.status}`);
-      const data = await res.json();
-      return { success: true, message: `Connected to cluster "${data.cluster_name || "unknown"}"` };
-    },
-    pinecone: async () => {
-      const res = await fetch("https://api.pinecone.io/indexes", {
-        headers: { "Api-Key": token },
-      });
-      if (!res.ok) throw new Error(`Pinecone API returned ${res.status}`);
-      return { success: true, message: "Connected to Pinecone" };
-    },
-    algolia: async () => {
-      const config =
-        typeof integration.config === "string"
-          ? JSON.parse(integration.config)
-          : integration.config || {};
-      const appId = config.app_id;
-      if (!appId) throw new Error("Algolia Application ID not configured");
-      const res = await fetch(`https://${appId}-dsn.algolia.net/1/keys`, {
-        headers: { "X-Algolia-Application-Id": appId, "X-Algolia-API-Key": token },
-      });
-      if (!res.ok) throw new Error(`Algolia API returned ${res.status}`);
-      return { success: true, message: "Connected to Algolia" };
-    },
+    // elasticsearch → migrated to providers/elasticsearch.ts
+    // pinecone → migrated to providers/pinecone.ts
+    // algolia → migrated to providers/algolia.ts
     // vercel → migrated to providers/vercel.ts
     // circleci → migrated to providers/circleci.ts
     // terraform → migrated to providers/terraform.ts
@@ -287,15 +240,7 @@ function buildConnectivityTests(integration, token, deps) {
       return { success: true, message: `Connected as ${data.user?.name || "verified"}` };
     },
     // jenkins → migrated to providers/jenkins.ts
-    dropbox: async () => {
-      const res = await fetch("https://api.dropboxapi.com/2/users/get_current_account", {
-        method: "POST",
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (!res.ok) throw new Error(`Dropbox API returned ${res.status}`);
-      const data = await res.json();
-      return { success: true, message: `Connected as ${data.name?.display_name || "verified"}` };
-    },
+    // dropbox → migrated to providers/dropbox.ts
     // twilio → migrated to providers/twilio.ts
     // telegram → migrated to providers/telegram.ts
     shopify: async () => {

--- a/backend-api/integrations/providers/legacy/envMaps.ts
+++ b/backend-api/integrations/providers/legacy/envMaps.ts
@@ -27,12 +27,12 @@ const INTEGRATION_ENV_MAP = {
   stripe: "STRIPE_SECRET_KEY",
   hubspot: "HUBSPOT_ACCESS_TOKEN",
   pipedrive: "PIPEDRIVE_API_KEY",
-  pinecone: "PINECONE_API_KEY",
+  // pinecone → migrated to providers/pinecone.ts
   // vercel → migrated to providers/vercel.ts
   // circleci → migrated to providers/circleci.ts
   // terraform → migrated to providers/terraform.ts
   pagerduty: "PAGERDUTY_TOKEN",
-  dropbox: "DROPBOX_ACCESS_TOKEN",
+  // dropbox → migrated to providers/dropbox.ts
   // twilio → migrated to providers/twilio.ts
   // telegram → migrated to providers/telegram.ts
   shopify: "SHOPIFY_ACCESS_TOKEN",
@@ -41,7 +41,7 @@ const INTEGRATION_ENV_MAP = {
   salesforce: "SALESFORCE_ACCESS_TOKEN",
   // twitter → migrated to providers/twitter.ts
   digitalocean: "DIGITALOCEAN_TOKEN",
-  algolia: "ALGOLIA_API_KEY",
+  // algolia → migrated to providers/algolia.ts
   clickup: "CLICKUP_API_KEY",
   monday: "MONDAY_API_KEY",
   zendesk: "ZENDESK_API_TOKEN",
@@ -53,24 +53,24 @@ const INTEGRATION_ENV_MAP = {
   grafana: "GRAFANA_TOKEN",
   woocommerce: "WOOCOMMERCE_SECRET_KEY",
   trello: "TRELLO_TOKEN",
-  elasticsearch: "ELASTICSEARCH_PASSWORD",
-  supabase: "SUPABASE_SERVICE_ROLE_KEY",
+  // elasticsearch → migrated to providers/elasticsearch.ts
+  // supabase → migrated to providers/supabase.ts
   facebook: "FACEBOOK_ACCESS_TOKEN",
   // Cloud / infra
   aws: "AWS_SECRET_ACCESS_KEY",
   azure: "AZURE_CLIENT_SECRET",
-  s3: "S3_SECRET_ACCESS_KEY",
+  // s3 → migrated to providers/s3.ts
   // Databases
-  mongodb: "MONGODB_URI",
-  redis: "REDIS_PASSWORD",
-  postgresql: "PGPASSWORD",
+  // mongodb → migrated to providers/mongodb.ts
+  // redis → migrated to providers/redis.ts
+  // postgresql → migrated to providers/postgresql.ts
   // Payments
   paypal: "PAYPAL_CLIENT_SECRET",
   // Analytics / automation
   segment: "SEGMENT_WRITE_KEY",
   mixpanel: "MIXPANEL_API_SECRET",
   // Vector DBs
-  weaviate: "WEAVIATE_API_KEY",
+  // weaviate → migrated to providers/weaviate.ts
   // Communication
   // email → migrated to providers/email.ts
   // Automation webhooks have no token; webhook_url is in INTEGRATION_CONFIG_ENV_MAP.
@@ -104,35 +104,18 @@ const INTEGRATION_CONFIG_ENV_MAP = {
   "gcp.project_id": "GCP_PROJECT_ID",
   "azure.tenant_id": "AZURE_TENANT_ID",
   "azure.client_id": "AZURE_CLIENT_ID",
-  // Storage
-  "s3.access_key_id": "S3_ACCESS_KEY_ID",
-  "s3.region": "S3_REGION",
-  "s3.bucket": "S3_BUCKET",
-  "google-drive.service_account_json": "GOOGLE_DRIVE_SA_JSON",
-  "google-drive.folder_id": "GOOGLE_DRIVE_FOLDER_ID",
-  // Databases
-  "postgresql.host": "PGHOST",
-  "postgresql.port": "PGPORT",
-  "postgresql.database": "PGDATABASE",
-  "postgresql.user": "PGUSER",
-  "mongodb.database": "MONGODB_DATABASE",
-  "redis.host": "REDIS_HOST",
-  "redis.port": "REDIS_PORT",
-  "redis.password": "REDIS_PASSWORD",
-  "supabase.url": "SUPABASE_URL",
-  "firebase.service_account_json": "FIREBASE_SA_JSON",
-  "firebase.database_url": "FIREBASE_DATABASE_URL",
-  "elasticsearch.node_url": "ELASTICSEARCH_URL",
-  "elasticsearch.username": "ELASTICSEARCH_USERNAME",
-  "elasticsearch.password": "ELASTICSEARCH_PASSWORD",
-  "elasticsearch.index": "ELASTICSEARCH_INDEX",
-  "weaviate.host": "WEAVIATE_HOST",
-  "weaviate.api_key": "WEAVIATE_API_KEY",
-  // Search
-  "pinecone.environment": "PINECONE_ENVIRONMENT",
-  "pinecone.index_name": "PINECONE_INDEX",
-  "algolia.app_id": "ALGOLIA_APP_ID",
-  "algolia.index_name": "ALGOLIA_INDEX",
+  // Storage / Databases / Search — all migrated to per-provider strategies:
+  //   s3 → providers/s3.ts
+  //   google-drive → providers/googleDrive.ts
+  //   postgresql → providers/postgresql.ts
+  //   mongodb → providers/mongodb.ts
+  //   redis → providers/redis.ts
+  //   supabase → providers/supabase.ts
+  //   firebase → providers/firebase.ts
+  //   elasticsearch → providers/elasticsearch.ts
+  //   weaviate → providers/weaviate.ts
+  //   pinecone → providers/pinecone.ts
+  //   algolia → providers/algolia.ts
   // Monitoring
   "datadog.app_key": "DD_APP_KEY",
   "datadog.site": "DD_SITE",

--- a/backend-api/integrations/providers/mongodb.ts
+++ b/backend-api/integrations/providers/mongodb.ts
@@ -1,0 +1,42 @@
+// MongoDB provider — connection string. The legacy schema uses
+// `connection_string` as a single password field, so the URI itself is
+// the credential. test() validates the URI parses and uses an mongodb://
+// or mongodb+srv:// scheme.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+} from "../types/provider";
+
+export const mongodbProvider: Provider = {
+  id: "mongodb",
+  authType: "credentials",
+
+  async test(ctx: DecryptedIntegration): Promise<ConnectivityResult> {
+    try {
+      const uri = String(ctx.token || "").trim();
+      if (!uri) throw new Error("MongoDB connection string is required");
+      let parsed: URL;
+      try {
+        parsed = new URL(uri);
+      } catch {
+        throw new Error("MongoDB connection string is not a valid URI");
+      }
+      if (!/^mongodb(\+srv)?:$/.test(parsed.protocol)) {
+        throw new Error("MongoDB URI must use mongodb:// or mongodb+srv:// scheme");
+      }
+      return {
+        success: true,
+        message: `Connection string stored — connectivity not verified (${parsed.hostname})`,
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(): EnvMapping {
+    return { primary: "MONGODB_URI", config: {} };
+  },
+};

--- a/backend-api/integrations/providers/pinecone.ts
+++ b/backend-api/integrations/providers/pinecone.ts
@@ -1,0 +1,34 @@
+// Pinecone provider — Api-Key header.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const pineconeProvider: Provider = {
+  id: "pinecone",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const res = await deps.fetch("https://api.pinecone.io/indexes", {
+        headers: { "Api-Key": ctx.token ?? "" },
+      });
+      if (!res.ok) throw new Error(`Pinecone API returned ${res.status}`);
+      return { success: true, message: "Connected to Pinecone" };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.environment) configEnv.environment = "PINECONE_ENVIRONMENT";
+    if (config.index_name) configEnv.index_name = "PINECONE_INDEX";
+    return { primary: "PINECONE_API_KEY", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/postgresql.ts
+++ b/backend-api/integrations/providers/postgresql.ts
@@ -1,0 +1,44 @@
+// PostgreSQL provider — credentials shape (host/port/database/user/password).
+// Connectivity isn't validated from the control plane (databases are
+// usually behind a private network). The agent runtime opens the
+// connection using the standard PG* env vars.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+} from "../types/provider";
+
+export const postgresqlProvider: Provider = {
+  id: "postgresql",
+  authType: "credentials",
+
+  async test(ctx: DecryptedIntegration): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      if (!config.host) throw new Error("PostgreSQL host is required");
+      const port = Number(config.port);
+      if (!port || port < 1 || port > 65535) throw new Error("PostgreSQL port must be 1–65535");
+      if (!config.database) throw new Error("PostgreSQL database is required");
+      if (!config.user) throw new Error("PostgreSQL user is required");
+      if (!ctx.token) throw new Error("PostgreSQL password is required");
+      return {
+        success: true,
+        message: `Credentials stored — connectivity not verified (${config.host}:${port}/${config.database})`,
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.host) configEnv.host = "PGHOST";
+    if (config.port !== undefined) configEnv.port = "PGPORT";
+    if (config.database) configEnv.database = "PGDATABASE";
+    if (config.user) configEnv.user = "PGUSER";
+    return { primary: "PGPASSWORD", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/redis.ts
+++ b/backend-api/integrations/providers/redis.ts
@@ -1,0 +1,38 @@
+// Redis provider — credentials shape. Password is optional (Redis allows
+// no-auth setups for trusted internal networks). Connectivity not
+// validated from the control plane.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+} from "../types/provider";
+
+export const redisProvider: Provider = {
+  id: "redis",
+  authType: "credentials",
+
+  async test(ctx: DecryptedIntegration): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      if (!config.host) throw new Error("Redis host is required");
+      const port = Number(config.port);
+      if (!port || port < 1 || port > 65535) throw new Error("Redis port must be 1–65535");
+      return {
+        success: true,
+        message: `Credentials stored — connectivity not verified (${config.host}:${port})`,
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.host) configEnv.host = "REDIS_HOST";
+    if (config.port !== undefined) configEnv.port = "REDIS_PORT";
+    return { primary: "REDIS_PASSWORD", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/s3.ts
+++ b/backend-api/integrations/providers/s3.ts
@@ -1,0 +1,38 @@
+// Amazon S3 provider — credentials shape (access key + secret + region +
+// bucket). Connectivity not validated from the control plane; the agent
+// uses the AWS SDK with the standard env vars at runtime.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+} from "../types/provider";
+
+export const s3Provider: Provider = {
+  id: "s3",
+  authType: "credentials",
+
+  async test(ctx: DecryptedIntegration): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      if (!config.access_key_id) throw new Error("S3 access key ID is required");
+      if (!ctx.token) throw new Error("S3 secret access key is required");
+      return {
+        success: true,
+        message: `Credentials stored — connectivity not verified${config.bucket_name ? ` (${config.bucket_name})` : ""}`,
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.access_key_id) configEnv.access_key_id = "AWS_ACCESS_KEY_ID";
+    if (config.region) configEnv.region = "AWS_REGION";
+    if (config.bucket_name) configEnv.bucket_name = "S3_BUCKET";
+    return { primary: "AWS_SECRET_ACCESS_KEY", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/supabase.ts
+++ b/backend-api/integrations/providers/supabase.ts
@@ -1,0 +1,37 @@
+// Supabase provider — project URL + anon/service key.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const supabaseProvider: Provider = {
+  id: "supabase",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      const rawUrl = config.url;
+      if (!rawUrl) throw new Error("Supabase project URL not configured");
+      const url = await deps.assertSafeUrl(String(rawUrl), "Supabase URL");
+      const res = await deps.fetch(`${url}/rest/v1/`, {
+        headers: { apikey: ctx.token ?? "", Authorization: `Bearer ${ctx.token ?? ""}` },
+      });
+      if (!res.ok) throw new Error(`Supabase API returned ${res.status}`);
+      return { success: true, message: "Connected to Supabase" };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.url) configEnv.url = "SUPABASE_URL";
+    return { primary: "SUPABASE_SERVICE_ROLE_KEY", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/weaviate.ts
+++ b/backend-api/integrations/providers/weaviate.ts
@@ -1,0 +1,44 @@
+// Weaviate provider — cluster URL + optional API key (anonymous read is
+// possible on some clusters). The connectivity test hits the cluster's
+// /.well-known/openid-configuration which is exposed by Weaviate Cloud
+// and self-hosted clusters alike.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const weaviateProvider: Provider = {
+  id: "weaviate",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      const rawUrl = config.host;
+      if (!rawUrl) throw new Error("Weaviate cluster URL not configured");
+      const baseUrl = await deps.assertSafeUrl(String(rawUrl), "Weaviate URL");
+      const headers: Record<string, string> = {};
+      if (ctx.token) headers.Authorization = `Bearer ${ctx.token}`;
+      const res = await deps.fetch(`${baseUrl}/v1/meta`, { headers });
+      if (!res.ok) throw new Error(`Weaviate API returned ${res.status}`);
+      const data: any = await res.json();
+      return {
+        success: true,
+        message: `Connected to Weaviate ${data.version || ""}`.trim(),
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.host) configEnv.host = "WEAVIATE_URL";
+    return { primary: "WEAVIATE_API_KEY", config: configEnv };
+  },
+};

--- a/backend-api/integrations/services/integrationsService.ts
+++ b/backend-api/integrations/services/integrationsService.ts
@@ -43,6 +43,18 @@ const { teamsProvider } = require("../providers/teams");
 const { emailProvider } = require("../providers/email");
 const { twilioProvider } = require("../providers/twilio");
 const { sendgridProvider } = require("../providers/sendgrid");
+const { postgresqlProvider } = require("../providers/postgresql");
+const { mongodbProvider } = require("../providers/mongodb");
+const { redisProvider } = require("../providers/redis");
+const { supabaseProvider } = require("../providers/supabase");
+const { firebaseProvider } = require("../providers/firebase");
+const { googleDriveProvider } = require("../providers/googleDrive");
+const { dropboxProvider } = require("../providers/dropbox");
+const { s3Provider } = require("../providers/s3");
+const { elasticsearchProvider } = require("../providers/elasticsearch");
+const { pineconeProvider } = require("../providers/pinecone");
+const { weaviateProvider } = require("../providers/weaviate");
+const { algoliaProvider } = require("../providers/algolia");
 
 const repo = createIntegrationsRepository(db);
 const secretCrypto = createSecretEncryption({
@@ -90,6 +102,18 @@ const providerRegistry = createProviderRegistry((providerId) =>
   emailProvider,
   twilioProvider,
   sendgridProvider,
+  postgresqlProvider,
+  mongodbProvider,
+  redisProvider,
+  supabaseProvider,
+  firebaseProvider,
+  googleDriveProvider,
+  dropboxProvider,
+  s3Provider,
+  elasticsearchProvider,
+  pineconeProvider,
+  weaviateProvider,
+  algoliaProvider,
 ].forEach((p) => providerRegistry.register(p));
 
 // Resolve fetch at call time so test mocks reassigning `global.fetch`

--- a/docs/guides/integrations/algolia.mdx
+++ b/docs/guides/integrations/algolia.mdx
@@ -1,0 +1,57 @@
+# Algolia
+
+> Where to find your Algolia Application ID + Admin API Key and connect them to Nora.
+
+Algolia integrations let your agents manage search indices, push records, and query results.
+
+## Where to apply for credentials
+
+<Card
+  title="Algolia Dashboard — API Keys"
+  href="https://dashboard.algolia.com/account/api-keys/all"
+  icon="search"
+  arrow
+>
+  https://dashboard.algolia.com/account/api-keys/all
+</Card>
+
+The page lists:
+
+- **Application ID** — public identifier
+- **Search-Only API Key** — for queries only
+- **Admin API Key** — full management access (treat as secret)
+- **Other API Keys** — scoped, custom-permission keys you create
+
+For agent management workflows (creating indices, pushing records), use the Admin Key. For pure read-only agents, create a custom search-only key.
+
+## Connect in Nora
+
+<Steps>
+  <Step title="Paste the Application ID">
+    Visible on every Algolia dashboard page.
+  </Step>
+
+<Step title="Paste the Admin API Key">
+  Or a custom key with the right ACLs. Avoid the public Search-Only key for write operations.
+</Step>
+
+<Step title="(Optional) Pin a default index">
+  Set the **Default Index** if your agent always operates against one index.
+</Step>
+
+  <Step title="Connect">
+    Click **Connect**. Nora calls `GET https://<app-id>-dsn.algolia.net/1/keys` to list keys in the application — confirms both Application ID and Admin Key are valid.
+  </Step>
+</Steps>
+
+## MCP server
+
+No official Algolia MCP server today.
+
+## Environment variables Nora injects
+
+| Variable          | Source                 |
+| ----------------- | ---------------------- |
+| `ALGOLIA_API_KEY` | Admin API Key field    |
+| `ALGOLIA_APP_ID`  | Application ID field   |
+| `ALGOLIA_INDEX`   | Default Index (if set) |

--- a/docs/guides/integrations/dropbox.mdx
+++ b/docs/guides/integrations/dropbox.mdx
@@ -1,0 +1,48 @@
+# Dropbox
+
+> How to issue a Dropbox access token and connect it to Nora.
+
+Dropbox integrations let your agents upload, download, and manage files in a Dropbox account. Nora authenticates with a Bearer access token issued from the Dropbox developer console.
+
+## Where to apply for credentials
+
+<Card title="Dropbox App Console" href="https://www.dropbox.com/developers/apps" icon="box" arrow>
+  https://www.dropbox.com/developers/apps
+</Card>
+
+<Steps>
+  <Step title="Create an app">
+    Click **Create app**. Choose **Scoped access**, then either **App folder** (sandbox to one folder) or **Full Dropbox** (broad access).
+  </Step>
+
+<Step title="Tick the permissions">
+  On the **Permissions** tab, tick the scopes your agent needs (e.g. `files.content.read`,
+  `files.content.write`, `files.metadata.read`). Click **Submit**.
+</Step>
+
+  <Step title="Generate an access token">
+    On the **Settings** tab, scroll to **OAuth 2 → Generated access token**. Click **Generate**. Copy the token.
+  </Step>
+</Steps>
+
+<Note>
+  The generated access token is short-lived (4 hours). For production agents, implement a refresh
+  flow: get the App key + secret from the same Settings page, do an OAuth2 authorization-code
+  exchange, and store the resulting refresh_token. Nora's current Dropbox integration shape uses the
+  long-lived token model — fine for personal/dev use, but you'll need to rotate the token manually
+  for now.
+</Note>
+
+## Connect in Nora
+
+Paste the access token into the **Access Token** field and click **Connect**. Nora calls `POST https://api.dropboxapi.com/2/users/get_current_account` to verify the token. The card shows your Dropbox display name on success.
+
+## MCP server
+
+No official Dropbox MCP server today.
+
+## Environment variables Nora injects
+
+| Variable               | Source             |
+| ---------------------- | ------------------ |
+| `DROPBOX_ACCESS_TOKEN` | Access Token field |

--- a/docs/guides/integrations/elasticsearch.mdx
+++ b/docs/guides/integrations/elasticsearch.mdx
@@ -1,0 +1,53 @@
+# Elasticsearch
+
+> How to connect Nora to an Elasticsearch cluster.
+
+Elasticsearch integrations let your agents index, search, and aggregate data. Nora supports any v7+ cluster — Elastic Cloud, self-hosted, or OpenSearch (which speaks the same API).
+
+## Where to apply for credentials
+
+| Setup                 | Where to find auth                                                         |
+| --------------------- | -------------------------------------------------------------------------- |
+| Elastic Cloud         | Deployments → your deployment → Endpoints (URL) + Security → Users (creds) |
+| OpenSearch (AWS)      | OpenSearch Dashboards → Security → Internal users                          |
+| Self-hosted (Bitnami) | `elasticsearch.yml` `xpack.security.enabled`; built-in users               |
+
+For Elastic Cloud the canonical pair is the `elastic` superuser. For production agents, create a [dedicated user](https://www.elastic.co/guide/en/elasticsearch/reference/current/built-in-users.html) with a least-privilege role.
+
+## Connect in Nora
+
+<Steps>
+  <Step title="Paste the node URL">
+    The node URL is the cluster's HTTPS endpoint, e.g. `https://my-cluster.es.us-east-1.aws.elastic-cloud.com:9243`. The control-plane SSRF guard rejects RFC1918 hosts — for self-hosted clusters behind a private network, your agent runtime needs reachable DNS.
+  </Step>
+
+<Step title="(Optional) Enter username + password">
+  For dev clusters with security off, leave both blank. For production, paste the user + password.
+</Step>
+
+<Step title="(Optional) Pin a default index">
+  If your agent always queries one index, set the **Default Index** field so the agent doesn't have
+  to specify it on every call.
+</Step>
+
+  <Step title="Connect">
+    Click **Connect**. Nora calls `GET <url>` (Elasticsearch's root metadata endpoint) and reports the cluster name on success.
+  </Step>
+</Steps>
+
+## Verify the connection
+
+The **Test** button repeats the cluster-info call. **401** means wrong username or password; **403** means the user lacks `monitor` cluster privilege.
+
+## MCP server
+
+No official Elasticsearch MCP server today.
+
+## Environment variables Nora injects
+
+| Variable                 | Source                  |
+| ------------------------ | ----------------------- |
+| `ELASTICSEARCH_PASSWORD` | Password field          |
+| `ELASTICSEARCH_URL`      | Node URL field          |
+| `ELASTICSEARCH_USERNAME` | Username field (if set) |
+| `ELASTICSEARCH_INDEX`    | Default Index (if set)  |

--- a/docs/guides/integrations/firebase.mdx
+++ b/docs/guides/integrations/firebase.mdx
@@ -1,0 +1,68 @@
+# Firebase
+
+> How to generate a Firebase service-account JSON and connect it to Nora.
+
+Firebase integrations cover Realtime Database, Firestore, Authentication, Cloud Functions, and Cloud Messaging. Nora authenticates with a Google service account — the same JSON file every server-side Firebase SDK expects.
+
+## Where to apply for credentials
+
+<Card title="Firebase Console" href="https://console.firebase.google.com/" icon="flame" arrow>
+  https://console.firebase.google.com/
+</Card>
+
+<Steps>
+  <Step title="Open Project Settings">
+    Pick your Firebase project, click the gear icon → **Project settings**.
+  </Step>
+
+<Step title="Open the Service accounts tab">
+  Tab labeled **Service accounts**. The default Firebase Admin SDK service account is there.
+</Step>
+
+  <Step title="Generate a private key">
+    Click **Generate new private key**. Firebase downloads a JSON file. Treat it as secret.
+  </Step>
+</Steps>
+
+## Required permissions
+
+The default Firebase Admin SDK service account already has full access to all Firebase services in the project. For tighter scoping, create a custom service account in **GCP IAM** and grant only the roles you need (e.g. `roles/firebasedatabase.viewer`, `roles/datastore.user`).
+
+## Connect in Nora
+
+<Steps>
+  <Step title="Open the Firebase integration">
+    From an agent's detail page, open the **Integrations** tab and find **Firebase**.
+  </Step>
+
+<Step title="Paste the JSON">
+  Open the downloaded file in a text editor and paste the **entire JSON contents** into the
+  **Service Account JSON** textarea. Nora encrypts it at rest with AES-256-GCM.
+</Step>
+
+<Step title="(Realtime DB only) Set the database URL">
+  If your agent uses Realtime Database, paste the database URL (e.g.
+  `https://my-proj.firebaseio.com`).
+</Step>
+
+  <Step title="Connect">
+    Click **Connect**. Nora validates the JSON parses and contains `client_email`, `private_key`, and `project_id`. **It does not call Google's auth server** — that happens in the agent runtime.
+  </Step>
+</Steps>
+
+## Verify the connection
+
+The **Test** button repeats the structural validation. End-to-end verification happens when your agent makes its first Firebase call.
+
+## MCP server
+
+No official Firebase MCP server today.
+
+## Environment variables Nora injects
+
+| Variable                              | Source               |
+| ------------------------------------- | -------------------- |
+| `GOOGLE_APPLICATION_CREDENTIALS_JSON` | Service Account JSON |
+| `FIREBASE_PROJECT_ID`                 | extracted from JSON  |
+
+The agent runtime writes the JSON to a file and points `GOOGLE_APPLICATION_CREDENTIALS` at the file path — that's what the Firebase Admin SDK expects.

--- a/docs/guides/integrations/google-drive.mdx
+++ b/docs/guides/integrations/google-drive.mdx
@@ -1,0 +1,70 @@
+# Google Drive
+
+> How to set up a service account for Google Drive and connect it to Nora.
+
+Google Drive integrations let your agents read/write files and folders in Drive. Nora uses a Google Cloud service account — same shape as Firebase.
+
+## Where to apply for credentials
+
+<Card
+  title="Google Cloud — Service Accounts"
+  href="https://console.cloud.google.com/iam-admin/serviceaccounts"
+  icon="hard-drive"
+  arrow
+>
+  https://console.cloud.google.com/iam-admin/serviceaccounts
+</Card>
+
+<Steps>
+  <Step title="Create a service account">
+    Open the IAM Service Accounts page. Click **Create Service Account**, give it a name (e.g. `nora-drive-agent`), and click **Create and Continue**. Skip the optional roles for now.
+  </Step>
+
+<Step title="Generate a JSON key">
+  Click the new service account → **Keys** tab → **Add Key → Create new key → JSON**. The file
+  downloads automatically.
+</Step>
+
+<Step title="Enable the Drive API">
+  In the GCP console, open **APIs & Services → Library**, search for **Google Drive API**, and click
+  **Enable**.
+</Step>
+
+  <Step title="Share the right Drive folders with the SA">
+    Service accounts don't auto-have access to your personal Drive. From Drive's UI, **share the folder** (or files) the agent should access with the service account's `client_email` (visible inside the JSON key).
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+<Steps>
+  <Step title="Open the Google Drive integration">
+    From an agent's detail page, open the **Integrations** tab and find **Google Drive**.
+  </Step>
+
+<Step title="Paste the JSON">Paste the entire service-account JSON into the textarea.</Step>
+
+<Step title="(Optional) Pin a default folder">
+  If the agent should default to a specific folder, paste the Drive folder ID (the URL fragment
+  after `folders/`) into the **Default Folder ID** field.
+</Step>
+
+  <Step title="Connect">
+    Click **Connect**. Nora validates the JSON parses and contains `client_email`, `private_key`, and `project_id`.
+  </Step>
+</Steps>
+
+## MCP server
+
+The reference Google Drive MCP server:
+
+- **Package:** `@modelcontextprotocol/server-gdrive`
+- **Docs:** [github.com/modelcontextprotocol/servers/tree/main/src/gdrive](https://github.com/modelcontextprotocol/servers/tree/main/src/gdrive)
+- **Env:** `GOOGLE_APPLICATION_CREDENTIALS` pointing at the SA JSON file path. Nora's agent runtime sets this automatically.
+
+## Environment variables Nora injects
+
+| Variable                              | Source                     |
+| ------------------------------------- | -------------------------- |
+| `GOOGLE_APPLICATION_CREDENTIALS_JSON` | Service Account JSON       |
+| `GOOGLE_DRIVE_SHARED_DRIVE_ID`        | Default Folder ID (if set) |

--- a/docs/guides/integrations/mongodb.mdx
+++ b/docs/guides/integrations/mongodb.mdx
@@ -1,0 +1,52 @@
+# MongoDB
+
+> Where to get a MongoDB connection string and how to connect it to Nora.
+
+MongoDB integrations expect a single connection string that encodes host, port, credentials, and database. The string is treated as a sensitive value (encrypted at rest) and exposed to the agent as the `MONGODB_URI` env var.
+
+## Where to apply for credentials
+
+| Provider       | Where to get the connection string                                  |
+| -------------- | ------------------------------------------------------------------- |
+| MongoDB Atlas  | Cluster → Connect → Connect your application → Driver: Node.js      |
+| AWS DocumentDB | RDS Console → DocumentDB → your cluster → Connect with mongo shell  |
+| Self-hosted    | Build by hand: `mongodb://user:pass@host:27017/db?authSource=admin` |
+
+For Atlas, the format is:
+
+```
+mongodb+srv://<user>:<password>@<cluster>.mongodb.net/<database>?retryWrites=true&w=majority
+```
+
+URL-encode any special characters in the username or password.
+
+## Connect in Nora
+
+<Steps>
+  <Step title="Open the MongoDB integration">
+    From an agent's detail page, open the **Integrations** tab and find **MongoDB**.
+  </Step>
+
+<Step title="Paste the connection string">
+  Paste the full URI into the **Connection String** field. Test it locally first with `mongosh` or
+  your driver — Nora doesn't dial out from the control plane.
+</Step>
+
+  <Step title="Connect">
+    Click **Connect**. Nora parses the URI to confirm it uses `mongodb://` or `mongodb+srv://` and stores it encrypted.
+  </Step>
+</Steps>
+
+## Verify the connection
+
+The **Test** button repeats the URI parse. The agent runtime verifies real connectivity on its first query.
+
+## MCP server
+
+No official MongoDB MCP server today. Community packages exist but aren't stable.
+
+## Environment variables Nora injects
+
+| Variable      | Source                  |
+| ------------- | ----------------------- |
+| `MONGODB_URI` | Connection String field |

--- a/docs/guides/integrations/pinecone.mdx
+++ b/docs/guides/integrations/pinecone.mdx
@@ -1,0 +1,51 @@
+# Pinecone
+
+> Where to issue a Pinecone API key and connect it to Nora.
+
+Pinecone integrations let your agents store and query vector embeddings — typically as the retrieval layer of a RAG pipeline.
+
+## Where to apply for credentials
+
+<Card
+  title="Pinecone — API Keys"
+  href="https://app.pinecone.io/organizations/-/projects/-/keys"
+  icon="database"
+  arrow
+>
+  https://app.pinecone.io/organizations/-/projects/-/keys
+</Card>
+
+The same page lists existing keys and lets you create new ones. While you're there, also note your **environment** (e.g. `us-east-1-aws`, `gcp-starter`) — it's part of the API URL Pinecone clients construct.
+
+## Connect in Nora
+
+<Steps>
+  <Step title="Paste the API key">
+    Pinecone keys start with `pc_`.
+  </Step>
+
+<Step title="Set the environment">
+  Required. Visible at the top of the Pinecone console. Examples: `us-east-1-aws`, `gcp-starter`,
+  `eu-west-1-gcp`.
+</Step>
+
+<Step title="(Optional) Pin an index">
+  If your agent queries a single index, set the **Index Name** field.
+</Step>
+
+  <Step title="Connect">
+    Click **Connect**. Nora calls `GET https://api.pinecone.io/indexes` with the key in the `Api-Key` header.
+  </Step>
+</Steps>
+
+## MCP server
+
+No official Pinecone MCP server today.
+
+## Environment variables Nora injects
+
+| Variable               | Source              |
+| ---------------------- | ------------------- |
+| `PINECONE_API_KEY`     | API Key field       |
+| `PINECONE_ENVIRONMENT` | Environment field   |
+| `PINECONE_INDEX`       | Index Name (if set) |

--- a/docs/guides/integrations/postgresql.mdx
+++ b/docs/guides/integrations/postgresql.mdx
@@ -1,0 +1,64 @@
+# PostgreSQL
+
+> Where to provision PostgreSQL credentials for your agent and how to connect them to Nora.
+
+PostgreSQL integrations let your agents query and write to a Postgres database. Nora stores the connection parameters encrypted; the agent runtime opens connections using the standard `PG*` env vars (`PGHOST`, `PGPORT`, `PGDATABASE`, `PGUSER`, `PGPASSWORD`) — every Postgres driver picks them up automatically.
+
+## Where to apply for credentials
+
+There's no single console for Postgres — pick whichever provider hosts your database:
+
+| Provider                      | Where credentials live                                      |
+| ----------------------------- | ----------------------------------------------------------- |
+| AWS RDS                       | RDS Console → Databases → your instance → Configuration tab |
+| Google Cloud SQL              | Cloud SQL Console → Connections → Networking + Users tab    |
+| Azure Database for PostgreSQL | Azure Portal → your server → Connection strings             |
+| Supabase                      | Project Settings → Database → Connection info               |
+| Neon                          | Console → Project → Dashboard → Connection details          |
+| Self-hosted                   | `psql` itself: `\du` lists roles, `\l` lists databases      |
+
+## Best practices
+
+- **Create a dedicated role** for the agent (`CREATE ROLE nora_agent LOGIN PASSWORD '...'`) — don't reuse `postgres` superuser.
+- **Grant only what's needed** — `GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO nora_agent;` for a typical CRUD agent; just `GRANT SELECT` for read-only.
+- **The DB host must be reachable from the agent's network.** Nora doesn't tunnel — for managed Postgres behind a VPC, your agent runtime needs network access to the same VPC.
+
+## Connect in Nora
+
+<Steps>
+  <Step title="Open the PostgreSQL integration">
+    From an agent's detail page, open the **Integrations** tab and find **PostgreSQL**.
+  </Step>
+
+<Step title="Fill in the connection fields">
+  Host, port (5432 default), database name, username, password.
+</Step>
+
+  <Step title="Connect">
+    Click **Connect**. Nora validates the field shapes (port range, presence) and stores credentials encrypted. **It does not open a connection** from the control plane — the agent runtime does.
+  </Step>
+</Steps>
+
+## Verify the connection
+
+The **Test** button repeats the structural check. End-to-end verification happens when your agent makes its first query.
+
+## MCP server
+
+The reference Postgres MCP server is published by the MCP project:
+
+- **Package:** `@modelcontextprotocol/server-postgres`
+- **Docs:** [github.com/modelcontextprotocol/servers/tree/main/src/postgres](https://github.com/modelcontextprotocol/servers/tree/main/src/postgres)
+- **Env:** `POSTGRES_URL` (the MCP server reads a single connection string).
+
+Nora doesn't auto-launch it. To use it, set `POSTGRES_URL` in your agent's runtime config (you can derive it from the `PG*` env vars Nora injects).
+
+## Environment variables Nora injects
+
+| Variable     | Source         |
+| ------------ | -------------- |
+| `PGPASSWORD` | Password field |
+| `PGHOST`     | Host field     |
+| `PGPORT`     | Port field     |
+| `PGDATABASE` | Database field |
+| `PGUSER`     | Username field |

--- a/docs/guides/integrations/redis.mdx
+++ b/docs/guides/integrations/redis.mdx
@@ -1,0 +1,47 @@
+# Redis
+
+> Where to get Redis credentials for your agent and how to connect them to Nora.
+
+Redis integrations let your agents read/write keys, run pub/sub, and use streams. Nora stores host + port + optional password.
+
+## Where to apply for credentials
+
+| Provider                 | Where credentials live                                    |
+| ------------------------ | --------------------------------------------------------- |
+| Redis Cloud / Redis Labs | Console → Subscriptions → Database → Configuration tab    |
+| AWS ElastiCache          | ElastiCache Console → Redis cluster → Connection endpoint |
+| Upstash                  | Console → Database → REST API & Connection                |
+| Self-hosted              | `/etc/redis/redis.conf` — `requirepass` if AUTH is on     |
+
+For Redis Cloud / Upstash use the TLS endpoint (`rediss://`) — most managed Redis services require it.
+
+## Connect in Nora
+
+<Steps>
+  <Step title="Open the Redis integration">
+    From an agent's detail page, open the **Integrations** tab and find **Redis**.
+  </Step>
+
+<Step title="Fill in host + port">Host and port are required. The default Redis port is 6379.</Step>
+
+<Step title="(Optional) Set password">
+  Leave the password field blank for no-auth dev clusters. For ACL'd Redis, use the password — Nora
+  doesn't yet model the ACL username separately, so use the `default` ACL user's password.
+</Step>
+
+  <Step title="Connect">
+    Click **Connect**. Nora validates the host/port shape and stores the credentials encrypted.
+  </Step>
+</Steps>
+
+## MCP server
+
+No official Redis MCP server today.
+
+## Environment variables Nora injects
+
+| Variable         | Source         |
+| ---------------- | -------------- |
+| `REDIS_PASSWORD` | Password field |
+| `REDIS_HOST`     | Host field     |
+| `REDIS_PORT`     | Port field     |

--- a/docs/guides/integrations/s3.mdx
+++ b/docs/guides/integrations/s3.mdx
@@ -1,0 +1,76 @@
+# Amazon S3
+
+> How to issue AWS IAM credentials scoped to S3 and connect them to Nora.
+
+S3 integrations let your agents read/write objects, list buckets, and manage object metadata. Nora authenticates with an AWS Access Key ID + Secret Access Key — same shape every AWS SDK uses.
+
+## Where to apply for credentials
+
+<Card
+  title="AWS IAM — Users"
+  href="https://console.aws.amazon.com/iam/home?#/users"
+  icon="archive"
+  arrow
+>
+  https://console.aws.amazon.com/iam/home?#/users
+</Card>
+
+<Steps>
+  <Step title="Create an IAM user (or pick an existing one)">
+    Open IAM → Users → **Create user**. Give it a programmatic-access name (e.g. `nora-agent-s3`). Skip console access — it's a service identity.
+  </Step>
+
+  <Step title="Attach an S3 policy">
+    Smallest policy that works for read/write on a single bucket:
+    ```json
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucket"],
+          "Resource": [
+            "arn:aws:s3:::your-bucket",
+            "arn:aws:s3:::your-bucket/*"
+          ]
+        }
+      ]
+    }
+    ```
+    For read-only agents, AWS's managed `AmazonS3ReadOnlyAccess` policy is fine.
+  </Step>
+
+  <Step title="Generate an access key">
+    Open the user → **Security credentials** → **Create access key** → choose **Application running outside AWS**. Copy the **Access key ID** and **Secret access key** (you only see the secret once).
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+<Steps>
+  <Step title="Open the Amazon S3 integration">
+    From an agent's detail page, open the **Integrations** tab and find **Amazon S3**.
+  </Step>
+
+<Step title="Paste the keys">
+  Paste **Access Key ID** + **Secret Access Key**. Set **Default Bucket** and **Region** if your
+  agent operates against a single bucket.
+</Step>
+
+  <Step title="Connect">
+    Click **Connect**. Nora validates the field shapes and stores credentials encrypted. **It does not sign a test request** — that happens at runtime with the AWS SDK.
+  </Step>
+</Steps>
+
+## MCP server
+
+No official S3 MCP server. The standard AWS SDK env vars are present (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_REGION`) so any community S3 MCP can pick them up.
+
+## Environment variables Nora injects
+
+| Variable                | Source                  |
+| ----------------------- | ----------------------- |
+| `AWS_SECRET_ACCESS_KEY` | Secret Access Key field |
+| `AWS_ACCESS_KEY_ID`     | Access Key ID field     |
+| `AWS_REGION`            | Region field            |
+| `S3_BUCKET`             | Default Bucket field    |

--- a/docs/guides/integrations/supabase.mdx
+++ b/docs/guides/integrations/supabase.mdx
@@ -1,0 +1,58 @@
+# Supabase
+
+> Where to get a Supabase project URL + service-role key, and how to connect them to Nora.
+
+Supabase integrations let your agents read/write Postgres tables, query auth users, manage storage buckets, and call edge functions through Supabase's PostgREST/Realtime/Storage APIs. Nora authenticates with the project URL plus an anon or service-role key.
+
+## Where to apply for credentials
+
+<Card
+  title="Supabase — Project API settings"
+  href="https://app.supabase.com/project/_/settings/api"
+  icon="database"
+  arrow
+>
+  https://app.supabase.com/project/_/settings/api
+</Card>
+
+The page shows three values:
+
+- **Project URL** — `https://<ref>.supabase.co`
+- **anon (public) key** — safe-ish to expose, respects Row-Level Security policies
+- **service_role key** — bypasses RLS; treat as secret
+
+Pick the smallest scope that fits your agent.
+
+## Connect in Nora
+
+<Steps>
+  <Step title="Open the Supabase integration">
+    From an agent's detail page, open the **Integrations** tab and find **Supabase**.
+  </Step>
+
+<Step title="Paste URL + key">
+  Paste the **Project URL** and the **service_role key** (or anon key for read-only agents).
+</Step>
+
+  <Step title="Connect">
+    Click **Connect**. Nora calls `GET <url>/rest/v1/` with the key as both `apikey` and `Authorization: Bearer <key>`. On success the card shows "Connected to Supabase".
+  </Step>
+</Steps>
+
+## Verify the connection
+
+The **Test** button hits the same endpoint. **401 Invalid API key** means the key is wrong; **404** means the URL is malformed.
+
+## MCP server
+
+A community MCP server exists:
+
+- **Package:** `@supabase/mcp-server-supabase`
+- **Docs:** [github.com/supabase-community/supabase-mcp](https://github.com/supabase-community/supabase-mcp)
+
+## Environment variables Nora injects
+
+| Variable                    | Source            |
+| --------------------------- | ----------------- |
+| `SUPABASE_SERVICE_ROLE_KEY` | Anon/Service Key  |
+| `SUPABASE_URL`              | Project URL field |

--- a/docs/guides/integrations/weaviate.mdx
+++ b/docs/guides/integrations/weaviate.mdx
@@ -1,0 +1,42 @@
+# Weaviate
+
+> Where to find your Weaviate cluster URL + API key and connect them to Nora.
+
+Weaviate is an open-source vector database — useful as the retrieval layer of agent workflows. Nora connects with the cluster URL and an optional API key (anonymous clusters are also supported for dev).
+
+## Where to apply for credentials
+
+| Setup                | Where to find auth                                                         |
+| -------------------- | -------------------------------------------------------------------------- |
+| Weaviate Cloud (WCS) | [console.weaviate.cloud](https://console.weaviate.cloud) → Cluster details |
+| Self-hosted          | The `WEAVIATE_API_KEY` env var on your Weaviate container                  |
+
+For Weaviate Cloud, the cluster URL has the shape `https://<id>.weaviate.network` and the API key is shown once on cluster creation.
+
+## Connect in Nora
+
+<Steps>
+  <Step title="Paste the cluster URL">
+    Required. Must be HTTPS. RFC1918 / loopback URLs are rejected.
+  </Step>
+
+<Step title="(Optional) Paste an API key">
+  For Weaviate Cloud and self-hosted clusters with API-key auth, paste the key. Leave blank for
+  anonymous (dev) clusters.
+</Step>
+
+  <Step title="Connect">
+    Click **Connect**. Nora calls `GET <url>/v1/meta` (with the Bearer header when a key is set) and reports the Weaviate version on success.
+  </Step>
+</Steps>
+
+## MCP server
+
+No official Weaviate MCP server today.
+
+## Environment variables Nora injects
+
+| Variable           | Source            |
+| ------------------ | ----------------- |
+| `WEAVIATE_API_KEY` | API Key field     |
+| `WEAVIATE_URL`     | Cluster URL field |


### PR DESCRIPTION
## Summary

- 12 providers move off the legacy connectivity-test switch onto strategy files.
- **API-validated**: `supabase`, `dropbox`, `elasticsearch`, `pinecone`, `weaviate`, `algolia` (each one calls a documented credential-validation endpoint).
- **Structurally validated** (DB / storage providers behind private networks): `postgresql`, `mongodb`, `redis`, `s3`, `firebase`, `google-drive`. The agent runtime opens the real connection.
- Catalog: `credentialsUrl` + `setupGuide` populated for all 12. Postgres, Google Drive, and Supabase get structured `mcp` metadata pointing at `@modelcontextprotocol/server-postgres`, `@modelcontextprotocol/server-gdrive`, and `@supabase/mcp-server-supabase`.
- Per-provider docs walk through where to provision credentials, scopes/permissions, the connect flow, and the env vars Nora injects.

## Test plan

- [x] `npx prettier --write` clean
- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 740/740 passing (was 693; +47 from 12 new mocked tests)
- [ ] Manual dashboard pass once merged