### PR TITLE
feat(integrations): migrate productivity providers (9 providers)

### DIFF
--- a/backend-api/__tests__/providers/airtableProvider.test.ts
+++ b/backend-api/__tests__/providers/airtableProvider.test.ts
@@ -1,0 +1,41 @@
+// @ts-nocheck
+const { airtableProvider } = require("../../integrations/providers/airtable");
+
+function deps(fetchImpl) {
+  return {
+    fetch: fetchImpl,
+    assertSafeUrl: async (u) => u,
+    encrypt: (s) => s,
+    decrypt: (s) => s,
+    ensureEncryptionConfigured: jest.fn(),
+    db: { query: jest.fn() },
+  };
+}
+
+describe("airtableProvider", () => {
+  it("calls /v0/meta/whoami with Bearer token", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ email: "alice@example.com" }),
+    });
+    const result = await airtableProvider.test(
+      { row: {}, token: "pat_x", config: {} },
+      deps(fetchImpl),
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.airtable.com/v0/meta/whoami",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer pat_x" }),
+      }),
+    );
+    expect(result.message).toContain("alice@example.com");
+  });
+
+  it("emits AIRTABLE_API_KEY + base_id when set", () => {
+    const env = airtableProvider.mapToEnv({ row: {}, token: null, config: { base_id: "appXYZ" } });
+    expect(env).toEqual({
+      primary: "AIRTABLE_API_KEY",
+      config: { base_id: "AIRTABLE_BASE_ID" },
+    });
+  });
+});

--- a/backend-api/__tests__/providers/asanaProvider.test.ts
+++ b/backend-api/__tests__/providers/asanaProvider.test.ts
@@ -1,0 +1,39 @@
+// @ts-nocheck
+const { asanaProvider } = require("../../integrations/providers/asana");
+
+const deps = (fetchImpl) => ({
+  fetch: fetchImpl,
+  assertSafeUrl: async (u) => u,
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+});
+
+describe("asanaProvider", () => {
+  it("hits /users/me with Bearer token", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: { name: "Alice" } }),
+    });
+    const result = await asanaProvider.test(
+      { row: {}, token: "1/abc", config: {} },
+      deps(fetchImpl),
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://app.asana.com/api/1.0/users/me",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer 1/abc" }),
+      }),
+    );
+    expect(result.message).toContain("Alice");
+  });
+
+  it("emits ASANA_TOKEN + ASANA_WORKSPACE_ID", () => {
+    const env = asanaProvider.mapToEnv({ row: {}, token: null, config: { workspace_id: "ws1" } });
+    expect(env).toEqual({
+      primary: "ASANA_TOKEN",
+      config: { workspace_id: "ASANA_WORKSPACE_ID" },
+    });
+  });
+});

--- a/backend-api/__tests__/providers/clickupProvider.test.ts
+++ b/backend-api/__tests__/providers/clickupProvider.test.ts
@@ -1,0 +1,37 @@
+// @ts-nocheck
+const { clickupProvider } = require("../../integrations/providers/clickup");
+
+const deps = (fetchImpl) => ({
+  fetch: fetchImpl,
+  assertSafeUrl: async (u) => u,
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+});
+
+describe("clickupProvider", () => {
+  it("calls /v2/user with raw token in Authorization header", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ user: { username: "alice" } }),
+    });
+    const result = await clickupProvider.test(
+      { row: {}, token: "pk_x", config: {} },
+      deps(fetchImpl),
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.clickup.com/api/v2/user",
+      expect.objectContaining({ headers: { Authorization: "pk_x" } }),
+    );
+    expect(result.message).toContain("alice");
+  });
+
+  it("emits CLICKUP_API_KEY + team_id", () => {
+    const env = clickupProvider.mapToEnv({ row: {}, token: null, config: { team_id: "t1" } });
+    expect(env).toEqual({
+      primary: "CLICKUP_API_KEY",
+      config: { team_id: "CLICKUP_TEAM_ID" },
+    });
+  });
+});

--- a/backend-api/__tests__/providers/confluenceProvider.test.ts
+++ b/backend-api/__tests__/providers/confluenceProvider.test.ts
@@ -1,0 +1,62 @@
+// @ts-nocheck
+const { confluenceProvider } = require("../../integrations/providers/confluence");
+
+const deps = (fetchImpl, assertSafeUrlImpl) => ({
+  fetch: fetchImpl,
+  assertSafeUrl: assertSafeUrlImpl || (async (u) => u),
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+});
+
+describe("confluenceProvider", () => {
+  it("calls /wiki/rest/api/user/current with HTTP Basic", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ displayName: "Alice" }),
+    });
+    const assertSafeUrl = jest.fn(async (u) => u);
+    const result = await confluenceProvider.test(
+      {
+        row: {},
+        token: "atoken",
+        config: { base_url: "https://acme.atlassian.net", email: "alice@example.com" },
+      },
+      deps(fetchImpl, assertSafeUrl),
+    );
+    expect(assertSafeUrl).toHaveBeenCalledWith("https://acme.atlassian.net", "Confluence base URL");
+    const expectedAuth = "Basic " + Buffer.from("alice@example.com:atoken").toString("base64");
+    expect(fetchImpl.mock.calls[0][0]).toBe(
+      "https://acme.atlassian.net/wiki/rest/api/user/current",
+    );
+    expect(fetchImpl.mock.calls[0][1].headers.Authorization).toBe(expectedAuth);
+    expect(result.message).toContain("Alice");
+  });
+
+  it("rejects missing base_url or email", async () => {
+    const fetchImpl = jest.fn();
+    let result = await confluenceProvider.test(
+      { row: {}, token: "t", config: { email: "x@y.com" } },
+      deps(fetchImpl),
+    );
+    expect(result.error).toContain("URL");
+    result = await confluenceProvider.test(
+      { row: {}, token: "t", config: { base_url: "https://x.atlassian.net" } },
+      deps(fetchImpl),
+    );
+    expect(result.error).toContain("email");
+  });
+
+  it("emits CONFLUENCE_TOKEN + email + base_url", () => {
+    const env = confluenceProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { base_url: "u", email: "e" },
+    });
+    expect(env).toEqual({
+      primary: "CONFLUENCE_TOKEN",
+      config: { email: "CONFLUENCE_EMAIL", base_url: "CONFLUENCE_BASE_URL" },
+    });
+  });
+});

