### PR TITLE
feat(integrations): migrate remaining social/monitoring/e-commerce/automation providers (11 providers)

### DIFF
--- a/backend-api/__tests__/providerRegistry.test.ts
+++ b/backend-api/__tests__/providerRegistry.test.ts
@@ -72,29 +72,21 @@ describe("createProviderRegistry", () => {
     });
   });
 
-  it("captures errors thrown by the legacy connectivity test as success=false", async () => {
+  it("returns the no-tester fallback for unknown providers (legacy connectivity table is now empty)", async () => {
+    // After PR 8 every catalog provider has a strategy and the legacy
+    // connectivityTests object is effectively empty. Unknown ids resolve
+    // through LegacyProviderAdapter and report the "credentials stored
+    // (not verified)" shape.
     const legacyFactory = (id) => createLegacyProviderAdapter(id, { envMap: {}, configEnvMap: {} });
     const registry = createProviderRegistry(legacyFactory);
 
-    const originalFetch = global.fetch;
-    global.fetch = jest.fn().mockResolvedValue({
-      ok: false,
-      status: 401,
-      json: async () => ({}),
-    });
-    try {
-      // datadog is still in the legacy connectivity-test switch
-      // (github/slack/linear/jira/twitter migrated to strategy in PR 4).
-      const provider = registry.resolve("datadog");
-      const result = await provider.test(
-        { row: { provider: "datadog" }, token: "bad-token", config: {} },
-        { fetch, assertSafeUrl: async (u) => u },
-      );
-      expect(result.success).toBe(false);
-      expect(result.error).toContain("Datadog API returned 401");
-    } finally {
-      global.fetch = originalFetch;
-    }
+    const provider = registry.resolve("not-a-real-provider");
+    const result = await provider.test(
+      { row: { provider: "not-a-real-provider" }, token: "x", config: {} },
+      { fetch: jest.fn(), assertSafeUrl: async (u) => u },
+    );
+    expect(result.success).toBe(true);
+    expect(result.message).toContain("connectivity not verified");
   });
 
   it("lists registered providers", () => {

--- a/backend-api/__tests__/providers/datadogProvider.test.ts
+++ b/backend-api/__tests__/providers/datadogProvider.test.ts
@@ -1,0 +1,34 @@
+// @ts-nocheck
+const { datadogProvider } = require("../../integrations/providers/datadog");
+
+const deps = (fetchImpl) => ({
+  fetch: fetchImpl,
+  assertSafeUrl: async (u) => u,
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+});
+
+describe("datadogProvider", () => {
+  it("calls /api/v1/validate with DD-API-KEY header", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: true });
+    await datadogProvider.test({ row: {}, token: "tok", config: {} }, deps(fetchImpl));
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.datadoghq.com/api/v1/validate",
+      expect.objectContaining({ headers: { "DD-API-KEY": "tok" } }),
+    );
+  });
+
+  it("emits DD_API_KEY + app_key + site", () => {
+    const env = datadogProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { app_key: "x", site: "datadoghq.eu" },
+    });
+    expect(env).toEqual({
+      primary: "DD_API_KEY",
+      config: { app_key: "DD_APP_KEY", site: "DD_SITE" },
+    });
+  });
+});

--- a/backend-api/__tests__/providers/facebookProvider.test.ts
+++ b/backend-api/__tests__/providers/facebookProvider.test.ts
@@ -1,0 +1,34 @@
+// @ts-nocheck
+const { facebookProvider } = require("../../integrations/providers/facebook");
+
+const deps = (fetchImpl) => ({
+  fetch: fetchImpl,
+  assertSafeUrl: async (u) => u,
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+});
+
+describe("facebookProvider", () => {
+  it("calls /me with access_token query param", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ name: "Acme Page" }),
+    });
+    await facebookProvider.test({ row: {}, token: "tok", config: {} }, deps(fetchImpl));
+    expect(fetchImpl).toHaveBeenCalledWith("https://graph.facebook.com/v18.0/me?access_token=tok");
+  });
+
+  it("emits FACEBOOK_ACCESS_TOKEN + page_id", () => {
+    const env = facebookProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { page_id: "1234" },
+    });
+    expect(env).toEqual({
+      primary: "FACEBOOK_ACCESS_TOKEN",
+      config: { page_id: "FACEBOOK_PAGE_ID" },
+    });
+  });
+});

--- a/backend-api/__tests__/providers/grafanaProvider.test.ts
+++ b/backend-api/__tests__/providers/grafanaProvider.test.ts
@@ -1,0 +1,45 @@
+// @ts-nocheck
+const { grafanaProvider } = require("../../integrations/providers/grafana");
+
+const deps = (fetchImpl, assertSafeUrlImpl) => ({
+  fetch: fetchImpl,
+  assertSafeUrl: assertSafeUrlImpl || (async (u) => u),
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+});
+
+describe("grafanaProvider", () => {
+  it("hits /api/org with Bearer at customer's URL", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ name: "Acme" }),
+    });
+    const assertSafeUrl = jest.fn(async (u) => u);
+    const result = await grafanaProvider.test(
+      { row: {}, token: "tok", config: { url: "https://grafana.example.com" } },
+      deps(fetchImpl, assertSafeUrl),
+    );
+    expect(assertSafeUrl).toHaveBeenCalledWith("https://grafana.example.com", "Grafana URL");
+    expect(fetchImpl.mock.calls[0][0]).toBe("https://grafana.example.com/api/org");
+    expect(result.message).toContain("Acme");
+  });
+
+  it("rejects missing URL", async () => {
+    const result = await grafanaProvider.test({ row: {}, token: "x", config: {} }, deps(jest.fn()));
+    expect(result.success).toBe(false);
+  });
+
+  it("emits GRAFANA_TOKEN + GRAFANA_URL", () => {
+    const env = grafanaProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { url: "https://g.example.com" },
+    });
+    expect(env).toEqual({
+      primary: "GRAFANA_TOKEN",
+      config: { url: "GRAFANA_URL" },
+    });
+  });
+});

--- a/backend-api/__tests__/providers/instagramProvider.test.ts
+++ b/backend-api/__tests__/providers/instagramProvider.test.ts
@@ -1,0 +1,45 @@
+// @ts-nocheck
+const { instagramProvider } = require("../../integrations/providers/instagram");
+
+const deps = (fetchImpl) => ({
+  fetch: fetchImpl,
+  assertSafeUrl: async (u) => u,
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+});
+
+describe("instagramProvider", () => {
+  it("hits the business_account_id endpoint when configured", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ username: "acme" }),
+    });
+    await instagramProvider.test(
+      { row: {}, token: "tok", config: { business_account_id: "17841400" } },
+      deps(fetchImpl),
+    );
+    expect(fetchImpl.mock.calls[0][0]).toContain("17841400?fields=id,username");
+  });
+
+  it("falls back to /me when business account is missing", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ name: "Acme" }),
+    });
+    await instagramProvider.test({ row: {}, token: "tok", config: {} }, deps(fetchImpl));
+    expect(fetchImpl.mock.calls[0][0]).toContain("me?fields=id,name");
+  });
+
+  it("emits INSTAGRAM_ACCESS_TOKEN + business + page", () => {
+    const env = instagramProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { business_account_id: "1", page_id: "p1" },
+    });
+    expect(env.primary).toBe("INSTAGRAM_ACCESS_TOKEN");
+    expect(env.config.business_account_id).toBe("INSTAGRAM_BUSINESS_ACCOUNT_ID");
+    expect(env.config.page_id).toBe("INSTAGRAM_PAGE_ID");
+  });
+});

--- a/backend-api/__tests__/providers/pagerdutyProvider.test.ts
+++ b/backend-api/__tests__/providers/pagerdutyProvider.test.ts
@@ -1,0 +1,39 @@
+// @ts-nocheck
+const { pagerdutyProvider } = require("../../integrations/providers/pagerduty");
+
+const deps = (fetchImpl) => ({
+  fetch: fetchImpl,
+  assertSafeUrl: async (u) => u,
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+});
+
+describe("pagerdutyProvider", () => {
+  it("uses Token token=<key> header", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ user: { name: "Alice" } }),
+    });
+    await pagerdutyProvider.test({ row: {}, token: "tok", config: {} }, deps(fetchImpl));
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://api.pagerduty.com/users/me",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Token token=tok" }),
+      }),
+    );
+  });
+
+  it("emits PAGERDUTY_TOKEN + routing_key", () => {
+    const env = pagerdutyProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { routing_key: "rk_x" },
+    });
+    expect(env).toEqual({
+      primary: "PAGERDUTY_TOKEN",
+      config: { routing_key: "PAGERDUTY_ROUTING_KEY" },
+    });
+  });
+});

