### PR TITLE
feat(integrations): migrate crm/payment/analytics providers (9 providers)

### DIFF
--- a/backend-api/__tests__/providers/googleAnalyticsProvider.test.ts
+++ b/backend-api/__tests__/providers/googleAnalyticsProvider.test.ts
@@ -1,0 +1,42 @@
+// @ts-nocheck
+const { googleAnalyticsProvider } = require("../../integrations/providers/googleAnalytics");
+
+const deps = {
+  fetch: jest.fn(),
+  assertSafeUrl: async (u) => u,
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+};
+
+const validSa = JSON.stringify({
+  client_email: "agent@p.iam.gserviceaccount.com",
+  private_key: "-----BEGIN PRIVATE KEY-----\nx\n-----END PRIVATE KEY-----\n",
+  project_id: "p",
+});
+
+describe("googleAnalyticsProvider", () => {
+  it("identifies as google-analytics / service_account", () => {
+    expect(googleAnalyticsProvider.id).toBe("google-analytics");
+    expect(googleAnalyticsProvider.authType).toBe("service_account");
+  });
+
+  it("validates SA JSON", async () => {
+    const result = await googleAnalyticsProvider.test(
+      { row: {}, token: null, config: { service_account_json: validSa } },
+      deps,
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("emits GOOGLE_APPLICATION_CREDENTIALS_JSON + GA4_PROPERTY_ID", () => {
+    const env = googleAnalyticsProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { service_account_json: validSa, property_id: "123456" },
+    });
+    expect(env.primary).toBeNull();
+    expect(env.config.property_id).toBe("GA4_PROPERTY_ID");
+  });
+});

--- a/backend-api/__tests__/providers/hubspotProvider.test.ts
+++ b/backend-api/__tests__/providers/hubspotProvider.test.ts
@@ -1,0 +1,31 @@
+// @ts-nocheck
+const { hubspotProvider } = require("../../integrations/providers/hubspot");
+
+const deps = (fetchImpl) => ({
+  fetch: fetchImpl,
+  assertSafeUrl: async (u) => u,
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+});
+
+describe("hubspotProvider", () => {
+  it("hits /crm/v3/objects/contacts with Bearer token", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: true });
+    await hubspotProvider.test({ row: {}, token: "pat-na1-x", config: {} }, deps(fetchImpl));
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.hubapi.com/crm/v3/objects/contacts?limit=1",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer pat-na1-x" }),
+      }),
+    );
+  });
+
+  it("emits HUBSPOT_ACCESS_TOKEN", () => {
+    expect(hubspotProvider.mapToEnv({ row: {}, token: null, config: {} })).toEqual({
+      primary: "HUBSPOT_ACCESS_TOKEN",
+      config: {},
+    });
+  });
+});

--- a/backend-api/__tests__/providers/mixpanelProvider.test.ts
+++ b/backend-api/__tests__/providers/mixpanelProvider.test.ts
@@ -1,0 +1,49 @@
+// @ts-nocheck
+const { mixpanelProvider } = require("../../integrations/providers/mixpanel");
+
+const deps = (fetchImpl) => ({
+  fetch: fetchImpl,
+  assertSafeUrl: async (u) => u,
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+});
+
+describe("mixpanelProvider", () => {
+  it("uses Basic auth with SA username when configured", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: true });
+    await mixpanelProvider.test(
+      {
+        row: {},
+        token: "sa-secret",
+        config: { service_account_username: "sa.acme" },
+      },
+      deps(fetchImpl),
+    );
+    const expected = "Basic " + Buffer.from("sa.acme:sa-secret").toString("base64");
+    expect(fetchImpl.mock.calls[0][1].headers.Authorization).toBe(expected);
+  });
+
+  it("falls back to project-token-only mode when SA username missing", async () => {
+    const fetchImpl = jest.fn();
+    const result = await mixpanelProvider.test(
+      { row: {}, token: "tok", config: {} },
+      deps(fetchImpl),
+    );
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("Project token stored");
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("emits MIXPANEL_API_SECRET + service_account_username", () => {
+    const env = mixpanelProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { service_account_username: "sa.acme", project_id: "1" },
+    });
+    expect(env.primary).toBe("MIXPANEL_API_SECRET");
+    expect(env.config.service_account_username).toBe("MIXPANEL_SERVICE_ACCOUNT_USERNAME");
+    expect(env.config.project_id).toBe("MIXPANEL_PROJECT_ID");
+  });
+});

--- a/backend-api/__tests__/providers/paypalProvider.test.ts
+++ b/backend-api/__tests__/providers/paypalProvider.test.ts
@@ -1,0 +1,60 @@
+// @ts-nocheck
+const { paypalProvider } = require("../../integrations/providers/paypal");
+
+const deps = (fetchImpl) => ({
+  fetch: fetchImpl,
+  assertSafeUrl: async (u) => u,
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+});
+
+describe("paypalProvider", () => {
+  it("identifies as paypal / credentials", () => {
+    expect(paypalProvider.id).toBe("paypal");
+    expect(paypalProvider.authType).toBe("credentials");
+  });
+
+  it("POSTs client_credentials to /v1/oauth2/token (production)", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: true });
+    const result = await paypalProvider.test(
+      { row: {}, token: "secret", config: { client_id: "AYx" } },
+      deps(fetchImpl),
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api-m.paypal.com/v1/oauth2/token",
+      expect.objectContaining({
+        method: "POST",
+        body: "grant_type=client_credentials",
+      }),
+    );
+    expect(result.message).toContain("production");
+  });
+
+  it("uses sandbox host when configured", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: true });
+    const result = await paypalProvider.test(
+      { row: {}, token: "secret", config: { client_id: "AYx", sandbox: true } },
+      deps(fetchImpl),
+    );
+    expect(fetchImpl.mock.calls[0][0]).toBe("https://api-m.sandbox.paypal.com/v1/oauth2/token");
+    expect(result.message).toContain("sandbox");
+  });
+
+  it("rejects missing client_id", async () => {
+    const result = await paypalProvider.test({ row: {}, token: "x", config: {} }, deps(jest.fn()));
+    expect(result.success).toBe(false);
+  });
+
+  it("emits PAYPAL_CLIENT_SECRET + client_id + sandbox", () => {
+    const env = paypalProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { client_id: "AYx", sandbox: true },
+    });
+    expect(env.primary).toBe("PAYPAL_CLIENT_SECRET");
+    expect(env.config.client_id).toBe("PAYPAL_CLIENT_ID");
+    expect(env.config.sandbox).toBe("PAYPAL_SANDBOX");
+  });
+});