--- a/backend-api/__tests__/providers/googleCalendarProvider.test.ts
+++ b/backend-api/__tests__/providers/googleCalendarProvider.test.ts
@@ -1,0 +1,42 @@
+// @ts-nocheck
+const { googleCalendarProvider } = require("../../integrations/providers/googleCalendar");
+
+const deps = {
+  fetch: jest.fn(),
+  assertSafeUrl: async (u) => u,
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+};
+
+const validSa = JSON.stringify({
+  client_email: "agent@p.iam.gserviceaccount.com",
+  private_key: "-----BEGIN PRIVATE KEY-----\nx\n-----END PRIVATE KEY-----\n",
+  project_id: "p",
+});
+
+describe("googleCalendarProvider", () => {
+  it("identifies as google-calendar / service_account", () => {
+    expect(googleCalendarProvider.id).toBe("google-calendar");
+    expect(googleCalendarProvider.authType).toBe("service_account");
+  });
+
+  it("validates the SA JSON structurally", async () => {
+    const result = await googleCalendarProvider.test(
+      { row: {}, token: null, config: { service_account_json: validSa } },
+      deps,
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("emits GOOGLE_APPLICATION_CREDENTIALS_JSON + calendar_id", () => {
+    const env = googleCalendarProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { service_account_json: validSa, calendar_id: "primary" },
+    });
+    expect(env.primary).toBeNull();
+    expect(env.config.calendar_id).toBe("GOOGLE_CALENDAR_DEFAULT_ID");
+  });
+});

--- a/backend-api/__tests__/providers/googleSheetsProvider.test.ts
+++ b/backend-api/__tests__/providers/googleSheetsProvider.test.ts
@@ -1,0 +1,52 @@
+// @ts-nocheck
+const { googleSheetsProvider } = require("../../integrations/providers/googleSheets");
+
+const deps = {
+  fetch: jest.fn(),
+  assertSafeUrl: async (u) => u,
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+};
+
+const validSa = JSON.stringify({
+  client_email: "agent@p.iam.gserviceaccount.com",
+  private_key: "-----BEGIN PRIVATE KEY-----\nx\n-----END PRIVATE KEY-----\n",
+  project_id: "p",
+});
+
+describe("googleSheetsProvider", () => {
+  it("identifies as google-sheets / service_account", () => {
+    expect(googleSheetsProvider.id).toBe("google-sheets");
+    expect(googleSheetsProvider.authType).toBe("service_account");
+  });
+
+  it("validates the SA JSON structurally", async () => {
+    const result = await googleSheetsProvider.test(
+      { row: {}, token: null, config: { service_account_json: validSa } },
+      deps,
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects missing required keys", async () => {
+    const result = await googleSheetsProvider.test(
+      { row: {}, token: null, config: { service_account_json: "{}" } },
+      deps,
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("missing required keys");
+  });
+
+  it("emits GOOGLE_APPLICATION_CREDENTIALS_JSON + spreadsheet_id", () => {
+    const env = googleSheetsProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { service_account_json: validSa, spreadsheet_id: "abc" },
+    });
+    expect(env.primary).toBeNull();
+    expect(env.config.service_account_json).toBe("GOOGLE_APPLICATION_CREDENTIALS_JSON");
+    expect(env.config.spreadsheet_id).toBe("GOOGLE_SHEETS_DEFAULT_SPREADSHEET_ID");
+  });
+});

--- a/backend-api/__tests__/providers/mondayProvider.test.ts
+++ b/backend-api/__tests__/providers/mondayProvider.test.ts
@@ -1,0 +1,40 @@
+// @ts-nocheck
+const { mondayProvider } = require("../../integrations/providers/monday");
+
+const deps = (fetchImpl) => ({
+  fetch: fetchImpl,
+  assertSafeUrl: async (u) => u,
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+});
+
+describe("mondayProvider", () => {
+  it("POSTs GraphQL with token in raw Authorization header", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: { me: { name: "Alice" } } }),
+    });
+    const result = await mondayProvider.test(
+      { row: {}, token: "tok", config: {} },
+      deps(fetchImpl),
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.monday.com/v2",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({ Authorization: "tok" }),
+        body: JSON.stringify({ query: "{ me { name } }" }),
+      }),
+    );
+    expect(result.message).toContain("Alice");
+  });
+
+  it("emits MONDAY_API_KEY", () => {
+    expect(mondayProvider.mapToEnv({ row: {}, token: null, config: {} })).toEqual({
+      primary: "MONDAY_API_KEY",
+      config: {},
+    });
+  });
+});

--- a/backend-api/__tests__/providers/notionProvider.test.ts
+++ b/backend-api/__tests__/providers/notionProvider.test.ts
@@ -1,0 +1,43 @@
+// @ts-nocheck
+const { notionProvider } = require("../../integrations/providers/notion");
+
+function deps(fetchImpl) {
+  return {
+    fetch: fetchImpl,
+    assertSafeUrl: async (u) => u,
+    encrypt: (s) => s,
+    decrypt: (s) => s,
+    ensureEncryptionConfigured: jest.fn(),
+    db: { query: jest.fn() },
+  };
+}
+
+describe("notionProvider", () => {
+  it("calls /v1/users/me with Bearer token + Notion-Version", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ name: "Alice", id: "abc" }),
+    });
+    const result = await notionProvider.test(
+      { row: {}, token: "secret_x", config: {} },
+      deps(fetchImpl),
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.notion.com/v1/users/me",
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: "Bearer secret_x",
+          "Notion-Version": "2022-06-28",
+        }),
+      }),
+    );
+    expect(result.message).toBe("Connected as Alice");
+  });
+
+  it("emits NOTION_TOKEN", () => {
+    expect(notionProvider.mapToEnv({ row: {}, token: null, config: {} })).toEqual({
+      primary: "NOTION_TOKEN",
+      config: {},
+    });
+  });
+});

--- a/backend-api/__tests__/providers/trelloProvider.test.ts
+++ b/backend-api/__tests__/providers/trelloProvider.test.ts
@@ -1,0 +1,45 @@
+// @ts-nocheck
+const { trelloProvider } = require("../../integrations/providers/trello");
+
+const deps = (fetchImpl) => ({
+  fetch: fetchImpl,
+  assertSafeUrl: async (u) => u,
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+});
+
+describe("trelloProvider", () => {
+  it("passes key + token as query params", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ username: "alice" }),
+    });
+    const result = await trelloProvider.test(
+      { row: {}, token: "tok", config: { api_key: "key123" } },
+      deps(fetchImpl),
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.trello.com/1/members/me?key=key123&token=tok",
+    );
+    expect(result.message).toContain("alice");
+  });
+
+  it("rejects when API key missing", async () => {
+    const result = await trelloProvider.test(
+      { row: {}, token: "tok", config: {} },
+      deps(jest.fn()),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("API key");
+  });
+
+  it("emits TRELLO_TOKEN + TRELLO_API_KEY", () => {
+    const env = trelloProvider.mapToEnv({ row: {}, token: null, config: { api_key: "k" } });
+    expect(env).toEqual({
+      primary: "TRELLO_TOKEN",
+      config: { api_key: "TRELLO_API_KEY" },
+    });
+  });
+});