--- a/backend-api/__tests__/providers/sentryProvider.test.ts
+++ b/backend-api/__tests__/providers/sentryProvider.test.ts
@@ -1,0 +1,36 @@
+// @ts-nocheck
+const { sentryProvider } = require("../../integrations/providers/sentry");
+
+const deps = (fetchImpl) => ({
+  fetch: fetchImpl,
+  assertSafeUrl: async (u) => u,
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+});
+
+describe("sentryProvider", () => {
+  it("calls /api/0/ with Bearer auth token", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: true });
+    await sentryProvider.test({ row: {}, token: "tok", config: {} }, deps(fetchImpl));
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://sentry.io/api/0/",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer tok" }),
+      }),
+    );
+  });
+
+  it("emits SENTRY_AUTH_TOKEN + organization + project", () => {
+    const env = sentryProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { organization: "acme", project: "web" },
+    });
+    expect(env).toEqual({
+      primary: "SENTRY_AUTH_TOKEN",
+      config: { organization: "SENTRY_ORG", project: "SENTRY_PROJECT" },
+    });
+  });
+});

--- a/backend-api/__tests__/providers/shopifyProvider.test.ts
+++ b/backend-api/__tests__/providers/shopifyProvider.test.ts
@@ -1,0 +1,59 @@
+// @ts-nocheck
+const { shopifyProvider } = require("../../integrations/providers/shopify");
+
+const deps = (fetchImpl) => ({
+  fetch: fetchImpl,
+  assertSafeUrl: async (u) => u,
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+});
+
+describe("shopifyProvider", () => {
+  it("appends .myshopify.com when shop_domain is bare", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ shop: { name: "Acme" } }),
+    });
+    await shopifyProvider.test(
+      { row: {}, token: "shpat_x", config: { shop_domain: "acme" } },
+      deps(fetchImpl),
+    );
+    expect(fetchImpl).toHaveBeenCalledWith(
+      "https://acme.myshopify.com/admin/api/2024-01/shop.json",
+      expect.objectContaining({
+        headers: expect.objectContaining({ "X-Shopify-Access-Token": "shpat_x" }),
+      }),
+    );
+  });
+
+  it("uses the full domain when configured", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ shop: { name: "Acme" } }),
+    });
+    await shopifyProvider.test(
+      { row: {}, token: "x", config: { shop_domain: "shop.acme.com" } },
+      deps(fetchImpl),
+    );
+    expect(fetchImpl.mock.calls[0][0]).toContain("shop.acme.com");
+  });
+
+  it("rejects missing shop_domain", async () => {
+    const result = await shopifyProvider.test({ row: {}, token: "x", config: {} }, deps(jest.fn()));
+    expect(result.success).toBe(false);
+  });
+
+  it("emits SHOPIFY_ACCESS_TOKEN + SHOPIFY_SHOP_DOMAIN", () => {
+    const env = shopifyProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { shop_domain: "acme" },
+    });
+    expect(env).toEqual({
+      primary: "SHOPIFY_ACCESS_TOKEN",
+      config: { shop_domain: "SHOPIFY_SHOP_DOMAIN" },
+    });
+  });
+});

--- a/backend-api/__tests__/providers/woocommerceProvider.test.ts
+++ b/backend-api/__tests__/providers/woocommerceProvider.test.ts
@@ -1,0 +1,55 @@
+// @ts-nocheck
+const { woocommerceProvider } = require("../../integrations/providers/woocommerce");
+
+const deps = (fetchImpl, assertSafeUrlImpl) => ({
+  fetch: fetchImpl,
+  assertSafeUrl: assertSafeUrlImpl || (async (u) => u),
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+});
+
+describe("woocommerceProvider", () => {
+  it("uses Basic auth with consumer key + secret", async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: true });
+    const assertSafeUrl = jest.fn(async (u) => u);
+    await woocommerceProvider.test(
+      {
+        row: {},
+        token: "cs_secret",
+        config: { site_url: "https://shop.example.com", consumer_key: "ck_xyz" },
+      },
+      deps(fetchImpl, assertSafeUrl),
+    );
+    const expectedAuth = "Basic " + Buffer.from("ck_xyz:cs_secret").toString("base64");
+    expect(fetchImpl.mock.calls[0][0]).toBe("https://shop.example.com/wp-json/wc/v3/system_status");
+    expect(fetchImpl.mock.calls[0][1].headers.Authorization).toBe(expectedAuth);
+  });
+
+  it("rejects missing site_url or consumer_key", async () => {
+    const fetchImpl = jest.fn();
+    let result = await woocommerceProvider.test(
+      { row: {}, token: "x", config: { consumer_key: "ck" } },
+      deps(fetchImpl),
+    );
+    expect(result.success).toBe(false);
+    result = await woocommerceProvider.test(
+      { row: {}, token: "x", config: { site_url: "https://x.com" } },
+      deps(fetchImpl),
+    );
+    expect(result.success).toBe(false);
+  });
+
+  it("emits WOOCOMMERCE_CONSUMER_SECRET + site/key", () => {
+    const env = woocommerceProvider.mapToEnv({
+      row: {},
+      token: null,
+      config: { site_url: "u", consumer_key: "ck" },
+    });
+    expect(env).toEqual({
+      primary: "WOOCOMMERCE_CONSUMER_SECRET",
+      config: { site_url: "WOOCOMMERCE_STORE_URL", consumer_key: "WOOCOMMERCE_CONSUMER_KEY" },
+    });
+  });
+});

--- a/backend-api/__tests__/providers/zapierProvider.test.ts
+++ b/backend-api/__tests__/providers/zapierProvider.test.ts
@@ -1,0 +1,50 @@
+// @ts-nocheck
+const { zapierProvider } = require("../../integrations/providers/zapier");
+const { makeProvider } = require("../../integrations/providers/make");
+const { n8nProvider } = require("../../integrations/providers/n8n");
+
+const deps = {
+  fetch: jest.fn(),
+  assertSafeUrl: async (u) => u,
+  encrypt: (s) => s,
+  decrypt: (s) => s,
+  ensureEncryptionConfigured: jest.fn(),
+  db: { query: jest.fn() },
+};
+
+describe.each([
+  ["zapier", zapierProvider, "ZAPIER_WEBHOOK_URL"],
+  ["make", makeProvider, "MAKE_WEBHOOK_URL"],
+  ["n8n", n8nProvider, "N8N_WEBHOOK_URL"],
+])("%s webhook provider", (id, provider, envKey) => {
+  it("identifies as " + id + " / webhook", () => {
+    expect(provider.id).toBe(id);
+    expect(provider.authType).toBe("webhook");
+  });
+
+  it("accepts a https webhook URL", async () => {
+    const result = await provider.test(
+      {
+        row: {},
+        token: null,
+        config: { webhook_url: `https://hooks.example.com/${id}/123` },
+      },
+      deps,
+    );
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects empty URL", async () => {
+    const result = await provider.test({ row: {}, token: null, config: {} }, deps);
+    expect(result.success).toBe(false);
+  });
+
+  it("emits the webhook env var via configEnv", () => {
+    const env = provider.mapToEnv({
+      row: {},
+      token: null,
+      config: { webhook_url: "https://x.com/y" },
+    });
+    expect(env.config.webhook_url).toBe(envKey);
+  });
+});

--- a/backend-api/integrations/catalog/catalog.json
+++ b/backend-api/integrations/catalog/catalog.json
@@ -588,7 +588,17 @@
       { "key": "app_key", "label": "Application Key", "type": "password", "required": false },
       { "key": "site", "label": "Datadog Site", "type": "text", "required": false }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://app.datadoghq.com/organization-settings/api-keys",
