### PR TITLE
feat(integrations): migrate cloud and AI/ML providers (7 providers)

### DIFF
--- a/backend-api/__tests__/providers/anthropicProvider.test.ts
+++ b/backend-api/__tests__/providers/anthropicProvider.test.ts
@@ -1,0 +1,51 @@
+// @ts-nocheck
+const { anthropicProvider } = require("../../integrations/providers/anthropic");
+
+function deps(fetchImpl) {
+  return {
+    fetch: fetchImpl,
+    assertSafeUrl: async (u) => u,
+    encrypt: (s) => s,
+    decrypt: (s) => s,
+    ensureEncryptionConfigured: jest.fn(),
+    db: { query: jest.fn() },
+  };
+}
+
+describe("anthropicProvider", () => {
+  it("uses x-api-key + anthropic-version headers", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: true });
+    await anthropicProvider.test({ row: {}, token: "sk-ant-x", config: {} }, deps(fetchImpl));
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.anthropic.com/v1/models",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "x-api-key": "sk-ant-x",
+          "anthropic-version": "2023-06-01",
+        }),
+      }),
+    );
+  });
+
+  it("returns success=false on 401", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: false, status: 401 });
+    const result = await anthropicProvider.test(
+      { row: {}, token: "bad", config: {} },
+      deps(fetchImpl),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Anthropic API returned 401");
+  });
+
+  it("emits ANTHROPIC_API_KEY + MODEL when set", () => {
+    const env = anthropicProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { model: "claude-opus-4-7" },
+    });
+    expect(env).toEqual({
+      primary: "ANTHROPIC_API_KEY",
+      config: { model: "ANTHROPIC_MODEL" },
+    });
+  });
+});

--- a/backend-api/__tests__/providers/awsProvider.test.ts
+++ b/backend-api/__tests__/providers/awsProvider.test.ts
@@ -1,0 +1,68 @@
+// @ts-nocheck
+const { awsProvider } = require("../../integrations/providers/aws");
+
+const deps = {
+  fetch: jest.fn(),
+  assertSafeUrl: async (u) => u,
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+};
+
+const validKey = "AKIAIOSFODNN7EXAMPLE";
+
+describe("awsProvider", () => {
+  it("identifies as aws / credentials", () => {
+    expect(awsProvider.id).toBe("aws");
+    expect(awsProvider.authType).toBe("credentials");
+  });
+
+  it("accepts a complete IAM credential set without making network calls", async () => {
+    const result = await awsProvider.test(
+      {
+        row: {},
+        token: "secret",
+        config: { access_key_id: validKey, region: "us-east-1" },
+      },
+      deps,
+    );
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("us-east-1");
+    expect(deps.fetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed access keys", async () => {
+    const result = await awsProvider.test(
+      {
+        row: {},
+        token: "secret",
+        config: { access_key_id: "not-an-aws-key", region: "us-east-1" },
+      },
+      deps,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("AKIA");
+  });
+
+  it("rejects missing region", async () => {
+    const result = await awsProvider.test(
+      { row: {}, token: "secret", config: { access_key_id: validKey } },
+      deps,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("region");
+  });
+
+  it("emits AWS_* env vars", () => {
+    const env = awsProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { access_key_id: validKey, region: "us-east-1" },
+    });
+    expect(env).toEqual({
+      primary: "AWS_SECRET_ACCESS_KEY",
+      config: { access_key_id: "AWS_ACCESS_KEY_ID", region: "AWS_DEFAULT_REGION" },
+    });
+  });
+});

--- a/backend-api/__tests__/providers/azureProvider.test.ts
+++ b/backend-api/__tests__/providers/azureProvider.test.ts
@@ -1,0 +1,60 @@
+// @ts-nocheck
+const { azureProvider } = require("../../integrations/providers/azure");
+
+const deps = {
+  fetch: jest.fn(),
+  assertSafeUrl: async (u) => u,
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+};
+
+const tenantId = "11111111-2222-3333-4444-555555555555";
+const clientId = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+describe("azureProvider", () => {
+  it("accepts a valid Service Principal credential set", async () => {
+    const result = await azureProvider.test(
+      { row: {}, token: "secret", config: { tenant_id: tenantId, client_id: clientId } },
+      deps,
+    );
+    expect(result.success).toBe(true);
+    expect(result.message).toContain(tenantId);
+    expect(deps.fetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed UUIDs", async () => {
+    const result = await azureProvider.test(
+      {
+        row: {},
+        token: "secret",
+        config: { tenant_id: "not-a-uuid", client_id: clientId },
+      },
+      deps,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("UUID");
+  });
+
+  it("rejects missing client secret", async () => {
+    const result = await azureProvider.test(
+      { row: {}, token: "", config: { tenant_id: tenantId, client_id: clientId } },
+      deps,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("client secret");
+  });
+
+  it("emits AZURE_* env vars", () => {
+    const env = azureProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { tenant_id: tenantId, client_id: clientId },
+    });
+    expect(env).toEqual({
+      primary: "AZURE_CLIENT_SECRET",
+      config: { tenant_id: "AZURE_TENANT_ID", client_id: "AZURE_CLIENT_ID" },
+    });
+  });
+});

--- a/backend-api/__tests__/providers/digitaloceanProvider.test.ts
+++ b/backend-api/__tests__/providers/digitaloceanProvider.test.ts
@@ -1,0 +1,40 @@
+// @ts-nocheck
+const { digitaloceanProvider } = require("../../integrations/providers/digitalocean");
+
+function deps(fetchImpl) {
+  return {
+    fetch: fetchImpl,
+    assertSafeUrl: async (u) => u,
+    encrypt: (s) => s,
+    decrypt: (s) => s,
+    ensureEncryptionConfigured: jest.fn(),
+    db: { query: jest.fn() },
+  };
+}
+
+describe("digitaloceanProvider", () => {
+  it("hits /v2/account with Bearer token", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ account: { email: "alice@example.com" } }),
+    });
+    const result = await digitaloceanProvider.test(
+      { row: {}, token: "dop_x", config: {} },
+      deps(fetchImpl),
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.digitalocean.com/v2/account",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer dop_x" }),
+      }),
+    );
+    expect(result.message).toContain("alice@example.com");
+  });
+
+  it("emits DIGITALOCEAN_TOKEN as primary", () => {
+    expect(digitaloceanProvider.mapToEnv({ row: {}, token: null, config: {} })).toEqual({
+      primary: "DIGITALOCEAN_TOKEN",
+      config: {},
+    });
+  });
+});

