### PR TITLE
docs(integrations): add per-provider guides for github/slack/linear/jira/twitter/linkedin

### DIFF
--- a/docs/guides/integrations/github.mdx
+++ b/docs/guides/integrations/github.mdx
@@ -1,0 +1,65 @@
+# GitHub
+
+> Where to issue a GitHub personal access token and connect it to Nora.
+
+GitHub integrations let your agents read repos, open pull requests, comment on issues, and trigger workflow runs. Nora authenticates with a personal access token (PAT) sent as `Authorization: Bearer <token>`.
+
+## Where to apply for credentials
+
+<Card
+  title="GitHub — Personal Access Tokens"
+  href="https://github.com/settings/tokens"
+  icon="github"
+  arrow
+>
+  Settings → Developer settings → Personal access tokens
+</Card>
+
+GitHub offers two PAT shapes:
+
+- **Fine-grained** (Settings → Developer settings → Personal access tokens → Fine-grained tokens) — preferred. Pick specific repos and exact permissions.
+- **Classic** (Tokens (classic)) — broader, repository-level scopes. Easier for dev.
+
+## Required scopes
+
+Pick the smallest scope that covers your agent's behavior:
+
+| Scope (classic) | When to use                                                       |
+| --------------- | ----------------------------------------------------------------- |
+| `repo`          | Full read/write on private + public repos. Most agents need this. |
+| `read:user`     | Connectivity test — Nora calls `GET /user` to verify              |
+| `workflow`      | If your agent triggers GitHub Actions runs                        |
+| `read:org`      | If your agent enumerates org members or teams                     |
+
+For fine-grained tokens, equivalent permissions live under **Repository permissions** (Contents, Pull requests, Issues, Workflows).
+
+## Connect in Nora
+
+<Steps>
+  <Step title="Open the GitHub integration">
+    From an agent's detail page, open the **Integrations** tab and find **GitHub**.
+  </Step>
+
+<Step title="Paste the token">
+  Paste your PAT into the **Personal Access Token** field. Optionally set an organization name.
+</Step>
+
+  <Step title="Connect">
+    Click **Connect**. Nora calls `GET https://api.github.com/user` with the token and reports your GitHub login on success.
+  </Step>
+</Steps>
+
+## MCP server
+
+GitHub maintains an official MCP server:
+
+- **Package:** `@github/github-mcp-server`
+- **Docs:** [github.com/github/github-mcp-server](https://github.com/github/github-mcp-server)
+- **Env:** `GITHUB_PERSONAL_ACCESS_TOKEN` — Nora injects `GITHUB_TOKEN`, set the MCP env var to that value at startup.
+
+## Environment variables Nora injects
+
+| Variable       | Source                |
+| -------------- | --------------------- |
+| `GITHUB_TOKEN` | Personal Access Token |
+| `GITHUB_ORG`   | Organization (if set) |

--- a/docs/guides/integrations/jira.mdx
+++ b/docs/guides/integrations/jira.mdx
@@ -1,0 +1,50 @@
+# Jira
+
+> Where to issue an Atlassian API token and connect Jira Cloud to Nora.
+
+Jira integrations let your agents read and write issues, transitions, and comments via the Jira REST API. Nora authenticates with HTTP Basic using your Atlassian email + an API token (same flow as [Confluence](/guides/integrations/confluence)).
+
+## Where to apply for credentials
+
+<Card
+  title="Atlassian — API Tokens"
+  href="https://id.atlassian.com/manage-profile/security/api-tokens"
+  icon="atlassian"
+  arrow
+>
+  id.atlassian.com/manage-profile/security/api-tokens
+</Card>
+
+<Steps>
+  <Step title="Create the API token">
+    Click **Create API token**, name it (e.g. "Nora"), and copy the value (only shown once).
+  </Step>
+
+  <Step title="Note your Jira site URL">
+    The integration needs your Jira Cloud origin (e.g. `https://acme.atlassian.net`) — the same site you sign in to.
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+| Field       | Value                                     |
+| ----------- | ----------------------------------------- |
+| Site URL    | `https://<site>.atlassian.net`            |
+| Email       | Your Atlassian account email              |
+| API Token   | The secret you generated                  |
+| Project Key | (Optional) default project key like `ENG` |
+
+Nora validates the URL through the SSRF guard, then calls `GET <url>/rest/api/3/myself` with HTTP Basic. Reports your display name on success.
+
+## MCP server
+
+No official Jira MCP server today.
+
+## Environment variables Nora injects
+
+| Variable           | Source               |
+| ------------------ | -------------------- |
+| `JIRA_API_TOKEN`   | API Token field      |
+| `JIRA_EMAIL`       | Email field          |
+| `JIRA_BASE_URL`    | Site URL field       |
+| `JIRA_PROJECT_KEY` | Project Key (if set) |

--- a/docs/guides/integrations/linear.mdx
+++ b/docs/guides/integrations/linear.mdx
@@ -1,0 +1,38 @@
+# Linear
+
+> Where to issue a Linear API key and connect it to Nora.
+
+Linear integrations let your agents query and create issues, projects, and cycles via Linear's GraphQL API.
+
+## Where to apply for credentials
+
+<Card title="Linear — API settings" href="https://linear.app/settings/api" icon="linear" arrow>
+  Settings → API
+</Card>
+
+<Steps>
+  <Step title="Create a Personal API key">
+    Click **Create new key**, name it (e.g. "Nora").
+  </Step>
+
+  <Step title="Copy the key">
+    Copy the value — Linear shows it once. Personal API keys inherit the issuing user's permissions.
+  </Step>
+</Steps>
+
+For team-wide access independent of a single user, register an OAuth Application instead. Nora's current Linear integration uses the personal API key shape.
+
+## Connect in Nora
+
+Paste the key. Optionally set a default Team ID (the team's UUID, visible in `/settings/teams` URLs). Nora calls a `viewer { name }` GraphQL query to verify.
+
+## MCP server
+
+No first-party Linear MCP server today. Community servers exist on npm.
+
+## Environment variables Nora injects
+
+| Variable         | Source           |
+| ---------------- | ---------------- |
+| `LINEAR_API_KEY` | API Key field    |
+| `LINEAR_TEAM_ID` | Team ID (if set) |

--- a/docs/guides/integrations/linkedin.mdx
+++ b/docs/guides/integrations/linkedin.mdx
@@ -1,0 +1,75 @@
+# LinkedIn
+
+> How to register a LinkedIn OAuth 2.0 app and connect it to Nora.
+
+LinkedIn integrations let your agents read profile data and post to LinkedIn via the Marketing/Sharing APIs. Nora uses **OAuth 2.0 (Authorization Code)** with automatic refresh-token rotation.
+
+## Where to apply for credentials
+
+<Card title="LinkedIn Developers" href="https://www.linkedin.com/developers/" icon="linkedin" arrow>
+  linkedin.com/developers
+</Card>
+
+<Steps>
+  <Step title="Create an app">
+    LinkedIn Developers → **Create app**. Associate it with a Company Page (required).
+  </Step>
+
+<Step title="Verify the app">
+  LinkedIn requires you to verify the app on behalf of the associated company before any OAuth flows
+  work. Follow the verification email sent to a Page admin.
+</Step>
+
+  <Step title="Add the Nora redirect URI">
+    On the app's **Auth** tab, paste the redirect URI Nora's integration modal shows (it's `https://<your-nora-host>/api/integrations/linkedin/oauth/callback`).
+  </Step>
+
+<Step title="Request scopes">
+  LinkedIn's `openid`, `profile`, `email` scopes are auto-available. For posting, you need
+  `w_member_social` — request it under the **Products** tab (Sign In with LinkedIn → Share on
+  LinkedIn).
+</Step>
+
+  <Step title="Copy Client ID + Client Secret">
+    Available on the Auth tab.
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+<Steps>
+  <Step title="Open the LinkedIn integration">
+    From an agent's detail page → **Integrations** tab → find **LinkedIn**.
+  </Step>
+
+<Step title="Paste the Client ID + Client Secret">
+  The integration modal also shows the redirect URI for you to copy into the LinkedIn app config
+  (above).
+</Step>
+
+  <Step title="Click Authorize with LinkedIn">
+    Nora redirects you to LinkedIn's consent screen. Approve. Nora's callback swaps the auth code for an access + refresh token (LinkedIn issues 60-day access tokens; Nora refreshes them automatically).
+  </Step>
+</Steps>
+
+## Required scopes
+
+| Scope             | Why                                       |
+| ----------------- | ----------------------------------------- |
+| `openid`          | OIDC — user identity                      |
+| `profile`         | Connected user's name + LinkedIn ID       |
+| `email`           | Connected user's email                    |
+| `w_member_social` | Required for posting on the user's behalf |
+
+## MCP server
+
+No official LinkedIn MCP server today. Community packages exist (e.g. `stickerdaniel/linkedin-mcp-server`).
+
+## Environment variables Nora injects
+
+| Variable                    | Source                        |
+| --------------------------- | ----------------------------- |
+| `LINKEDIN_ACCESS_TOKEN`     | Auto-rotating OAuth token     |
+| `LINKEDIN_DEFAULT_USERNAME` | Connected user's display name |
+
+Client ID and Client Secret stay on the Nora control plane — they're never sent to the agent.

--- a/docs/guides/integrations/slack.mdx
+++ b/docs/guides/integrations/slack.mdx
@@ -1,0 +1,50 @@
+# Slack
+
+> Where to issue a Slack bot token and connect it to Nora.
+
+Slack integrations let your agents post messages, react to events, and read channel history. Nora authenticates with a Slack **Bot User OAuth Token** (`xoxb-...`).
+
+## Where to apply for credentials
+
+<Card title="Slack — Your apps" href="https://api.slack.com/apps" icon="slack" arrow>
+  Slack API — Your apps
+</Card>
+
+<Steps>
+  <Step title="Create a Slack app">
+    Click **Create New App** → **From scratch**. Pick the workspace where the agent should live.
+  </Step>
+
+<Step title="Configure Bot Token Scopes">
+  Open **OAuth & Permissions**. Under **Bot Token Scopes**, add the scopes your agent needs (e.g.
+  `chat:write`, `channels:read`, `channels:history`, `users:read`).
+</Step>
+
+<Step title="Install to Workspace">
+  Click **Install to Workspace** at the top of OAuth & Permissions. Slack returns a **Bot User OAuth
+  Token** starting with `xoxb-`. Copy it.
+</Step>
+
+  <Step title="Invite the bot to channels">
+    The bot can only post in channels it's been invited to. From any channel, type `/invite @your-bot-name`.
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+Paste the `xoxb-...` token. Optionally set a default channel ID (for agents that always post to one channel). Nora calls `auth.test` to verify the token and reports the bot user's name.
+
+## MCP server
+
+A Slack MCP server is available:
+
+- **Package:** `@modelcontextprotocol/server-slack`
+- **Docs:** [github.com/modelcontextprotocol/servers/tree/main/src/slack](https://github.com/modelcontextprotocol/servers/tree/main/src/slack)
+- **Env:** `SLACK_BOT_TOKEN` — Nora injects this automatically.
+
+## Environment variables Nora injects
+
+| Variable                | Source                   |
+| ----------------------- | ------------------------ |
+| `SLACK_BOT_TOKEN`       | Bot Token field          |
+| `SLACK_DEFAULT_CHANNEL` | Default Channel (if set) |

--- a/docs/guides/integrations/twitter.mdx
+++ b/docs/guides/integrations/twitter.mdx
@@ -1,0 +1,69 @@
+# Twitter / X
+
+> How to register an X (Twitter) OAuth 2.0 app and connect it to Nora.
+
+Twitter / X integrations let your agents post tweets, read timelines, and manage user data through the X API v2. Nora uses **OAuth 2.0 with PKCE** — the dashboard runs the full authorize → callback flow, so you never paste a long-lived token directly.
+
+## Where to apply for credentials
+
+<Card
+  title="X Developer Portal"
+  href="https://developer.x.com/en/portal/dashboard"
+  icon="twitter"
+  arrow
+>
+  developer.x.com → Projects & Apps
+</Card>
+
+<Steps>
+  <Step title="Create a project + app">
+    In the X Developer Portal, create a project, then a new app inside it. Pick **Web App, Automated App or Bot** as the type when prompted.
+  </Step>
+
+<Step title="Set up User authentication">
+  On the app's **Settings** tab, click **Set up** under User authentication settings. Pick **Read
+  and write** (or read-only as needed). App permissions = **Web App, Automated App or Bot**.
+</Step>
+
+  <Step title="Add the Nora redirect URI">
+    Under **Callback URI / Redirect URL**, paste the URL Nora's integration modal shows you (it's `https://<your-nora-host>/api/integrations/twitter/oauth/callback`). Set Website URL to anything reasonable.
+  </Step>
+
+  <Step title="Copy Client ID + Client Secret">
+    Open the **Keys and tokens** tab. Under OAuth 2.0, copy the Client ID. Generate (or rotate) and copy the Client Secret.
+  </Step>
+</Steps>
+
+## Connect in Nora
+
+<Steps>
+  <Step title="Open the Twitter / X integration">
+    From an agent's detail page, open the **Integrations** tab and find **Twitter / X**.
+  </Step>
+
+<Step title="Paste the Client ID + Client Secret">
+  The integration modal also shows the redirect URI to copy into the app config (above).
+</Step>
+
+<Step title="Click Authorize">
+  Nora redirects you to X's consent screen. Approve, and Nora's callback exchanges the authorization
+  code for an access token + refresh token.
+</Step>
+
+  <Step title="Tokens refresh automatically">
+    X access tokens expire after 60 minutes; Nora rotates them via the stored refresh token.
+  </Step>
+</Steps>
+
+## MCP server
+
+No official X MCP server today. Community packages exist but are unstable.
+
+## Environment variables Nora injects
+
+| Variable                   | Source                    |
+| -------------------------- | ------------------------- |
+| `TWITTER_ACCESS_TOKEN`     | Auto-rotating OAuth token |
+| `TWITTER_DEFAULT_USERNAME` | Connected user's @handle  |
+
+The Client ID and Client Secret never reach the agent — they stay on the Nora control plane.


### PR DESCRIPTION
Catches up the 6 providers that were already migrated when the per-provider docs effort started. Now every catalog provider (68 total) has a /guides/integrations/<id>.mdx page.