+    "setupGuide": {
+      "steps": [
+        "Sign in to Datadog and open Organization Settings → API Keys.",
+        "Click New Key, name it (e.g. 'Nora'), copy the value.",
+        "(Optional) Generate an Application Key under Application Keys for query-time access.",
+        "Set Datadog Site if you're not on us1 (e.g. 'datadoghq.eu', 'us3.datadoghq.com')."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "pagerduty",
@@ -606,7 +616,17 @@
         "required": false
       }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://support.pagerduty.com/docs/api-access-keys",
+    "setupGuide": {
+      "steps": [
+        "Sign in to PagerDuty as an admin.",
+        "Open Integrations → API Access Keys → Create New API Key.",
+        "Pick read-only or read-write scope.",
+        "(Optional) For Events API v2, also create a service integration to get a routing key."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "notion",
@@ -1220,7 +1240,18 @@
       },
       { "key": "page_id", "label": "Page ID", "type": "text", "required": true }
     ],
-    "capabilities": ["read", "write", "webhook"]
+    "capabilities": ["read", "write", "webhook"],
+    "credentialsUrl": "https://developers.facebook.com/apps/",
+    "setupGuide": {
+      "steps": [
+        "Open Meta for Developers (developers.facebook.com/apps) and create a Business app.",
+        "Add the Facebook Login + Pages product.",
+        "Use the Graph API Explorer to mint a long-lived Page Access Token (get a User Access Token first, then exchange).",
+        "Find the Page ID via the page's About tab."
+      ],
+      "scopes": ["pages_show_list", "pages_manage_posts", "pages_read_engagement"]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "instagram",
@@ -1239,7 +1270,18 @@
       },
       { "key": "page_id", "label": "Facebook Page ID", "type": "text", "required": false }
     ],