--- a/backend-api/integrations/catalog/catalog.json
+++ b/backend-api/integrations/catalog/catalog.json
@@ -619,7 +619,23 @@
       { "key": "api_key", "label": "Integration Token", "type": "password", "required": true },
       { "key": "workspace_id", "label": "Workspace ID", "type": "text", "required": false }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://www.notion.so/my-integrations",
+    "setupGuide": {
+      "steps": [
+        "Open Notion integrations page (notion.so/my-integrations) and click New integration.",
+        "Pick the workspace, name your integration, and choose Internal as the type.",
+        "Copy the Internal Integration Token (starts with secret_).",
+        "From the page or database you want the agent to access, click Share → Add the integration."
+      ]
+    },
+    "mcp": {
+      "available": true,
+      "transport": "stdio",
+      "npmPackage": "@notionhq/notion-mcp-server",
+      "docsUrl": "https://github.com/makenotion/notion-mcp-server",
+      "notes": "Official Notion MCP server. Reads NOTION_TOKEN env var."
+    }
   },
   {
     "id": "airtable",
@@ -632,7 +648,18 @@
       { "key": "api_key", "label": "Personal Access Token", "type": "password", "required": true },
       { "key": "base_id", "label": "Default Base ID", "type": "text", "required": false }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://airtable.com/create/tokens",
+    "setupGuide": {
+      "steps": [
+        "Sign in to Airtable and open the personal access tokens page (airtable.com/create/tokens).",
+        "Click Create new token. Pick scopes (data.records:read, data.records:write, schema.bases:read).",
+        "Add the bases the agent should access under Access.",
+        "Copy the token (starts with pat...)."
+      ],
+      "scopes": ["data.records:read", "data.records:write", "schema.bases:read"]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "google-sheets",
@@ -655,7 +682,17 @@
         "required": false
       }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://console.cloud.google.com/iam-admin/serviceaccounts",
+    "setupGuide": {
+      "steps": [
+        "In GCP Console, create a service account and download a JSON key.",
+        "Enable the Google Sheets API for the project (APIs & Services → Library).",
+        "Share each spreadsheet you want the agent to access with the SA's client_email.",
+        "Paste the JSON contents into the textarea."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "trello",
@@ -669,7 +706,17 @@
       { "key": "token", "label": "Token", "type": "password", "required": true },
       { "key": "board_id", "label": "Default Board ID", "type": "text", "required": false }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://trello.com/power-ups/admin",
+    "setupGuide": {
+      "steps": [
+        "Open Trello Power-Ups admin (trello.com/power-ups/admin) and create a new Power-Up — this gives you the API Key.",
+        "On the Power-Up's API Key page, click Token (right side) to OAuth-authorize a token.",
+        "Copy the API Key + Token (Trello shows the token once after the OAuth flow).",
+        "(Optional) Find a board ID from its URL — the second path segment after /b/."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "asana",
@@ -687,7 +734,17 @@
       },
       { "key": "workspace_gid", "label": "Workspace GID", "type": "text", "required": false }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://app.asana.com/0/my-apps",
+    "setupGuide": {
+      "steps": [
+        "Sign in to Asana and open My Apps (app.asana.com/0/my-apps).",
+        "Click Create new token, name it, accept the API ToS.",
+        "Copy the token (only shown once).",
+        "(Optional) Find your workspace GID via GET https://app.asana.com/api/1.0/workspaces."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "monday",
@@ -699,7 +756,16 @@
     "configFields": [
       { "key": "api_key", "label": "API Token", "type": "password", "required": true }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://monday.com/developers/v2/admin",
+    "setupGuide": {
+      "steps": [
+        "Sign in to monday.com and open Avatar → Developers → My Access Tokens.",
+        "Click Show and copy the Personal API Token, OR generate a new one.",
+        "Token gives access to whatever you can see in the UI — for finer scoping, use OAuth apps."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "clickup",
@@ -712,7 +778,17 @@
       { "key": "api_key", "label": "API Key", "type": "password", "required": true },
       { "key": "workspace_id", "label": "Workspace ID", "type": "text", "required": false }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://app.clickup.com/settings/apps",
+    "setupGuide": {
+      "steps": [
+        "Sign in to ClickUp and open Settings → Apps.",
+        "Click Generate next to API Token.",
+        "Copy the token (starts with pk_...).",
+        "(Optional) Find your workspace ID by viewing any workspace URL — it's the long number after /."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "salesforce",
@@ -1516,7 +1592,17 @@
       },
       { "key": "calendar_id", "label": "Calendar ID", "type": "text", "required": false }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://console.cloud.google.com/iam-admin/serviceaccounts",
+    "setupGuide": {
+      "steps": [
+        "In GCP Console, create a service account and download a JSON key.",
+        "Enable the Google Calendar API for the project.",
+        "For each calendar the agent should access, share it with the SA's client_email (in Calendar Settings → Share with specific people).",
+        "Paste the JSON contents into the textarea."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "confluence",
@@ -1524,13 +1610,23 @@
     "icon": "book-open",
     "category": "productivity",
     "description": "Create and manage Confluence pages, spaces, and content",
-    "authType": "api_key",
+    "authType": "basic",
     "configFields": [
       { "key": "base_url", "label": "Confluence URL", "type": "url", "required": true },
       { "key": "email", "label": "Email", "type": "email", "required": true },
       { "key": "api_token", "label": "API Token", "type": "password", "required": true }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://id.atlassian.com/manage-profile/security/api-tokens",
+    "setupGuide": {
+      "steps": [
+        "Open id.atlassian.com/manage-profile/security/api-tokens.",
+        "Click Create API token, name it (e.g. 'Nora'), copy the value.",
+        "Enter your Confluence Cloud URL (e.g. https://acme.atlassian.net) — the same site you sign in to.",
+        "Enter the email tied to your Atlassian account."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "docker-hub",

--- a/backend-api/integrations/index.ts
+++ b/backend-api/integrations/index.ts
@@ -74,6 +74,15 @@ export { digitaloceanProvider } from "./providers/digitalocean";
 export { awsProvider } from "./providers/aws";
 export { gcpProvider } from "./providers/gcp";
 export { azureProvider } from "./providers/azure";
+export { notionProvider } from "./providers/notion";
+export { airtableProvider } from "./providers/airtable";
+export { asanaProvider } from "./providers/asana";
+export { mondayProvider } from "./providers/monday";
+export { clickupProvider } from "./providers/clickup";
+export { trelloProvider } from "./providers/trello";
+export { confluenceProvider } from "./providers/confluence";
+export { googleSheetsProvider } from "./providers/googleSheets";
+export { googleCalendarProvider } from "./providers/googleCalendar";
 
 // The orchestration service is the recommended import for callers that
 // need the high-level operations (connect, list, test, sync, env-vars).

--- a/backend-api/integrations/providers/airtable.ts
+++ b/backend-api/integrations/providers/airtable.ts
@@ -1,0 +1,34 @@
+// Airtable provider — Personal Access Token (PAT), Bearer auth.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const airtableProvider: Provider = {
+  id: "airtable",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const res = await deps.fetch("https://api.airtable.com/v0/meta/whoami", {
+        headers: { Authorization: `Bearer ${ctx.token ?? ""}` },
+      });
+      if (!res.ok) throw new Error(`Airtable API returned ${res.status}`);
+      const data: any = await res.json();
+      return { success: true, message: `Connected as ${data.email || data.id}` };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.base_id) configEnv.base_id = "AIRTABLE_BASE_ID";
+    return { primary: "AIRTABLE_API_KEY", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/asana.ts
+++ b/backend-api/integrations/providers/asana.ts
@@ -1,0 +1,37 @@
+// Asana provider — Personal Access Token (Bearer).
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const asanaProvider: Provider = {
+  id: "asana",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const res = await deps.fetch("https://app.asana.com/api/1.0/users/me", {
+        headers: { Authorization: `Bearer ${ctx.token ?? ""}` },
+      });
+      if (!res.ok) throw new Error(`Asana API returned ${res.status}`);
+      const data: any = await res.json();
+      return {
+        success: true,
+        message: `Connected as ${data.data?.name || "verified"}`,
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.workspace_id) configEnv.workspace_id = "ASANA_WORKSPACE_ID";
+    return { primary: "ASANA_TOKEN", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/clickup.ts
+++ b/backend-api/integrations/providers/clickup.ts
@@ -1,0 +1,37 @@
+// ClickUp provider — Personal API token in raw Authorization header.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const clickupProvider: Provider = {
+  id: "clickup",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const res = await deps.fetch("https://api.clickup.com/api/v2/user", {
+        headers: { Authorization: ctx.token ?? "" },
+      });
+      if (!res.ok) throw new Error(`ClickUp API returned ${res.status}`);
+      const data: any = await res.json();
+      return {
+        success: true,
+        message: `Connected as ${data.user?.username || "verified"}`,
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.team_id) configEnv.team_id = "CLICKUP_TEAM_ID";
+    return { primary: "CLICKUP_API_KEY", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/confluence.ts
+++ b/backend-api/integrations/providers/confluence.ts
@@ -1,0 +1,44 @@
+// Confluence Cloud provider — Basic auth (email + API token) against the
+// customer's site. Validates the site URL to block SSRF.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const confluenceProvider: Provider = {
+  id: "confluence",
+  authType: "basic",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      const baseUrl = config.base_url;
+      const email = config.email;
+      if (!baseUrl) throw new Error("Confluence URL not configured");
+      if (!email) throw new Error("Confluence email not configured");
+      const rawUrl = String(baseUrl).includes("://") ? String(baseUrl) : `https://${baseUrl}`;
+      const url = await deps.assertSafeUrl(rawUrl, "Confluence base URL");
+      const credentials = Buffer.from(`${email}:${ctx.token ?? ""}`).toString("base64");
+      const res = await deps.fetch(`${url}/wiki/rest/api/user/current`, {
+        headers: { Authorization: `Basic ${credentials}` },
+      });
+      if (!res.ok) throw new Error(`Confluence API returned ${res.status}`);
+      const data: any = await res.json();
+      return { success: true, message: `Connected as ${data.displayName || data.email}` };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.email) configEnv.email = "CONFLUENCE_EMAIL";
+    if (config.base_url) configEnv.base_url = "CONFLUENCE_BASE_URL";
+    return { primary: "CONFLUENCE_TOKEN", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/googleCalendar.ts
+++ b/backend-api/integrations/providers/googleCalendar.ts
@@ -1,0 +1,49 @@
+// Google Calendar provider — service-account JSON.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+} from "../types/provider";
+
+const REQUIRED_SA_KEYS = ["client_email", "private_key", "project_id"] as const;
+
+export const googleCalendarProvider: Provider = {
+  id: "google-calendar",
+  authType: "service_account",
+
+  async test(ctx: DecryptedIntegration): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      const raw = String(config.service_account_json || "").trim();
+      if (!raw) throw new Error("Google Calendar service account JSON is required");
+      let parsed: any;
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        throw new Error("Service account JSON is not valid JSON");
+      }
+      const missing = REQUIRED_SA_KEYS.filter((k) => !parsed[k]);
+      if (missing.length > 0) {
+        throw new Error(`Service account JSON is missing required keys: ${missing.join(", ")}`);
+      }
+      return {
+        success: true,
+        message: `Service account stored (${parsed.client_email})`,
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.service_account_json) {
+      configEnv.service_account_json = "GOOGLE_APPLICATION_CREDENTIALS_JSON";
+    }
+    if (config.calendar_id) configEnv.calendar_id = "GOOGLE_CALENDAR_DEFAULT_ID";
+    return { primary: null, config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/googleSheets.ts
+++ b/backend-api/integrations/providers/googleSheets.ts
@@ -1,0 +1,51 @@
+// Google Sheets provider — service-account JSON. Same shape as Firebase /
+// Drive / GCP. Agent runtime mounts the JSON as a file and points
+// GOOGLE_APPLICATION_CREDENTIALS at it.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+} from "../types/provider";
+
+const REQUIRED_SA_KEYS = ["client_email", "private_key", "project_id"] as const;
+
+export const googleSheetsProvider: Provider = {
+  id: "google-sheets",
+  authType: "service_account",
+
+  async test(ctx: DecryptedIntegration): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      const raw = String(config.service_account_json || "").trim();
+      if (!raw) throw new Error("Google Sheets service account JSON is required");
+      let parsed: any;
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        throw new Error("Service account JSON is not valid JSON");
+      }
+      const missing = REQUIRED_SA_KEYS.filter((k) => !parsed[k]);
+      if (missing.length > 0) {
+        throw new Error(`Service account JSON is missing required keys: ${missing.join(", ")}`);
+      }
+      return {
+        success: true,
+        message: `Service account stored (${parsed.client_email})`,
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.service_account_json) {
+      configEnv.service_account_json = "GOOGLE_APPLICATION_CREDENTIALS_JSON";
+    }
+    if (config.spreadsheet_id) configEnv.spreadsheet_id = "GOOGLE_SHEETS_DEFAULT_SPREADSHEET_ID";
+    return { primary: null, config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/legacy/connectivityTests.ts
+++ b/backend-api/integrations/providers/legacy/connectivityTests.ts
@@ -45,14 +45,7 @@ function buildConnectivityTests(integration, token, deps) {
   return {
     // gitlab → migrated to providers/gitlab.ts
     // discord → migrated to providers/discord.ts
-    notion: async () => {
-      const res = await fetch("https://api.notion.com/v1/users/me", {
-        headers: { Authorization: `Bearer ${token}`, "Notion-Version": "2022-06-28" },
-      });
-      if (!res.ok) throw new Error(`Notion API returned ${res.status}`);
-      const data = await res.json();
-      return { success: true, message: `Connected as ${data.name || data.id}` };
-    },
+    // notion → migrated to providers/notion.ts
     datadog: async () => {
       const res = await fetch("https://api.datadoghq.com/api/v1/validate", {
         headers: { "DD-API-KEY": token },
@@ -72,75 +65,12 @@ function buildConnectivityTests(integration, token, deps) {
     // anthropic → migrated to providers/anthropic.ts
     // huggingface → migrated to providers/huggingface.ts
     // bitbucket → migrated to providers/bitbucket.ts
-    airtable: async () => {
-      const res = await fetch("https://api.airtable.com/v0/meta/whoami", {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (!res.ok) throw new Error(`Airtable API returned ${res.status}`);
-      const data = await res.json();
-      return { success: true, message: `Connected as ${data.email || data.id}` };
-    },
-    asana: async () => {
-      const res = await fetch("https://app.asana.com/api/1.0/users/me", {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (!res.ok) throw new Error(`Asana API returned ${res.status}`);
-      const data = await res.json();
-      return { success: true, message: `Connected as ${data.data?.name || "verified"}` };
-    },
-    monday: async () => {
-      const res = await fetch("https://api.monday.com/v2", {
-        method: "POST",
-        headers: { Authorization: token, "Content-Type": "application/json" },
-        body: JSON.stringify({ query: "{ me { name } }" }),
-      });
-      if (!res.ok) throw new Error(`Monday.com API returned ${res.status}`);
-      const data = await res.json();
-      return { success: true, message: `Connected as ${data.data?.me?.name || "verified"}` };
-    },
-    clickup: async () => {
-      const res = await fetch("https://api.clickup.com/api/v2/user", {
-        headers: { Authorization: token },
-      });
-      if (!res.ok) throw new Error(`ClickUp API returned ${res.status}`);
-      const data = await res.json();
-      return { success: true, message: `Connected as ${data.user?.username || "verified"}` };
-    },
-    trello: async () => {
-      const config =
-        typeof integration.config === "string"
-          ? JSON.parse(integration.config)
-          : integration.config || {};
-      const apiKey = config.api_key;
-      if (!apiKey) throw new Error("Trello API key not configured");
-      const res = await fetch(
-        `https://api.trello.com/1/members/me?key=${encodeURIComponent(apiKey)}&token=${encodeURIComponent(token)}`,
-      );
-      if (!res.ok) throw new Error(`Trello API returned ${res.status}`);
-      const data = await res.json();
-      return { success: true, message: `Connected as ${data.username}` };
-    },
-    confluence: async () => {
-      const config =
-        typeof integration.config === "string"
-          ? JSON.parse(integration.config)
-          : integration.config || {};
-      const baseUrl = config.base_url;
-      const email = config.email;
-      if (!baseUrl) throw new Error("Confluence URL not configured");
-      if (!email) throw new Error("Confluence email not configured");
-      const rawUrl = baseUrl.includes("://") ? baseUrl : `https://${baseUrl}`;
-      const url = await assertSafeUrl(rawUrl, "Confluence base URL");
-      const res = await fetch(`${url}/wiki/rest/api/user/current`, {
-        headers: { Authorization: `Basic ${Buffer.from(`${email}:${token}`).toString("base64")}` },
-      });
-      if (!res.ok) throw new Error(`Confluence API returned ${res.status}`);
-      const data = await res.json();
-      return {
-        success: true,
-        message: `Connected as ${data.displayName || data.username || "verified"}`,
-      };
-    },
+    // airtable → migrated to providers/airtable.ts
+    // asana → migrated to providers/asana.ts
+    // monday → migrated to providers/monday.ts
+    // clickup → migrated to providers/clickup.ts
+    // trello → migrated to providers/trello.ts
+    // confluence → migrated to providers/confluence.ts
     // digitalocean → migrated to providers/digitalocean.ts
     // supabase → migrated to providers/supabase.ts
     stripe: async () => {

--- a/backend-api/integrations/providers/legacy/envMaps.ts
+++ b/backend-api/integrations/providers/legacy/envMaps.ts
@@ -15,15 +15,15 @@ const INTEGRATION_ENV_MAP = {
   // gitlab → migrated to providers/gitlab.ts
   // slack → migrated to providers/slack.ts
   // discord → migrated to providers/discord.ts
-  notion: "NOTION_TOKEN",
+  // notion → migrated to providers/notion.ts
   // linear → migrated to providers/linear.ts
   datadog: "DD_API_KEY",
   sentry: "SENTRY_AUTH_TOKEN",
   // sendgrid → migrated to providers/sendgrid.ts
   // openai → migrated to providers/openai.ts
   // anthropic → migrated to providers/anthropic.ts
-  airtable: "AIRTABLE_API_KEY",
-  asana: "ASANA_TOKEN",
+  // airtable → migrated to providers/airtable.ts
+  // asana → migrated to providers/asana.ts
   stripe: "STRIPE_SECRET_KEY",
   hubspot: "HUBSPOT_ACCESS_TOKEN",
   pipedrive: "PIPEDRIVE_API_KEY",
@@ -42,17 +42,17 @@ const INTEGRATION_ENV_MAP = {
   // twitter → migrated to providers/twitter.ts
   // digitalocean → migrated to providers/digitalocean.ts
   // algolia → migrated to providers/algolia.ts
-  clickup: "CLICKUP_API_KEY",
-  monday: "MONDAY_API_KEY",
+  // clickup → migrated to providers/clickup.ts
+  // monday → migrated to providers/monday.ts
   zendesk: "ZENDESK_API_TOKEN",
   // docker-hub → migrated to providers/dockerHub.ts
   // bitbucket → migrated to providers/bitbucket.ts
-  confluence: "CONFLUENCE_TOKEN",
+  // confluence → migrated to providers/confluence.ts
   // jira → migrated to providers/jira.ts
   // jenkins → migrated to providers/jenkins.ts
   grafana: "GRAFANA_TOKEN",
   woocommerce: "WOOCOMMERCE_SECRET_KEY",
-  trello: "TRELLO_TOKEN",
+  // trello → migrated to providers/trello.ts
   // elasticsearch → migrated to providers/elasticsearch.ts
   // supabase → migrated to providers/supabase.ts
   facebook: "FACEBOOK_ACCESS_TOKEN",
@@ -129,17 +129,16 @@ const INTEGRATION_CONFIG_ENV_MAP = {
   "kubernetes.kubeconfig": "KUBECONFIG_CONTENT",
   "kubernetes.context": "KUBE_CONTEXT",
   // Productivity
-  "notion.workspace_id": "NOTION_WORKSPACE_ID",
-  "airtable.base_id": "AIRTABLE_BASE_ID",
-  "trello.api_key": "TRELLO_API_KEY",
-  "trello.board_id": "TRELLO_BOARD_ID",
-  "clickup.workspace_id": "CLICKUP_WORKSPACE_ID",
-  "confluence.base_url": "CONFLUENCE_BASE_URL",
-  "confluence.email": "CONFLUENCE_EMAIL",
-  "google-sheets.service_account_json": "GOOGLE_SHEETS_SA_JSON",
-  "google-sheets.spreadsheet_id": "GOOGLE_SHEETS_SPREADSHEET_ID",
-  "google-calendar.service_account_json": "GOOGLE_CALENDAR_SA_JSON",
-  "google-calendar.calendar_id": "GOOGLE_CALENDAR_ID",
+  // Productivity — all migrated to per-provider strategies:
+  //   notion → providers/notion.ts
+  //   airtable → providers/airtable.ts
+  //   trello → providers/trello.ts
+  //   clickup → providers/clickup.ts
+  //   asana → providers/asana.ts
+  //   monday → providers/monday.ts
+  //   confluence → providers/confluence.ts
+  //   google-sheets → providers/googleSheets.ts
+  //   google-calendar → providers/googleCalendar.ts
   // CRM
   "salesforce.instance_url": "SALESFORCE_INSTANCE_URL",
   "zendesk.subdomain": "ZENDESK_SUBDOMAIN",

--- a/backend-api/integrations/providers/monday.ts
+++ b/backend-api/integrations/providers/monday.ts
@@ -1,0 +1,37 @@
+// Monday.com provider — GraphQL with raw token in Authorization header
+// (no Bearer prefix, per Monday's docs).
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const mondayProvider: Provider = {
+  id: "monday",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const res = await deps.fetch("https://api.monday.com/v2", {
+        method: "POST",
+        headers: { Authorization: ctx.token ?? "", "Content-Type": "application/json" },
+        body: JSON.stringify({ query: "{ me { name } }" }),
+      });
+      if (!res.ok) throw new Error(`Monday.com API returned ${res.status}`);
+      const data: any = await res.json();
+      return {
+        success: true,
+        message: `Connected as ${data.data?.me?.name || "verified"}`,
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(): EnvMapping {
+    return { primary: "MONDAY_API_KEY", config: {} };
+  },
+};

--- a/backend-api/integrations/providers/notion.ts
+++ b/backend-api/integrations/providers/notion.ts
@@ -1,0 +1,34 @@
+// Notion provider — internal-integration token (Bearer) + version header.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const notionProvider: Provider = {
+  id: "notion",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const res = await deps.fetch("https://api.notion.com/v1/users/me", {
+        headers: {
+          Authorization: `Bearer ${ctx.token ?? ""}`,
+          "Notion-Version": "2022-06-28",
+        },
+      });
+      if (!res.ok) throw new Error(`Notion API returned ${res.status}`);
+      const data: any = await res.json();
+      return { success: true, message: `Connected as ${data.name || data.id}` };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(): EnvMapping {
+    return { primary: "NOTION_TOKEN", config: {} };
+  },
+};

--- a/backend-api/integrations/providers/trello.ts
+++ b/backend-api/integrations/providers/trello.ts
@@ -1,0 +1,39 @@
+// Trello provider — API key (in config) + token (the secret). Trello
+// expects both as query-string parameters rather than headers.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const trelloProvider: Provider = {
+  id: "trello",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      const apiKey = String(config.api_key || "").trim();
+      if (!apiKey) throw new Error("Trello API key not configured");
+      const token = encodeURIComponent(ctx.token ?? "");
+      const res = await deps.fetch(
+        `https://api.trello.com/1/members/me?key=${encodeURIComponent(apiKey)}&token=${token}`,
+      );
+      if (!res.ok) throw new Error(`Trello API returned ${res.status}`);
+      const data: any = await res.json();
+      return { success: true, message: `Connected as ${data.username}` };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.api_key) configEnv.api_key = "TRELLO_API_KEY";
+    return { primary: "TRELLO_TOKEN", config: configEnv };
+  },
+};

--- a/backend-api/integrations/services/integrationsService.ts
+++ b/backend-api/integrations/services/integrationsService.ts
@@ -62,6 +62,15 @@ const { digitaloceanProvider } = require("../providers/digitalocean");
 const { awsProvider } = require("../providers/aws");
 const { gcpProvider } = require("../providers/gcp");
 const { azureProvider } = require("../providers/azure");
+const { notionProvider } = require("../providers/notion");
+const { airtableProvider } = require("../providers/airtable");
+const { asanaProvider } = require("../providers/asana");
+const { mondayProvider } = require("../providers/monday");
+const { clickupProvider } = require("../providers/clickup");
+const { trelloProvider } = require("../providers/trello");
+const { confluenceProvider } = require("../providers/confluence");
+const { googleSheetsProvider } = require("../providers/googleSheets");
+const { googleCalendarProvider } = require("../providers/googleCalendar");
 
 const repo = createIntegrationsRepository(db);
 const secretCrypto = createSecretEncryption({
@@ -128,6 +137,15 @@ const providerRegistry = createProviderRegistry((providerId) =>
   awsProvider,
   gcpProvider,
   azureProvider,
+  notionProvider,
+  airtableProvider,
+  asanaProvider,
+  mondayProvider,
+  clickupProvider,
+  trelloProvider,
+  confluenceProvider,
+  googleSheetsProvider,
+  googleCalendarProvider,
 ].forEach((p) => providerRegistry.register(p));
 
 // Resolve fetch at call time so test mocks reassigning `global.fetch`

--- a/docs/guides/integrations/airtable.mdx
+++ b/docs/guides/integrations/airtable.mdx
@@ -1,0 +1,51 @@
+# Airtable
+
+> Where to issue an Airtable Personal Access Token (PAT) and connect it to Nora.
+
+Airtable integrations let your agents read/write records, list bases and tables, and inspect schemas. Nora authenticates with a PAT (Bearer auth).
+
+## Where to apply for credentials
+
+<Card
+  title="Airtable — Personal Access Tokens"
+  href="https://airtable.com/create/tokens"
+  icon="grid"
+  arrow
+>
+  https://airtable.com/create/tokens
+</Card>
+
+<Steps>
+  <Step title="Create a PAT">
+    Click **Create new token**. Name it (e.g. "Nora").
+  </Step>
+
+<Step title="Pick the scopes">
+  Recommended for full CRUD agents: `data.records:read`, `data.records:write`, `schema.bases:read`.
+  Add `data.recordComments:write` if your agent leaves comments.
+</Step>
+
+<Step title="Add base access">
+  Under **Access**, click **Add a base** and pick the bases the agent should reach. (PATs default to
+  no access — you have to opt in per base.)
+</Step>
+
+  <Step title="Copy the token">
+    Starts with `pat...`.
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+Paste the token, optionally set a default base ID, and click **Connect**. Nora calls `GET /v0/meta/whoami` and reports the email tied to the PAT.
+
+## MCP server
+
+No official Airtable MCP server today.
+
+## Environment variables Nora injects
+
+| Variable           | Source                   |
+| ------------------ | ------------------------ |
+| `AIRTABLE_API_KEY` | Personal Access Token    |
+| `AIRTABLE_BASE_ID` | Default Base ID (if set) |

--- a/docs/guides/integrations/asana.mdx
+++ b/docs/guides/integrations/asana.mdx
@@ -1,0 +1,40 @@
+# Asana
+
+> Where to issue an Asana Personal Access Token and connect it to Nora.
+
+Asana integrations let your agents create tasks, query projects, and manage workspaces. Nora authenticates with a personal access token (Bearer auth).
+
+## Where to apply for credentials
+
+<Card title="Asana — My Apps" href="https://app.asana.com/0/my-apps" icon="check-circle" arrow>
+  https://app.asana.com/0/my-apps
+</Card>
+
+<Steps>
+  <Step title="Create a token">
+    Open My Apps → **Create new token**. Name it, accept the API ToS.
+  </Step>
+
+  <Step title="Copy the token">
+    Asana shows it once. Format: `1/<digits>:<random>`.
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+Paste the token. Optionally set a workspace GID — find it via:
+
+```bash
+curl -H "Authorization: Bearer <your-token>" https://app.asana.com/api/1.0/workspaces
+```
+
+## MCP server
+
+No official Asana MCP server today.
+
+## Environment variables Nora injects
+
+| Variable             | Source                      |
+| -------------------- | --------------------------- |
+| `ASANA_TOKEN`        | Personal Access Token field |
+| `ASANA_WORKSPACE_ID` | Workspace ID (if set)       |

--- a/docs/guides/integrations/clickup.mdx
+++ b/docs/guides/integrations/clickup.mdx
@@ -1,0 +1,41 @@
+# ClickUp
+
+> Where to issue a ClickUp API key and connect it to Nora.
+
+ClickUp integrations let your agents read/write tasks, lists, and spaces. Nora authenticates by passing the token in the raw `Authorization` header (ClickUp doesn't expect a `Bearer` prefix).
+
+## Where to apply for credentials
+
+<Card
+  title="ClickUp — Apps settings"
+  href="https://app.clickup.com/settings/apps"
+  icon="target"
+  arrow
+>
+  Settings → Apps
+</Card>
+
+<Steps>
+  <Step title="Generate the API token">
+    On the Apps page, click **Generate** next to **API Token**.
+  </Step>
+
+  <Step title="Copy the token">
+    Starts with `pk_...`.
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+Paste the token. Nora calls `GET /api/v2/user` and reports the username.
+
+## MCP server
+
+No official ClickUp MCP server today.
+
+## Environment variables Nora injects
+
+| Variable          | Source           |
+| ----------------- | ---------------- |
+| `CLICKUP_API_KEY` | API Key field    |
+| `CLICKUP_TEAM_ID` | Team ID (if set) |

--- a/docs/guides/integrations/confluence.mdx
+++ b/docs/guides/integrations/confluence.mdx
@@ -1,0 +1,50 @@
+# Confluence
+
+> Where to issue an Atlassian API token and connect Confluence Cloud to Nora.
+
+Confluence integrations let your agents read and write pages, attachments, and space content via the Confluence Cloud REST API. Nora authenticates with HTTP Basic using your Atlassian email + an API token (same shape as [Jira](/guides/integrations/jira)).
+
+## Where to apply for credentials
+
+<Card
+  title="Atlassian — API Tokens"
+  href="https://id.atlassian.com/manage-profile/security/api-tokens"
+  icon="book-open"
+  arrow
+>
+  id.atlassian.com/manage-profile/security/api-tokens
+</Card>
+
+<Steps>
+  <Step title="Create the API token">
+    Click **Create API token**, name it (e.g. "Nora"), and copy the value (only shown once).
+  </Step>
+
+  <Step title="Note your Confluence URL">
+    The integration needs your Confluence Cloud origin (e.g. `https://acme.atlassian.net`) — same site you sign in to.
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+<Steps>
+  <Step title="Paste the URL, email, and token">
+    Confluence URL = `https://<site>.atlassian.net`. Email = your Atlassian account email. API Token = the secret you generated.
+  </Step>
+
+  <Step title="Connect">
+    Click **Connect**. Nora validates the URL through the SSRF guard, then calls `GET <url>/wiki/rest/api/user/current` with HTTP Basic auth. The card shows your display name on success.
+  </Step>
+</Steps>
+
+## MCP server
+
+No official Confluence MCP server today.
+
+## Environment variables Nora injects
+
+| Variable              | Source               |
+| --------------------- | -------------------- |
+| `CONFLUENCE_TOKEN`    | API Token field      |
+| `CONFLUENCE_EMAIL`    | Email field          |
+| `CONFLUENCE_BASE_URL` | Confluence URL field |

--- a/docs/guides/integrations/google-calendar.mdx
+++ b/docs/guides/integrations/google-calendar.mdx
@@ -1,0 +1,38 @@
+# Google Calendar
+
+> How to set up a service account for Google Calendar and connect it to Nora.
+
+Google Calendar integrations let your agents read, create, and update events.
+
+## Where to apply for credentials
+
+Same flow as [Google Drive](/guides/integrations/google-drive) and [Google Sheets](/guides/integrations/google-sheets):
+
+<Steps>
+  <Step title="Create a service account in GCP">
+    [console.cloud.google.com/iam-admin/serviceaccounts](https://console.cloud.google.com/iam-admin/serviceaccounts) → Create Service Account → generate a JSON key.
+  </Step>
+
+<Step title="Enable the Calendar API">
+  GCP Console → APIs & Services → Library → Google Calendar API → Enable.
+</Step>
+
+  <Step title="Share each calendar with the SA">
+    Open Google Calendar → calendar settings → **Share with specific people** → add the SA's `client_email`. Pick the permission level (Make changes to events, etc.).
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+Paste the JSON, optionally set the calendar ID (`primary` or a calendar's ID from its settings page).
+
+## MCP server
+
+No official Google Calendar MCP server today.
+
+## Environment variables Nora injects
+
+| Variable                              | Source               |
+| ------------------------------------- | -------------------- |
+| `GOOGLE_APPLICATION_CREDENTIALS_JSON` | Service Account JSON |
+| `GOOGLE_CALENDAR_DEFAULT_ID`          | Calendar ID (if set) |

--- a/docs/guides/integrations/google-sheets.mdx
+++ b/docs/guides/integrations/google-sheets.mdx
@@ -1,0 +1,47 @@
+# Google Sheets
+
+> How to set up a service account for Google Sheets and connect it to Nora.
+
+Google Sheets integrations let your agents read and write spreadsheet rows, columns, and ranges. Same service-account flow as [Google Drive](/guides/integrations/google-drive).
+
+## Where to apply for credentials
+
+<Card
+  title="Google Cloud — Service Accounts"
+  href="https://console.cloud.google.com/iam-admin/serviceaccounts"
+  icon="table"
+  arrow
+>
+  https://console.cloud.google.com/iam-admin/serviceaccounts
+</Card>
+
+<Steps>
+  <Step title="Create a service account">
+    GCP Console → IAM & Admin → Service Accounts → Create Service Account.
+  </Step>
+
+<Step title="Generate a JSON key">Open the SA → Keys → Add Key → Create new key → JSON.</Step>
+
+<Step title="Enable the Google Sheets API">
+  APIs & Services → Library → Google Sheets API → Enable.
+</Step>
+
+  <Step title="Share each spreadsheet with the SA">
+    Open the spreadsheet in Google Sheets, click **Share**, and add the SA's `client_email`.
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+Paste the JSON, optionally set a default spreadsheet ID (the long string in the spreadsheet URL after `/d/`).
+
+## MCP server
+
+No official Google Sheets MCP server today.
+
+## Environment variables Nora injects
+
+| Variable                               | Source                          |
+| -------------------------------------- | ------------------------------- |
+| `GOOGLE_APPLICATION_CREDENTIALS_JSON`  | Service Account JSON            |
+| `GOOGLE_SHEETS_DEFAULT_SPREADSHEET_ID` | Default Spreadsheet ID (if set) |

--- a/docs/guides/integrations/monday.mdx
+++ b/docs/guides/integrations/monday.mdx
@@ -1,0 +1,48 @@
+# Monday.com
+
+> Where to issue a Monday.com personal API token and connect it to Nora.
+
+Monday.com integrations let your agents read and write boards, items, and updates via Monday's GraphQL API. Nora authenticates by passing the token in the `Authorization` header (no `Bearer` prefix — Monday's docs are explicit on this).
+
+## Where to apply for credentials
+
+<Card
+  title="Monday.com — Developer settings"
+  href="https://monday.com/developers/v2/admin"
+  icon="calendar"
+  arrow
+>
+  Avatar → Developers → My Access Tokens
+</Card>
+
+<Steps>
+  <Step title="Open My Access Tokens">
+    Click your avatar (bottom-left) → **Developers**. Open **My Access Tokens**.
+  </Step>
+
+<Step title="Show or generate a token">
+  Click **Show** to reveal your existing personal token, or generate a fresh one.
+</Step>
+
+  <Step title="Copy">
+    Treat the token as a password — it inherits all your account permissions.
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+Paste the token. Nora POSTs `{ me { name } }` to `https://api.monday.com/v2` to verify it.
+
+## Limitations
+
+Personal tokens grant whatever permissions the user has. For tighter scoping, register a **Monday Apps** OAuth app — Nora's current integration uses the personal-token model.
+
+## MCP server
+
+No official Monday.com MCP server today.
+
+## Environment variables Nora injects
+
+| Variable         | Source          |
+| ---------------- | --------------- |
+| `MONDAY_API_KEY` | API Token field |

--- a/docs/guides/integrations/notion.mdx
+++ b/docs/guides/integrations/notion.mdx
@@ -1,0 +1,46 @@
+# Notion
+
+> Where to issue a Notion internal-integration token and connect it to Nora.
+
+Notion integrations let your agents create pages, query and edit databases, and walk page hierarchies. Nora authenticates with an internal-integration token (Bearer auth) plus the standard `Notion-Version: 2022-06-28` header.
+
+## Where to apply for credentials
+
+<Card
+  title="Notion — My integrations"
+  href="https://www.notion.so/my-integrations"
+  icon="file-text"
+  arrow
+>
+  https://www.notion.so/my-integrations
+</Card>
+
+<Steps>
+  <Step title="Create an internal integration">
+    Click **+ New integration**. Pick the workspace, name it (e.g. "Nora agent"), choose **Internal** as the type.
+  </Step>
+
+<Step title="Copy the token">The Internal Integration Token starts with `secret_...`.</Step>
+
+  <Step title="Share pages with the integration">
+    Notion integrations don't auto-have access to pages. From any Notion page or database you want the agent to read/write, click **Share → Add connection** and pick your integration.
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+Paste the token, optionally set a workspace ID, and click **Connect**. Nora calls `GET /v1/users/me` to verify the token and reports the bot user's name.
+
+## MCP server
+
+Notion ships an official MCP server:
+
+- **Package:** `@notionhq/notion-mcp-server`
+- **Docs:** [github.com/makenotion/notion-mcp-server](https://github.com/makenotion/notion-mcp-server)
+- **Env:** `NOTION_TOKEN` (which Nora injects automatically).
+
+## Environment variables Nora injects
+
+| Variable       | Source            |
+| -------------- | ----------------- |
+| `NOTION_TOKEN` | Integration Token |

--- a/docs/guides/integrations/trello.mdx
+++ b/docs/guides/integrations/trello.mdx
@@ -1,0 +1,43 @@
+# Trello
+
+> Where to issue a Trello API key + token and connect them to Nora.
+
+Trello integrations let your agents read/write boards, lists, and cards. Trello uses a two-part credential — an **API Key** that identifies the app and a **Token** that authorizes access to the user's data.
+
+## Where to apply for credentials
+
+<Card
+  title="Trello — Power-Ups Admin"
+  href="https://trello.com/power-ups/admin"
+  icon="layout"
+  arrow
+>
+  trello.com/power-ups/admin
+</Card>
+
+<Steps>
+  <Step title="Create a Power-Up">
+    Open Power-Ups Admin → **Create Power-Up**. This is how Trello issues an API Key. Name it (e.g. "Nora").
+  </Step>
+
+<Step title="Copy the API Key">On the Power-Up's API Key page, copy the **Key** value.</Step>
+
+  <Step title="Generate a token">
+    Same page — click **Token** (in the right column). You'll be sent through an OAuth-like flow that grants the Power-Up access to your account. Trello returns a token at the end.
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+Paste the **API Key** and **Token**. Optionally set a default board ID (from any board's URL — the segment after `/b/`). Nora calls `GET /1/members/me?key=...&token=...` and reports the username.
+
+## MCP server
+
+No official Trello MCP server today.
+
+## Environment variables Nora injects
+
+| Variable         | Source        |
+| ---------------- | ------------- |
+| `TRELLO_TOKEN`   | Token field   |
+| `TRELLO_API_KEY` | API Key field |


### PR DESCRIPTION
## Summary

- 9 providers migrated: `notion`, `airtable`, `asana`, `monday`, `clickup`, `trello`, `confluence`, `google-sheets`, `google-calendar`.
- Confluence's `authType` corrected from `api_key` to `basic` (matches Jira and the API's HTTP Basic shape).
- Notion gets structured `mcp` metadata for the official `@notionhq/notion-mcp-server`.
- Per-provider docs cover Trello's quirky two-part credential, Asana's API ToS acceptance, Monday's no-Bearer header, etc.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 786/786 passing (was 763; +23 from 9 new tests)