--- a/backend-api/__tests__/providers/pipedriveProvider.test.ts
+++ b/backend-api/__tests__/providers/pipedriveProvider.test.ts
@@ -1,0 +1,34 @@
+// @ts-nocheck
+const { pipedriveProvider } = require("../../integrations/providers/pipedrive");
+
+const deps = (fetchImpl) => ({
+  fetch: fetchImpl,
+  assertSafeUrl: async (u) => u,
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+});
+
+describe("pipedriveProvider", () => {
+  it("passes the token as a query-string param", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: { name: "Alice" } }),
+    });
+    await pipedriveProvider.test({ row: {}, token: "tok", config: {} }, deps(fetchImpl));
+    expect(fetchImpl).toHaveBeenCalledWith("https://api.pipedrive.com/v1/users/me?api_token=tok");
+  });
+
+  it("emits PIPEDRIVE_API_KEY + company_domain", () => {
+    const env = pipedriveProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { company_domain: "acme" },
+    });
+    expect(env).toEqual({
+      primary: "PIPEDRIVE_API_KEY",
+      config: { company_domain: "PIPEDRIVE_COMPANY_DOMAIN" },
+    });
+  });
+});

--- a/backend-api/__tests__/providers/salesforceProvider.test.ts
+++ b/backend-api/__tests__/providers/salesforceProvider.test.ts
@@ -1,0 +1,53 @@
+// @ts-nocheck
+const { salesforceProvider } = require("../../integrations/providers/salesforce");
+
+const deps = (fetchImpl) => ({
+  fetch: fetchImpl,
+  assertSafeUrl: async (u) => u,
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+});
+
+describe("salesforceProvider", () => {
+  it("calls /services/data/v59.0/ with Bearer at the customer's instance URL", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: true });
+    const result = await salesforceProvider.test(
+      {
+        row: {},
+        token: "00D!x",
+        config: { instance_url: "https://my.salesforce.com" },
+      },
+      deps(fetchImpl),
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://my.salesforce.com/services/data/v59.0/",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer 00D!x" }),
+      }),
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects when instance_url missing", async () => {
+    const result = await salesforceProvider.test(
+      { row: {}, token: "x", config: {} },
+      deps(jest.fn()),
+    );
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("instance URL");
+  });
+
+  it("emits SALESFORCE_ACCESS_TOKEN + SALESFORCE_INSTANCE_URL", () => {
+    const env = salesforceProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { instance_url: "u" },
+    });
+    expect(env).toEqual({
+      primary: "SALESFORCE_ACCESS_TOKEN",
+      config: { instance_url: "SALESFORCE_INSTANCE_URL" },
+    });
+  });
+});

--- a/backend-api/__tests__/providers/segmentProvider.test.ts
+++ b/backend-api/__tests__/providers/segmentProvider.test.ts
@@ -1,0 +1,32 @@
+// @ts-nocheck
+const { segmentProvider } = require("../../integrations/providers/segment");
+
+const deps = {
+  fetch: jest.fn(),
+  assertSafeUrl: async (u) => u,
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+};
+
+describe("segmentProvider", () => {
+  it("accepts a non-empty write key without making network calls", async () => {
+    const result = await segmentProvider.test({ row: {}, token: "wk_x", config: {} }, deps);
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("validation endpoint");
+    expect(deps.fetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects empty write key", async () => {
+    const result = await segmentProvider.test({ row: {}, token: "", config: {} }, deps);
+    expect(result.success).toBe(false);
+  });
+
+  it("emits SEGMENT_WRITE_KEY", () => {
+    expect(segmentProvider.mapToEnv({ row: {}, token: null, config: {} })).toEqual({
+      primary: "SEGMENT_WRITE_KEY",
+      config: {},
+    });
+  });
+});

--- a/backend-api/__tests__/providers/stripeProvider.test.ts
+++ b/backend-api/__tests__/providers/stripeProvider.test.ts
@@ -1,0 +1,36 @@
+// @ts-nocheck
+const { stripeProvider } = require("../../integrations/providers/stripe");
+
+const deps = (fetchImpl) => ({
+  fetch: fetchImpl,
+  assertSafeUrl: async (u) => u,
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+});
+
+describe("stripeProvider", () => {
+  it("hits /v1/balance with Bearer secret key", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: true });
+    await stripeProvider.test({ row: {}, token: "sk_x", config: {} }, deps(fetchImpl));
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.stripe.com/v1/balance",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer sk_x" }),
+      }),
+    );
+  });
+
+  it("emits STRIPE_SECRET_KEY + STRIPE_WEBHOOK_SECRET when configured", () => {
+    const env = stripeProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { webhook_secret: "whsec_x" },
+    });
+    expect(env).toEqual({
+      primary: "STRIPE_SECRET_KEY",
+      config: { webhook_secret: "STRIPE_WEBHOOK_SECRET" },
+    });
+  });
+});

--- a/backend-api/__tests__/providers/zendeskProvider.test.ts
+++ b/backend-api/__tests__/providers/zendeskProvider.test.ts
@@ -1,0 +1,57 @@
+// @ts-nocheck
+const { zendeskProvider } = require("../../integrations/providers/zendesk");
+
+const deps = (fetchImpl) => ({
+  fetch: fetchImpl,
+  assertSafeUrl: async (u) => u,
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+});
+
+describe("zendeskProvider", () => {
+  it("uses Zendesk's email/token Basic-auth shape", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ user: { name: "Alice" } }),
+    });
+    await zendeskProvider.test(
+      {
+        row: {},
+        token: "tok",
+        config: { subdomain: "acme", email: "alice@example.com" },
+      },
+      deps(fetchImpl),
+    );
+    const expected = "Basic " + Buffer.from("alice@example.com/token:tok").toString("base64");
+    expect(fetchImpl.mock.calls[0][0]).toBe("https://acme.zendesk.com/api/v2/users/me.json");
+    expect(fetchImpl.mock.calls[0][1].headers.Authorization).toBe(expected);
+  });
+
+  it("rejects missing subdomain or email", async () => {
+    const fetchImpl = jest.fn();
+    let result = await zendeskProvider.test(
+      { row: {}, token: "t", config: { email: "a@b.c" } },
+      deps(fetchImpl),
+    );
+    expect(result.success).toBe(false);
+    result = await zendeskProvider.test(
+      { row: {}, token: "t", config: { subdomain: "x" } },
+      deps(fetchImpl),
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("emits ZENDESK_API_TOKEN + subdomain + email", () => {
+    const env = zendeskProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { subdomain: "acme", email: "a@b.c" },
+    });
+    expect(env).toEqual({
+      primary: "ZENDESK_API_TOKEN",
+      config: { subdomain: "ZENDESK_SUBDOMAIN", email: "ZENDESK_EMAIL" },
+    });
+  });
+});

--- a/backend-api/integrations/catalog/catalog.json
+++ b/backend-api/integrations/catalog/catalog.json
@@ -807,7 +807,17 @@
         "placeholder": "https://your-instance.salesforce.com"
       }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://help.salesforce.com/s/articleView?id=sf.security_access_token.htm",