--- a/backend-api/__tests__/providers/gcpProvider.test.ts
+++ b/backend-api/__tests__/providers/gcpProvider.test.ts
@@ -1,0 +1,59 @@
+// @ts-nocheck
+const { gcpProvider } = require("../../integrations/providers/gcp");
+
+const deps = {
+  fetch: jest.fn(),
+  assertSafeUrl: async (u) => u,
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+};
+
+const validSa = JSON.stringify({
+  client_email: "agent@p.iam.gserviceaccount.com",
+  private_key: "-----BEGIN PRIVATE KEY-----\nx\n-----END PRIVATE KEY-----\n",
+  project_id: "my-proj",
+});
+
+describe("gcpProvider", () => {
+  it("identifies as gcp / service_account", () => {
+    expect(gcpProvider.id).toBe("gcp");
+    expect(gcpProvider.authType).toBe("service_account");
+  });
+
+  it("validates service account JSON structurally", async () => {
+    const result = await gcpProvider.test(
+      { row: {}, token: null, config: { service_account_json: validSa } },
+      deps,
+    );
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("my-proj");
+  });
+
+  it("rejects missing required keys", async () => {
+    const result = await gcpProvider.test(
+      {
+        row: {},
+        token: null,
+        config: { service_account_json: JSON.stringify({ client_email: "x" }) },
+      },
+      deps,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("missing required keys");
+  });
+
+  it("emits GOOGLE_APPLICATION_CREDENTIALS_JSON + GCP_PROJECT_ID", () => {
+    const env = gcpProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { service_account_json: validSa, project_id: "my-proj" },
+    });
+    expect(env.primary).toBeNull();
+    expect(env.config).toEqual({
+      service_account_json: "GOOGLE_APPLICATION_CREDENTIALS_JSON",
+      project_id: "GCP_PROJECT_ID",
+    });
+  });
+});

--- a/backend-api/__tests__/providers/huggingfaceProvider.test.ts
+++ b/backend-api/__tests__/providers/huggingfaceProvider.test.ts
@@ -1,0 +1,40 @@
+// @ts-nocheck
+const { huggingfaceProvider } = require("../../integrations/providers/huggingface");
+
+function deps(fetchImpl) {
+  return {
+    fetch: fetchImpl,
+    assertSafeUrl: async (u) => u,
+    encrypt: (s) => s,
+    decrypt: (s) => s,
+    ensureEncryptionConfigured: jest.fn(),
+    db: { query: jest.fn() },
+  };
+}
+
+describe("huggingfaceProvider", () => {
+  it("hits /api/whoami-v2 with Bearer token", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ name: "alice" }),
+    });
+    const result = await huggingfaceProvider.test(
+      { row: {}, token: "hf_x", config: {} },
+      deps(fetchImpl),
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://huggingface.co/api/whoami-v2",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer hf_x" }),
+      }),
+    );
+    expect(result.message).toContain("alice");
+  });
+
+  it("emits HF_TOKEN as primary", () => {
+    expect(huggingfaceProvider.mapToEnv({ row: {}, token: null, config: {} })).toEqual({
+      primary: "HF_TOKEN",
+      config: {},
+    });
+  });
+});

--- a/backend-api/__tests__/providers/openaiProvider.test.ts
+++ b/backend-api/__tests__/providers/openaiProvider.test.ts
@@ -1,0 +1,55 @@
+// @ts-nocheck
+const { openaiProvider } = require("../../integrations/providers/openai");
+
+function deps(fetchImpl) {
+  return {
+    fetch: fetchImpl,
+    assertSafeUrl: async (u) => u,
+    encrypt: (s) => s,
+    decrypt: (s) => s,
+    ensureEncryptionConfigured: jest.fn(),
+    db: { query: jest.fn() },
+  };
+}
+
+describe("openaiProvider", () => {
+  it("hits /v1/models with Bearer token", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [{}, {}, {}] }),
+    });
+    const result = await openaiProvider.test(
+      { row: {}, token: "sk-x", config: {} },
+      deps(fetchImpl),
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.openai.com/v1/models",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer sk-x" }),
+      }),
+    );
+    expect(result.message).toContain("3 models available");
+  });
+
+  it("returns success=false on 401", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: false, status: 401 });
+    const result = await openaiProvider.test(
+      { row: {}, token: "bad", config: {} },
+      deps(fetchImpl),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("OpenAI API returned 401");
+  });
+
+  it("emits OPENAI_API_KEY + ORG_ID + MODEL when set", () => {
+    const env = openaiProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { org_id: "org_abc", model: "gpt-4o-mini" },
+    });
+    expect(env).toEqual({
+      primary: "OPENAI_API_KEY",
+      config: { org_id: "OPENAI_ORG_ID", model: "OPENAI_MODEL" },
+    });
+  });
+});

--- a/backend-api/integrations/catalog/catalog.json
+++ b/backend-api/integrations/catalog/catalog.json
@@ -333,7 +333,17 @@
       { "key": "org_id", "label": "Organization ID", "type": "text", "required": false },
       { "key": "model", "label": "Default Model", "type": "text", "required": false }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://platform.openai.com/api-keys",