-    "capabilities": ["read"]
+    "capabilities": ["read"],
+    "credentialsUrl": "https://developers.facebook.com/apps/",
+    "setupGuide": {
+      "steps": [
+        "Instagram Graph requires a Meta business app — same flow as Facebook.",
+        "Convert your Instagram account to a Business or Creator account.",
+        "Connect it to a Facebook Page; copy the Page's Instagram Business Account ID via the Graph API.",
+        "Use a long-lived User or Page Access Token with instagram_basic + instagram_content_publish scopes."
+      ],
+      "scopes": ["instagram_basic", "instagram_content_publish", "pages_show_list"]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "google-analytics",
@@ -1586,7 +1628,18 @@
       { "key": "organization", "label": "Organization Slug", "type": "text", "required": false },
       { "key": "project", "label": "Project Slug", "type": "text", "required": false }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://sentry.io/settings/account/api/auth-tokens/",
+    "setupGuide": {
+      "steps": [
+        "Sign in to sentry.io.",
+        "Open Settings → Account → API → Auth Tokens.",
+        "Click Create New Token. Pick scopes (project:read, project:write, org:read).",
+        "Copy the token (only shown once)."
+      ],
+      "scopes": ["project:read", "project:write", "org:read"]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "grafana",
@@ -1599,7 +1652,17 @@
       { "key": "url", "label": "Grafana URL", "type": "url", "required": true },
       { "key": "api_key", "label": "API Key", "type": "password", "required": true }
     ],
-    "capabilities": ["read", "write"]
+    "capabilities": ["read", "write"],
+    "credentialsUrl": "https://grafana.com/docs/grafana/latest/administration/service-accounts/",
+    "setupGuide": {
+      "steps": [
+        "Open your Grafana instance → Administration → Service accounts → Add service account.",
+        "Pick a role (Viewer, Editor, Admin) and click Add service account token.",
+        "Copy the token.",
+        "Set the Grafana URL to your instance origin (must be reachable from Nora; loopback rejected)."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "zapier",
@@ -1611,7 +1674,16 @@
     "configFields": [
       { "key": "webhook_url", "label": "Webhook URL", "type": "url", "required": true }
     ],
-    "capabilities": ["write"]
+    "capabilities": ["write"],
+    "credentialsUrl": "https://zapier.com/apps/webhook/integrations",
+    "setupGuide": {
+      "steps": [
+        "In Zapier, create a new Zap and pick Webhooks by Zapier as the Trigger.",
+        "Choose Catch Hook as the trigger event. Zapier generates a unique webhook URL.",
+        "Copy the URL into Nora and finish the Zap."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "make",
@@ -1623,7 +1695,16 @@
     "configFields": [
       { "key": "webhook_url", "label": "Webhook URL", "type": "url", "required": true }
     ],
-    "capabilities": ["write"]
+    "capabilities": ["write"],
+    "credentialsUrl": "https://www.make.com/en/help/tools/webhooks",
+    "setupGuide": {
+      "steps": [
+        "In Make, create a new Scenario and add a Webhooks → Custom webhook trigger.",
+        "Click Add to generate the webhook URL.",
+        "Copy the URL into Nora and finish your scenario."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "n8n",
@@ -1636,7 +1717,17 @@
       { "key": "webhook_url", "label": "Webhook URL", "type": "url", "required": true },
       { "key": "api_key", "label": "API Key (optional)", "type": "password", "required": false }
     ],
-    "capabilities": ["write"]
+    "capabilities": ["write"],
+    "credentialsUrl": "https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.webhook/",
+    "setupGuide": {
+      "steps": [
+        "In your n8n instance, create a workflow with a Webhook trigger node.",
+        "Configure the path and HTTP method, save the workflow, and activate it.",
+        "Copy the production webhook URL n8n shows.",
+        "(Optional) For n8n Cloud, also paste your API key for management calls."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "shopify",
@@ -1654,7 +1745,18 @@
         "required": true
       }
     ],
-    "capabilities": ["read", "write", "webhook"]
+    "capabilities": ["read", "write", "webhook"],
+    "credentialsUrl": "https://help.shopify.com/en/manual/apps/app-types/custom-apps",
+    "setupGuide": {
+      "steps": [
+        "In Shopify Admin, open Settings → Apps and sales channels → Develop apps.",
+        "Create a custom app, configure Admin API scopes (read_products, write_orders, etc.).",
+        "Click Install app, then copy the Admin API access token (starts with shpat_).",
+        "Shop Domain = your store slug (e.g. 'my-shop' for my-shop.myshopify.com)."
+      ],
+      "scopes": ["read_products", "write_products", "read_orders", "write_orders"]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "woocommerce",
@@ -1668,7 +1770,17 @@
       { "key": "consumer_key", "label": "Consumer Key", "type": "text", "required": true },
       { "key": "consumer_secret", "label": "Consumer Secret", "type": "password", "required": true }
     ],
-    "capabilities": ["read", "write", "webhook"]
+    "capabilities": ["read", "write", "webhook"],
+    "credentialsUrl": "https://woocommerce.com/document/woocommerce-rest-api/",
+    "setupGuide": {
+      "steps": [
+        "In WordPress Admin, open WooCommerce → Settings → Advanced → REST API.",
+        "Click Add Key. Pick Read/Write permissions and select a user.",
+        "Copy the Consumer Key (ck_...) and Consumer Secret (cs_...).",
+        "Site URL = your WordPress site origin (e.g. https://shop.example.com)."
+      ]
+    },
+    "mcp": { "available": false }
   },
   {
     "id": "google-calendar",

--- a/backend-api/integrations/index.ts
+++ b/backend-api/integrations/index.ts
@@ -92,6 +92,17 @@ export { paypalProvider } from "./providers/paypal";
 export { googleAnalyticsProvider } from "./providers/googleAnalytics";
 export { mixpanelProvider } from "./providers/mixpanel";
 export { segmentProvider } from "./providers/segment";
+export { datadogProvider } from "./providers/datadog";
+export { sentryProvider } from "./providers/sentry";
+export { grafanaProvider } from "./providers/grafana";
+export { pagerdutyProvider } from "./providers/pagerduty";
+export { shopifyProvider } from "./providers/shopify";
+export { woocommerceProvider } from "./providers/woocommerce";
+export { facebookProvider } from "./providers/facebook";
+export { instagramProvider } from "./providers/instagram";
+export { zapierProvider } from "./providers/zapier";
+export { makeProvider } from "./providers/make";
+export { n8nProvider } from "./providers/n8n";
 
 // The orchestration service is the recommended import for callers that
 // need the high-level operations (connect, list, test, sync, env-vars).

--- a/backend-api/integrations/providers/datadog.ts
+++ b/backend-api/integrations/providers/datadog.ts
@@ -1,0 +1,34 @@
+// Datadog provider — DD-API-KEY header.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const datadogProvider: Provider = {
+  id: "datadog",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const res = await deps.fetch("https://api.datadoghq.com/api/v1/validate", {
+        headers: { "DD-API-KEY": ctx.token ?? "" },
+      });
+      if (!res.ok) throw new Error(`Datadog API returned ${res.status}`);
+      return { success: true, message: "API key validated" };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.app_key) configEnv.app_key = "DD_APP_KEY";
+    if (config.site) configEnv.site = "DD_SITE";
+    return { primary: "DD_API_KEY", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/facebook.ts
+++ b/backend-api/integrations/providers/facebook.ts
@@ -1,0 +1,34 @@
+// Facebook provider — Graph API access token (long-lived user or page
+// token). Token passed as query string param.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const facebookProvider: Provider = {
+  id: "facebook",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const token = encodeURIComponent(ctx.token ?? "");
+      const res = await deps.fetch(`https://graph.facebook.com/v18.0/me?access_token=${token}`);
+      if (!res.ok) throw new Error(`Facebook API returned ${res.status}`);
+      const data: any = await res.json();
+      return { success: true, message: `Connected as ${data.name || "verified"}` };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.page_id) configEnv.page_id = "FACEBOOK_PAGE_ID";
+    return { primary: "FACEBOOK_ACCESS_TOKEN", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/grafana.ts
+++ b/backend-api/integrations/providers/grafana.ts
@@ -1,0 +1,39 @@
+// Grafana provider — Bearer service-account token against a customer
+// instance URL. URL goes through assertSafeUrl.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const grafanaProvider: Provider = {
+  id: "grafana",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      const rawUrl = config.url;
+      if (!rawUrl) throw new Error("Grafana URL not configured");
+      const url = await deps.assertSafeUrl(String(rawUrl), "Grafana URL");
+      const res = await deps.fetch(`${url}/api/org`, {
+        headers: { Authorization: `Bearer ${ctx.token ?? ""}` },
+      });
+      if (!res.ok) throw new Error(`Grafana API returned ${res.status}`);
+      const data: any = await res.json();
+      return { success: true, message: `Connected to ${data.name || "Grafana"}` };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.url) configEnv.url = "GRAFANA_URL";
+    return { primary: "GRAFANA_TOKEN", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/instagram.ts
+++ b/backend-api/integrations/providers/instagram.ts
@@ -1,0 +1,45 @@
+// Instagram (Graph API) provider — uses the same Facebook Graph access
+// token. Optionally hits a specific business_account_id when provided.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const instagramProvider: Provider = {
+  id: "instagram",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      const accountId = String(config.business_account_id || "").trim();
+      const token = encodeURIComponent(ctx.token ?? "");
+      const path = accountId
+        ? `${encodeURIComponent(accountId)}?fields=id,username&access_token=${token}`
+        : `me?fields=id,name&access_token=${token}`;
+      const res = await deps.fetch(`https://graph.facebook.com/v18.0/${path}`);
+      if (!res.ok) throw new Error(`Instagram Graph API returned ${res.status}`);
+      const data: any = await res.json();
+      return {
+        success: true,
+        message: `Connected as ${data.username || data.name || data.id || "verified"}`,
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.business_account_id) {
+      configEnv.business_account_id = "INSTAGRAM_BUSINESS_ACCOUNT_ID";
+    }
+    if (config.page_id) configEnv.page_id = "INSTAGRAM_PAGE_ID";
+    return { primary: "INSTAGRAM_ACCESS_TOKEN", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/legacy/connectivityTests.ts
+++ b/backend-api/integrations/providers/legacy/connectivityTests.ts
@@ -46,20 +46,8 @@ function buildConnectivityTests(integration, token, deps) {
     // gitlab → migrated to providers/gitlab.ts
     // discord → migrated to providers/discord.ts
     // notion → migrated to providers/notion.ts
-    datadog: async () => {
-      const res = await fetch("https://api.datadoghq.com/api/v1/validate", {
-        headers: { "DD-API-KEY": token },
-      });
-      if (!res.ok) throw new Error(`Datadog API returned ${res.status}`);
-      return { success: true, message: "API key validated" };
-    },
-    sentry: async () => {
-      const res = await fetch("https://sentry.io/api/0/", {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (!res.ok) throw new Error(`Sentry API returned ${res.status}`);
-      return { success: true, message: "Authenticated successfully" };
-    },
+    // datadog → migrated to providers/datadog.ts
+    // sentry → migrated to providers/sentry.ts
     // sendgrid → migrated to providers/sendgrid.ts
     // openai → migrated to providers/openai.ts
     // anthropic → migrated to providers/anthropic.ts
@@ -83,93 +71,16 @@ function buildConnectivityTests(integration, token, deps) {
     // vercel → migrated to providers/vercel.ts
     // circleci → migrated to providers/circleci.ts
     // terraform → migrated to providers/terraform.ts
-    grafana: async () => {
-      const config =
-        typeof integration.config === "string"
-          ? JSON.parse(integration.config)
-          : integration.config || {};
-      const rawUrl = config.url;
-      if (!rawUrl) throw new Error("Grafana URL not configured");
-      const url = await assertSafeUrl(rawUrl, "Grafana URL");
-      const res = await fetch(`${url}/api/org`, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-      if (!res.ok) throw new Error(`Grafana API returned ${res.status}`);
-      const data = await res.json();
-      return { success: true, message: `Connected to ${data.name || "Grafana"}` };
-    },
-    pagerduty: async () => {
-      const res = await fetch("https://api.pagerduty.com/users/me", {
-        headers: { Authorization: `Token token=${token}`, "Content-Type": "application/json" },
-      });
-      if (!res.ok) throw new Error(`PagerDuty API returned ${res.status}`);
-      const data = await res.json();
-      return { success: true, message: `Connected as ${data.user?.name || "verified"}` };
-    },
+    // grafana → migrated to providers/grafana.ts
+    // pagerduty → migrated to providers/pagerduty.ts
     // jenkins → migrated to providers/jenkins.ts
     // dropbox → migrated to providers/dropbox.ts
     // twilio → migrated to providers/twilio.ts
     // telegram → migrated to providers/telegram.ts
-    shopify: async () => {
-      const config =
-        typeof integration.config === "string"
-          ? JSON.parse(integration.config)
-          : integration.config || {};
-      const shop = config.shop_domain;
-      if (!shop) throw new Error("Shopify shop domain not configured");
-      const domain = shop.includes(".") ? shop : `${shop}.myshopify.com`;
-      const res = await fetch(`https://${domain}/admin/api/2024-01/shop.json`, {
-        headers: { "X-Shopify-Access-Token": token },
-      });
-      if (!res.ok) throw new Error(`Shopify API returned ${res.status}`);
-      const data = await res.json();
-      return { success: true, message: `Connected to ${data.shop?.name || shop}` };
-    },
-    woocommerce: async () => {
-      const config =
-        typeof integration.config === "string"
-          ? JSON.parse(integration.config)
-          : integration.config || {};
-      const siteUrl = config.site_url;
-      const consumerKey = config.consumer_key;
-      if (!siteUrl) throw new Error("WooCommerce site URL not configured");
-      if (!consumerKey) throw new Error("WooCommerce consumer key not configured");
-      const url = await assertSafeUrl(siteUrl, "WooCommerce site URL");
-      const res = await fetch(`${url}/wp-json/wc/v3/system_status`, {
-        headers: {
-          Authorization: `Basic ${Buffer.from(`${consumerKey}:${token}`).toString("base64")}`,
-        },
-      });
-      if (!res.ok) throw new Error(`WooCommerce API returned ${res.status}`);
-      return { success: true, message: "Connected to WooCommerce" };
-    },
-    facebook: async () => {
-      const res = await fetch(
-        `https://graph.facebook.com/v18.0/me?access_token=${encodeURIComponent(token)}`,
-      );
-      if (!res.ok) throw new Error(`Facebook API returned ${res.status}`);
-      const data = await res.json();
-      return { success: true, message: `Connected as ${data.name || "verified"}` };
-    },
-    instagram: async () => {
-      const config =
-        typeof integration.config === "string"
-          ? JSON.parse(integration.config)
-          : integration.config || {};
-      const accountId = String(config.business_account_id || "").trim();
-      const path = accountId
-        ? `${encodeURIComponent(accountId)}?fields=id,username`
-        : "me?fields=id,name";
-      const res = await fetch(
-        `https://graph.facebook.com/v18.0/${path}&access_token=${encodeURIComponent(token)}`,
-      );
-      if (!res.ok) throw new Error(`Instagram Graph API returned ${res.status}`);
-      const data = await res.json();
-      return {
-        success: true,
-        message: `Connected as ${data.username || data.name || data.id || "verified"}`,
-      };
-    },
+    // shopify → migrated to providers/shopify.ts
+    // woocommerce → migrated to providers/woocommerce.ts
+    // facebook → migrated to providers/facebook.ts
+    // instagram → migrated to providers/instagram.ts
     // docker-hub → migrated to providers/dockerHub.ts
     // salesforce → migrated to providers/salesforce.ts
   };

--- a/backend-api/integrations/providers/legacy/envMaps.ts
+++ b/backend-api/integrations/providers/legacy/envMaps.ts
@@ -17,8 +17,8 @@ const INTEGRATION_ENV_MAP = {
   // discord → migrated to providers/discord.ts
   // notion → migrated to providers/notion.ts
   // linear → migrated to providers/linear.ts
-  datadog: "DD_API_KEY",
-  sentry: "SENTRY_AUTH_TOKEN",
+  // datadog → migrated to providers/datadog.ts
+  // sentry → migrated to providers/sentry.ts
   // sendgrid → migrated to providers/sendgrid.ts
   // openai → migrated to providers/openai.ts
   // anthropic → migrated to providers/anthropic.ts
@@ -31,13 +31,13 @@ const INTEGRATION_ENV_MAP = {
   // vercel → migrated to providers/vercel.ts
   // circleci → migrated to providers/circleci.ts
   // terraform → migrated to providers/terraform.ts
-  pagerduty: "PAGERDUTY_TOKEN",
+  // pagerduty → migrated to providers/pagerduty.ts
   // dropbox → migrated to providers/dropbox.ts
   // twilio → migrated to providers/twilio.ts
   // telegram → migrated to providers/telegram.ts
-  shopify: "SHOPIFY_ACCESS_TOKEN",
+  // shopify → migrated to providers/shopify.ts
   // linkedin → migrated to providers/linkedin.ts
-  instagram: "INSTAGRAM_ACCESS_TOKEN",
+  // instagram → migrated to providers/instagram.ts
   // salesforce → migrated to providers/salesforce.ts
   // twitter → migrated to providers/twitter.ts
   // digitalocean → migrated to providers/digitalocean.ts
@@ -50,12 +50,12 @@ const INTEGRATION_ENV_MAP = {
   // confluence → migrated to providers/confluence.ts
   // jira → migrated to providers/jira.ts
   // jenkins → migrated to providers/jenkins.ts
-  grafana: "GRAFANA_TOKEN",
-  woocommerce: "WOOCOMMERCE_SECRET_KEY",
+  // grafana → migrated to providers/grafana.ts
+  // woocommerce → migrated to providers/woocommerce.ts
   // trello → migrated to providers/trello.ts
   // elasticsearch → migrated to providers/elasticsearch.ts
   // supabase → migrated to providers/supabase.ts
-  facebook: "FACEBOOK_ACCESS_TOKEN",
+  // facebook → migrated to providers/facebook.ts
   // Cloud / infra
   // aws → migrated to providers/aws.ts
   // azure → migrated to providers/azure.ts
@@ -114,20 +114,16 @@ const INTEGRATION_CONFIG_ENV_MAP = {
   //   weaviate → providers/weaviate.ts
   //   pinecone → providers/pinecone.ts
   //   algolia → providers/algolia.ts
-  // Monitoring
-  "datadog.app_key": "DD_APP_KEY",
-  "datadog.site": "DD_SITE",
-  "pagerduty.routing_key": "PAGERDUTY_ROUTING_KEY",
-  "sentry.organization": "SENTRY_ORG",
-  "sentry.project": "SENTRY_PROJECT",
-  "grafana.url": "GRAFANA_URL",
-  // DevOps
-  "jenkins.url": "JENKINS_URL",
-  "jenkins.username": "JENKINS_USERNAME",
-  "vercel.team_id": "VERCEL_TEAM_ID",
-  "terraform.organization": "TF_ORGANIZATION",
-  "kubernetes.kubeconfig": "KUBECONFIG_CONTENT",
-  "kubernetes.context": "KUBE_CONTEXT",
+  // Monitoring — all migrated:
+  //   datadog → providers/datadog.ts
+  //   pagerduty → providers/pagerduty.ts
+  //   sentry → providers/sentry.ts
+  //   grafana → providers/grafana.ts
+  // DevOps — all migrated:
+  //   jenkins → providers/jenkins.ts
+  //   vercel → providers/vercel.ts
+  //   terraform → providers/terraform.ts
+  //   kubernetes → providers/kubernetes.ts
   // Productivity
   // Productivity — all migrated to per-provider strategies:
   //   notion → providers/notion.ts
@@ -145,25 +141,20 @@ const INTEGRATION_CONFIG_ENV_MAP = {
   //   pipedrive → providers/pipedrive.ts
   //   stripe → providers/stripe.ts
   //   paypal → providers/paypal.ts
-  // Social
-  // twitter.api_key/api_secret/default_username → providers/twitter.ts
-  "facebook.page_id": "FACEBOOK_PAGE_ID",
-  "instagram.business_account_id": "INSTAGRAM_BUSINESS_ACCOUNT_ID",
-  "instagram.page_id": "INSTAGRAM_PAGE_ID",
+  // Social — all migrated:
+  //   twitter → providers/twitter.ts
+  //   facebook → providers/facebook.ts
+  //   instagram → providers/instagram.ts
   // Analytics — all migrated:
   //   mixpanel → providers/mixpanel.ts
   //   google-analytics → providers/googleAnalytics.ts
-  // E-commerce
-  "shopify.shop_domain": "SHOPIFY_SHOP_DOMAIN",
-  "woocommerce.site_url": "WOOCOMMERCE_STORE_URL",
-  "woocommerce.consumer_key": "WOOCOMMERCE_CONSUMER_KEY",
-  // Automation webhooks
-  "zapier.webhook_url": "ZAPIER_WEBHOOK_URL",
-  "make.webhook_url": "MAKE_WEBHOOK_URL",
-  "n8n.webhook_url": "N8N_WEBHOOK_URL",
-  "n8n.api_key": "N8N_API_KEY",
-  // DevOps
-  "docker-hub.username": "DOCKER_HUB_USERNAME",
+  // E-commerce / Automation — all migrated:
+  //   shopify → providers/shopify.ts
+  //   woocommerce → providers/woocommerce.ts
+  //   zapier → providers/zapier.ts
+  //   make → providers/make.ts
+  //   n8n → providers/n8n.ts
+  // DevOps — docker-hub migrated to providers/dockerHub.ts
 };
 
 const LLM_AUTH_ENV_VARS = new Set(

--- a/backend-api/integrations/providers/make.ts
+++ b/backend-api/integrations/providers/make.ts
@@ -1,0 +1,43 @@
+// Make.com (formerly Integromat) provider — webhook URL.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+} from "../types/provider";
+
+export const makeProvider: Provider = {
+  id: "make",
+  authType: "webhook",
+
+  async test(ctx: DecryptedIntegration): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      const url = String(config.webhook_url || "").trim();
+      if (!url) throw new Error("Make.com webhook URL not configured");
+      let parsed: URL;
+      try {
+        parsed = new URL(url);
+      } catch {
+        throw new Error("Make.com webhook URL is not a valid URL");
+      }
+      if (parsed.protocol !== "https:") {
+        throw new Error("Make.com webhook URL must use https://");
+      }
+      return {
+        success: true,
+        message: "Webhook URL stored — Make.com webhooks have no validation endpoint",
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.webhook_url) configEnv.webhook_url = "MAKE_WEBHOOK_URL";
+    return { primary: null, config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/n8n.ts
+++ b/backend-api/integrations/providers/n8n.ts
@@ -1,0 +1,44 @@
+// n8n provider — webhook URL or API key against the customer's instance.
+// We treat it as webhook (since most agent → n8n flows are inbound webhooks).
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+} from "../types/provider";
+
+export const n8nProvider: Provider = {
+  id: "n8n",
+  authType: "webhook",
+
+  async test(ctx: DecryptedIntegration): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      const url = String(config.webhook_url || "").trim();
+      if (!url) throw new Error("n8n webhook URL not configured");
+      let parsed: URL;
+      try {
+        parsed = new URL(url);
+      } catch {
+        throw new Error("n8n webhook URL is not a valid URL");
+      }
+      if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+        throw new Error("n8n webhook URL must use http:// or https://");
+      }
+      return {
+        success: true,
+        message: "Webhook URL stored — n8n webhooks have no validation endpoint",
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.webhook_url) configEnv.webhook_url = "N8N_WEBHOOK_URL";
+    return { primary: "N8N_API_KEY", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/pagerduty.ts
+++ b/backend-api/integrations/providers/pagerduty.ts
@@ -1,0 +1,40 @@
+// PagerDuty provider — Token token=<api_key> Authorization header.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const pagerdutyProvider: Provider = {
+  id: "pagerduty",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const res = await deps.fetch("https://api.pagerduty.com/users/me", {
+        headers: {
+          Authorization: `Token token=${ctx.token ?? ""}`,
+          "Content-Type": "application/json",
+        },
+      });
+      if (!res.ok) throw new Error(`PagerDuty API returned ${res.status}`);
+      const data: any = await res.json();
+      return {
+        success: true,
+        message: `Connected as ${data.user?.name || "verified"}`,
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.routing_key) configEnv.routing_key = "PAGERDUTY_ROUTING_KEY";
+    return { primary: "PAGERDUTY_TOKEN", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/sentry.ts
+++ b/backend-api/integrations/providers/sentry.ts
@@ -1,0 +1,35 @@
+// Sentry provider — Bearer auth token. /api/0/ is Sentry's root and a
+// safe smoke test for any auth token (returns the API surface index).
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const sentryProvider: Provider = {
+  id: "sentry",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const res = await deps.fetch("https://sentry.io/api/0/", {
+        headers: { Authorization: `Bearer ${ctx.token ?? ""}` },
+      });
+      if (!res.ok) throw new Error(`Sentry API returned ${res.status}`);
+      return { success: true, message: "Authenticated successfully" };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.organization) configEnv.organization = "SENTRY_ORG";
+    if (config.project) configEnv.project = "SENTRY_PROJECT";
+    return { primary: "SENTRY_AUTH_TOKEN", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/shopify.ts
+++ b/backend-api/integrations/providers/shopify.ts
@@ -1,0 +1,39 @@
+// Shopify provider — Admin API access token via X-Shopify-Access-Token
+// against the shop's myshopify.com host.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const shopifyProvider: Provider = {
+  id: "shopify",
+  authType: "api_key",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      const shop = String(config.shop_domain || "").trim();
+      if (!shop) throw new Error("Shopify shop domain not configured");
+      const domain = shop.includes(".") ? shop : `${shop}.myshopify.com`;
+      const res = await deps.fetch(`https://${domain}/admin/api/2024-01/shop.json`, {
+        headers: { "X-Shopify-Access-Token": ctx.token ?? "" },
+      });
+      if (!res.ok) throw new Error(`Shopify API returned ${res.status}`);
+      const data: any = await res.json();
+      return { success: true, message: `Connected to ${data.shop?.name || shop}` };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.shop_domain) configEnv.shop_domain = "SHOPIFY_SHOP_DOMAIN";
+    return { primary: "SHOPIFY_ACCESS_TOKEN", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/woocommerce.ts
+++ b/backend-api/integrations/providers/woocommerce.ts
@@ -1,0 +1,42 @@
+// WooCommerce provider — Consumer Key + Consumer Secret as HTTP Basic
+// against the customer's WordPress site.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+export const woocommerceProvider: Provider = {
+  id: "woocommerce",
+  authType: "credentials",
+
+  async test(ctx: DecryptedIntegration, deps: ProviderDeps): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      const siteUrl = config.site_url;
+      const consumerKey = config.consumer_key;
+      if (!siteUrl) throw new Error("WooCommerce site URL not configured");
+      if (!consumerKey) throw new Error("WooCommerce consumer key not configured");
+      const url = await deps.assertSafeUrl(String(siteUrl), "WooCommerce site URL");
+      const credentials = Buffer.from(`${consumerKey}:${ctx.token ?? ""}`).toString("base64");
+      const res = await deps.fetch(`${url}/wp-json/wc/v3/system_status`, {
+        headers: { Authorization: `Basic ${credentials}` },
+      });
+      if (!res.ok) throw new Error(`WooCommerce API returned ${res.status}`);
+      return { success: true, message: "Connected to WooCommerce" };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.site_url) configEnv.site_url = "WOOCOMMERCE_STORE_URL";
+    if (config.consumer_key) configEnv.consumer_key = "WOOCOMMERCE_CONSUMER_KEY";
+    return { primary: "WOOCOMMERCE_CONSUMER_SECRET", config: configEnv };
+  },
+};

--- a/backend-api/integrations/providers/zapier.ts
+++ b/backend-api/integrations/providers/zapier.ts
@@ -1,0 +1,44 @@
+// Zapier provider — webhook integration. Stored-only: Nora can't safely
+// hit a one-way webhook URL from the control plane.
+
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+} from "../types/provider";
+
+export const zapierProvider: Provider = {
+  id: "zapier",
+  authType: "webhook",
+
+  async test(ctx: DecryptedIntegration): Promise<ConnectivityResult> {
+    try {
+      const config = (ctx.config || {}) as Record<string, any>;
+      const url = String(config.webhook_url || "").trim();
+      if (!url) throw new Error("Zapier webhook URL not configured");
+      let parsed: URL;
+      try {
+        parsed = new URL(url);
+      } catch {
+        throw new Error("Zapier webhook URL is not a valid URL");
+      }
+      if (parsed.protocol !== "https:") {
+        throw new Error("Zapier webhook URL must use https://");
+      }
+      return {
+        success: true,
+        message: "Webhook URL stored — Zapier webhooks have no validation endpoint",
+      };
+    } catch (e: any) {
+      return { success: false, error: e?.message ?? String(e) };
+    }
+  },
+
+  mapToEnv(ctx: DecryptedIntegration): EnvMapping {
+    const config = ctx.config || {};
+    const configEnv: Record<string, string> = {};
+    if (config.webhook_url) configEnv.webhook_url = "ZAPIER_WEBHOOK_URL";
+    return { primary: null, config: configEnv };
+  },
+};

--- a/backend-api/integrations/services/integrationsService.ts
+++ b/backend-api/integrations/services/integrationsService.ts
@@ -80,6 +80,17 @@ const { paypalProvider } = require("../providers/paypal");
 const { googleAnalyticsProvider } = require("../providers/googleAnalytics");
 const { mixpanelProvider } = require("../providers/mixpanel");
 const { segmentProvider } = require("../providers/segment");
+const { datadogProvider } = require("../providers/datadog");
+const { sentryProvider } = require("../providers/sentry");
+const { grafanaProvider } = require("../providers/grafana");
+const { pagerdutyProvider } = require("../providers/pagerduty");
+const { shopifyProvider } = require("../providers/shopify");
+const { woocommerceProvider } = require("../providers/woocommerce");
+const { facebookProvider } = require("../providers/facebook");
+const { instagramProvider } = require("../providers/instagram");
+const { zapierProvider } = require("../providers/zapier");
+const { makeProvider } = require("../providers/make");
+const { n8nProvider } = require("../providers/n8n");
 
 const repo = createIntegrationsRepository(db);
 const secretCrypto = createSecretEncryption({
@@ -164,6 +175,17 @@ const providerRegistry = createProviderRegistry((providerId) =>
   googleAnalyticsProvider,
   mixpanelProvider,
   segmentProvider,
+  datadogProvider,
+  sentryProvider,
+  grafanaProvider,
+  pagerdutyProvider,
+  shopifyProvider,
+  woocommerceProvider,
+  facebookProvider,
+  instagramProvider,
+  zapierProvider,
+  makeProvider,
+  n8nProvider,
 ].forEach((p) => providerRegistry.register(p));
 
 // Resolve fetch at call time so test mocks reassigning `global.fetch`

--- a/docs/guides/integrations/datadog.mdx
+++ b/docs/guides/integrations/datadog.mdx
@@ -1,0 +1,34 @@
+# Datadog
+
+> Where to issue Datadog API + application keys and connect them to Nora.
+
+## Where to apply for credentials
+
+<Card
+  title="Datadog — API Keys"
+  href="https://app.datadoghq.com/organization-settings/api-keys"
+  icon="activity"
+  arrow
+>
+  Organization Settings → API Keys
+</Card>
+
+The same admin page lists Application Keys under a separate tab. Both are required if your agent issues query API calls; only the API key is needed for ingestion.
+
+## Connect in Nora
+
+Paste the **API Key**. Optionally add an **Application Key** (for query-time access) and **Datadog Site** (`datadoghq.com`, `datadoghq.eu`, `us3.datadoghq.com`, etc.).
+
+Nora calls `GET /api/v1/validate` with `DD-API-KEY` to verify.
+
+## MCP server
+
+No official Datadog MCP server today.
+
+## Environment variables Nora injects
+
+| Variable     | Source                   |
+| ------------ | ------------------------ |
+| `DD_API_KEY` | API Key field            |
+| `DD_APP_KEY` | Application Key (if set) |
+| `DD_SITE`    | Datadog Site (if set)    |

--- a/docs/guides/integrations/facebook.mdx
+++ b/docs/guides/integrations/facebook.mdx
@@ -1,0 +1,47 @@
+# Facebook
+
+> How to mint a Facebook Page Access Token and connect it to Nora.
+
+## Where to apply for credentials
+
+<Card
+  title="Meta for Developers"
+  href="https://developers.facebook.com/apps/"
+  icon="facebook"
+  arrow
+>
+  developers.facebook.com/apps
+</Card>
+
+<Steps>
+  <Step title="Create a Business app">
+    Click **Create App** → choose **Business** type. Name it.
+  </Step>
+
+<Step title="Add Products">Add **Pages** and **Facebook Login** products.</Step>
+
+<Step title="Mint a long-lived Page Access Token">
+  Use the [Graph API Explorer](https://developers.facebook.com/tools/explorer/): get a User Access
+  Token with `pages_show_list`, `pages_manage_posts`, `pages_read_engagement` scopes; use the
+  `/me/accounts` endpoint to swap it for a long-lived Page token.
+</Step>
+
+  <Step title="Find the Page ID">
+    The page's About tab shows it. Copy it into Nora.
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+Paste the Page Access Token + Page ID. Nora calls `GET /me?access_token=...` to verify.
+
+## MCP server
+
+No official Facebook MCP server today.
+
+## Environment variables Nora injects
+
+| Variable                | Source            |
+| ----------------------- | ----------------- |
+| `FACEBOOK_ACCESS_TOKEN` | Page Access Token |
+| `FACEBOOK_PAGE_ID`      | Page ID field     |

--- a/docs/guides/integrations/grafana.mdx
+++ b/docs/guides/integrations/grafana.mdx
@@ -1,0 +1,43 @@
+# Grafana
+
+> How to issue a Grafana service-account token and connect it to Nora.
+
+## Where to apply for credentials
+
+<Card
+  title="Grafana — Service accounts docs"
+  href="https://grafana.com/docs/grafana/latest/administration/service-accounts/"
+  icon="bar-chart"
+  arrow
+>
+  https://grafana.com/docs/grafana/latest/administration/service-accounts/
+</Card>
+
+<Steps>
+  <Step title="Open Service accounts">
+    Your Grafana instance → **Administration → Service accounts** → **Add service account**.
+  </Step>
+
+<Step title="Pick a role">
+  Viewer for read-only agents, Editor for dashboard authorship, Admin for cluster-level changes.
+</Step>
+
+  <Step title="Add a token to the SA">
+    Click the new SA → **Add service account token**. Set an expiration (or none). Copy the value.
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+Set **Grafana URL** to your instance origin (must be public — RFC1918 hosts rejected). Paste the **API Key**. Nora calls `GET <url>/api/org` with Bearer auth and reports the org name.
+
+## MCP server
+
+No official Grafana MCP server today.
+
+## Environment variables Nora injects
+
+| Variable        | Source            |
+| --------------- | ----------------- |
+| `GRAFANA_TOKEN` | API Key field     |
+| `GRAFANA_URL`   | Grafana URL field |

--- a/docs/guides/integrations/instagram.mdx
+++ b/docs/guides/integrations/instagram.mdx
@@ -1,0 +1,48 @@
+# Instagram (Graph API)
+
+> How to set up Instagram Graph access through a Meta Business app and connect it to Nora.
+
+Instagram's API runs on top of the Facebook Graph API — same Meta Business app, same access tokens, additional `instagram_*` scopes. The integration covers Instagram Business and Creator accounts (not personal accounts).
+
+## Where to apply for credentials
+
+Same flow as [Facebook](/guides/integrations/facebook):
+
+<Steps>
+  <Step title="Convert your Instagram account">
+    Switch to a Business or Creator account in the Instagram app.
+  </Step>
+
+<Step title="Connect to a Facebook Page">
+  Link the Instagram account to a Facebook Page (via Instagram → Settings → Account → Linked
+  accounts).
+</Step>
+
+  <Step title="Find the Business Account ID">
+    Use Graph API Explorer: `GET /<page-id>?fields=instagram_business_account` returns the Instagram business account ID.
+  </Step>
+
+  <Step title="Mint a token">
+    Long-lived User or Page token with `instagram_basic`, `instagram_content_publish`, `pages_show_list`.
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+| Field               | Value                                       |
+| ------------------- | ------------------------------------------- |
+| Access Token        | The long-lived token                        |
+| Business Account ID | `17841...` (numeric IG Business account ID) |
+| Facebook Page ID    | (Optional) the linked Page's ID             |
+
+## MCP server
+
+No official Instagram MCP server today.
+
+## Environment variables Nora injects
+
+| Variable                        | Source                    |
+| ------------------------------- | ------------------------- |
+| `INSTAGRAM_ACCESS_TOKEN`        | Access Token field        |
+| `INSTAGRAM_BUSINESS_ACCOUNT_ID` | Business Account ID       |
+| `INSTAGRAM_PAGE_ID`             | Facebook Page ID (if set) |

--- a/docs/guides/integrations/make.mdx
+++ b/docs/guides/integrations/make.mdx
@@ -1,0 +1,45 @@
+# Make (Integromat)
+
+> How to set up a Make custom webhook and connect it to Nora.
+
+Make.com (formerly Integromat) integrations are write-only: Nora POSTs events to your scenario's webhook URL.
+
+## Where to apply for credentials
+
+<Card
+  title="Make — Webhooks docs"
+  href="https://www.make.com/en/help/tools/webhooks"
+  icon="repeat"
+  arrow
+>
+  Make.com → Webhooks
+</Card>
+
+<Steps>
+  <Step title="Create a Scenario">
+    In Make, click Create a new scenario. Add a **Webhooks → Custom webhook** trigger.
+  </Step>
+
+<Step title="Generate the URL">
+  Click **Add** in the trigger config. Make generates a unique webhook URL.
+</Step>
+
+<Step title="Run once">
+  Click Run once on the scenario so it's listening, then send a test payload to the URL — Make will
+  pick up the data structure for downstream modules.
+</Step>
+
+  <Step title="Activate">
+    Build out the rest of the scenario and turn it on.
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+Paste the URL. Stored without a test message.
+
+## Environment variables Nora injects
+
+| Variable           | Source            |
+| ------------------ | ----------------- |
+| `MAKE_WEBHOOK_URL` | Webhook URL field |

--- a/docs/guides/integrations/n8n.mdx
+++ b/docs/guides/integrations/n8n.mdx
@@ -1,0 +1,44 @@
+# n8n
+
+> How to expose an n8n webhook for Nora to send events into.
+
+## Where to apply for credentials
+
+<Card
+  title="n8n — Webhook node docs"
+  href="https://docs.n8n.io/integrations/builtin/core-nodes/n8n-nodes-base.webhook/"
+  icon="git-merge"
+  arrow
+>
+  n8n Webhook trigger
+</Card>
+
+<Steps>
+  <Step title="Create a workflow">
+    In your n8n instance (n8n.cloud or self-hosted), open Workflows → New.
+  </Step>
+
+<Step title="Add a Webhook trigger">
+  First node: **Webhook**. Configure the path, HTTP method (POST), and authentication mode.
+</Step>
+
+<Step title="Save + activate">
+  Save the workflow and toggle **Active**. n8n shows two URLs — use the **Production** URL (not
+  Test).
+</Step>
+
+  <Step title="(n8n Cloud only) Generate an API key">
+    For management calls beyond webhooks, get an API key from your n8n Cloud account settings.
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+Paste the production webhook URL. Optionally paste an API key. Nora validates the URL shape and stores both encrypted.
+
+## Environment variables Nora injects
+
+| Variable          | Source            |
+| ----------------- | ----------------- |
+| `N8N_API_KEY`     | API Key (if set)  |
+| `N8N_WEBHOOK_URL` | Webhook URL field |

--- a/docs/guides/integrations/pagerduty.mdx
+++ b/docs/guides/integrations/pagerduty.mdx
@@ -1,0 +1,39 @@
+# PagerDuty
+
+> Where to issue a PagerDuty API key (and optional routing key) and connect them to Nora.
+
+## Where to apply for credentials
+
+<Card
+  title="PagerDuty — API Access Keys"
+  href="https://support.pagerduty.com/docs/api-access-keys"
+  icon="bell"
+  arrow
+>
+  Integrations → API Access Keys
+</Card>
+
+<Steps>
+  <Step title="Create an API access key">
+    Sign in as admin → Integrations → API Access Keys → **Create New API Key**. Pick read-only or read-write scope.
+  </Step>
+
+  <Step title="(Optional) Get a routing key for Events API">
+    Services → pick a Service → Integrations tab → add a Generic API integration. Copy the Integration Key (a.k.a. routing key).
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+Paste the API Key. Optionally paste a Routing Key for Events API v2 ingestion. Nora calls `GET /users/me` with the `Token token=<key>` Authorization header.
+
+## MCP server
+
+No official PagerDuty MCP server today.
+
+## Environment variables Nora injects
+
+| Variable                | Source               |
+| ----------------------- | -------------------- |
+| `PAGERDUTY_TOKEN`       | API Key field        |
+| `PAGERDUTY_ROUTING_KEY` | Routing Key (if set) |

--- a/docs/guides/integrations/sentry.mdx
+++ b/docs/guides/integrations/sentry.mdx
@@ -1,0 +1,40 @@
+# Sentry
+
+> Where to issue a Sentry auth token and connect it to Nora.
+
+## Where to apply for credentials
+
+<Card
+  title="Sentry — Auth Tokens"
+  href="https://sentry.io/settings/account/api/auth-tokens/"
+  icon="alert-triangle"
+  arrow
+>
+  Settings → Account → API → Auth Tokens
+</Card>
+
+<Steps>
+  <Step title="Click Create New Token">
+    Pick scopes — `project:read`, `project:write`, `org:read` are the common minimum.
+  </Step>
+
+  <Step title="Copy">
+    Sentry shows the token once.
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+Paste the token. Optionally set the Organization Slug + Project Slug. Nora calls `GET /api/0/` with Bearer auth to verify.
+
+## MCP server
+
+No official Sentry MCP server today.
+
+## Environment variables Nora injects
+
+| Variable            | Source                |
+| ------------------- | --------------------- |
+| `SENTRY_AUTH_TOKEN` | Auth Token field      |
+| `SENTRY_ORG`        | Organization (if set) |
+| `SENTRY_PROJECT`    | Project (if set)      |

--- a/docs/guides/integrations/shopify.mdx
+++ b/docs/guides/integrations/shopify.mdx
@@ -1,0 +1,51 @@
+# Shopify
+
+> How to provision a Shopify Admin API access token from a custom app and connect it to Nora.
+
+## Where to apply for credentials
+
+<Card
+  title="Shopify — Custom apps"
+  href="https://help.shopify.com/en/manual/apps/app-types/custom-apps"
+  icon="shopping-cart"
+  arrow
+>
+  Settings → Apps and sales channels → Develop apps
+</Card>
+
+<Steps>
+  <Step title="Enable custom app development">
+    Shopify Admin → Settings → Apps and sales channels → **Develop apps**. (Requires shop owner permission once.)
+  </Step>
+
+<Step title="Create a custom app">Click **Create an app**, give it a name.</Step>
+
+<Step title="Configure Admin API scopes">
+  On the app's Configuration tab, click **Configure Admin API scopes** and tick what your agent
+  needs (e.g. `read_products`, `write_orders`, `read_customers`).
+</Step>
+
+  <Step title="Install + copy the token">
+    Click **Install app**. The Admin API access token (`shpat_...`) is shown once on the API credentials tab.
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+| Field        | Value                                                 |
+| ------------ | ----------------------------------------------------- |
+| Shop Domain  | `acme` (Nora appends `.myshopify.com`) or full domain |
+| Access Token | The `shpat_...` token from above                      |
+
+Nora calls `GET /admin/api/2024-01/shop.json` with `X-Shopify-Access-Token`.
+
+## MCP server
+
+No official Shopify MCP server today.
+
+## Environment variables Nora injects
+
+| Variable               | Source             |
+| ---------------------- | ------------------ |
+| `SHOPIFY_ACCESS_TOKEN` | Access Token field |
+| `SHOPIFY_SHOP_DOMAIN`  | Shop Domain field  |

--- a/docs/guides/integrations/woocommerce.mdx
+++ b/docs/guides/integrations/woocommerce.mdx
@@ -1,0 +1,51 @@
+# WooCommerce
+
+> Where to issue WooCommerce REST API keys and connect them to Nora.
+
+## Where to apply for credentials
+
+<Card
+  title="WooCommerce REST API docs"
+  href="https://woocommerce.com/document/woocommerce-rest-api/"
+  icon="shopping-bag"
+  arrow
+>
+  WooCommerce → Settings → Advanced → REST API
+</Card>
+
+<Steps>
+  <Step title="Open the REST API tab">
+    WordPress Admin → WooCommerce → Settings → **Advanced → REST API**.
+  </Step>
+
+<Step title="Generate keys">
+  Click **Add Key**. Pick a user (the API operates with that user's permissions), choose
+  **Read/Write** if your agent updates products/orders.
+</Step>
+
+  <Step title="Copy">
+    Consumer Key starts with `ck_`. Consumer Secret starts with `cs_`. Both shown once.
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+| Field           | Value                                              |
+| --------------- | -------------------------------------------------- |
+| Site URL        | `https://shop.example.com` (your WordPress origin) |
+| Consumer Key    | `ck_...`                                           |
+| Consumer Secret | `cs_...`                                           |
+
+Nora calls `/wp-json/wc/v3/system_status` with HTTP Basic.
+
+## MCP server
+
+No official WooCommerce MCP server today.
+
+## Environment variables Nora injects
+
+| Variable                      | Source             |
+| ----------------------------- | ------------------ |
+| `WOOCOMMERCE_CONSUMER_SECRET` | Consumer Secret    |
+| `WOOCOMMERCE_STORE_URL`       | Site URL field     |
+| `WOOCOMMERCE_CONSUMER_KEY`    | Consumer Key field |

--- a/docs/guides/integrations/zapier.mdx
+++ b/docs/guides/integrations/zapier.mdx
@@ -1,0 +1,46 @@
+# Zapier
+
+> How to set up a Zapier Catch Hook and connect it to Nora.
+
+Zapier integrations are write-only: Nora POSTs events to your Zap's webhook URL. Zapier then routes them to whichever downstream apps your Zap is configured for.
+
+## Where to apply for credentials
+
+<Card
+  title="Zapier — Webhooks by Zapier"
+  href="https://zapier.com/apps/webhook/integrations"
+  icon="zap"
+  arrow
+>
+  Zapier app builder → Webhooks by Zapier
+</Card>
+
+<Steps>
+  <Step title="Create a Zap">
+    Pick **Webhooks by Zapier** as the Trigger.
+  </Step>
+
+<Step title="Pick Catch Hook">
+  Trigger event: **Catch Hook**. Zapier generates a unique webhook URL.
+</Step>
+
+<Step title="Copy the URL">Use it in Nora.</Step>
+
+  <Step title="Finish your Zap">
+    Add downstream Action steps (Slack, Sheets, etc.) and turn the Zap on.
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+Paste the URL. Nora validates it's HTTPS and stores it. **No test message** — that would deliver to your Zap.
+
+## MCP server
+
+No MCP for Zapier (webhook integrations don't expose a query API).
+
+## Environment variables Nora injects
+
+| Variable             | Source            |
+| -------------------- | ----------------- |
+| `ZAPIER_WEBHOOK_URL` | Webhook URL field |


### PR DESCRIPTION
## Summary

- 11 providers migrated: `datadog`, `sentry`, `grafana`, `pagerduty`, `shopify`, `woocommerce`, `facebook`, `instagram`, `zapier`, `make`, `n8n`.
- Webhook providers (zapier/make/n8n) validate URL shape but don't send test messages.
- After this PR, the legacy `connectivityTests.ts` switch and `INTEGRATION_ENV_MAP` are essentially empty — PR 9 will retire the legacy adapter entirely.
- `providerRegistry.test.ts` updated to test the no-tester fallback (datadog used to be the legacy fixture; now it's strategy-resolved).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 845/845 (was 812; +33 across 11 new tests)

## What's next

PR 9 will delete `providers/legacy.ts`, `providers/legacy/connectivityTests.ts`, and `providers/legacy/envMaps.ts`, and remove the legacy fallback from the registry.