+    "setupGuide": {
+      "steps": [
+        "In Salesforce, open Setup → App Manager → New Connected App. Set OAuth scopes (api, refresh_token, full).",
+        "Run the OAuth 2.0 Web Server flow against your org and capture the access_token + instance_url from the response.",
+        "Paste the access_token and instance_url into Nora.",
+        "Tokens expire — for production, store the refresh_token outside Nora and rotate."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "hubspot",
@@ -824,7 +834,17 @@
         "required": true
       }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://app.hubspot.com/private-apps",
+    "setupGuide": {
+      "steps": [
+        "In HubSpot, open Settings → Integrations → Private Apps.",
+        "Click Create a private app, name it, and on the Scopes tab pick the CRM scopes you need.",
+        "Click Create app → Show token → Copy.",
+        "Token starts with pat-na1- (or similar region prefix)."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "pipedrive",
@@ -837,7 +857,16 @@
       { "key": "api_token", "label": "API Token", "type": "password", "required": true },
       { "key": "company_domain", "label": "Company Domain", "type": "text", "required": false }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://app.pipedrive.com/settings/api",
+    "setupGuide": {
+      "steps": [
+        "Sign in to Pipedrive and open Settings → Personal preferences → API.",
+        "Copy the API Token shown there.",
+        "(Optional) Find your company domain (the slug before .pipedrive.com)."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "zendesk",
@@ -851,7 +880,17 @@
       { "key": "email", "label": "Email", "type": "email", "required": true },
       { "key": "api_token", "label": "API Token", "type": "password", "required": true }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://docs.zendesk.com/api-reference/introduction/security-and-auth/#api-token",
+    "setupGuide": {
+      "steps": [
+        "In Zendesk Admin Center, open Apps and integrations → Zendesk APIs → Settings.",
+        "Enable Token access if it isn't already, then click Add API token.",
+        "Copy the token (only shown once).",
+        "Subdomain = the slug before .zendesk.com. Email = the agent's account email."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "google-drive",
@@ -956,7 +995,24 @@
         "required": false
       }
     ],
-    "capabilities": ["read", "write", "webhook"]
+    "capabilities": ["read", "write", "webhook"],
+    "credentialsUrl": "https://dashboard.stripe.com/apikeys",
+    "setupGuide": {
+      "steps": [
+        "Sign in to dashboard.stripe.com.",
+        "Open Developers → API keys.",
+        "Use a Restricted Key for production agents — pick only the resources the agent needs.",
+        "Copy the secret key (sk_live_... or sk_test_...).",
+        "(Optional) Generate a webhook signing secret under Developers → Webhooks if your agent listens for events."
+      ]
+    },
+    "mcp": {
+      "available": true,
+      "transport": "stdio",
+      "npmPackage": "@stripe/mcp",
+      "docsUrl": "https://github.com/stripe/agent-toolkit/tree/main/typescript/examples/mcp",
+      "notes": "Official Stripe MCP server. Reads STRIPE_SECRET_KEY env var."
+    }
   },
   {
     "id": "paypal",
@@ -970,7 +1026,17 @@
       { "key": "client_secret", "label": "Client Secret", "type": "password", "required": true },
       { "key": "sandbox", "label": "Use Sandbox", "type": "text", "required": false }
     ],
-    "capabilities": ["read", "write", "webhook"]
+    "capabilities": ["read", "write", "webhook"],
+    "credentialsUrl": "https://developer.paypal.com/dashboard/applications/sandbox",
+    "setupGuide": {
+      "steps": [
+        "Sign in to developer.paypal.com.",
+        "Open Apps & Credentials → Sandbox or Live tab.",
+        "Click Create App, give it a name, choose the right environment.",
+        "Copy the Client ID and Client Secret. For testing, use sandbox = true."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "twitter",
@@ -1191,7 +1257,17 @@
       },
       { "key": "property_id", "label": "GA4 Property ID", "type": "text", "required": true }
     ],
-    "capabilities": ["read"]
+    "capabilities": ["read"],
+    "credentialsUrl": "https://console.cloud.google.com/iam-admin/serviceaccounts",
+    "setupGuide": {
+      "steps": [
+        "Create a service account in GCP and generate a JSON key.",
+        "Enable the Google Analytics Data API for the project.",
+        "In Google Analytics Admin → Property Access Management, add the SA's client_email as a Viewer.",
+        "Find your GA4 Property ID under Property Settings."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "mixpanel",
@@ -1204,7 +1280,16 @@
       { "key": "project_token", "label": "Project Token", "type": "text", "required": true },
       { "key": "api_secret", "label": "API Secret", "type": "password", "required": false }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://mixpanel.com/settings/project",
+    "setupGuide": {
+      "steps": [
+        "Sign in to Mixpanel and open Project settings.",
+        "Copy the Project Token (used for ingestion).",
+        "(Optional) For server-side / query API access, create a Service Account under Access security and copy its secret."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "segment",
@@ -1216,7 +1301,16 @@
     "configFields": [
       { "key": "write_key", "label": "Write Key", "type": "password", "required": true }
     ],
-    "capabilities": ["write"]
+    "capabilities": ["write"],
+    "credentialsUrl": "https://app.segment.com/",
+    "setupGuide": {
+      "steps": [
+        "Sign in to Segment.",
+        "Pick the Source you want to write into (or create a new one).",
+        "Copy the Write Key from the source's Settings → API Keys."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "elasticsearch",

--- a/backend-api/integrations/index.ts
+++ b/backend-api/integrations/index.ts
@@ -83,6 +83,15 @@ export { trelloProvider } from "./providers/trello";
 export { confluenceProvider } from "./providers/confluence";
 export { googleSheetsProvider } from "./providers/googleSheets";
 export { googleCalendarProvider } from "./providers/googleCalendar";
+export { salesforceProvider } from "./providers/salesforce";
+export { hubspotProvider } from "./providers/hubspot";
+export { pipedriveProvider } from "./providers/pipedrive";
+export { zendeskProvider } from "./providers/zendesk";
+export { stripeProvider } from "./providers/stripe";
+export { paypalProvider } from "./providers/paypal";
+export { googleAnalyticsProvider } from "./providers/googleAnalytics";
+export { mixpanelProvider } from "./providers/mixpanel";
+export { segmentProvider } from "./providers/segment";
 
 // The orchestration service is the recommended import for callers that
 // need the high-level operations (connect, list, test, sync, env-vars).

--- a/backend-api/integrations/providers/googleAnalytics.ts
+++ b/backend-api/integrations/providers/googleAnalytics.ts
@@ -1,0 +1,49 @@
+// Google Analytics provider — service-account JSON.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+} from "../types/provider";
+
+const REQUIRED_SA_KEYS = ["client_email", "private_key", "project_id"] as const;
+
+export const googleAnalyticsProvider: Provider = {
+  id: "google-analytics",
+  authType: "service_account",
+
+  async test(ctx: DecryptedIntegration): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      const raw = String(config.service_account_json || "").trim();
+      if (!raw) throw new Error("Google Analytics service account JSON is required");
+      let parsed: any;
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        throw new Error("Service account JSON is not valid JSON");
+      }
+      const missing = REQUIRED_SA_KEYS.filter((k) => !parsed[k]);
+      if (missing.length > 0) {
+        throw new Error(`Service account JSON is missing required keys: ${missing.join(", ")}`);
+      }
+      return {
+        success: true,
+        message: `Service account stored (${parsed.client_email})`,
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.service_account_json) {
+      configEnv.service_account_json = "GOOGLE_APPLICATION_CREDENTIALS_JSON";
+    }
+    if (config.property_id) configEnv.property_id = "GA4_PROPERTY_ID";
+    return { primary: null, config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/hubspot.ts
+++ b/backend-api/integrations/providers/hubspot.ts
@@ -1,0 +1,30 @@
+// HubSpot provider — Private App access token (Bearer).
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const hubspotProvider: Provider = {
+  id: "hubspot",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const res = await deps.fetch("https://api.hubapi.com/crm/v3/objects/contacts?limit=1", {
+        headers: { Authorization: `Bearer ${ctx.token ?? ""}` },
+      });
+      if (!res.ok) throw new Error(`HubSpot API returned ${res.status}`);
+      return { success: true, message: "Connected to HubSpot" };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(): EnvMapping {
+    return { primary: "HUBSPOT_ACCESS_TOKEN", config: {} };
+  },
+};

--- a/backend-api/integrations/providers/legacy/connectivityTests.ts
+++ b/backend-api/integrations/providers/legacy/connectivityTests.ts
@@ -73,46 +73,10 @@ function buildConnectivityTests(integration, token, deps) {
     // confluence → migrated to providers/confluence.ts
     // digitalocean → migrated to providers/digitalocean.ts
     // supabase → migrated to providers/supabase.ts
-    stripe: async () => {
-      const res = await fetch("https://api.stripe.com/v1/balance", {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (!res.ok) throw new Error(`Stripe API returned ${res.status}`);
-      return { success: true, message: "Balance verified" };
-    },
-    hubspot: async () => {
-      const res = await fetch("https://api.hubapi.com/crm/v3/objects/contacts?limit=1", {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (!res.ok) throw new Error(`HubSpot API returned ${res.status}`);
-      return { success: true, message: "Connected to HubSpot" };
-    },
-    pipedrive: async () => {
-      const res = await fetch(
-        `https://api.pipedrive.com/v1/users/me?api_token=${encodeURIComponent(token)}`,
-      );
-      if (!res.ok) throw new Error(`Pipedrive API returned ${res.status}`);
-      const data = await res.json();
-      return { success: true, message: `Connected as ${data.data?.name || "verified"}` };
-    },
-    zendesk: async () => {
-      const config =
-        typeof integration.config === "string"
-          ? JSON.parse(integration.config)
-          : integration.config || {};
-      const subdomain = config.subdomain;
-      const email = config.email;
-      if (!subdomain) throw new Error("Zendesk subdomain not configured");
-      if (!email) throw new Error("Zendesk email not configured");
-      const res = await fetch(`https://${subdomain}.zendesk.com/api/v2/users/me.json`, {
-        headers: {
-          Authorization: `Basic ${Buffer.from(`${email}/token:${token}`).toString("base64")}`,
-        },
-      });
-      if (!res.ok) throw new Error(`Zendesk API returned ${res.status}`);
-      const data = await res.json();
-      return { success: true, message: `Connected as ${data.user?.name || "verified"}` };
-    },
+    // stripe → migrated to providers/stripe.ts
+    // hubspot → migrated to providers/hubspot.ts
+    // pipedrive → migrated to providers/pipedrive.ts
+    // zendesk → migrated to providers/zendesk.ts
     // elasticsearch → migrated to providers/elasticsearch.ts
     // pinecone → migrated to providers/pinecone.ts
     // algolia → migrated to providers/algolia.ts
@@ -207,20 +171,7 @@ function buildConnectivityTests(integration, token, deps) {
       };
     },
     // docker-hub → migrated to providers/dockerHub.ts
-    salesforce: async () => {
-      const config =
-        typeof integration.config === "string"
-          ? JSON.parse(integration.config)
-          : integration.config || {};
-      const rawUrl = config.instance_url;
-      if (!rawUrl) throw new Error("Salesforce instance URL not configured");
-      const instanceUrl = await assertSafeUrl(rawUrl, "Salesforce instance URL");
-      const res = await fetch(`${instanceUrl}/services/data/v59.0/`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (!res.ok) throw new Error(`Salesforce API returned ${res.status}`);
-      return { success: true, message: "Connected to Salesforce" };
-    },
+    // salesforce → migrated to providers/salesforce.ts
   };
 }
 

--- a/backend-api/integrations/providers/legacy/envMaps.ts
+++ b/backend-api/integrations/providers/legacy/envMaps.ts
@@ -24,9 +24,9 @@ const INTEGRATION_ENV_MAP = {
   // anthropic → migrated to providers/anthropic.ts
   // airtable → migrated to providers/airtable.ts
   // asana → migrated to providers/asana.ts
-  stripe: "STRIPE_SECRET_KEY",
-  hubspot: "HUBSPOT_ACCESS_TOKEN",
-  pipedrive: "PIPEDRIVE_API_KEY",
+  // stripe → migrated to providers/stripe.ts
+  // hubspot → migrated to providers/hubspot.ts
+  // pipedrive → migrated to providers/pipedrive.ts
   // pinecone → migrated to providers/pinecone.ts
   // vercel → migrated to providers/vercel.ts
   // circleci → migrated to providers/circleci.ts
@@ -38,13 +38,13 @@ const INTEGRATION_ENV_MAP = {
   shopify: "SHOPIFY_ACCESS_TOKEN",
   // linkedin → migrated to providers/linkedin.ts
   instagram: "INSTAGRAM_ACCESS_TOKEN",
-  salesforce: "SALESFORCE_ACCESS_TOKEN",
+  // salesforce → migrated to providers/salesforce.ts
   // twitter → migrated to providers/twitter.ts
   // digitalocean → migrated to providers/digitalocean.ts
   // algolia → migrated to providers/algolia.ts
   // clickup → migrated to providers/clickup.ts
   // monday → migrated to providers/monday.ts
-  zendesk: "ZENDESK_API_TOKEN",
+  // zendesk → migrated to providers/zendesk.ts
   // docker-hub → migrated to providers/dockerHub.ts
   // bitbucket → migrated to providers/bitbucket.ts
   // confluence → migrated to providers/confluence.ts
@@ -66,10 +66,10 @@ const INTEGRATION_ENV_MAP = {
   // redis → migrated to providers/redis.ts
   // postgresql → migrated to providers/postgresql.ts
   // Payments
-  paypal: "PAYPAL_CLIENT_SECRET",
+  // paypal → migrated to providers/paypal.ts
   // Analytics / automation
-  segment: "SEGMENT_WRITE_KEY",
-  mixpanel: "MIXPANEL_API_SECRET",
+  // segment → migrated to providers/segment.ts
+  // mixpanel → migrated to providers/mixpanel.ts
   // Vector DBs
   // weaviate → migrated to providers/weaviate.ts
   // Communication
@@ -139,23 +139,20 @@ const INTEGRATION_CONFIG_ENV_MAP = {
   //   confluence → providers/confluence.ts
   //   google-sheets → providers/googleSheets.ts
   //   google-calendar → providers/googleCalendar.ts
-  // CRM
-  "salesforce.instance_url": "SALESFORCE_INSTANCE_URL",
-  "zendesk.subdomain": "ZENDESK_SUBDOMAIN",
-  "zendesk.email": "ZENDESK_EMAIL",
-  "pipedrive.company_domain": "PIPEDRIVE_DOMAIN",
-  // Payment
-  "paypal.client_id": "PAYPAL_CLIENT_ID",
-  "stripe.webhook_secret": "STRIPE_WEBHOOK_SECRET",
+  // CRM / Payment — all migrated:
+  //   salesforce → providers/salesforce.ts
+  //   zendesk → providers/zendesk.ts
+  //   pipedrive → providers/pipedrive.ts
+  //   stripe → providers/stripe.ts
+  //   paypal → providers/paypal.ts
   // Social
   // twitter.api_key/api_secret/default_username → providers/twitter.ts
   "facebook.page_id": "FACEBOOK_PAGE_ID",
   "instagram.business_account_id": "INSTAGRAM_BUSINESS_ACCOUNT_ID",
   "instagram.page_id": "INSTAGRAM_PAGE_ID",
-  // Analytics
-  "mixpanel.project_token": "MIXPANEL_PROJECT_TOKEN",
-  "google-analytics.service_account_json": "GOOGLE_ANALYTICS_SA_JSON",
-  "google-analytics.property_id": "GA4_PROPERTY_ID",
+  // Analytics — all migrated:
+  //   mixpanel → providers/mixpanel.ts
+  //   google-analytics → providers/googleAnalytics.ts
   // E-commerce
   "shopify.shop_domain": "SHOPIFY_SHOP_DOMAIN",
   "woocommerce.site_url": "WOOCOMMERCE_STORE_URL",

--- a/backend-api/integrations/providers/mixpanel.ts
+++ b/backend-api/integrations/providers/mixpanel.ts
@@ -1,0 +1,52 @@
+// Mixpanel provider — Service Account credentials (project-scoped).
+// The Project Token field is for client-side ingestion; the Service
+// Account secret is the server-side credential used here. The connectivity
+// test hits /api/2.0/me which returns the SA's display name.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const mixpanelProvider: Provider = {
+  id: "mixpanel",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      const username = String(config.service_account_username || "").trim();
+      if (!username) {
+        // Fall back to project-token-only mode (track API). We can't validate
+        // it without sending a real event — store and let the runtime use it.
+        if (!ctx.token)
+          throw new Error("Mixpanel project token or service account secret is required");
+        return {
+          success: true,
+          message: "Project token stored — Mixpanel doesn't support server-side validation",
+        };
+      }
+      const auth = Buffer.from(`${username}:${ctx.token ?? ""}`).toString("base64");
+      const res = await deps.fetch("https://mixpanel.com/api/app/me/", {
+        headers: { Authorization: `Basic ${auth}` },
+      });
+      if (!res.ok) throw new Error(`Mixpanel API returned ${res.status}`);
+      return { success: true, message: "Connected to Mixpanel" };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.project_id) configEnv.project_id = "MIXPANEL_PROJECT_ID";
+    if (config.service_account_username) {
+      configEnv.service_account_username = "MIXPANEL_SERVICE_ACCOUNT_USERNAME";
+    }
+    return { primary: "MIXPANEL_API_SECRET", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/paypal.ts
+++ b/backend-api/integrations/providers/paypal.ts
@@ -1,0 +1,55 @@
+// PayPal provider — client credentials grant. The connectivity test
+// hits /v1/oauth2/token (the documented credential-validation endpoint)
+// to swap the client_id + client_secret for an access token.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+const PRODUCTION_HOST = "https://api-m.paypal.com";
+const SANDBOX_HOST = "https://api-m.sandbox.paypal.com";
+
+export const paypalProvider: Provider = {
+  id: "paypal",
+  authType: "credentials",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      const clientId = String(config.client_id || "").trim();
+      if (!clientId) throw new Error("PayPal Client ID not configured");
+      if (!ctx.token) throw new Error("PayPal Client Secret is required");
+      const sandbox = config.sandbox === true || config.sandbox === "true";
+      const base = sandbox ? SANDBOX_HOST : PRODUCTION_HOST;
+      const auth = Buffer.from(`${clientId}:${ctx.token}`).toString("base64");
+      const res = await deps.fetch(`${base}/v1/oauth2/token`, {
+        method: "POST",
+        headers: {
+          Authorization: `Basic ${auth}`,
+          "Content-Type": "application/x-www-form-urlencoded",
+          Accept: "application/json",
+        },
+        body: "grant_type=client_credentials",
+      });
+      if (!res.ok) throw new Error(`PayPal API returned ${res.status}`);
+      return {
+        success: true,
+        message: `Connected to PayPal (${sandbox ? "sandbox" : "production"})`,
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.client_id) configEnv.client_id = "PAYPAL_CLIENT_ID";
+    if (config.sandbox !== undefined) configEnv.sandbox = "PAYPAL_SANDBOX";
+    return { primary: "PAYPAL_CLIENT_SECRET", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/pipedrive.ts
+++ b/backend-api/integrations/providers/pipedrive.ts
@@ -1,0 +1,36 @@
+// Pipedrive provider — API token passed as query-string param.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const pipedriveProvider: Provider = {
+  id: "pipedrive",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const token = encodeURIComponent(ctx.token ?? "");
+      const res = await deps.fetch(`https://api.pipedrive.com/v1/users/me?api_token=${token}`);
+      if (!res.ok) throw new Error(`Pipedrive API returned ${res.status}`);
+      const data: any = await res.json();
+      return {
+        success: true,
+        message: `Connected as ${data.data?.name || "verified"}`,
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.company_domain) configEnv.company_domain = "PIPEDRIVE_COMPANY_DOMAIN";
+    return { primary: "PIPEDRIVE_API_KEY", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/salesforce.ts
+++ b/backend-api/integrations/providers/salesforce.ts
@@ -1,0 +1,38 @@
+// Salesforce provider — Bearer access token against the customer's
+// instance URL. The instance URL goes through assertSafeUrl to block SSRF.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const salesforceProvider: Provider = {
+  id: "salesforce",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      const rawUrl = config.instance_url;
+      if (!rawUrl) throw new Error("Salesforce instance URL not configured");
+      const instanceUrl = await deps.assertSafeUrl(String(rawUrl), "Salesforce instance URL");
+      const res = await deps.fetch(`${instanceUrl}/services/data/v59.0/`, {
+        headers: { Authorization: `Bearer ${ctx.token ?? ""}` },
+      });
+      if (!res.ok) throw new Error(`Salesforce API returned ${res.status}`);
+      return { success: true, message: "Connected to Salesforce" };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.instance_url) configEnv.instance_url = "SALESFORCE_INSTANCE_URL";
+    return { primary: "SALESFORCE_ACCESS_TOKEN", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/segment.ts
+++ b/backend-api/integrations/providers/segment.ts
@@ -1,0 +1,32 @@
+// Segment provider — Source Write Key. Segment doesn't expose a
+// validation endpoint for write keys (they're write-only), so test() is
+// structural — confirms the key looks like a Segment write key and is
+// non-empty.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+} from "../types/provider";
+
+export const segmentProvider: Provider = {
+  id: "segment",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration): Promise<ConnectivityResult> {
+    try {
+      if (!ctx.token) throw new Error("Segment Write Key is required");
+      return {
+        success: true,
+        message: "Write key stored — Segment doesn't expose a validation endpoint",
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(): EnvMapping {
+    return { primary: "SEGMENT_WRITE_KEY", config: {} };
+  },
+};

--- a/backend-api/integrations/providers/stripe.ts
+++ b/backend-api/integrations/providers/stripe.ts
@@ -1,0 +1,34 @@
+// Stripe provider — Bearer secret key. /v1/balance is in every key's
+// default scope.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const stripeProvider: Provider = {
+  id: "stripe",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const res = await deps.fetch("https://api.stripe.com/v1/balance", {
+        headers: { Authorization: `Bearer ${ctx.token ?? ""}` },
+      });
+      if (!res.ok) throw new Error(`Stripe API returned ${res.status}`);
+      return { success: true, message: "Balance verified" };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.webhook_secret) configEnv.webhook_secret = "STRIPE_WEBHOOK_SECRET";
+    return { primary: "STRIPE_SECRET_KEY", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/zendesk.ts
+++ b/backend-api/integrations/providers/zendesk.ts
@@ -1,0 +1,45 @@
+// Zendesk provider — subdomain + email + API token. Uses the special
+// Zendesk Basic-auth shape `<email>/token:<api_token>`.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const zendeskProvider: Provider = {
+  id: "zendesk",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      const subdomain = String(config.subdomain || "").trim();
+      const email = String(config.email || "").trim();
+      if (!subdomain) throw new Error("Zendesk subdomain not configured");
+      if (!email) throw new Error("Zendesk email not configured");
+      const credentials = Buffer.from(`${email}/token:${ctx.token ?? ""}`).toString("base64");
+      const res = await deps.fetch(`https://${subdomain}.zendesk.com/api/v2/users/me.json`, {
+        headers: { Authorization: `Basic ${credentials}` },
+      });
+      if (!res.ok) throw new Error(`Zendesk API returned ${res.status}`);
+      const data: any = await res.json();
+      return {
+        success: true,
+        message: `Connected as ${data.user?.name || data.user?.email || "verified"}`,
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.subdomain) configEnv.subdomain = "ZENDESK_SUBDOMAIN";
+    if (config.email) configEnv.email = "ZENDESK_EMAIL";
+    return { primary: "ZENDESK_API_TOKEN", config: configEnv };
+  },
+};

--- a/backend-api/integrations/services/integrationsService.ts
+++ b/backend-api/integrations/services/integrationsService.ts
@@ -71,6 +71,15 @@ const { trelloProvider } = require("../providers/trello");
 const { confluenceProvider } = require("../providers/confluence");
 const { googleSheetsProvider } = require("../providers/googleSheets");
 const { googleCalendarProvider } = require("../providers/googleCalendar");
+const { salesforceProvider } = require("../providers/salesforce");
+const { hubspotProvider } = require("../providers/hubspot");
+const { pipedriveProvider } = require("../providers/pipedrive");
+const { zendeskProvider } = require("../providers/zendesk");
+const { stripeProvider } = require("../providers/stripe");
+const { paypalProvider } = require("../providers/paypal");
+const { googleAnalyticsProvider } = require("../providers/googleAnalytics");
+const { mixpanelProvider } = require("../providers/mixpanel");
+const { segmentProvider } = require("../providers/segment");
 
 const repo = createIntegrationsRepository(db);
 const secretCrypto = createSecretEncryption({
@@ -146,6 +155,15 @@ const providerRegistry = createProviderRegistry((providerId) =>
   confluenceProvider,
   googleSheetsProvider,
   googleCalendarProvider,
+  salesforceProvider,
+  hubspotProvider,
+  pipedriveProvider,
+  zendeskProvider,
+  stripeProvider,
+  paypalProvider,
+  googleAnalyticsProvider,
+  mixpanelProvider,
+  segmentProvider,
 ].forEach((p) => providerRegistry.register(p));
 
 // Resolve fetch at call time so test mocks reassigning `global.fetch`

--- a/docs/guides/integrations/google-analytics.mdx
+++ b/docs/guides/integrations/google-analytics.mdx
@@ -1,0 +1,50 @@
+# Google Analytics
+
+> How to set up a service account for Google Analytics 4 and connect it to Nora.
+
+Google Analytics integrations let your agents query the GA4 Data API for pageviews, sessions, conversions, and custom events. Nora authenticates with a Google Cloud service account (same shape as [Firebase](/guides/integrations/firebase) and [Google Drive](/guides/integrations/google-drive)).
+
+## Where to apply for credentials
+
+<Card
+  title="GCP — Service Accounts"
+  href="https://console.cloud.google.com/iam-admin/serviceaccounts"
+  icon="bar-chart-2"
+  arrow
+>
+  https://console.cloud.google.com/iam-admin/serviceaccounts
+</Card>
+
+<Steps>
+  <Step title="Create a service account in GCP">
+    Generate a JSON key. Treat it as secret.
+  </Step>
+
+<Step title="Enable the GA4 Data API">
+  GCP Console → APIs & Services → Library → **Google Analytics Data API** → Enable.
+</Step>
+
+<Step title="Grant access in Google Analytics">
+  Open Google Analytics → Admin (gear icon) → Property Access Management → **Add user**. Use the
+  SA's `client_email` and grant **Viewer** access (or higher if your agent writes events).
+</Step>
+
+  <Step title="Find the GA4 Property ID">
+    Admin → Property Settings — the numeric Property ID is at the top.
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+Paste the JSON contents. Set the GA4 Property ID (required for the Data API).
+
+## MCP server
+
+No official Google Analytics MCP server today.
+
+## Environment variables Nora injects
+
+| Variable                              | Source                |
+| ------------------------------------- | --------------------- |
+| `GOOGLE_APPLICATION_CREDENTIALS_JSON` | Service Account JSON  |
+| `GA4_PROPERTY_ID`                     | GA4 Property ID field |

--- a/docs/guides/integrations/hubspot.mdx
+++ b/docs/guides/integrations/hubspot.mdx
@@ -1,0 +1,40 @@
+# HubSpot
+
+> Where to issue a HubSpot Private App access token and connect it to Nora.
+
+HubSpot integrations let your agents read and write contacts, deals, tickets, and marketing campaigns. Nora authenticates with a private-app access token (Bearer auth) — HubSpot's preferred replacement for the deprecated API key.
+
+## Where to apply for credentials
+
+<Card title="HubSpot — Private Apps" href="https://app.hubspot.com/private-apps" icon="users" arrow>
+  Settings → Integrations → Private Apps
+</Card>
+
+<Steps>
+  <Step title="Create a private app">
+    Settings → Integrations → Private Apps → **Create a private app**. Name it (e.g. "Nora").
+  </Step>
+
+<Step title="Pick scopes">
+  On the **Scopes** tab, tick the CRM scopes the agent needs (e.g. `crm.objects.contacts.read`,
+  `crm.objects.contacts.write`, `crm.objects.deals.write`).
+</Step>
+
+  <Step title="Copy the access token">
+    Click **Create app** → **Show token**. Copy it (starts with `pat-na1-...` or your region prefix).
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+Paste the token. Nora calls `GET /crm/v3/objects/contacts?limit=1` to verify it.
+
+## MCP server
+
+No official HubSpot MCP server today.
+
+## Environment variables Nora injects
+
+| Variable               | Source                   |
+| ---------------------- | ------------------------ |
+| `HUBSPOT_ACCESS_TOKEN` | Private App Access Token |

--- a/docs/guides/integrations/mixpanel.mdx
+++ b/docs/guides/integrations/mixpanel.mdx
@@ -1,0 +1,49 @@
+# Mixpanel
+
+> Where to find your Mixpanel project token + service account, and how to connect them to Nora.
+
+Mixpanel integrations let your agents send events to Mixpanel and query existing analytics via the Service Account API.
+
+## Where to apply for credentials
+
+<Card
+  title="Mixpanel — Project settings"
+  href="https://mixpanel.com/settings/project"
+  icon="pie-chart"
+  arrow
+>
+  Project settings
+</Card>
+
+<Steps>
+  <Step title="Copy the Project Token">
+    Project settings → Overview → **Project Token**. This is what client SDKs use for ingestion.
+  </Step>
+
+  <Step title="(For server-side) Create a Service Account">
+    Project settings → **Access security** → **Service accounts** → Create. Pick a role (Project Member, Project Admin, Viewer). Copy the Username + Secret.
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+| Field                    | Value                                                              |
+| ------------------------ | ------------------------------------------------------------------ |
+| Project Token            | For ingestion (the `track` API).                                   |
+| API Secret               | The Service Account secret (server-side queries).                  |
+| Service Account Username | The Service Account username.                                      |
+| Project ID               | Numeric ID from the Project URL (`mixpanel.com/project/<id>/...`). |
+
+Nora calls `/api/app/me/` with HTTP Basic when an SA username is set, otherwise stores the project token without verification (Mixpanel doesn't expose a write-key validation endpoint).
+
+## MCP server
+
+No official Mixpanel MCP server today.
+
+## Environment variables Nora injects
+
+| Variable                            | Source               |
+| ----------------------------------- | -------------------- |
+| `MIXPANEL_API_SECRET`               | API Secret field     |
+| `MIXPANEL_SERVICE_ACCOUNT_USERNAME` | SA Username (if set) |
+| `MIXPANEL_PROJECT_ID`               | Project ID (if set)  |

--- a/docs/guides/integrations/paypal.mdx
+++ b/docs/guides/integrations/paypal.mdx
@@ -1,0 +1,50 @@
+# PayPal
+
+> How to register a PayPal REST API app and connect its Client ID + Secret to Nora.
+
+PayPal integrations let your agents create orders, capture payments, issue refunds, and inspect transactions. Nora uses the **Client Credentials** OAuth grant — `client_id` + `client_secret` swapped for an access token at `/v1/oauth2/token`.
+
+## Where to apply for credentials
+
+<Card
+  title="PayPal Developer Dashboard"
+  href="https://developer.paypal.com/dashboard/applications/sandbox"
+  icon="dollar-sign"
+  arrow
+>
+  developer.paypal.com → Apps & Credentials
+</Card>
+
+<Steps>
+  <Step title="Pick environment">
+    Toggle between **Sandbox** and **Live** — develop with sandbox credentials, switch to live for production.
+  </Step>
+
+<Step title="Create an app">Apps & Credentials → **Create App**. Name it (e.g. "Nora").</Step>
+
+  <Step title="Copy Client ID + Secret">
+    Both visible on the app's detail page. Treat the secret as a password.
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+| Field         | Value                                           |
+| ------------- | ----------------------------------------------- |
+| Client ID     | The PayPal app's client ID                      |
+| Client Secret | The PayPal app's client secret                  |
+| Use Sandbox   | `true` for sandbox apps, blank/`false` for live |
+
+Nora POSTs `grant_type=client_credentials` against `/v1/oauth2/token` (sandbox or live host) to verify.
+
+## MCP server
+
+No official PayPal MCP server today.
+
+## Environment variables Nora injects
+
+| Variable               | Source              |
+| ---------------------- | ------------------- |
+| `PAYPAL_CLIENT_SECRET` | Client Secret field |
+| `PAYPAL_CLIENT_ID`     | Client ID field     |
+| `PAYPAL_SANDBOX`       | Use Sandbox flag    |

--- a/docs/guides/integrations/pipedrive.mdx
+++ b/docs/guides/integrations/pipedrive.mdx
@@ -1,0 +1,33 @@
+# Pipedrive
+
+> Where to find your Pipedrive API token and connect it to Nora.
+
+Pipedrive integrations let your agents read and update deals, contacts, and pipelines.
+
+## Where to apply for credentials
+
+<Card
+  title="Pipedrive — Personal API token"
+  href="https://app.pipedrive.com/settings/api"
+  icon="trending-up"
+  arrow
+>
+  Settings → Personal preferences → API
+</Card>
+
+The page shows your Personal API Token directly — copy it. (For team-scoped agents, use OAuth apps instead.)
+
+## Connect in Nora
+
+Paste the token. Optionally set your **Company Domain** (the slug before `.pipedrive.com`). Nora calls `GET /v1/users/me` and reports the username.
+
+## MCP server
+
+No official Pipedrive MCP server today.
+
+## Environment variables Nora injects
+
+| Variable                   | Source                  |
+| -------------------------- | ----------------------- |
+| `PIPEDRIVE_API_KEY`        | API Token field         |
+| `PIPEDRIVE_COMPANY_DOMAIN` | Company Domain (if set) |

--- a/docs/guides/integrations/salesforce.mdx
+++ b/docs/guides/integrations/salesforce.mdx
@@ -1,0 +1,46 @@
+# Salesforce
+
+> How to OAuth into Salesforce and connect the resulting access token + instance URL to Nora.
+
+Salesforce integrations let your agents query and update CRM records. Nora authenticates with a Bearer access token against your **instance URL** (which Salesforce returns as part of the OAuth flow).
+
+## Where to apply for credentials
+
+Salesforce uses OAuth 2.0 — there's no static "API key" page. The flow:
+
+<Steps>
+  <Step title="Create a Connected App">
+    Setup → App Manager → **New Connected App**. Set **Enable OAuth Settings** = on. Pick scopes: `api`, `refresh_token offline_access`, `full` (or tighter as needed). Set a callback URL pointing at any HTTPS endpoint you control.
+  </Step>
+
+<Step title="Get the consumer key + secret">
+  Once the Connected App is created, copy its **Consumer Key** + **Consumer Secret**.
+</Step>
+
+<Step title="Run the OAuth Web Server flow">
+  Use a script or [the Salesforce OAuth
+  playground](https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/intro_oauth_and_connected_apps.htm)
+  to swap an authorization code for an access token. The response also includes `instance_url`.
+</Step>
+
+  <Step title="Paste into Nora">
+    Paste **Access Token** and **Instance URL** into Nora. The instance URL goes through the SSRF guard (must be a public Salesforce host).
+  </Step>
+</Steps>
+
+<Note>
+  Salesforce access tokens expire (typically 2 hours). For production, you need to also store the
+  refresh_token outside Nora and refresh proactively. This integration uses a single static token —
+  fine for dev and prototyping; not for long-running production agents.
+</Note>
+
+## MCP server
+
+No official Salesforce MCP server today.
+
+## Environment variables Nora injects
+
+| Variable                  | Source             |
+| ------------------------- | ------------------ |
+| `SALESFORCE_ACCESS_TOKEN` | Access Token field |
+| `SALESFORCE_INSTANCE_URL` | Instance URL field |

--- a/docs/guides/integrations/segment.mdx
+++ b/docs/guides/integrations/segment.mdx
@@ -1,0 +1,35 @@
+# Segment
+
+> Where to find your Segment Source Write Key and connect it to Nora.
+
+Segment integrations let your agents send events into Segment for routing to downstream destinations (warehouses, analytics tools, marketing platforms). Nora stores the Source Write Key — Segment's write keys are **write-only** and have no validation endpoint.
+
+## Where to apply for credentials
+
+<Card title="Segment app" href="https://app.segment.com/" icon="git-branch" arrow>
+  https://app.segment.com/
+</Card>
+
+<Steps>
+  <Step title="Pick a Source">
+    Each Segment Source has its own write key. For server-side agents, create or pick a **Node.js** source.
+  </Step>
+
+  <Step title="Copy the Write Key">
+    Source → Settings → **API Keys** → copy the Write Key.
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+Paste the Write Key. Nora stores it without making any network call (Segment doesn't expose a validation endpoint for write keys). End-to-end verification happens when your agent sends its first event.
+
+## MCP server
+
+No official Segment MCP server today.
+
+## Environment variables Nora injects
+
+| Variable            | Source          |
+| ------------------- | --------------- |
+| `SEGMENT_WRITE_KEY` | Write Key field |

--- a/docs/guides/integrations/stripe.mdx
+++ b/docs/guides/integrations/stripe.mdx
@@ -1,0 +1,48 @@
+# Stripe
+
+> Where to issue a Stripe secret key and connect it to Nora.
+
+Stripe integrations let your agents create charges, manage subscriptions, refund customers, and read transaction history. Nora authenticates with a Bearer secret key.
+
+## Where to apply for credentials
+
+<Card
+  title="Stripe Dashboard — API Keys"
+  href="https://dashboard.stripe.com/apikeys"
+  icon="credit-card"
+  arrow
+>
+  https://dashboard.stripe.com/apikeys
+</Card>
+
+<Steps>
+  <Step title="Pick a key type">
+    - **Restricted Key** (recommended for production) — pick only the resources the agent needs.
+    - **Standard Secret Key** (`sk_live_...`) — full access. Easier for dev, dangerous for production.
+  </Step>
+
+<Step title="Copy the key">Stripe shows it once. Test mode keys start with `sk_test_`.</Step>
+
+  <Step title="(Optional) Webhook secret">
+    For event-driven agents, generate a webhook signing secret under **Developers → Webhooks**.
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+Paste the secret key. Optionally paste a webhook signing secret. Nora calls `GET /v1/balance` to verify.
+
+## MCP server
+
+Stripe ships an official MCP server:
+
+- **Package:** `@stripe/mcp`
+- **Docs:** [github.com/stripe/agent-toolkit](https://github.com/stripe/agent-toolkit/tree/main/typescript/examples/mcp)
+- **Env:** `STRIPE_SECRET_KEY` (which Nora injects).
+
+## Environment variables Nora injects
+
+| Variable                | Source                          |
+| ----------------------- | ------------------------------- |
+| `STRIPE_SECRET_KEY`     | Secret Key field                |
+| `STRIPE_WEBHOOK_SECRET` | Webhook Signing Secret (if set) |

--- a/docs/guides/integrations/zendesk.mdx
+++ b/docs/guides/integrations/zendesk.mdx
@@ -1,0 +1,48 @@
+# Zendesk
+
+> Where to issue a Zendesk API token and connect it to Nora.
+
+Zendesk integrations let your agents read and update tickets, users, and organizations. Nora authenticates with HTTP Basic using Zendesk's special `<email>/token:<api_token>` shape.
+
+## Where to apply for credentials
+
+<Card
+  title="Zendesk — API Tokens"
+  href="https://docs.zendesk.com/api-reference/introduction/security-and-auth/#api-token"
+  icon="help-circle"
+  arrow
+>
+  Admin Center → Apps and integrations → Zendesk APIs → Settings
+</Card>
+
+<Steps>
+  <Step title="Enable token access">
+    In Admin Center, open **Apps and integrations → Zendesk APIs → Settings**. Make sure **Token access** is enabled.
+  </Step>
+
+  <Step title="Create a token">
+    Click **Add API token**, give it a description, copy the value (only shown once).
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+| Field     | Value                                                               |
+| --------- | ------------------------------------------------------------------- |
+| Subdomain | The slug before `.zendesk.com` (e.g. `acme` for `acme.zendesk.com`) |
+| Email     | The agent account's email — Zendesk uses it for `email/token` auth  |
+| API Token | The token from above                                                |
+
+Nora calls `GET /api/v2/users/me.json` and reports the agent's name on success.
+
+## MCP server
+
+No official Zendesk MCP server today.
+
+## Environment variables Nora injects
+
+| Variable            | Source          |
+| ------------------- | --------------- |
+| `ZENDESK_API_TOKEN` | API Token field |
+| `ZENDESK_SUBDOMAIN` | Subdomain field |
+| `ZENDESK_EMAIL`     | Email field     |


### PR DESCRIPTION
## Summary

- 9 providers migrated: `salesforce`, `hubspot`, `pipedrive`, `zendesk`, `stripe`, `paypal`, `google-analytics`, `mixpanel`, `segment`.
- PayPal switched to a real OAuth verification flow against `/v1/oauth2/token` (sandbox or live host).
- Stripe gets structured `mcp` metadata pointing at the official `@stripe/mcp` server.
- Salesforce kept as static-token model — docs note that production agents need an external refresh-token rotation.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 812/812 (was 786; +26 across 9 new tests)