+    "setupGuide": {
+      "steps": [
+        "Sign in to OpenAI at platform.openai.com.",
+        "Open Settings → API Keys → Create new secret key.",
+        "Copy the key (sk-...) — OpenAI shows it only once.",
+        "(Optional) Find your org ID under Settings → Organization for cost-attribution / project scoping."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "anthropic",
@@ -346,7 +356,17 @@
       { "key": "api_key", "label": "API Key", "type": "password", "required": true },
       { "key": "model", "label": "Default Model", "type": "text", "required": false }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://console.anthropic.com/settings/keys",
+    "setupGuide": {
+      "steps": [
+        "Sign in at console.anthropic.com.",
+        "Open Settings → API keys → Create Key.",
+        "Copy the key (sk-ant-...) — it's only shown once.",
+        "(Optional) Pin a default Claude model (claude-opus-4-7, claude-sonnet-4-6, claude-haiku-4-5)."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "huggingface",
@@ -359,7 +379,17 @@
       { "key": "api_key", "label": "API Token", "type": "password", "required": true },
       { "key": "model_id", "label": "Default Model ID", "type": "text", "required": false }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://huggingface.co/settings/tokens",
+    "setupGuide": {
+      "steps": [
+        "Sign in to huggingface.co.",
+        "Open Settings → Access Tokens → New token.",
+        "Pick the role: Read for model inference, Write for pushing to repos.",
+        "Copy the token (hf_...)."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "aws",
@@ -378,7 +408,18 @@
       },
       { "key": "region", "label": "Default Region", "type": "text", "required": false }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://console.aws.amazon.com/iam/home?#/users",
+    "setupGuide": {
+      "steps": [
+        "In AWS Console → IAM → Users, create a programmatic-access user.",
+        "Attach a least-privilege policy (avoid AdministratorAccess unless your agent really needs it).",
+        "Open the user → Security credentials → Create access key → Application running outside AWS.",
+        "Copy the Access Key ID + Secret Access Key (only shown once).",
+        "Pick a default region (e.g. us-east-1) so the agent doesn't have to specify it on every call."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "gcp",
@@ -396,7 +437,17 @@
       },
       { "key": "project_id", "label": "Project ID", "type": "text", "required": true }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://console.cloud.google.com/iam-admin/serviceaccounts",
+    "setupGuide": {
+      "steps": [
+        "In GCP Console → IAM & Admin → Service Accounts, create a service account.",
+        "Grant the roles your agent needs (least privilege wins).",
+        "Open the SA → Keys → Add Key → Create new key → JSON.",
+        "Paste the entire JSON file contents into the textarea."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "azure",
@@ -410,7 +461,17 @@
       { "key": "client_id", "label": "Client ID", "type": "text", "required": true },
       { "key": "client_secret", "label": "Client Secret", "type": "password", "required": true }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade",
+    "setupGuide": {
+      "steps": [
+        "In the Azure Portal, open Microsoft Entra ID (Azure AD) → App registrations → New registration.",
+        "Once registered, copy the Application (client) ID and Directory (tenant) ID.",
+        "Open Certificates & secrets → New client secret. Copy the value (only shown once).",
+        "Grant the app the right Azure RBAC roles on the resources / subscription it needs to manage (Subscriptions → Access control → Add role assignment)."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "digitalocean",
@@ -422,7 +483,17 @@
     "configFields": [
       { "key": "api_token", "label": "API Token", "type": "password", "required": true }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://cloud.digitalocean.com/account/api/tokens",
+    "setupGuide": {
+      "steps": [
+        "Sign in to cloud.digitalocean.com.",
+        "Open API → Tokens/Keys → Generate New Token.",
+        "Pick Full Access (read + write) or scope to specific permissions.",
+        "Copy the token (only shown once)."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "postgresql",

--- a/backend-api/integrations/index.ts
+++ b/backend-api/integrations/index.ts
@@ -67,6 +67,13 @@ export { elasticsearchProvider } from "./providers/elasticsearch";
 export { pineconeProvider } from "./providers/pinecone";
 export { weaviateProvider } from "./providers/weaviate";
 export { algoliaProvider } from "./providers/algolia";
+export { openaiProvider } from "./providers/openai";
+export { anthropicProvider } from "./providers/anthropic";
+export { huggingfaceProvider } from "./providers/huggingface";
+export { digitaloceanProvider } from "./providers/digitalocean";
+export { awsProvider } from "./providers/aws";
+export { gcpProvider } from "./providers/gcp";
+export { azureProvider } from "./providers/azure";
 
 // The orchestration service is the recommended import for callers that
 // need the high-level operations (connect, list, test, sync, env-vars).

--- a/backend-api/integrations/providers/anthropic.ts
+++ b/backend-api/integrations/providers/anthropic.ts
@@ -1,0 +1,33 @@
+// Anthropic provider — x-api-key header + anthropic-version pinning.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const anthropicProvider: Provider = {
+  id: "anthropic",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const res = await deps.fetch("https://api.anthropic.com/v1/models", {
+        headers: { "x-api-key": ctx.token ?? "", "anthropic-version": "2023-06-01" },
+      });
+      if (!res.ok) throw new Error(`Anthropic API returned ${res.status}`);
+      return { success: true, message: "API key validated" };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.model) configEnv.model = "ANTHROPIC_MODEL";
+    return { primary: "ANTHROPIC_API_KEY", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/aws.ts
+++ b/backend-api/integrations/providers/aws.ts
@@ -1,0 +1,46 @@
+// AWS provider — programmatic access keys (IAM user). The connectivity
+// test is structural; verifying signed AWS calls without the SDK isn't
+// worth recreating. The agent runtime uses the standard AWS_* env vars.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+} from "../types/provider";
+
+const AWS_ACCESS_KEY_RE = /^AKIA[0-9A-Z]{16}$/;
+
+export const awsProvider: Provider = {
+  id: "aws",
+  authType: "credentials",
+
+  async test(ctx: DecryptedIntegration): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      const accessKey = String(config.access_key_id || "").trim();
+      if (!accessKey) throw new Error("AWS access key ID is required");
+      if (!ctx.token) throw new Error("AWS secret access key is required");
+      if (!config.region) throw new Error("AWS region is required (e.g. us-east-1)");
+      if (!AWS_ACCESS_KEY_RE.test(accessKey)) {
+        throw new Error(
+          "AWS access key ID should look like AKIA followed by 16 alphanumeric chars",
+        );
+      }
+      return {
+        success: true,
+        message: `Credentials stored for ${accessKey.slice(0, 4)}…${accessKey.slice(-4)} (${config.region})`,
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.access_key_id) configEnv.access_key_id = "AWS_ACCESS_KEY_ID";
+    if (config.region) configEnv.region = "AWS_DEFAULT_REGION";
+    return { primary: "AWS_SECRET_ACCESS_KEY", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/azure.ts
+++ b/backend-api/integrations/providers/azure.ts
@@ -1,0 +1,45 @@
+// Azure provider — Service Principal credentials (tenant + client + secret).
+// Agents using @azure/identity automatically pick up the environment
+// variables. Connectivity not validated from the control plane (token
+// acquisition is non-trivial without the SDK).
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+} from "../types/provider";
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const azureProvider: Provider = {
+  id: "azure",
+  authType: "credentials",
+
+  async test(ctx: DecryptedIntegration): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      const tenantId = String(config.tenant_id || "").trim();
+      const clientId = String(config.client_id || "").trim();
+      if (!tenantId) throw new Error("Azure tenant ID is required");
+      if (!clientId) throw new Error("Azure client ID is required");
+      if (!ctx.token) throw new Error("Azure client secret is required");
+      if (!UUID_RE.test(tenantId)) throw new Error("Azure tenant ID is not a valid UUID");
+      if (!UUID_RE.test(clientId)) throw new Error("Azure client ID is not a valid UUID");
+      return {
+        success: true,
+        message: `Service principal stored for tenant ${tenantId}`,
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.tenant_id) configEnv.tenant_id = "AZURE_TENANT_ID";
+    if (config.client_id) configEnv.client_id = "AZURE_CLIENT_ID";
+    return { primary: "AZURE_CLIENT_SECRET", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/digitalocean.ts
+++ b/backend-api/integrations/providers/digitalocean.ts
@@ -1,0 +1,35 @@
+// DigitalOcean provider — Bearer token, GET /v2/account returns the
+// account's email + UUID.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const digitaloceanProvider: Provider = {
+  id: "digitalocean",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const res = await deps.fetch("https://api.digitalocean.com/v2/account", {
+        headers: { Authorization: `Bearer ${ctx.token ?? ""}` },
+      });
+      if (!res.ok) throw new Error(`DigitalOcean API returned ${res.status}`);
+      const data: any = await res.json();
+      return {
+        success: true,
+        message: `Connected (${data.account?.email || "verified"})`,
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(): EnvMapping {
+    return { primary: "DIGITALOCEAN_TOKEN", config: {} };
+  },
+};

--- a/backend-api/integrations/providers/gcp.ts
+++ b/backend-api/integrations/providers/gcp.ts
@@ -1,0 +1,51 @@
+// GCP provider — service-account JSON. Same shape as Firebase / Drive,
+// but mapped through the canonical GOOGLE_APPLICATION_CREDENTIALS_JSON
+// env var that all gcloud SDKs respect.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+} from "../types/provider";
+
+const REQUIRED_SA_KEYS = ["client_email", "private_key", "project_id"] as const;
+
+export const gcpProvider: Provider = {
+  id: "gcp",
+  authType: "service_account",
+
+  async test(ctx: DecryptedIntegration): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      const raw = String(config.service_account_json || "").trim();
+      if (!raw) throw new Error("GCP service account JSON is required");
+      let parsed: any;
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        throw new Error("Service account JSON is not valid JSON");
+      }
+      const missing = REQUIRED_SA_KEYS.filter((k) => !parsed[k]);
+      if (missing.length > 0) {
+        throw new Error(`Service account JSON is missing required keys: ${missing.join(", ")}`);
+      }
+      return {
+        success: true,
+        message: `Service account stored for project ${parsed.project_id}`,
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.service_account_json) {
+      configEnv.service_account_json = "GOOGLE_APPLICATION_CREDENTIALS_JSON";
+    }
+    if (config.project_id) configEnv.project_id = "GCP_PROJECT_ID";
+    return { primary: null, config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/huggingface.ts
+++ b/backend-api/integrations/providers/huggingface.ts
@@ -1,0 +1,36 @@
+// Hugging Face provider — Bearer token, GET /api/whoami-v2 returns the
+// authenticated user's profile (covers tokens generated via the
+// Settings → Access Tokens UI).
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const huggingfaceProvider: Provider = {
+  id: "huggingface",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const res = await deps.fetch("https://huggingface.co/api/whoami-v2", {
+        headers: { Authorization: `Bearer ${ctx.token ?? ""}` },
+      });
+      if (!res.ok) throw new Error(`Hugging Face API returned ${res.status}`);
+      const data: any = await res.json();
+      return {
+        success: true,
+        message: `Connected as ${data.name || data.fullname || "verified"}`,
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(): EnvMapping {
+    return { primary: "HF_TOKEN", config: {} };
+  },
+};

--- a/backend-api/integrations/providers/legacy/connectivityTests.ts
+++ b/backend-api/integrations/providers/legacy/connectivityTests.ts
@@ -68,29 +68,9 @@ function buildConnectivityTests(integration, token, deps) {
       return { success: true, message: "Authenticated successfully" };
     },
     // sendgrid → migrated to providers/sendgrid.ts
-    openai: async () => {
-      const res = await fetch("https://api.openai.com/v1/models", {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (!res.ok) throw new Error(`OpenAI API returned ${res.status}`);
-      const data = await res.json();
-      return { success: true, message: `Connected (${data.data?.length || 0} models available)` };
-    },
-    anthropic: async () => {
-      const res = await fetch("https://api.anthropic.com/v1/models", {
-        headers: { "x-api-key": token, "anthropic-version": "2023-06-01" },
-      });
-      if (!res.ok) throw new Error(`Anthropic API returned ${res.status}`);
-      return { success: true, message: "API key validated" };
-    },
-    huggingface: async () => {
-      const res = await fetch("https://huggingface.co/api/whoami-v2", {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (!res.ok) throw new Error(`Hugging Face API returned ${res.status}`);
-      const data = await res.json();
-      return { success: true, message: `Connected as ${data.name || data.fullname || "verified"}` };
-    },
+    // openai → migrated to providers/openai.ts
+    // anthropic → migrated to providers/anthropic.ts
+    // huggingface → migrated to providers/huggingface.ts
     // bitbucket → migrated to providers/bitbucket.ts
     airtable: async () => {
       const res = await fetch("https://api.airtable.com/v0/meta/whoami", {
@@ -161,14 +141,7 @@ function buildConnectivityTests(integration, token, deps) {
         message: `Connected as ${data.displayName || data.username || "verified"}`,
       };
     },
-    digitalocean: async () => {
-      const res = await fetch("https://api.digitalocean.com/v2/account", {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (!res.ok) throw new Error(`DigitalOcean API returned ${res.status}`);
-      const data = await res.json();
-      return { success: true, message: `Connected (${data.account?.email || "verified"})` };
-    },
+    // digitalocean → migrated to providers/digitalocean.ts
     // supabase → migrated to providers/supabase.ts
     stripe: async () => {
       const res = await fetch("https://api.stripe.com/v1/balance", {

--- a/backend-api/integrations/providers/legacy/envMaps.ts
+++ b/backend-api/integrations/providers/legacy/envMaps.ts
@@ -10,7 +10,7 @@ const llmProviders = require("../../../llmProviders");
 // access_token column). The access_token column stores the first
 // password+required configField per provider.
 const INTEGRATION_ENV_MAP = {
-  huggingface: "HF_TOKEN",
+  // huggingface → migrated to providers/huggingface.ts
   // github → migrated to providers/github.ts
   // gitlab → migrated to providers/gitlab.ts
   // slack → migrated to providers/slack.ts
@@ -20,8 +20,8 @@ const INTEGRATION_ENV_MAP = {
   datadog: "DD_API_KEY",
   sentry: "SENTRY_AUTH_TOKEN",
   // sendgrid → migrated to providers/sendgrid.ts
-  openai: "OPENAI_API_KEY",
-  anthropic: "ANTHROPIC_API_KEY",
+  // openai → migrated to providers/openai.ts
+  // anthropic → migrated to providers/anthropic.ts
   airtable: "AIRTABLE_API_KEY",
   asana: "ASANA_TOKEN",
   stripe: "STRIPE_SECRET_KEY",
@@ -40,7 +40,7 @@ const INTEGRATION_ENV_MAP = {
   instagram: "INSTAGRAM_ACCESS_TOKEN",
   salesforce: "SALESFORCE_ACCESS_TOKEN",
   // twitter → migrated to providers/twitter.ts
-  digitalocean: "DIGITALOCEAN_TOKEN",
+  // digitalocean → migrated to providers/digitalocean.ts
   // algolia → migrated to providers/algolia.ts
   clickup: "CLICKUP_API_KEY",
   monday: "MONDAY_API_KEY",
@@ -57,8 +57,9 @@ const INTEGRATION_ENV_MAP = {
   // supabase → migrated to providers/supabase.ts
   facebook: "FACEBOOK_ACCESS_TOKEN",
   // Cloud / infra
-  aws: "AWS_SECRET_ACCESS_KEY",
-  azure: "AZURE_CLIENT_SECRET",
+  // aws → migrated to providers/aws.ts
+  // azure → migrated to providers/azure.ts
+  // gcp → migrated to providers/gcp.ts (no primary token; uses service_account JSON)
   // s3 → migrated to providers/s3.ts
   // Databases
   // mongodb → migrated to providers/mongodb.ts
@@ -97,13 +98,10 @@ const INTEGRATION_CONFIG_ENV_MAP = {
   // AI / ML
   "openai.org_id": "OPENAI_ORG_ID",
   "huggingface.model_id": "HF_DEFAULT_MODEL",
-  // Cloud
-  "aws.access_key_id": "AWS_ACCESS_KEY_ID",
-  "aws.region": "AWS_DEFAULT_REGION",
-  "gcp.service_account_json": "GOOGLE_APPLICATION_CREDENTIALS_JSON",
-  "gcp.project_id": "GCP_PROJECT_ID",
-  "azure.tenant_id": "AZURE_TENANT_ID",
-  "azure.client_id": "AZURE_CLIENT_ID",
+  // Cloud — all migrated:
+  //   aws → providers/aws.ts
+  //   gcp → providers/gcp.ts
+  //   azure → providers/azure.ts
   // Storage / Databases / Search — all migrated to per-provider strategies:
   //   s3 → providers/s3.ts
   //   google-drive → providers/googleDrive.ts
@@ -178,9 +176,17 @@ const LLM_AUTH_ENV_VARS = new Set(
     .filter(Boolean),
 );
 
+// Strategy-provider IDs whose primary env var matters for LLM auth.
+// Mirrors what the legacy INTEGRATION_ENV_MAP used to provide; kept here
+// so this file can answer the question without importing the registry
+// (which would be circular).
+const LLM_AUTH_PROVIDER_IDS = new Set(["openai", "anthropic", "huggingface"]);
+
 function integrationProviderAffectsLlmAuth(provider) {
   const providerId = String(provider || "").trim();
   if (!providerId) return false;
+
+  if (LLM_AUTH_PROVIDER_IDS.has(providerId)) return true;
 
   const primaryEnv = INTEGRATION_ENV_MAP[providerId];
   if (primaryEnv && LLM_AUTH_ENV_VARS.has(primaryEnv)) return true;

--- a/backend-api/integrations/providers/openai.ts
+++ b/backend-api/integrations/providers/openai.ts
@@ -1,0 +1,39 @@
+// OpenAI provider — Bearer API key. /v1/models is in the default scope of
+// every API key, so it's a safe validation endpoint.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const openaiProvider: Provider = {
+  id: "openai",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const res = await deps.fetch("https://api.openai.com/v1/models", {
+        headers: { Authorization: `Bearer ${ctx.token ?? ""}` },
+      });
+      if (!res.ok) throw new Error(`OpenAI API returned ${res.status}`);
+      const data: any = await res.json();
+      return {
+        success: true,
+        message: `Connected (${data.data?.length || 0} models available)`,
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.org_id) configEnv.org_id = "OPENAI_ORG_ID";
+    if (config.model) configEnv.model = "OPENAI_MODEL";
+    return { primary: "OPENAI_API_KEY", config: configEnv };
+  },
+};

--- a/backend-api/integrations/services/integrationsService.ts
+++ b/backend-api/integrations/services/integrationsService.ts
@@ -55,6 +55,13 @@ const { elasticsearchProvider } = require("../providers/elasticsearch");
 const { pineconeProvider } = require("../providers/pinecone");
 const { weaviateProvider } = require("../providers/weaviate");
 const { algoliaProvider } = require("../providers/algolia");
+const { openaiProvider } = require("../providers/openai");
+const { anthropicProvider } = require("../providers/anthropic");
+const { huggingfaceProvider } = require("../providers/huggingface");
+const { digitaloceanProvider } = require("../providers/digitalocean");
+const { awsProvider } = require("../providers/aws");
+const { gcpProvider } = require("../providers/gcp");
+const { azureProvider } = require("../providers/azure");
 
 const repo = createIntegrationsRepository(db);
 const secretCrypto = createSecretEncryption({
@@ -114,6 +121,13 @@ const providerRegistry = createProviderRegistry((providerId) =>
   pineconeProvider,
   weaviateProvider,
   algoliaProvider,
+  openaiProvider,
+  anthropicProvider,
+  huggingfaceProvider,
+  digitaloceanProvider,
+  awsProvider,
+  gcpProvider,
+  azureProvider,
 ].forEach((p) => providerRegistry.register(p));
 
 // Resolve fetch at call time so test mocks reassigning `global.fetch`

--- a/docs/guides/integrations/anthropic.mdx
+++ b/docs/guides/integrations/anthropic.mdx
@@ -1,0 +1,51 @@
+# Anthropic
+
+> Where to issue an Anthropic API key and connect it to Nora.
+
+Anthropic integrations let your agents call Claude (Opus, Sonnet, Haiku) for text generation and analysis. Nora authenticates with the standard `x-api-key` header.
+
+## Where to apply for credentials
+
+<Card
+  title="Anthropic API Keys"
+  href="https://console.anthropic.com/settings/keys"
+  icon="sparkles"
+  arrow
+>
+  https://console.anthropic.com/settings/keys
+</Card>
+
+<Steps>
+  <Step title="Sign in">
+    Open [console.anthropic.com](https://console.anthropic.com).
+  </Step>
+
+<Step title="Create a key">
+  Settings → API keys → **Create Key**. Give it a descriptive name (e.g. "nora-prod-agent").
+</Step>
+
+  <Step title="Copy the key">
+    Starts with `sk-ant-...`. Only shown once.
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+Paste the API key. Optionally set **Default Model** to one of:
+
+- `claude-opus-4-7` — most capable
+- `claude-sonnet-4-6` — balanced cost / quality
+- `claude-haiku-4-5` — fastest, cheapest
+
+Nora calls `GET https://api.anthropic.com/v1/models` to validate.
+
+## MCP server
+
+No official Anthropic MCP server today.
+
+## Environment variables Nora injects
+
+| Variable            | Source                 |
+| ------------------- | ---------------------- |
+| `ANTHROPIC_API_KEY` | API Key field          |
+| `ANTHROPIC_MODEL`   | Default Model (if set) |

--- a/docs/guides/integrations/aws.mdx
+++ b/docs/guides/integrations/aws.mdx
@@ -1,0 +1,63 @@
+# Amazon Web Services
+
+> How to issue scoped AWS IAM credentials and connect them to Nora.
+
+The AWS integration is the broad-spectrum equivalent of [S3](/guides/integrations/s3) — same shape, but the credentials cover whichever services your agent's IAM policy permits (EC2, Lambda, SES, DynamoDB, etc.).
+
+## Where to apply for credentials
+
+<Card
+  title="AWS IAM — Users"
+  href="https://console.aws.amazon.com/iam/home?#/users"
+  icon="cloud"
+  arrow
+>
+  https://console.aws.amazon.com/iam/home?#/users
+</Card>
+
+<Steps>
+  <Step title="Create a programmatic-access user">
+    IAM → Users → **Create user**. Name it (e.g. `nora-agent-prod`). Skip console access — it's a service identity.
+  </Step>
+
+<Step title="Attach least-privilege policies">
+  Don't reach for `AdministratorAccess`. Compose a custom policy that lists exactly the actions your
+  agent needs (e.g. `ec2:DescribeInstances`, `lambda:InvokeFunction`, `ses:SendEmail`).
+</Step>
+
+  <Step title="Generate an access key">
+    Open the user → **Security credentials** → **Create access key** → **Application running outside AWS**. Copy the Access Key ID + Secret Access Key (only shown once).
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+<Steps>
+  <Step title="Paste the keys">
+    Access Key ID + Secret Access Key.
+  </Step>
+
+<Step title="Set the default region">
+  Required for most AWS SDK calls. The agent runtime exposes this as `AWS_DEFAULT_REGION`.
+</Step>
+
+  <Step title="Connect">
+    Click **Connect**. Nora validates the access key format (must start with `AKIA` followed by 16 alphanumeric chars) and stores the credentials encrypted. **It does not sign a test request** — that happens in the agent runtime via the AWS SDK.
+  </Step>
+</Steps>
+
+## Verify the connection
+
+The **Test** button repeats the structural validation. End-to-end verification happens when your agent makes its first AWS SDK call.
+
+## MCP server
+
+There's an [AWS Labs MCP project](https://github.com/awslabs/mcp) that publishes per-service MCP servers (S3, Lambda, etc.). Pick whichever ones your agent needs and configure them with the standard AWS SDK env vars Nora injects.
+
+## Environment variables Nora injects
+
+| Variable                | Source            |
+| ----------------------- | ----------------- |
+| `AWS_SECRET_ACCESS_KEY` | Secret Access Key |
+| `AWS_ACCESS_KEY_ID`     | Access Key ID     |
+| `AWS_DEFAULT_REGION`    | Default Region    |

--- a/docs/guides/integrations/azure.mdx
+++ b/docs/guides/integrations/azure.mdx
@@ -1,0 +1,52 @@
+# Microsoft Azure
+
+> How to register an Entra ID (Azure AD) app and connect its Service Principal to Nora.
+
+The Azure integration uses **Service Principal** credentials — Tenant ID + Client ID + Client Secret — which the `@azure/identity` library picks up from `AZURE_TENANT_ID`, `AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET` env vars automatically.
+
+## Where to apply for credentials
+
+<Card
+  title="Azure Portal — App registrations"
+  href="https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade"
+  icon="cloud"
+  arrow
+>
+  Azure Portal → Microsoft Entra ID → App registrations
+</Card>
+
+<Steps>
+  <Step title="Register an app">
+    Microsoft Entra ID → **App registrations** → **New registration**. Name it (e.g. `nora-agent-prod`). Leave redirect URI blank — this is a service identity.
+  </Step>
+
+<Step title="Copy the Tenant + Client IDs">
+  After creation, the Overview page shows **Application (client) ID** and **Directory (tenant) ID**.
+  Copy both.
+</Step>
+
+<Step title="Generate a client secret">
+  Open **Certificates & secrets → Client secrets → New client secret**. Set an expiry (Azure caps at
+  24 months). Copy the **Value** field — Azure only shows it once.
+</Step>
+
+  <Step title="Grant Azure RBAC roles">
+    The service principal has no permissions yet. Open **Subscriptions → your subscription → Access control (IAM) → Add role assignment** and grant the SP the role(s) it needs (e.g. **Reader** for read-only, **Contributor** for typical management). Scope tightly when possible (specific resource groups instead of the whole subscription).
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+Paste **Tenant ID**, **Client ID**, and **Client Secret**. Nora validates the IDs are well-formed UUIDs and stores everything encrypted.
+
+## MCP server
+
+No official Azure MCP server today.
+
+## Environment variables Nora injects
+
+| Variable              | Source              |
+| --------------------- | ------------------- |
+| `AZURE_CLIENT_SECRET` | Client Secret field |
+| `AZURE_TENANT_ID`     | Tenant ID field     |
+| `AZURE_CLIENT_ID`     | Client ID field     |

--- a/docs/guides/integrations/digitalocean.mdx
+++ b/docs/guides/integrations/digitalocean.mdx
@@ -1,0 +1,45 @@
+# DigitalOcean
+
+> Where to issue a DigitalOcean Personal Access Token and connect it to Nora.
+
+DigitalOcean integrations let your agents manage Droplets, Spaces (object storage), Kubernetes clusters (DOKS), Functions, and the Apps Platform.
+
+## Where to apply for credentials
+
+<Card
+  title="DigitalOcean — API Tokens"
+  href="https://cloud.digitalocean.com/account/api/tokens"
+  icon="droplet"
+  arrow
+>
+  https://cloud.digitalocean.com/account/api/tokens
+</Card>
+
+<Steps>
+  <Step title="Sign in">
+    Open [cloud.digitalocean.com](https://cloud.digitalocean.com).
+  </Step>
+
+<Step title="Create a Personal Access Token">
+  API → Tokens/Keys → **Generate New Token**. Pick **Custom Scopes** for least privilege, or **Full
+  Access** for development.
+</Step>
+
+  <Step title="Copy the token">
+    DO shows it once.
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+Paste the token and click **Connect**. Nora calls `GET https://api.digitalocean.com/v2/account` and reports your email on success.
+
+## MCP server
+
+No official DigitalOcean MCP server today.
+
+## Environment variables Nora injects
+
+| Variable             | Source          |
+| -------------------- | --------------- |
+| `DIGITALOCEAN_TOKEN` | API Token field |

--- a/docs/guides/integrations/gcp.mdx
+++ b/docs/guides/integrations/gcp.mdx
@@ -1,0 +1,61 @@
+# Google Cloud Platform
+
+> How to provision a GCP service account JSON and connect it to Nora.
+
+The GCP integration covers any service the gcloud SDKs support — Compute Engine, Cloud Storage, BigQuery, Pub/Sub, Cloud Run, etc. Nora authenticates with a service-account JSON that the agent runtime mounts and points `GOOGLE_APPLICATION_CREDENTIALS` at.
+
+## Where to apply for credentials
+
+<Card
+  title="GCP — Service Accounts"
+  href="https://console.cloud.google.com/iam-admin/serviceaccounts"
+  icon="cloud"
+  arrow
+>
+  https://console.cloud.google.com/iam-admin/serviceaccounts
+</Card>
+
+<Steps>
+  <Step title="Create a service account">
+    GCP Console → IAM & Admin → Service Accounts → **Create Service Account**. Give it a descriptive name. Skip the optional roles assignment — you'll do it next.
+  </Step>
+
+<Step title="Grant least-privilege roles">
+  On the created SA's IAM page, attach the roles your agent needs (e.g.
+  `roles/storage.objectViewer`, `roles/bigquery.user`). Avoid `roles/owner` and `roles/editor` for
+  production agents.
+</Step>
+
+  <Step title="Generate a JSON key">
+    Open the SA → **Keys** → **Add Key → Create new key → JSON**. The file downloads — treat it as secret.
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+<Steps>
+  <Step title="Paste the JSON">
+    Open the downloaded file in a text editor and paste the entire contents into the **Service Account JSON** textarea.
+  </Step>
+
+<Step title="Set the project ID">
+  Required field. Visible at the top of the GCP Console (or inside the JSON file as `project_id`).
+</Step>
+
+  <Step title="Connect">
+    Click **Connect**. Nora validates that the JSON parses and contains `client_email`, `private_key`, and `project_id`.
+  </Step>
+</Steps>
+
+## MCP server
+
+No first-party GCP MCP server today. AWS has `awslabs/mcp` — a Google equivalent hasn't shipped.
+
+## Environment variables Nora injects
+
+| Variable                              | Source               |
+| ------------------------------------- | -------------------- |
+| `GOOGLE_APPLICATION_CREDENTIALS_JSON` | Service Account JSON |
+| `GCP_PROJECT_ID`                      | Project ID field     |
+
+The agent runtime writes `GOOGLE_APPLICATION_CREDENTIALS_JSON` to a file at startup and points `GOOGLE_APPLICATION_CREDENTIALS` at the file path — that's what every gcloud SDK expects.

--- a/docs/guides/integrations/huggingface.mdx
+++ b/docs/guides/integrations/huggingface.mdx
@@ -1,0 +1,45 @@
+# Hugging Face
+
+> Where to issue a Hugging Face access token and connect it to Nora.
+
+Hugging Face integrations let your agents query the Inference API, push to model/dataset repos, and fetch private model weights.
+
+## Where to apply for credentials
+
+<Card
+  title="Hugging Face Access Tokens"
+  href="https://huggingface.co/settings/tokens"
+  icon="brain"
+  arrow
+>
+  https://huggingface.co/settings/tokens
+</Card>
+
+<Steps>
+  <Step title="Sign in">
+    Open [huggingface.co](https://huggingface.co) and sign in.
+  </Step>
+
+<Step title="Create a token">
+  Settings → Access Tokens → **New token**. Pick: - **Read** — for inference API calls + downloading
+  public/private models you have access to. - **Write** — additionally allows pushing to your repos.
+</Step>
+
+  <Step title="Copy the token">
+    Starts with `hf_...`.
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+Paste the token, optionally set a default model ID (e.g. `meta-llama/Llama-3-8B-Instruct`), and click **Connect**. Nora calls `GET https://huggingface.co/api/whoami-v2` and reports your username on success.
+
+## MCP server
+
+No official Hugging Face MCP server today. Community servers exist for specific use cases (e.g. local Inference Endpoints).
+
+## Environment variables Nora injects
+
+| Variable   | Source          |
+| ---------- | --------------- |
+| `HF_TOKEN` | API Token field |

--- a/docs/guides/integrations/openai.mdx
+++ b/docs/guides/integrations/openai.mdx
@@ -1,0 +1,50 @@
+# OpenAI
+
+> Where to issue an OpenAI API key and connect it to Nora.
+
+OpenAI integrations let your agents call GPT models, generate embeddings, render images via DALL-E, and transcribe audio with Whisper.
+
+## Where to apply for credentials
+
+<Card title="OpenAI API Keys" href="https://platform.openai.com/api-keys" icon="brain" arrow>
+  https://platform.openai.com/api-keys
+</Card>
+
+<Steps>
+  <Step title="Sign in">
+    Open [platform.openai.com](https://platform.openai.com).
+  </Step>
+
+<Step title="Create a project key">
+  Settings → API Keys → **Create new secret key**. Pick **Project** scoping for production agents
+  (revocable per project) or **Service account** for shared infra agents.
+</Step>
+
+  <Step title="Copy the key">
+    The key starts with `sk-...`. OpenAI shows it only once.
+  </Step>
+</Steps>
+
+## (Optional) Org / project IDs
+
+If you're on a multi-org account, find the **Organization ID** under Settings → Organization → General. Project IDs live under Project Settings. Setting these on the integration is mostly useful for cost attribution.
+
+## Connect in Nora
+
+Paste the API key into the **API Key** field, optionally set Organization ID and a default model (e.g. `gpt-4o-mini`), and click **Connect**. Nora calls `GET https://api.openai.com/v1/models` and reports how many models are visible to the key.
+
+## Verify the connection
+
+The **Test** button calls `/v1/models`. **401** means the key was revoked; **429** means you're rate-limited (try again).
+
+## MCP server
+
+No official OpenAI MCP server today. The standard env var (`OPENAI_API_KEY`) is exposed to the agent so any community OpenAI MCP can pick it up.
+
+## Environment variables Nora injects
+
+| Variable         | Source                   |
+| ---------------- | ------------------------ |
+| `OPENAI_API_KEY` | API Key field            |
+| `OPENAI_ORG_ID`  | Organization ID (if set) |
+| `OPENAI_MODEL`   | Default Model (if set)   |


### PR DESCRIPTION
## Summary

- 7 providers move off the legacy switch: `openai`, `anthropic`, `huggingface`, `digitalocean`, `aws`, `gcp`, `azure`.
- API-validated: openai, anthropic, huggingface, digitalocean. Structurally validated: aws (AKIA-prefix check), gcp (SA JSON shape), azure (UUID format).
- `credentialsUrl` + `setupGuide` populated for all 7 (with concrete IAM-policy snippet for AWS).
- The legacy `integrationProviderAffectsLlmAuth` helper now hard-codes `{openai, anthropic, huggingface}` as LLM-auth-affecting since their env-map rows were removed.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 763/763 passing (was 740; +23 from 7 new tests + the env-map regression catch)
- [ ] Manual dashboard pass once merged