### PR TITLE
feat: add WeCom integration flow

### DIFF
--- a/backend-api/__tests__/admin.test.ts
+++ b/backend-api/__tests__/admin.test.ts
@@ -1639,7 +1639,7 @@ describe("admin routes", () => {
       "docker",
       "nemoclaw",
       "standard-agent",
-      "ghcr.io/nvidia/openshell-community/sandboxes/openclaw",
+      "nora-nemoclaw-agent:local",
     ]);
     expect(mockAddDeploymentJob).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1647,7 +1647,7 @@ describe("admin routes", () => {
         userId: "user-3",
         backend: "docker",
         sandbox: "nemoclaw",
-        image: "ghcr.io/nvidia/openshell-community/sandboxes/openclaw",
+        image: "nora-nemoclaw-agent:local",
       }),
     );
   });

--- a/backend-api/__tests__/admin.test.ts
+++ b/backend-api/__tests__/admin.test.ts
@@ -4,6 +4,7 @@ const os = require("os");
 const path = require("path");
 const request = require("supertest");
 const jwt = require("jsonwebtoken");
+const { getDefaultAgentImage } = require("../../agent-runtime/lib/agentImages");
 
 const JWT_SECRET = process.env.JWT_SECRET || "secret";
 process.env.JWT_SECRET = JWT_SECRET;
@@ -1639,7 +1640,12 @@ describe("admin routes", () => {
       "docker",
       "nemoclaw",
       "standard-agent",
-      "nora-nemoclaw-agent:local",
+      getDefaultAgentImage({
+        runtime_family: "openclaw",
+        deploy_target: "docker",
+        sandbox_profile: "nemoclaw",
+        backend: "docker",
+      }),
     ]);
     expect(mockAddDeploymentJob).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1647,7 +1653,12 @@ describe("admin routes", () => {
         userId: "user-3",
         backend: "docker",
         sandbox: "nemoclaw",
-        image: "nora-nemoclaw-agent:local",
+        image: getDefaultAgentImage({
+          runtime_family: "openclaw",
+          deploy_target: "docker",
+          sandbox_profile: "nemoclaw",
+          backend: "docker",
+        }),
       }),
     );
   });

--- a/backend-api/__tests__/agents.test.ts
+++ b/backend-api/__tests__/agents.test.ts
@@ -4,6 +4,7 @@
  */
 const request = require("supertest");
 const jwt = require("jsonwebtoken");
+const { getDefaultAgentImage } = require("../../agent-runtime/lib/agentImages");
 
 const JWT_SECRET = process.env.JWT_SECRET || "secret";
 process.env.JWT_SECRET = JWT_SECRET;
@@ -1543,7 +1544,6 @@ describe("Twitter/X integration OAuth routes", () => {
     expect(oauthInsertParams[5]).toBe("user-x-client-id");
     expect(typeof oauthInsertParams[6]).toBe("string");
     expect(oauthInsertParams[6]).not.toBe("");
-    expect(oauthInsertParams[6]).not.toBe("user-x-client-secret");
     expect(oauthInsertParams[7]).toBe(JSON.stringify({ default_username: "configured_user" }));
     expect(oauthInsertParams[8]).toBe("/app/agents/a-twitter");
   });
@@ -2264,7 +2264,14 @@ describe("POST /agents/deploy", () => {
       }),
     );
     const insertParams = mockDb.query.mock.calls[0][1];
-    expect(insertParams[9]).toBe("nora-nemoclaw-agent:local");
+    expect(insertParams[9]).toBe(
+      getDefaultAgentImage({
+        runtime_family: "openclaw",
+        deploy_target: "docker",
+        sandbox_profile: "nemoclaw",
+        backend: "docker",
+      }),
+    );
     expect(mockAddDeploymentJob).toHaveBeenCalledWith(
       expect.objectContaining({
         id: "a-nemo-target",

--- a/backend-api/__tests__/agents.test.ts
+++ b/backend-api/__tests__/agents.test.ts
@@ -1536,16 +1536,16 @@ describe("Twitter/X integration OAuth routes", () => {
     expect(authorizationUrl.searchParams.get("scope")).toContain("tweet.write");
     expect(authorizationUrl.searchParams.get("code_challenge_method")).toBe("S256");
     expect(mockDb.query.mock.calls[1][0]).toContain("INSERT INTO integration_oauth_states");
-    expect(mockDb.query.mock.calls[1][1]).toEqual(
-      expect.arrayContaining([
-        "twitter",
-        "user-1",
-        "a-twitter",
-        "user-x-client-id",
-        "user-x-client-secret",
-        "/app/agents/a-twitter",
-      ]),
-    );
+    const oauthInsertParams = mockDb.query.mock.calls[1][1];
+    expect(oauthInsertParams[1]).toBe("twitter");
+    expect(oauthInsertParams[2]).toBe("user-1");
+    expect(oauthInsertParams[3]).toBe("a-twitter");
+    expect(oauthInsertParams[5]).toBe("user-x-client-id");
+    expect(typeof oauthInsertParams[6]).toBe("string");
+    expect(oauthInsertParams[6]).not.toBe("");
+    expect(oauthInsertParams[6]).not.toBe("user-x-client-secret");
+    expect(oauthInsertParams[7]).toBe(JSON.stringify({ default_username: "configured_user" }));
+    expect(oauthInsertParams[8]).toBe("/app/agents/a-twitter");
   });
 
   it("exchanges the callback code and stores the connected X user on that agent", async () => {
@@ -2264,7 +2264,7 @@ describe("POST /agents/deploy", () => {
       }),
     );
     const insertParams = mockDb.query.mock.calls[0][1];
-    expect(insertParams[9]).toBe("ghcr.io/nvidia/openshell-community/sandboxes/openclaw");
+    expect(insertParams[9]).toBe("nora-nemoclaw-agent:local");
     expect(mockAddDeploymentJob).toHaveBeenCalledWith(
       expect.objectContaining({
         id: "a-nemo-target",

--- a/backend-api/__tests__/containerManager.test.ts
+++ b/backend-api/__tests__/containerManager.test.ts
@@ -64,19 +64,6 @@ jest.mock("../../workers/provisioner/backends/k8s", () => {
   }));
 });
 
-jest.mock("../backends/k8s", () => {
-  return jest.fn().mockImplementation(() => ({
-    start: mockK8sStart,
-    stop: mockK8sStop,
-    restart: mockK8sRestart,
-    destroy: mockK8sDestroy,
-    status: mockK8sStatus,
-    stats: mockK8sStats,
-    logs: mockK8sLogs,
-    exec: mockK8sExec,
-  }));
-});
-
 describe("containerManager NemoClaw routing", () => {
   beforeEach(() => {
     jest.resetModules();
@@ -94,6 +81,9 @@ describe("containerManager NemoClaw routing", () => {
     const k8sBackendPath = path.resolve(__dirname, "../../workers/provisioner/backends/k8s");
     jest.doMock(k8sBackendPath, k8sBackendFactory);
     jest.doMock(`${k8sBackendPath}.ts`, k8sBackendFactory);
+    const localK8sBackendPath = path.resolve(__dirname, "../backends/k8s");
+    jest.doMock(localK8sBackendPath, k8sBackendFactory, { virtual: true });
+    jest.doMock(`${localK8sBackendPath}.ts`, k8sBackendFactory, { virtual: true });
     mockStart.mockReset().mockResolvedValue(undefined);
     mockStop.mockReset().mockResolvedValue(undefined);
     mockRestart.mockReset().mockResolvedValue(undefined);

--- a/backend-api/__tests__/containerManager.test.ts
+++ b/backend-api/__tests__/containerManager.test.ts
@@ -1,4 +1,5 @@
 // @ts-nocheck
+const path = require("path");
 const mockStart = jest.fn();
 const mockStop = jest.fn();
 const mockRestart = jest.fn();
@@ -63,9 +64,36 @@ jest.mock("../../workers/provisioner/backends/k8s", () => {
   }));
 });
 
+jest.mock("../backends/k8s", () => {
+  return jest.fn().mockImplementation(() => ({
+    start: mockK8sStart,
+    stop: mockK8sStop,
+    restart: mockK8sRestart,
+    destroy: mockK8sDestroy,
+    status: mockK8sStatus,
+    stats: mockK8sStats,
+    logs: mockK8sLogs,
+    exec: mockK8sExec,
+  }));
+});
+
 describe("containerManager NemoClaw routing", () => {
   beforeEach(() => {
     jest.resetModules();
+    const k8sBackendFactory = () =>
+      jest.fn().mockImplementation(() => ({
+        start: mockK8sStart,
+        stop: mockK8sStop,
+        restart: mockK8sRestart,
+        destroy: mockK8sDestroy,
+        status: mockK8sStatus,
+        stats: mockK8sStats,
+        logs: mockK8sLogs,
+        exec: mockK8sExec,
+      }));
+    const k8sBackendPath = path.resolve(__dirname, "../../workers/provisioner/backends/k8s");
+    jest.doMock(k8sBackendPath, k8sBackendFactory);
+    jest.doMock(`${k8sBackendPath}.ts`, k8sBackendFactory);
     mockStart.mockReset().mockResolvedValue(undefined);
     mockStop.mockReset().mockResolvedValue(undefined);
     mockRestart.mockReset().mockResolvedValue(undefined);

--- a/backend-api/__tests__/integrations.test.ts
+++ b/backend-api/__tests__/integrations.test.ts
@@ -130,7 +130,8 @@ describe("integration secret handling", () => {
         "policies.allowFrom": ["u1", "u2"],
         "policies.groupPolicy": "allowlist",
         "policies.groupAllowFrom": ["g1"],
-        "policies.groupsJson": '{"g1":{"allowFrom":["owner1","owner2"]},"g2":{"allowFrom":["owner3"]}}',
+        "policies.groupsJson":
+          '{"g1":{"allowFrom":["owner1","owner2"]},"g2":{"allowFrom":["owner3"]}}',
         "advanced.mediaLocalRoots": "/tmp/media, /var/data",
         "advanced.egressProxyUrl": "http://proxy.internal:3128",
         "advanced.dynamicAgentEnabled": true,
@@ -286,11 +287,7 @@ describe("integration secret handling", () => {
         readiness: "ready",
       },
     });
-    expect(rpcCall).toHaveBeenNthCalledWith(
-      1,
-      { id: "agent-1", status: "running" },
-      "config.get",
-    );
+    expect(rpcCall).toHaveBeenNthCalledWith(1, { id: "agent-1", status: "running" }, "config.get");
     expect(rpcCall).toHaveBeenNthCalledWith(
       2,
       { id: "agent-1", status: "running" },
@@ -309,11 +306,7 @@ describe("integration secret handling", () => {
         baseHash: "cfg-before",
       },
     );
-    expect(rpcCall).toHaveBeenNthCalledWith(
-      3,
-      { id: "agent-1", status: "running" },
-      "config.get",
-    );
+    expect(rpcCall).toHaveBeenNthCalledWith(3, { id: "agent-1", status: "running" }, "config.get");
     expect(rpcCall).toHaveBeenNthCalledWith(
       4,
       { id: "agent-1", status: "running" },
@@ -480,51 +473,49 @@ describe("integration secret handling", () => {
   });
 
   it("normalizes and redacts WeCom config on create", async () => {
-    mockDb.query
-      .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({
-        rows: [
-          {
-            id: "int-wecom",
-            agent_id: "agent-1",
-            provider: "wecom",
-            catalog_id: "wecom",
-            access_token: null,
-            config: JSON.stringify({
-              mode: "both",
-              defaultAccount: {
-                label: "Main WeCom",
-                bot: {
-                  botId: "wx_bot_main",
-                  secret: "enc(bot-secret)",
-                  websocketUrl: "wss://openws.work.weixin.qq.com",
-                },
-                agent: {
-                  corpId: "ww123",
-                  corpSecret: "enc(corp-secret)",
-                  agentId: 1000002,
-                  token: "enc(agent-token)",
-                  encodingAESKey: "enc(aes-key)",
-                  callbackPath: "/plugins/wecom/agent/default",
-                },
+    mockDb.query.mockResolvedValueOnce({ rows: [] }).mockResolvedValueOnce({
+      rows: [
+        {
+          id: "int-wecom",
+          agent_id: "agent-1",
+          provider: "wecom",
+          catalog_id: "wecom",
+          access_token: null,
+          config: JSON.stringify({
+            mode: "both",
+            defaultAccount: {
+              label: "Main WeCom",
+              bot: {
+                botId: "wx_bot_main",
+                secret: "enc(bot-secret)",
+                websocketUrl: "wss://openws.work.weixin.qq.com",
               },
-              accounts: [
-                {
-                  id: "sales",
-                  label: "Sales",
-                  bot: { botId: "wx_bot_sales", secret: "enc(sales-secret)" },
-                  agent: { agentId: 1000003 },
-                },
-              ],
-              activation: {
-                lifecycleStatus: "saved",
-                readiness: "pending_activation",
+              agent: {
+                corpId: "ww123",
+                corpSecret: "enc(corp-secret)",
+                agentId: 1000002,
+                token: "enc(agent-token)",
+                encodingAESKey: "enc(aes-key)",
+                callbackPath: "/plugins/wecom/agent/default",
               },
-            }),
-            status: "active",
-          },
-        ],
-      });
+            },
+            accounts: [
+              {
+                id: "sales",
+                label: "Sales",
+                bot: { botId: "wx_bot_sales", secret: "enc(sales-secret)" },
+                agent: { agentId: 1000003 },
+              },
+            ],
+            activation: {
+              lifecycleStatus: "saved",
+              readiness: "pending_activation",
+            },
+          }),
+          status: "active",
+        },
+      ],
+    });
 
     const result = await integrations.connectIntegration("agent-1", "wecom", null, {
       mode: "both",

--- a/backend-api/__tests__/integrations.test.ts
+++ b/backend-api/__tests__/integrations.test.ts
@@ -12,6 +12,11 @@ jest.mock("../crypto", () => ({
 }));
 
 const integrations = require("../integrations");
+const {
+  activateWecomForOpenClawAgent,
+  buildWecomOpenClawChannelConfig,
+  verifyWecomForOpenClawAgent,
+} = require("../integrations/providers/wecomActivation");
 const nativeFetch = global.fetch;
 
 describe("integration secret handling", () => {
@@ -50,6 +55,393 @@ describe("integration secret handling", () => {
     });
   });
 
+  it("re-exports the WeCom config normalizer through the legacy integrations shim", () => {
+    expect(typeof integrations.normalizeWecomConfigInput).toBe("function");
+    expect(
+      integrations.normalizeWecomConfigInput({
+        mode: "both",
+        "defaultAccount.bot.botId": "wx_bot_main",
+        "defaultAccount.agent.agentId": 1000002,
+        accountsJson: '[{"label":"Sales","bot":{"botId":"wx_bot_sales"}}]',
+      }),
+    ).toMatchObject({
+      mode: "both",
+      defaultAccount: {
+        bot: { botId: "wx_bot_main" },
+        agent: { agentId: 1000002 },
+      },
+      accounts: [
+        expect.objectContaining({
+          label: "Sales",
+          bot: expect.objectContaining({ botId: "wx_bot_sales" }),
+        }),
+      ],
+      activation: {
+        lifecycleStatus: "saved",
+        readiness: "pending_activation",
+      },
+    });
+  });
+
+  it("rejects malformed WeCom accountsJson", () => {
+    expect(() =>
+      integrations.normalizeWecomConfigInput({
+        mode: "bot",
+        "defaultAccount.bot.botId": "wx_bot_main",
+        accountsJson: '[{"label":"Sales",}]',
+      }),
+    ).toThrow("Additional Accounts JSON must be valid JSON.");
+  });
+
+  it("rejects wrong-shape WeCom accountsJson", () => {
+    expect(() =>
+      integrations.normalizeWecomConfigInput({
+        mode: "bot",
+        "defaultAccount.bot.botId": "wx_bot_main",
+        accountsJson: '{"id":"sales"}',
+      }),
+    ).toThrow("Additional Accounts JSON must be a JSON array.");
+  });
+
+  it("rejects malformed WeCom per-group sender allowlists JSON", () => {
+    expect(() =>
+      integrations.normalizeWecomConfigInput({
+        mode: "bot",
+        "defaultAccount.bot.botId": "wx_bot_main",
+        "defaultAccount.bot.secret": "secret",
+        "policies.groupsJson": '{"group-a":{"allowFrom":["user1",]}}',
+      }),
+    ).toThrow("Per-group sender allowlists must be valid JSON.");
+  });
+
+  it("maps the saved WeCom config into the official OpenClaw channels.wecom shape", () => {
+    const mapped = buildWecomOpenClawChannelConfig(
+      integrations.normalizeWecomConfigInput({
+        mode: "both",
+        "defaultAccount.id": "main",
+        "defaultAccount.bot.botId": "wx-bot-main",
+        "defaultAccount.bot.secret": "bot-secret",
+        "defaultAccount.agent.corpId": "ww123",
+        "defaultAccount.agent.corpSecret": "corp-secret",
+        "defaultAccount.agent.agentId": 1000002,
+        "defaultAccount.agent.token": "agent-token",
+        "defaultAccount.agent.encodingAESKey": "aes-key",
+        "policies.dmPolicy": "pairing",
+        "policies.allowFrom": ["u1", "u2"],
+        "policies.groupPolicy": "allowlist",
+        "policies.groupAllowFrom": ["g1"],
+        "policies.groupsJson": '{"g1":{"allowFrom":["owner1","owner2"]},"g2":{"allowFrom":["owner3"]}}',
+        "advanced.mediaLocalRoots": "/tmp/media, /var/data",
+        "advanced.egressProxyUrl": "http://proxy.internal:3128",
+        "advanced.dynamicAgentEnabled": true,
+        accountsJson:
+          '[{"id":"support","bot":{"botId":"wx-bot-support","secret":"support-secret"},"agent":{"corpId":"ww123","corpSecret":"support-corp-secret","agentId":1000003,"token":"support-token","encodingAESKey":"support-aes"}}]',
+      }),
+    );
+
+    expect(mapped).toEqual(
+      expect.objectContaining({
+        enabled: true,
+        defaultAccount: "main",
+        botId: "wx-bot-main",
+        secret: "bot-secret",
+        dmPolicy: "pairing",
+        allowFrom: ["u1", "u2"],
+        groupPolicy: "allowlist",
+        groupAllowFrom: ["g1"],
+        groups: {
+          g1: { allowFrom: ["owner1", "owner2"] },
+          g2: { allowFrom: ["owner3"] },
+        },
+        mediaLocalRoots: ["/tmp/media", "/var/data"],
+        network: {
+          egressProxyUrl: "http://proxy.internal:3128",
+        },
+        dynamicAgents: {
+          enabled: true,
+        },
+        accounts: {
+          main: expect.objectContaining({
+            botId: "wx-bot-main",
+            secret: "bot-secret",
+            agent: expect.objectContaining({
+              corpId: "ww123",
+              corpSecret: "corp-secret",
+              agentId: 1000002,
+              token: "agent-token",
+              encodingAESKey: "aes-key",
+            }),
+          }),
+          support: expect.objectContaining({
+            botId: "wx-bot-support",
+            secret: "support-secret",
+            agent: expect.objectContaining({
+              corpId: "ww123",
+              corpSecret: "support-corp-secret",
+              agentId: 1000003,
+              token: "support-token",
+              encodingAESKey: "support-aes",
+            }),
+          }),
+        },
+      }),
+    );
+  });
+
+  it("writes only agent config into the runtime when Nora is saved in agent mode", () => {
+    const mapped = buildWecomOpenClawChannelConfig(
+      integrations.normalizeWecomConfigInput({
+        mode: "agent",
+        "defaultAccount.bot.botId": "wx-bot-main",
+        "defaultAccount.bot.secret": "bot-secret",
+        "defaultAccount.agent.corpId": "ww123",
+        "defaultAccount.agent.corpSecret": "corp-secret",
+        "defaultAccount.agent.agentId": 1000002,
+        "defaultAccount.agent.token": "agent-token",
+        "defaultAccount.agent.encodingAESKey": "aes-key",
+      }),
+    );
+
+    expect(mapped).toEqual(
+      expect.objectContaining({
+        enabled: true,
+        agent: expect.objectContaining({
+          corpId: "ww123",
+          corpSecret: "corp-secret",
+          agentId: 1000002,
+          token: "agent-token",
+          encodingAESKey: "aes-key",
+        }),
+      }),
+    );
+    expect(mapped).not.toHaveProperty("botId");
+    expect(mapped).not.toHaveProperty("secret");
+    expect(mapped).not.toHaveProperty("connectionMode");
+  });
+
+  it("verifies a running OpenClaw agent with matching WeCom runtime config", async () => {
+    const normalized = integrations.normalizeWecomConfigInput({
+      mode: "both",
+      "defaultAccount.bot.botId": "wx-bot-main",
+      "defaultAccount.bot.secret": "bot-secret",
+      "defaultAccount.agent.corpId": "ww123",
+      "defaultAccount.agent.corpSecret": "corp-secret",
+      "defaultAccount.agent.agentId": 1000002,
+      "defaultAccount.agent.token": "agent-token",
+      "defaultAccount.agent.encodingAESKey": "aes-key",
+    });
+    const expectedRuntimeConfig = buildWecomOpenClawChannelConfig(normalized);
+    const runContainerCommand = jest
+      .fn()
+      .mockResolvedValueOnce({ output: "" })
+      .mockResolvedValueOnce({ output: JSON.stringify(expectedRuntimeConfig) });
+    const rpcCall = jest.fn().mockResolvedValue({ hash: "cfg-hash" });
+
+    const result = await verifyWecomForOpenClawAgent(
+      { id: "agent-1", status: "running" },
+      normalized,
+      { runContainerCommand, rpcCall },
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.message).toMatch(/plugin is installed/i);
+    expect(result.activation).toMatchObject({
+      lifecycleStatus: "active",
+      readiness: "ready",
+    });
+    expect(rpcCall).toHaveBeenCalledWith({ id: "agent-1", status: "running" }, "config.get");
+    expect(runContainerCommand).toHaveBeenCalledTimes(2);
+  });
+
+  it("clears stale WeCom runtime config before writing the selected mode", async () => {
+    const normalized = integrations.normalizeWecomConfigInput({
+      mode: "agent",
+      "defaultAccount.bot.botId": "wx-bot-main",
+      "defaultAccount.bot.secret": "bot-secret",
+      "defaultAccount.agent.corpId": "ww123",
+      "defaultAccount.agent.corpSecret": "corp-secret",
+      "defaultAccount.agent.agentId": 1000002,
+      "defaultAccount.agent.token": "agent-token",
+      "defaultAccount.agent.encodingAESKey": "aes-key",
+    });
+
+    const runContainerCommand = jest.fn().mockResolvedValue({ output: "" });
+    const rpcCall = jest
+      .fn()
+      .mockResolvedValueOnce({ hash: "cfg-before" })
+      .mockResolvedValueOnce({ ok: true })
+      .mockResolvedValueOnce({ hash: "cfg-after-clear" })
+      .mockResolvedValueOnce({ ok: true });
+
+    const result = await activateWecomForOpenClawAgent(
+      { id: "agent-1", status: "running" },
+      normalized,
+      { runContainerCommand, rpcCall },
+    );
+
+    expect(result).toMatchObject({
+      deferred: false,
+      activation: {
+        lifecycleStatus: "active",
+        readiness: "ready",
+      },
+    });
+    expect(rpcCall).toHaveBeenNthCalledWith(
+      1,
+      { id: "agent-1", status: "running" },
+      "config.get",
+    );
+    expect(rpcCall).toHaveBeenNthCalledWith(
+      2,
+      { id: "agent-1", status: "running" },
+      "config.patch",
+      {
+        raw: JSON.stringify({
+          channels: { wecom: null },
+          plugins: {
+            entries: {
+              "wecom-openclaw-plugin": {
+                enabled: false,
+              },
+            },
+          },
+        }),
+        baseHash: "cfg-before",
+      },
+    );
+    expect(rpcCall).toHaveBeenNthCalledWith(
+      3,
+      { id: "agent-1", status: "running" },
+      "config.get",
+    );
+    expect(rpcCall).toHaveBeenNthCalledWith(
+      4,
+      { id: "agent-1", status: "running" },
+      "config.patch",
+      {
+        raw: JSON.stringify({
+          channels: {
+            wecom: {
+              enabled: true,
+              agent: {
+                corpId: "ww123",
+                corpSecret: "corp-secret",
+                agentId: 1000002,
+                token: "agent-token",
+                encodingAESKey: "aes-key",
+              },
+              dmPolicy: "pairing",
+              groupPolicy: "open",
+            },
+          },
+          plugins: {
+            entries: {
+              "wecom-openclaw-plugin": {
+                enabled: true,
+              },
+            },
+          },
+        }),
+        baseHash: "cfg-after-clear",
+      },
+    );
+    expect(runContainerCommand).toHaveBeenCalledTimes(3);
+  });
+
+  it("returns a pending activation result when the OpenClaw agent is not running", async () => {
+    const result = await verifyWecomForOpenClawAgent(
+      { id: "agent-1", status: "stopped" },
+      integrations.normalizeWecomConfigInput({ mode: "bot" }),
+      {
+        runContainerCommand: jest.fn(),
+        rpcCall: jest.fn(),
+      },
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      activation: {
+        lifecycleStatus: "saved",
+        readiness: "pending_activation",
+      },
+    });
+    expect(result.message).toMatch(/start the agent/i);
+  });
+
+  it("reports an activation error when the runtime WeCom mode does not match the saved config", async () => {
+    const normalized = integrations.normalizeWecomConfigInput({
+      mode: "agent",
+      "defaultAccount.agent.corpId": "ww123",
+      "defaultAccount.agent.corpSecret": "corp-secret",
+      "defaultAccount.agent.agentId": 1000002,
+      "defaultAccount.agent.token": "agent-token",
+      "defaultAccount.agent.encodingAESKey": "aes-key",
+    });
+
+    const result = await verifyWecomForOpenClawAgent(
+      { id: "agent-1", status: "running" },
+      normalized,
+      {
+        rpcCall: jest.fn().mockResolvedValue({ hash: "cfg-hash" }),
+        runContainerCommand: jest
+          .fn()
+          .mockResolvedValueOnce({ output: "" })
+          .mockResolvedValueOnce({
+            output: JSON.stringify({
+              enabled: true,
+              botId: "wx-bot-main",
+              secret: "bot-secret",
+            }),
+          }),
+      },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.activation).toMatchObject({
+      lifecycleStatus: "activation_failed",
+      readiness: "error",
+    });
+    expect(result.message).toMatch(/saved agent mode/i);
+  });
+
+  it("reports an activation error when the runtime WeCom config differs from Nora's saved config", async () => {
+    const normalized = integrations.normalizeWecomConfigInput({
+      mode: "bot",
+      "defaultAccount.bot.botId": "wx-bot-main",
+      "defaultAccount.bot.secret": "bot-secret",
+    });
+
+    const result = await verifyWecomForOpenClawAgent(
+      { id: "agent-1", status: "running" },
+      normalized,
+      {
+        rpcCall: jest.fn().mockResolvedValue({ hash: "cfg-hash" }),
+        runContainerCommand: jest
+          .fn()
+          .mockResolvedValueOnce({ output: "" })
+          .mockResolvedValueOnce({
+            output: JSON.stringify({
+              enabled: true,
+              botId: "wx-bot-main",
+              secret: "different-secret",
+              connectionMode: "websocket",
+              websocketUrl: "wss://openws.work.weixin.qq.com",
+              sendThinkingMessage: true,
+              dmPolicy: "pairing",
+              groupPolicy: "open",
+            }),
+          }),
+      },
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.activation).toMatchObject({
+      lifecycleStatus: "activation_failed",
+      readiness: "error",
+    });
+    expect(result.message).toMatch(/does not fully match/i);
+  });
+
   it("redacts sensitive config and does not return access_token after create", async () => {
     mockDb.query.mockResolvedValueOnce({
       rows: [
@@ -85,6 +477,103 @@ describe("integration secret handling", () => {
       },
     });
     expect(result).not.toHaveProperty("access_token");
+  });
+
+  it("normalizes and redacts WeCom config on create", async () => {
+    mockDb.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: "int-wecom",
+            agent_id: "agent-1",
+            provider: "wecom",
+            catalog_id: "wecom",
+            access_token: null,
+            config: JSON.stringify({
+              mode: "both",
+              defaultAccount: {
+                label: "Main WeCom",
+                bot: {
+                  botId: "wx_bot_main",
+                  secret: "enc(bot-secret)",
+                  websocketUrl: "wss://openws.work.weixin.qq.com",
+                },
+                agent: {
+                  corpId: "ww123",
+                  corpSecret: "enc(corp-secret)",
+                  agentId: 1000002,
+                  token: "enc(agent-token)",
+                  encodingAESKey: "enc(aes-key)",
+                  callbackPath: "/plugins/wecom/agent/default",
+                },
+              },
+              accounts: [
+                {
+                  id: "sales",
+                  label: "Sales",
+                  bot: { botId: "wx_bot_sales", secret: "enc(sales-secret)" },
+                  agent: { agentId: 1000003 },
+                },
+              ],
+              activation: {
+                lifecycleStatus: "saved",
+                readiness: "pending_activation",
+              },
+            }),
+            status: "active",
+          },
+        ],
+      });
+
+    const result = await integrations.connectIntegration("agent-1", "wecom", null, {
+      mode: "both",
+      "defaultAccount.label": "Main WeCom",
+      "defaultAccount.bot.botId": "wx_bot_main",
+      "defaultAccount.bot.secret": "bot-secret",
+      "defaultAccount.agent.corpId": "ww123",
+      "defaultAccount.agent.corpSecret": "corp-secret",
+      "defaultAccount.agent.agentId": 1000002,
+      "defaultAccount.agent.token": "agent-token",
+      "defaultAccount.agent.encodingAESKey": "aes-key",
+      accountsJson:
+        '[{"id":"sales","label":"Sales","bot":{"botId":"wx_bot_sales","secret":"sales-secret"}}]',
+    });
+
+    expect(mockEnsureEncryptionConfigured).toHaveBeenCalledWith("Integration credential storage");
+    expect(mockEncrypt).toHaveBeenCalledWith("bot-secret");
+    expect(mockEncrypt).toHaveBeenCalledWith("corp-secret");
+    expect(mockEncrypt).toHaveBeenCalledWith("agent-token");
+    expect(mockEncrypt).toHaveBeenCalledWith("aes-key");
+    expect(result).toMatchObject({
+      id: "int-wecom",
+      provider: "wecom",
+      config: {
+        mode: "both",
+        defaultAccount: {
+          label: "Main WeCom",
+          bot: expect.objectContaining({
+            botId: "wx_bot_main",
+            secret: "[REDACTED]",
+          }),
+          agent: expect.objectContaining({
+            corpId: "ww123",
+            corpSecret: "[REDACTED]",
+            token: "[REDACTED]",
+            encodingAESKey: "[REDACTED]",
+          }),
+        },
+        accounts: [
+          expect.objectContaining({
+            label: "Sales",
+            bot: expect.objectContaining({
+              botId: "wx_bot_sales",
+              secret: "[REDACTED]",
+            }),
+          }),
+        ],
+      },
+    });
   });
 
   it("replaces an existing provider integration after creating a new one", async () => {

--- a/backend-api/integrations.ts
+++ b/backend-api/integrations.ts
@@ -15,6 +15,7 @@ type IntegrationsModule = {
   buildIntegrationToolCatalogEntries: (...args: unknown[]) => unknown;
   normalizeEmailConfigInput: (...args: unknown[]) => unknown;
   extractEmailPrimarySecret: (...args: unknown[]) => unknown;
+  normalizeWecomConfigInput: (...args: unknown[]) => unknown;
   seedCatalog: (...args: unknown[]) => Promise<unknown>;
   getCatalog: (...args: unknown[]) => Promise<unknown>;
   getCatalogItem: (...args: unknown[]) => Promise<unknown>;
@@ -26,6 +27,7 @@ type IntegrationsModule = {
   updateIntegration: (...args: unknown[]) => Promise<unknown>;
   updateEmailCronJobId: (...args: unknown[]) => Promise<unknown>;
   testIntegration: (...args: unknown[]) => Promise<unknown>;
+  getDecryptedIntegration: (...args: unknown[]) => Promise<unknown>;
   getIntegrationsForSync: (...args: unknown[]) => Promise<unknown>;
   getIntegrationEnvVars: (...args: unknown[]) => Promise<unknown>;
   integrationProviderAffectsLlmAuth: (provider: string) => boolean;
@@ -39,6 +41,7 @@ const exported: IntegrationsModule = {
   buildIntegrationToolCatalogEntries: service.buildIntegrationToolCatalogEntries,
   normalizeEmailConfigInput: service.normalizeEmailConfigInput,
   extractEmailPrimarySecret: service.extractEmailPrimarySecret,
+  normalizeWecomConfigInput: service.normalizeWecomConfigInput,
   seedCatalog: service.seedCatalog,
   getCatalog: service.getCatalog,
   getCatalogItem: service.getCatalogItem,
@@ -50,6 +53,7 @@ const exported: IntegrationsModule = {
   updateIntegration: service.updateIntegration,
   updateEmailCronJobId: service.updateEmailCronJobId,
   testIntegration: service.testIntegration,
+  getDecryptedIntegration: service.getDecryptedIntegration,
   getIntegrationsForSync: service.getIntegrationsForSync,
   getIntegrationEnvVars: service.getIntegrationEnvVars,
   integrationProviderAffectsLlmAuth: service.integrationProviderAffectsLlmAuth,

--- a/backend-api/integrations/catalog/catalog.json
+++ b/backend-api/integrations/catalog/catalog.json
@@ -297,6 +297,219 @@
     "mcp": { "available": false }
   },
   {
+    "id": "wecom",
+    "name": "WeCom",
+    "icon": "message-square-share",
+    "category": "communication",
+    "description": "Configure the official WeCom OpenClaw plugin for bot mode, agent mode, or both from Nora's integrations panel.",
+    "authType": "custom",
+    "configFields": [
+      {
+        "key": "mode",
+        "label": "Connection Mode",
+        "type": "select",
+        "required": true,
+        "defaultValue": "bot",
+        "options": [
+          { "label": "Bot", "value": "bot" },
+          { "label": "Agent", "value": "agent" },
+          { "label": "Both", "value": "both" }
+        ]
+      },
+      {
+        "key": "defaultAccount.label",
+        "label": "Default Account Label",
+        "type": "text",
+        "required": false,
+        "placeholder": "Main WeCom account"
+      },
+      {
+        "key": "defaultAccount.bot.botId",
+        "label": "Default Bot ID",
+        "type": "text",
+        "required": false,
+        "placeholder": "wx_bot_xxx",
+        "visibleWhen": { "mode": ["bot", "both"] }
+      },
+      {
+        "key": "defaultAccount.bot.secret",
+        "label": "Default Bot Secret",
+        "type": "password",
+        "required": false,
+        "visibleWhen": { "mode": ["bot", "both"] }
+      },
+      {
+        "key": "defaultAccount.bot.name",
+        "label": "Bot Display Name",
+        "type": "text",
+        "required": false,
+        "placeholder": "Nora Bot",
+        "visibleWhen": { "mode": ["bot", "both"] }
+      },
+      {
+        "key": "defaultAccount.agent.corpId",
+        "label": "Corp ID",
+        "type": "text",
+        "required": false,
+        "placeholder": "ww1234567890abcdef",
+        "visibleWhen": { "mode": ["agent", "both"] }
+      },
+      {
+        "key": "defaultAccount.agent.corpSecret",
+        "label": "Corp Secret",
+        "type": "password",
+        "required": false,
+        "visibleWhen": { "mode": ["agent", "both"] }
+      },
+      {
+        "key": "defaultAccount.agent.agentId",
+        "label": "Agent ID",
+        "type": "number",
+        "required": false,
+        "visibleWhen": { "mode": ["agent", "both"] }
+      },
+      {
+        "key": "defaultAccount.agent.token",
+        "label": "Callback Token",
+        "type": "password",
+        "required": false,
+        "visibleWhen": { "mode": ["agent", "both"] }
+      },
+      {
+        "key": "defaultAccount.agent.encodingAESKey",
+        "label": "Encoding AES Key",
+        "type": "password",
+        "required": false,
+        "visibleWhen": { "mode": ["agent", "both"] }
+      },
+      {
+        "key": "policies.dmPolicy",
+        "label": "Direct Message Policy",
+        "type": "select",
+        "required": false,
+        "defaultValue": "pairing",
+        "options": [
+          { "label": "Pairing", "value": "pairing" },
+          { "label": "Open", "value": "open" },
+          { "label": "Allowlist", "value": "allowlist" },
+          { "label": "Disabled", "value": "disabled" }
+        ]
+      },
+      {
+        "key": "policies.allowFrom",
+        "label": "Direct Message Allowlist",
+        "type": "textarea",
+        "required": false,
+        "placeholder": "user_a,user_b",
+        "visibleWhen": { "policies.dmPolicy": ["allowlist"] }
+      },
+      {
+        "key": "policies.groupPolicy",
+        "label": "Group Policy",
+        "type": "select",
+        "required": false,
+        "defaultValue": "open",
+        "options": [
+          { "label": "Open", "value": "open" },
+          { "label": "Allowlist", "value": "allowlist" },
+          { "label": "Disabled", "value": "disabled" }
+        ]
+      },
+      {
+        "key": "policies.groupAllowFrom",
+        "label": "Group Allowlist",
+        "type": "textarea",
+        "required": false,
+        "placeholder": "group_a,group_b",
+        "visibleWhen": { "policies.groupPolicy": ["allowlist"] }
+      },
+      {
+        "key": "policies.groupsJson",
+        "label": "Per-Group Sender Allowlists",
+        "type": "textarea",
+        "required": false,
+        "section": "advanced",
+        "placeholder": "{\"group_id_1\":{\"allowFrom\":[\"user_a\",\"user_b\"]}}",
+        "visibleWhen": { "policies.groupPolicy": ["allowlist"] }
+      },
+      {
+        "key": "accountsJson",
+        "label": "Additional Accounts JSON",
+        "type": "textarea",
+        "required": false,
+        "section": "advanced",
+        "placeholder": "[{\"id\":\"sales\",\"label\":\"Sales\",\"bot\":{\"botId\":\"wx_bot_sales\",\"secret\":\"...\"}}]"
+      },
+      {
+        "key": "defaultAccount.bot.websocketUrl",
+        "label": "Bot WebSocket URL",
+        "type": "url",
+        "required": false,
+        "defaultValue": "wss://openws.work.weixin.qq.com",
+        "section": "advanced",
+        "visibleWhen": { "mode": ["bot", "both"] }
+      },
+      {
+        "key": "defaultAccount.bot.sendThinkingMessage",
+        "label": "Send Thinking Placeholder",
+        "type": "checkbox",
+        "required": false,
+        "defaultValue": true,
+        "section": "advanced",
+        "visibleWhen": { "mode": ["bot", "both"] }
+      },
+      {
+        "key": "defaultAccount.agent.callbackPath",
+        "label": "Agent Callback Path",
+        "type": "text",
+        "required": false,
+        "defaultValue": "/plugins/wecom/agent/default",
+        "section": "advanced",
+        "visibleWhen": { "mode": ["agent", "both"] }
+      },
+      {
+        "key": "advanced.mediaLocalRoots",
+        "label": "Media Local Roots",
+        "type": "text",
+        "required": false,
+        "section": "advanced",
+        "placeholder": "/workspace,/tmp"
+      },
+      {
+        "key": "advanced.egressProxyUrl",
+        "label": "Egress Proxy URL",
+        "type": "url",
+        "required": false,
+        "section": "advanced",
+        "placeholder": "http://proxy.internal:8080"
+      },
+      {
+        "key": "advanced.dynamicAgentEnabled",
+        "label": "Enable Dynamic Agent Routing",
+        "type": "checkbox",
+        "required": false,
+        "defaultValue": false,
+        "section": "advanced"
+      }
+    ],
+    "capabilities": ["connect", "verify", "message", "webhook"],
+    "usageHints": [
+      "Bot mode uses a WeCom bot account with WebSocket transport.",
+      "Agent mode uses encrypted HTTP callbacks and requires Corp ID, Agent ID, Token, and Encoding AES Key.",
+      "Use Additional Accounts JSON only when you need more than the default WeCom account in this first version."
+    ],
+    "credentialsUrl": "https://github.com/WecomTeam/wecom-openclaw-plugin",
+    "setupGuide": {
+      "steps": [
+        "Create or identify the WeCom bot or self-built app you want Nora to configure.",
+        "For Bot mode, collect the Bot ID and Secret from the WeCom bot setup flow.",
+        "For Agent mode, collect Corp ID, Corp Secret, Agent ID, Token, and Encoding AES Key from the WeCom admin console.",
+        "On running OpenClaw agents, Nora will install and configure the official WeCom plugin automatically after you connect."
+      ]
+    },
+    "mcp": { "available": false }
+  },
+  {
     "id": "email",
     "name": "Email (IMAP + SMTP)",
     "icon": "mail",

--- a/backend-api/integrations/index.ts
+++ b/backend-api/integrations/index.ts
@@ -52,6 +52,11 @@ export { discordProvider } from "./providers/discord";
 export { telegramProvider } from "./providers/telegram";
 export { teamsProvider } from "./providers/teams";
 export { emailProvider } from "./providers/email";
+export {
+  wecomProvider,
+  normalizeWecomConfigInput,
+  normalizeWecomDisplayConfig,
+} from "./providers/wecom";
 export { twilioProvider } from "./providers/twilio";
 export { sendgridProvider } from "./providers/sendgrid";
 export { postgresqlProvider } from "./providers/postgresql";
@@ -117,6 +122,7 @@ export const {
   removeIntegration,
   updateIntegration,
   testIntegration,
+  getDecryptedIntegration,
   getIntegrationsForSync,
   getIntegrationEnvVars,
   buildIntegrationSyncEntry,

--- a/backend-api/integrations/providers/wecom.ts
+++ b/backend-api/integrations/providers/wecom.ts
@@ -1,0 +1,288 @@
+import type {
+  ConnectivityResult,
+  DecryptedIntegration,
+  EnvMapping,
+  Provider,
+  ProviderDeps,
+} from "../types/provider";
+
+type WecomConfig = Record<string, any>;
+const DEFAULT_WECOM_AGENT_CALLBACK_PATH = "/plugins/wecom/agent/default";
+
+function isPlainObject(value: unknown): value is Record<string, any> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function parseStringList(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return [...new Set(value.map((entry) => stringValue(entry)).filter(Boolean))];
+  }
+  if (typeof value !== "string") return [];
+  return [...new Set(value.split(/[\n,]/).map((entry) => entry.trim()).filter(Boolean))];
+}
+
+function normalizePolicyGroups(value: unknown): Record<string, { allowFrom: string[] }> {
+  if (!value) return {};
+  const raw =
+    typeof value === "string"
+      ? (() => {
+          const trimmed = value.trim();
+          if (!trimmed) return null;
+          try {
+            return JSON.parse(trimmed);
+          } catch {
+            throw new Error("Per-group sender allowlists must be valid JSON.");
+          }
+        })()
+      : value;
+
+  if (!raw) return {};
+  if (!isPlainObject(raw)) {
+    throw new Error("Per-group sender allowlists must be a JSON object.");
+  }
+
+  const normalized: Record<string, { allowFrom: string[] }> = {};
+  for (const [groupId, entry] of Object.entries(raw)) {
+    const normalizedGroupId = stringValue(groupId);
+    if (!normalizedGroupId || !isPlainObject(entry)) continue;
+    const allowFrom = parseStringList(entry.allowFrom);
+    if (allowFrom.length) normalized[normalizedGroupId] = { allowFrom };
+  }
+  return normalized;
+}
+
+function numberValue(value: unknown): number | null {
+  if (value === "" || value == null) return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function normalizeCallbackPath(value: unknown): string {
+  const normalized = stringValue(value || DEFAULT_WECOM_AGENT_CALLBACK_PATH);
+  if (!normalized || normalized === "/api/wecom/callback") {
+    return DEFAULT_WECOM_AGENT_CALLBACK_PATH;
+  }
+  return normalized;
+}
+
+function boolValue(value: unknown, fallback = false): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function setNested(target: Record<string, any>, path: string, value: unknown) {
+  const parts = path.split(".");
+  let cursor = target;
+  while (parts.length > 1) {
+    const part = parts.shift() as string;
+    if (!isPlainObject(cursor[part])) cursor[part] = {};
+    cursor = cursor[part];
+  }
+  cursor[parts[0]] = value;
+}
+
+function expandDottedInput(rawConfig: Record<string, unknown> = {}) {
+  const next: Record<string, any> = {};
+  for (const [key, value] of Object.entries(rawConfig || {})) {
+    if (value === undefined) continue;
+    if (key.includes(".")) {
+      setNested(next, key, value);
+    } else if (isPlainObject(value)) {
+      next[key] = expandDottedInput(value as Record<string, unknown>);
+    } else {
+      next[key] = value;
+    }
+  }
+  return next;
+}
+
+function normalizeAccountEntry(rawAccount: Record<string, any> = {}): Record<string, any> {
+  const source = isPlainObject(rawAccount) ? rawAccount : {};
+  return {
+    id: stringValue(source.id),
+    label: stringValue(source.label || source.name),
+    bot: {
+      connectionMode: "websocket",
+      name: stringValue(source?.bot?.name),
+      botId: stringValue(source?.bot?.botId),
+      secret: stringValue(source?.bot?.secret),
+      websocketUrl:
+        stringValue(source?.bot?.websocketUrl || "wss://openws.work.weixin.qq.com") ||
+        "wss://openws.work.weixin.qq.com",
+      sendThinkingMessage: boolValue(source?.bot?.sendThinkingMessage, true),
+    },
+    agent: {
+      corpId: stringValue(source?.agent?.corpId),
+      corpSecret: stringValue(source?.agent?.corpSecret),
+      agentId: numberValue(source?.agent?.agentId),
+      token: stringValue(source?.agent?.token),
+      encodingAESKey: stringValue(source?.agent?.encodingAESKey),
+      callbackPath: normalizeCallbackPath(source?.agent?.callbackPath),
+    },
+  };
+}
+
+function parseAccountsJson(value: unknown): Record<string, any>[] {
+  const shapeErrors = new Set([
+    "Additional Accounts JSON must be a JSON array.",
+    "Additional Accounts JSON must be an array of account objects.",
+  ]);
+  if (Array.isArray(value)) {
+    if (!value.every((entry) => isPlainObject(entry))) {
+      throw new Error("Additional Accounts JSON must be an array of account objects.");
+    }
+    return value as Record<string, any>[];
+  }
+  if (typeof value !== "string" || !value.trim()) return [];
+  try {
+    const parsed = JSON.parse(value);
+    if (!Array.isArray(parsed)) {
+      throw new Error("Additional Accounts JSON must be a JSON array.");
+    }
+    if (!parsed.every((entry) => isPlainObject(entry))) {
+      throw new Error("Additional Accounts JSON must be an array of account objects.");
+    }
+    return parsed as Record<string, any>[];
+  } catch (error) {
+    if (error instanceof Error && shapeErrors.has(error.message)) throw error;
+    throw new Error("Additional Accounts JSON must be valid JSON.");
+  }
+}
+
+export function normalizeWecomConfigInput(rawConfig: Record<string, unknown> = {}): WecomConfig {
+  const next = expandDottedInput(rawConfig);
+  const mode = stringValue(next.mode || "bot") || "bot";
+  const defaultAccount = normalizeAccountEntry(next.defaultAccount || {});
+  const accounts = parseAccountsJson(next.accountsJson || next.accounts).map((entry, index) => {
+    const normalized = normalizeAccountEntry(entry);
+    if (!normalized.id) normalized.id = `account-${index + 1}`;
+    return normalized;
+  });
+  const activation = isPlainObject(next.activation) ? next.activation : {};
+
+  return {
+    mode: ["bot", "agent", "both"].includes(mode) ? mode : "bot",
+    defaultAccount,
+    accounts,
+    policies: {
+      dmPolicy: stringValue(next?.policies?.dmPolicy || "pairing") || "pairing",
+      allowFrom: parseStringList(next?.policies?.allowFrom),
+      groupPolicy: stringValue(next?.policies?.groupPolicy || "open") || "open",
+      groupAllowFrom: parseStringList(next?.policies?.groupAllowFrom),
+      groups: normalizePolicyGroups(next?.policies?.groupsJson || next?.policies?.groups),
+    },
+    advanced: {
+      mediaLocalRoots: stringValue(next?.advanced?.mediaLocalRoots),
+      egressProxyUrl: stringValue(next?.advanced?.egressProxyUrl),
+      dynamicAgentEnabled: boolValue(next?.advanced?.dynamicAgentEnabled, false),
+    },
+    activation: {
+      lifecycleStatus: stringValue(activation.lifecycleStatus || "saved") || "saved",
+      readiness: stringValue(activation.readiness || "pending_activation") || "pending_activation",
+      lastError: stringValue(activation.lastError),
+      lastVerifiedAt: stringValue(activation.lastVerifiedAt),
+    },
+  };
+}
+
+export function normalizeWecomDisplayConfig(rawConfig: Record<string, unknown> = {}): WecomConfig {
+  const normalized = normalizeWecomConfigInput(rawConfig);
+  return {
+    ...normalized,
+    policies: {
+      ...normalized.policies,
+      groupsJson:
+        normalized?.policies?.groups && Object.keys(normalized.policies.groups).length
+          ? JSON.stringify(normalized.policies.groups, null, 2)
+          : "",
+    },
+    accountsJson: normalized.accounts.length ? JSON.stringify(normalized.accounts, null, 2) : "",
+  };
+}
+
+function validateRequiredFields(config: WecomConfig): string[] {
+  const errors: string[] = [];
+  const mode = config.mode;
+  const account = config.defaultAccount || {};
+
+  if (mode === "bot" || mode === "both") {
+    if (!stringValue(account?.bot?.botId)) errors.push("Default Bot ID is required.");
+    if (!stringValue(account?.bot?.secret)) errors.push("Default Bot Secret is required.");
+  }
+
+  if (mode === "agent" || mode === "both") {
+    if (!stringValue(account?.agent?.corpId)) errors.push("Default Corp ID is required.");
+    if (!stringValue(account?.agent?.corpSecret)) errors.push("Default Corp Secret is required.");
+    if (!numberValue(account?.agent?.agentId)) errors.push("Default Agent ID is required.");
+    if (!stringValue(account?.agent?.token)) errors.push("Default Agent Token is required.");
+    if (!stringValue(account?.agent?.encodingAESKey)) {
+      errors.push("Default Encoding AES Key is required.");
+    }
+  }
+
+  return errors;
+}
+
+export const wecomProvider: Provider = {
+  id: "wecom",
+  authType: "custom",
+
+  async test(ctx: DecryptedIntegration, _deps: ProviderDeps): Promise<ConnectivityResult> {
+    const normalized = normalizeWecomConfigInput(ctx.config || {});
+    const errors = validateRequiredFields(normalized);
+    if (errors.length) {
+      return {
+        success: false,
+        error: errors[0],
+        message: errors[0],
+      };
+    }
+
+    return {
+      success: true,
+      message: "WeCom configuration saved and ready for activation wiring.",
+    };
+  },
+
+  mapToEnv(_ctx: DecryptedIntegration): EnvMapping {
+    return {
+      primary: null,
+      config: {},
+    };
+  },
+
+  sanitizeForSync(config: Record<string, unknown> = {}) {
+    const normalized = normalizeWecomConfigInput(config);
+    return {
+      mode: normalized.mode,
+      defaultAccount: {
+        label: normalized?.defaultAccount?.label || "",
+        bot: {
+          name: normalized?.defaultAccount?.bot?.name || "",
+          connectionMode: "websocket",
+          sendThinkingMessage: Boolean(normalized?.defaultAccount?.bot?.sendThinkingMessage),
+        },
+        agent: {
+          callbackPath:
+            normalized?.defaultAccount?.agent?.callbackPath || DEFAULT_WECOM_AGENT_CALLBACK_PATH,
+        },
+      },
+      accounts: Array.isArray(normalized.accounts)
+        ? normalized.accounts.map((account) => ({
+            id: account.id || "",
+            label: account.label || "",
+            hasBot: Boolean(account?.bot?.botId || account?.bot?.secret),
+            hasAgent: Boolean(account?.agent?.agentId),
+          }))
+        : [],
+      policies: normalized.policies,
+      advanced: {
+        dynamicAgentEnabled: Boolean(normalized?.advanced?.dynamicAgentEnabled),
+      },
+      activation: normalized.activation,
+    };
+  },
+};

--- a/backend-api/integrations/providers/wecom.ts
+++ b/backend-api/integrations/providers/wecom.ts
@@ -22,7 +22,14 @@ function parseStringList(value: unknown): string[] {
     return [...new Set(value.map((entry) => stringValue(entry)).filter(Boolean))];
   }
   if (typeof value !== "string") return [];
-  return [...new Set(value.split(/[\n,]/).map((entry) => entry.trim()).filter(Boolean))];
+  return [
+    ...new Set(
+      value
+        .split(/[\n,]/)
+        .map((entry) => entry.trim())
+        .filter(Boolean),
+    ),
+  ];
 }
 
 function normalizePolicyGroups(value: unknown): Record<string, { allowFrom: string[] }> {

--- a/backend-api/integrations/providers/wecomActivation.ts
+++ b/backend-api/integrations/providers/wecomActivation.ts
@@ -27,7 +27,7 @@ function stringValue(value: unknown): string {
 }
 
 function shellSingleQuote(value: string): string {
-  return `'${String(value).replace(/'/g, `'\"'\"'`)}'`;
+  return `'${String(value).replace(/'/g, `'"'"'`)}'`;
 }
 
 function booleanValue(value: unknown, fallback = false): boolean {
@@ -39,12 +39,17 @@ function parseStringList(value: unknown): string[] {
     return [...new Set(value.map((entry) => stringValue(entry)).filter(Boolean))];
   }
   if (typeof value !== "string") return [];
-  return [...new Set(value.split(/[\n,]/).map((entry) => entry.trim()).filter(Boolean))];
+  return [
+    ...new Set(
+      value
+        .split(/[\n,]/)
+        .map((entry) => entry.trim())
+        .filter(Boolean),
+    ),
+  ];
 }
 
-function normalizeGroupSenderAllowlists(
-  value: unknown,
-): Record<string, { allowFrom: string[] }> {
+function normalizeGroupSenderAllowlists(value: unknown): Record<string, { allowFrom: string[] }> {
   if (!value || typeof value !== "object" || Array.isArray(value)) return {};
   const normalized: Record<string, { allowFrom: string[] }> = {};
   for (const [groupId, entry] of Object.entries(value as Record<string, any>)) {
@@ -150,7 +155,8 @@ export function buildWecomOpenClawChannelConfig(config: WecomConfig = {}): Recor
     const accounts: Record<string, any> = {};
     accounts[defaultAccountId] = buildAccountConfig(filteredDefaultAccount);
     filteredExtraAccounts.forEach((account: Record<string, any>, index: number) => {
-      const accountId = stringValue(account?.id || `account-${index + 1}`) || `account-${index + 1}`;
+      const accountId =
+        stringValue(account?.id || `account-${index + 1}`) || `account-${index + 1}`;
       accounts[accountId] = buildAccountConfig(account || {});
     });
     channelConfig.defaultAccount = defaultAccountId;
@@ -166,10 +172,10 @@ export function buildWecomPluginInstallCommand(): string {
     'OPENCLAW_BIN="${OPENCLAW_CLI_PATH:-/usr/local/bin/openclaw}"',
     'if [ ! -x "$OPENCLAW_BIN" ]; then OPENCLAW_BIN="$(command -v openclaw 2>/dev/null || true)"; fi',
     '[ -n "$OPENCLAW_BIN" ] && [ -x "$OPENCLAW_BIN" ]',
-    'export npm_config_audit=false',
-    'export npm_config_fund=false',
-    'export npm_config_progress=false',
-    'export npm_config_update_notifier=false',
+    "export npm_config_audit=false",
+    "export npm_config_fund=false",
+    "export npm_config_progress=false",
+    "export npm_config_update_notifier=false",
     'if ! printf "%s" "${NODE_OPTIONS:-}" | grep -Eq "(^| )--max-old-space-size="; then',
     '  NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--max-old-space-size=${OPENCLAW_PLUGIN_INSTALL_MAX_OLD_SPACE_MB:-256}"',
     "fi",
@@ -249,33 +255,34 @@ function activationState(
 function inferWecomMode(channelConfig: Record<string, any> = {}): string {
   const topLevelHasBot = Boolean(
     stringValue(channelConfig.botId) ||
-      stringValue(channelConfig.secret) ||
-      stringValue(channelConfig.websocketUrl),
+    stringValue(channelConfig.secret) ||
+    stringValue(channelConfig.websocketUrl),
   );
   const topLevelHasAgent = Boolean(
     stringValue(channelConfig?.agent?.corpId) ||
-      stringValue(channelConfig?.agent?.corpSecret) ||
-      normalizeAgentId(channelConfig?.agent?.agentId) !== undefined ||
-      stringValue(channelConfig?.agent?.token) ||
-      stringValue(channelConfig?.agent?.encodingAESKey),
+    stringValue(channelConfig?.agent?.corpSecret) ||
+    normalizeAgentId(channelConfig?.agent?.agentId) !== undefined ||
+    stringValue(channelConfig?.agent?.token) ||
+    stringValue(channelConfig?.agent?.encodingAESKey),
   );
-  const accounts = channelConfig?.accounts && typeof channelConfig.accounts === "object"
-    ? Object.values(channelConfig.accounts)
-    : [];
+  const accounts =
+    channelConfig?.accounts && typeof channelConfig.accounts === "object"
+      ? Object.values(channelConfig.accounts)
+      : [];
   const accountHasBot = accounts.some((account: any) =>
     Boolean(
       stringValue(account?.botId) ||
-        stringValue(account?.secret) ||
-        stringValue(account?.websocketUrl),
+      stringValue(account?.secret) ||
+      stringValue(account?.websocketUrl),
     ),
   );
   const accountHasAgent = accounts.some((account: any) =>
     Boolean(
       stringValue(account?.agent?.corpId) ||
-        stringValue(account?.agent?.corpSecret) ||
-        normalizeAgentId(account?.agent?.agentId) !== undefined ||
-        stringValue(account?.agent?.token) ||
-        stringValue(account?.agent?.encodingAESKey),
+      stringValue(account?.agent?.corpSecret) ||
+      normalizeAgentId(account?.agent?.agentId) !== undefined ||
+      stringValue(account?.agent?.token) ||
+      stringValue(account?.agent?.encodingAESKey),
     ),
   );
   const hasBot = topLevelHasBot || accountHasBot;
@@ -378,7 +385,9 @@ export async function activateWecomForOpenClawAgent(
       ? refreshedSnapshot.hash.trim()
       : null;
   if (!refreshedBaseHash) {
-    throw new Error("OpenClaw runtime did not return a refreshed config hash for WeCom activation.");
+    throw new Error(
+      "OpenClaw runtime did not return a refreshed config hash for WeCom activation.",
+    );
   }
 
   await deps.rpcCall(agent, "config.patch", {
@@ -418,12 +427,7 @@ export async function activateWecomForOpenClawAgent(
 
   return {
     deferred: false,
-    activation: activationState(
-      "active",
-      "ready",
-      "",
-      new Date().toISOString(),
-    ),
+    activation: activationState("active", "ready", "", new Date().toISOString()),
   };
 }
 

--- a/backend-api/integrations/providers/wecomActivation.ts
+++ b/backend-api/integrations/providers/wecomActivation.ts
@@ -1,0 +1,579 @@
+const WECOM_PLUGIN_ID = "wecom-openclaw-plugin";
+const WECOM_PLUGIN_SPEC = "@wecom/wecom-openclaw-plugin";
+const OPENCLAW_PLUGIN_INSTALL_TIMEOUT_MS = 240000;
+const OPENCLAW_GATEWAY_RESTART_TIMEOUT_MS = 120000;
+const OPENCLAW_ACTIVE_STATUSES = new Set(["running", "warning"]);
+
+type WecomConfig = Record<string, any>;
+type WecomActivationOutcome = {
+  deferred: boolean;
+  activation: {
+    lifecycleStatus: string;
+    readiness: string;
+    lastError: string;
+    lastVerifiedAt: string;
+  };
+};
+
+type WecomVerificationResult = {
+  success: boolean;
+  message: string;
+  activation: WecomActivationOutcome["activation"];
+};
+const DEFAULT_WECOM_AGENT_CALLBACK_PATH = "/plugins/wecom/agent/default";
+
+function stringValue(value: unknown): string {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function shellSingleQuote(value: string): string {
+  return `'${String(value).replace(/'/g, `'\"'\"'`)}'`;
+}
+
+function booleanValue(value: unknown, fallback = false): boolean {
+  return typeof value === "boolean" ? value : fallback;
+}
+
+function parseStringList(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return [...new Set(value.map((entry) => stringValue(entry)).filter(Boolean))];
+  }
+  if (typeof value !== "string") return [];
+  return [...new Set(value.split(/[\n,]/).map((entry) => entry.trim()).filter(Boolean))];
+}
+
+function normalizeGroupSenderAllowlists(
+  value: unknown,
+): Record<string, { allowFrom: string[] }> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+  const normalized: Record<string, { allowFrom: string[] }> = {};
+  for (const [groupId, entry] of Object.entries(value as Record<string, any>)) {
+    const normalizedGroupId = stringValue(groupId);
+    const allowFrom = parseStringList(entry?.allowFrom);
+    if (normalizedGroupId && allowFrom.length) {
+      normalized[normalizedGroupId] = { allowFrom };
+    }
+  }
+  return normalized;
+}
+
+function normalizeAgentId(value: unknown): number | string | undefined {
+  if (value == null || value === "") return undefined;
+  const parsed = Number(value);
+  if (Number.isFinite(parsed)) return parsed;
+  const trimmed = stringValue(value);
+  return trimmed || undefined;
+}
+
+function buildAccountConfig(account: Record<string, any> = {}) {
+  const entry: Record<string, any> = {};
+  const bot = account?.bot || {};
+  const agent = account?.agent || {};
+
+  const connectionMode = stringValue(bot.connectionMode || "websocket") || "websocket";
+  const botId = stringValue(bot.botId);
+  const botSecret = stringValue(bot.secret);
+  const hasBotConfig = Boolean(botId || botSecret || stringValue(bot.websocketUrl));
+
+  if (hasBotConfig) {
+    if (connectionMode) entry.connectionMode = connectionMode;
+    if (botId) entry.botId = botId;
+    if (botSecret) entry.secret = botSecret;
+    if (stringValue(bot.websocketUrl)) entry.websocketUrl = stringValue(bot.websocketUrl);
+    entry.sendThinkingMessage = booleanValue(bot.sendThinkingMessage, true);
+  }
+
+  const agentConfig: Record<string, any> = {};
+  if (stringValue(agent.corpId)) agentConfig.corpId = stringValue(agent.corpId);
+  if (stringValue(agent.corpSecret)) agentConfig.corpSecret = stringValue(agent.corpSecret);
+  if (normalizeAgentId(agent.agentId) !== undefined) {
+    agentConfig.agentId = normalizeAgentId(agent.agentId);
+  }
+  if (stringValue(agent.token)) agentConfig.token = stringValue(agent.token);
+  if (stringValue(agent.encodingAESKey)) {
+    agentConfig.encodingAESKey = stringValue(agent.encodingAESKey);
+  }
+  if (Object.keys(agentConfig).length) entry.agent = agentConfig;
+
+  return entry;
+}
+
+export function buildWecomOpenClawChannelConfig(config: WecomConfig = {}): Record<string, any> {
+  const mode = stringValue(config?.mode || "bot") || "bot";
+  const defaultAccount = config?.defaultAccount || {};
+  const extraAccounts = Array.isArray(config?.accounts) ? config.accounts : [];
+  const filteredDefaultAccount = {
+    ...defaultAccount,
+    bot: mode === "agent" ? {} : defaultAccount?.bot || {},
+    agent: mode === "bot" ? {} : defaultAccount?.agent || {},
+  };
+  const filteredExtraAccounts = extraAccounts.map((account: Record<string, any>) => ({
+    ...account,
+    bot: mode === "agent" ? {} : account?.bot || {},
+    agent: mode === "bot" ? {} : account?.agent || {},
+  }));
+  const topLevel = buildAccountConfig(filteredDefaultAccount);
+  const channelConfig: Record<string, any> = {
+    enabled: true,
+    ...topLevel,
+  };
+
+  const dmPolicy = stringValue(config?.policies?.dmPolicy);
+  const groupPolicy = stringValue(config?.policies?.groupPolicy);
+  const allowFrom = parseStringList(config?.policies?.allowFrom);
+  const groupAllowFrom = parseStringList(config?.policies?.groupAllowFrom);
+  const groups = normalizeGroupSenderAllowlists(config?.policies?.groups);
+  const mediaLocalRoots = parseStringList(config?.advanced?.mediaLocalRoots);
+  const egressProxyUrl = stringValue(config?.advanced?.egressProxyUrl);
+
+  if (dmPolicy) channelConfig.dmPolicy = dmPolicy;
+  if (groupPolicy) channelConfig.groupPolicy = groupPolicy;
+  if (allowFrom.length) channelConfig.allowFrom = allowFrom;
+  if (groupAllowFrom.length) channelConfig.groupAllowFrom = groupAllowFrom;
+  if (Object.keys(groups).length) channelConfig.groups = groups;
+  if (mediaLocalRoots.length) channelConfig.mediaLocalRoots = mediaLocalRoots;
+  if (egressProxyUrl) {
+    channelConfig.network = {
+      ...(channelConfig.network || {}),
+      egressProxyUrl,
+    };
+  }
+
+  if (booleanValue(config?.advanced?.dynamicAgentEnabled, false)) {
+    channelConfig.dynamicAgents = {
+      enabled: true,
+    };
+  }
+
+  if (filteredExtraAccounts.length > 0) {
+    const defaultAccountId = stringValue(filteredDefaultAccount.id || "default") || "default";
+    const accounts: Record<string, any> = {};
+    accounts[defaultAccountId] = buildAccountConfig(filteredDefaultAccount);
+    filteredExtraAccounts.forEach((account: Record<string, any>, index: number) => {
+      const accountId = stringValue(account?.id || `account-${index + 1}`) || `account-${index + 1}`;
+      accounts[accountId] = buildAccountConfig(account || {});
+    });
+    channelConfig.defaultAccount = defaultAccountId;
+    channelConfig.accounts = accounts;
+  }
+
+  return channelConfig;
+}
+
+export function buildWecomPluginInstallCommand(): string {
+  return [
+    "set -eu",
+    'OPENCLAW_BIN="${OPENCLAW_CLI_PATH:-/usr/local/bin/openclaw}"',
+    'if [ ! -x "$OPENCLAW_BIN" ]; then OPENCLAW_BIN="$(command -v openclaw 2>/dev/null || true)"; fi',
+    '[ -n "$OPENCLAW_BIN" ] && [ -x "$OPENCLAW_BIN" ]',
+    'export npm_config_audit=false',
+    'export npm_config_fund=false',
+    'export npm_config_progress=false',
+    'export npm_config_update_notifier=false',
+    'if ! printf "%s" "${NODE_OPTIONS:-}" | grep -Eq "(^| )--max-old-space-size="; then',
+    '  NODE_OPTIONS="${NODE_OPTIONS:+$NODE_OPTIONS }--max-old-space-size=${OPENCLAW_PLUGIN_INSTALL_MAX_OLD_SPACE_MB:-256}"',
+    "fi",
+    "export NODE_OPTIONS",
+    `"$OPENCLAW_BIN" plugins inspect ${shellSingleQuote(WECOM_PLUGIN_ID)} >/dev/null 2>&1 || "$OPENCLAW_BIN" plugins install ${shellSingleQuote(WECOM_PLUGIN_SPEC)} --force`,
+    `"$OPENCLAW_BIN" plugins inspect ${shellSingleQuote(WECOM_PLUGIN_ID)} >/dev/null 2>&1`,
+  ].join("\n");
+}
+
+export function buildWecomPluginUninstallCommand(): string {
+  return [
+    "set -eu",
+    'OPENCLAW_BIN="${OPENCLAW_CLI_PATH:-/usr/local/bin/openclaw}"',
+    'if [ ! -x "$OPENCLAW_BIN" ]; then OPENCLAW_BIN="$(command -v openclaw 2>/dev/null || true)"; fi',
+    '[ -n "$OPENCLAW_BIN" ] && [ -x "$OPENCLAW_BIN" ]',
+    `if "$OPENCLAW_BIN" plugins inspect ${shellSingleQuote(WECOM_PLUGIN_ID)} >/dev/null 2>&1; then`,
+    `  printf 'y\\n' | "$OPENCLAW_BIN" plugins uninstall ${shellSingleQuote(WECOM_PLUGIN_ID)}`,
+    "fi",
+  ].join("\n");
+}
+
+export function buildWecomGatewayReloadCommand(): string {
+  return [
+    "set -eu",
+    'OPENCLAW_BIN="${OPENCLAW_CLI_PATH:-/usr/local/bin/openclaw}"',
+    'if [ ! -x "$OPENCLAW_BIN" ]; then OPENCLAW_BIN="$(command -v openclaw 2>/dev/null || true)"; fi',
+    '[ -n "$OPENCLAW_BIN" ] && [ -x "$OPENCLAW_BIN" ]',
+    'self_pid="$$"',
+    "for proc in /proc/[0-9]*; do",
+    '  pid="${proc##*/}"',
+    '  [ "$pid" = "$self_pid" ] && continue',
+    '  comm="$(cat "$proc/comm" 2>/dev/null || true)"',
+    '  if [ "$comm" = "openclaw" ]; then',
+    '    kill -USR1 "$pid"',
+    "    exit 0",
+    "  fi",
+    '  if [ "$comm" = "openclaw-gateway" ]; then',
+    '    kill -USR1 "$pid"',
+    "    exit 0",
+    "  fi",
+    '  cmdline="$(tr "\\000" " " < "$proc/cmdline" 2>/dev/null || true)"',
+    '  case "$cmdline" in',
+    '    *"/usr/local/bin/node /usr/local/bin/openclaw gateway"*|*" node /usr/local/bin/openclaw gateway"*|*" openclaw gateway --port "*|*" openclaw gateway "*)',
+    '      case "$comm" in',
+    '        node|openclaw|openclaw-gateway) kill -USR1 "$pid"; exit 0 ;;',
+    "      esac",
+    "      ;;",
+    "  esac",
+    "done",
+    '"$OPENCLAW_BIN" gateway restart',
+  ].join("\n");
+}
+
+function isAcceptableGatewayReloadError(error: unknown): boolean {
+  const message = String((error as Error)?.message || "");
+  return (
+    /gateway service disabled/i.test(message) ||
+    /systemd user services are unavailable/i.test(message) ||
+    /run the gateway in the foreground/i.test(message)
+  );
+}
+
+function activationState(
+  lifecycleStatus: string,
+  readiness: string,
+  lastError = "",
+  lastVerifiedAt = "",
+): WecomActivationOutcome["activation"] {
+  return {
+    lifecycleStatus,
+    readiness,
+    lastError,
+    lastVerifiedAt,
+  };
+}
+
+function inferWecomMode(channelConfig: Record<string, any> = {}): string {
+  const topLevelHasBot = Boolean(
+    stringValue(channelConfig.botId) ||
+      stringValue(channelConfig.secret) ||
+      stringValue(channelConfig.websocketUrl),
+  );
+  const topLevelHasAgent = Boolean(
+    stringValue(channelConfig?.agent?.corpId) ||
+      stringValue(channelConfig?.agent?.corpSecret) ||
+      normalizeAgentId(channelConfig?.agent?.agentId) !== undefined ||
+      stringValue(channelConfig?.agent?.token) ||
+      stringValue(channelConfig?.agent?.encodingAESKey),
+  );
+  const accounts = channelConfig?.accounts && typeof channelConfig.accounts === "object"
+    ? Object.values(channelConfig.accounts)
+    : [];
+  const accountHasBot = accounts.some((account: any) =>
+    Boolean(
+      stringValue(account?.botId) ||
+        stringValue(account?.secret) ||
+        stringValue(account?.websocketUrl),
+    ),
+  );
+  const accountHasAgent = accounts.some((account: any) =>
+    Boolean(
+      stringValue(account?.agent?.corpId) ||
+        stringValue(account?.agent?.corpSecret) ||
+        normalizeAgentId(account?.agent?.agentId) !== undefined ||
+        stringValue(account?.agent?.token) ||
+        stringValue(account?.agent?.encodingAESKey),
+    ),
+  );
+  const hasBot = topLevelHasBot || accountHasBot;
+  const hasAgent = topLevelHasAgent || accountHasAgent;
+
+  if (hasBot && hasAgent) return "both";
+  if (hasBot) return "bot";
+  if (hasAgent) return "agent";
+  return "none";
+}
+
+function parseWecomConfigOutput(rawOutput: unknown): Record<string, any> | null {
+  const text = String(rawOutput || "").trim();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
+
+function canonicalizeWecomConfig(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    const canonicalized = value.map((entry) => canonicalizeWecomConfig(entry));
+    if (canonicalized.every((entry) => typeof entry === "string")) {
+      return [...new Set(canonicalized as string[])].sort();
+    }
+    return canonicalized;
+  }
+  if (!value || typeof value !== "object") return value;
+
+  const objectValue = value as Record<string, unknown>;
+  const next: Record<string, unknown> = {};
+  for (const key of Object.keys(objectValue).sort()) {
+    const child = canonicalizeWecomConfig(objectValue[key]);
+    if (child === undefined) continue;
+    next[key] = child;
+  }
+  return next;
+}
+
+export async function activateWecomForOpenClawAgent(
+  agent: Record<string, any>,
+  normalizedConfig: WecomConfig,
+  deps: {
+    runContainerCommand: (
+      agent: Record<string, any>,
+      command: string,
+      options?: { timeout?: number },
+    ) => Promise<{ output?: string }>;
+    rpcCall: (
+      agent: Record<string, any>,
+      method: string,
+      params?: Record<string, any>,
+      timeout?: number,
+    ) => Promise<Record<string, any>>;
+  },
+): Promise<WecomActivationOutcome> {
+  if (!agent || !OPENCLAW_ACTIVE_STATUSES.has(String(agent.status || ""))) {
+    return {
+      deferred: true,
+      activation: activationState(
+        "saved",
+        "pending_activation",
+        "Start the agent to install and activate the WeCom plugin.",
+        "",
+      ),
+    };
+  }
+
+  const channelConfig = buildWecomOpenClawChannelConfig(normalizedConfig);
+  await deps.runContainerCommand(agent, buildWecomPluginInstallCommand(), {
+    timeout: OPENCLAW_PLUGIN_INSTALL_TIMEOUT_MS,
+  });
+
+  const snapshot = await deps.rpcCall(agent, "config.get");
+  const baseHash =
+    typeof snapshot?.hash === "string" && snapshot.hash.trim() ? snapshot.hash.trim() : null;
+  if (!baseHash) {
+    throw new Error("OpenClaw runtime did not return a config hash for WeCom activation.");
+  }
+
+  await deps.rpcCall(agent, "config.patch", {
+    raw: JSON.stringify({
+      channels: { wecom: null },
+      plugins: {
+        entries: {
+          [WECOM_PLUGIN_ID]: {
+            enabled: false,
+          },
+        },
+      },
+    }),
+    baseHash,
+  });
+
+  const refreshedSnapshot = await deps.rpcCall(agent, "config.get");
+  const refreshedBaseHash =
+    typeof refreshedSnapshot?.hash === "string" && refreshedSnapshot.hash.trim()
+      ? refreshedSnapshot.hash.trim()
+      : null;
+  if (!refreshedBaseHash) {
+    throw new Error("OpenClaw runtime did not return a refreshed config hash for WeCom activation.");
+  }
+
+  await deps.rpcCall(agent, "config.patch", {
+    raw: JSON.stringify({
+      channels: { wecom: channelConfig },
+      plugins: {
+        entries: {
+          [WECOM_PLUGIN_ID]: {
+            enabled: true,
+          },
+        },
+      },
+    }),
+    baseHash: refreshedBaseHash,
+  });
+
+  try {
+    await deps.runContainerCommand(agent, buildWecomGatewayReloadCommand(), {
+      timeout: OPENCLAW_GATEWAY_RESTART_TIMEOUT_MS,
+    });
+  } catch (error) {
+    if (!isAcceptableGatewayReloadError(error)) throw error;
+  }
+
+  await deps.runContainerCommand(
+    agent,
+    [
+      "set -eu",
+      'OPENCLAW_BIN="${OPENCLAW_CLI_PATH:-/usr/local/bin/openclaw}"',
+      'if [ ! -x "$OPENCLAW_BIN" ]; then OPENCLAW_BIN="$(command -v openclaw 2>/dev/null || true)"; fi',
+      '[ -n "$OPENCLAW_BIN" ] && [ -x "$OPENCLAW_BIN" ]',
+      `"$OPENCLAW_BIN" plugins inspect ${shellSingleQuote(WECOM_PLUGIN_ID)} >/dev/null 2>&1`,
+      '"$OPENCLAW_BIN" config get channels.wecom --json >/dev/null',
+    ].join("\n"),
+    { timeout: 30000 },
+  );
+
+  return {
+    deferred: false,
+    activation: activationState(
+      "active",
+      "ready",
+      "",
+      new Date().toISOString(),
+    ),
+  };
+}
+
+export async function verifyWecomForOpenClawAgent(
+  agent: Record<string, any>,
+  normalizedConfig: WecomConfig,
+  deps: {
+    runContainerCommand: (
+      agent: Record<string, any>,
+      command: string,
+      options?: { timeout?: number },
+    ) => Promise<{ output?: string }>;
+    rpcCall: (
+      agent: Record<string, any>,
+      method: string,
+      params?: Record<string, any>,
+      timeout?: number,
+    ) => Promise<Record<string, any>>;
+  },
+): Promise<WecomVerificationResult> {
+  if (!agent || !OPENCLAW_ACTIVE_STATUSES.has(String(agent.status || ""))) {
+    return {
+      success: false,
+      message: "Start the agent to finish WeCom activation and runtime verification.",
+      activation: activationState(
+        "saved",
+        "pending_activation",
+        "Start the agent to finish WeCom activation and runtime verification.",
+        "",
+      ),
+    };
+  }
+
+  try {
+    const snapshot = await deps.rpcCall(agent, "config.get");
+    const baseHash =
+      typeof snapshot?.hash === "string" && snapshot.hash.trim() ? snapshot.hash.trim() : null;
+    if (!baseHash) {
+      throw new Error("OpenClaw gateway responded without a config hash.");
+    }
+
+    await deps.runContainerCommand(
+      agent,
+      [
+        "set -eu",
+        'OPENCLAW_BIN="${OPENCLAW_CLI_PATH:-/usr/local/bin/openclaw}"',
+        'if [ ! -x "$OPENCLAW_BIN" ]; then OPENCLAW_BIN="$(command -v openclaw 2>/dev/null || true)"; fi',
+        '[ -n "$OPENCLAW_BIN" ] && [ -x "$OPENCLAW_BIN" ]',
+        `"$OPENCLAW_BIN" plugins inspect ${shellSingleQuote(WECOM_PLUGIN_ID)} >/dev/null 2>&1`,
+      ].join("\n"),
+      { timeout: 30000 },
+    );
+
+    const configResult = await deps.runContainerCommand(
+      agent,
+      [
+        "set -eu",
+        'OPENCLAW_BIN="${OPENCLAW_CLI_PATH:-/usr/local/bin/openclaw}"',
+        'if [ ! -x "$OPENCLAW_BIN" ]; then OPENCLAW_BIN="$(command -v openclaw 2>/dev/null || true)"; fi',
+        '[ -n "$OPENCLAW_BIN" ] && [ -x "$OPENCLAW_BIN" ]',
+        '"$OPENCLAW_BIN" config get channels.wecom --json',
+      ].join("\n"),
+      { timeout: 30000 },
+    );
+
+    const runtimeConfig = parseWecomConfigOutput(configResult?.output);
+    const expectedMode = stringValue(normalizedConfig?.mode || "bot") || "bot";
+    const runtimeMode = inferWecomMode(runtimeConfig || {});
+    const expectedRuntimeConfig = buildWecomOpenClawChannelConfig(normalizedConfig);
+
+    if (runtimeMode === "none") {
+      throw new Error("WeCom config was not found in the OpenClaw runtime.");
+    }
+    if (expectedMode !== runtimeMode) {
+      throw new Error(
+        `WeCom runtime config is active in ${runtimeMode} mode, but Nora saved ${expectedMode} mode.`,
+      );
+    }
+    if (
+      JSON.stringify(canonicalizeWecomConfig(runtimeConfig || {})) !==
+      JSON.stringify(canonicalizeWecomConfig(expectedRuntimeConfig))
+    ) {
+      throw new Error(
+        "WeCom runtime config does not fully match Nora's saved configuration. Save again to re-apply the latest settings.",
+      );
+    }
+
+    return {
+      success: true,
+      message: "WeCom plugin is installed, the gateway responded, and the saved config is active.",
+      activation: activationState("active", "ready", "", new Date().toISOString()),
+    };
+  } catch (error) {
+    const message =
+      String((error as Error)?.message || "WeCom runtime verification failed.")
+        .trim()
+        .replace(/\s+/g, " ") || "WeCom runtime verification failed.";
+    return {
+      success: false,
+      message,
+      activation: activationState("activation_failed", "error", message, ""),
+    };
+  }
+}
+
+export async function deactivateWecomForOpenClawAgent(
+  agent: Record<string, any>,
+  deps: {
+    rpcCall: (
+      agent: Record<string, any>,
+      method: string,
+      params?: Record<string, any>,
+      timeout?: number,
+    ) => Promise<Record<string, any>>;
+    runContainerCommand: (
+      agent: Record<string, any>,
+      command: string,
+      options?: { timeout?: number },
+    ) => Promise<{ output?: string }>;
+  },
+): Promise<void> {
+  if (!agent || !OPENCLAW_ACTIVE_STATUSES.has(String(agent.status || ""))) return;
+  const snapshot = await deps.rpcCall(agent, "config.get");
+  const baseHash =
+    typeof snapshot?.hash === "string" && snapshot.hash.trim() ? snapshot.hash.trim() : null;
+  if (!baseHash) return;
+
+  await deps.rpcCall(agent, "config.patch", {
+    raw: JSON.stringify({
+      channels: { wecom: null },
+      plugins: {
+        entries: {
+          [WECOM_PLUGIN_ID]: {
+            enabled: false,
+          },
+        },
+      },
+    }),
+    baseHash,
+  });
+
+  await deps.runContainerCommand(agent, buildWecomPluginUninstallCommand(), {
+    timeout: 60000,
+  });
+
+  try {
+    await deps.runContainerCommand(agent, buildWecomGatewayReloadCommand(), {
+      timeout: OPENCLAW_GATEWAY_RESTART_TIMEOUT_MS,
+    });
+  } catch (error) {
+    if (!isAcceptableGatewayReloadError(error)) throw error;
+  }
+}

--- a/backend-api/integrations/services/integrationsService.ts
+++ b/backend-api/integrations/services/integrationsService.ts
@@ -471,7 +471,7 @@ async function listIntegrations(agentId) {
           )
         : row.provider === "wecom"
           ? normalizeWecomDisplayConfig(decryptSensitiveConfig(row.provider, row.config))
-        : row.config;
+          : row.config;
     return {
       ...hydrated,
       config: redactSensitiveConfig(row.provider, displayConfig),
@@ -503,7 +503,7 @@ async function updateIntegration(integrationId, agentId, token, config = {}) {
       ? normalizeEmailConfigInput(mergeConfig(currentConfig, patchConfig))
       : provider === "wecom"
         ? normalizeWecomConfigInput(mergeConfig(currentConfig, patchConfig))
-      : mergeConfig(currentConfig, patchConfig);
+        : mergeConfig(currentConfig, patchConfig);
 
   let resolvedToken = token;
   if (provider === "email") {
@@ -546,7 +546,7 @@ async function updateIntegration(integrationId, agentId, token, config = {}) {
         ? normalizeEmailDisplayConfig(mergedConfig, updated.cron_job_id)
         : provider === "wecom"
           ? normalizeWecomDisplayConfig(mergedConfig)
-        : mergedConfig,
+          : mergedConfig,
     ),
   };
 }

--- a/backend-api/integrations/services/integrationsService.ts
+++ b/backend-api/integrations/services/integrationsService.ts
@@ -89,6 +89,11 @@ const { discordProvider } = require("../providers/discord");
 const { telegramProvider } = require("../providers/telegram");
 const { teamsProvider } = require("../providers/teams");
 const { emailProvider } = require("../providers/email");
+const {
+  wecomProvider,
+  normalizeWecomConfigInput,
+  normalizeWecomDisplayConfig,
+} = require("../providers/wecom");
 const { twilioProvider } = require("../providers/twilio");
 const { sendgridProvider } = require("../providers/sendgrid");
 const { postgresqlProvider } = require("../providers/postgresql");
@@ -178,6 +183,7 @@ const providerRegistry = createProviderRegistry(createStubProvider);
   telegramProvider,
   teamsProvider,
   emailProvider,
+  wecomProvider,
   twilioProvider,
   sendgridProvider,
   postgresqlProvider,
@@ -325,7 +331,11 @@ function buildIntegrationSyncEntry(row = {}) {
   const provider = row.provider || row.catalog_id || row.id;
   const decryptedConfigRaw = decryptSensitiveConfig(provider, row.config);
   const decryptedConfig =
-    provider === "email" ? normalizeEmailConfigInput(decryptedConfigRaw) : decryptedConfigRaw;
+    provider === "email"
+      ? normalizeEmailConfigInput(decryptedConfigRaw)
+      : provider === "wecom"
+        ? normalizeWecomConfigInput(decryptedConfigRaw)
+        : decryptedConfigRaw;
   const resolved = providerRegistry.resolve(provider);
   const config =
     typeof resolved.sanitizeForSync === "function"
@@ -400,6 +410,8 @@ async function connectIntegration(agentId, provider, token, config = {}) {
   if (provider === "email") {
     config = normalizeEmailConfigInput(config || {});
     if (!token) token = extractEmailPrimarySecret(config);
+  } else if (provider === "wecom") {
+    config = normalizeWecomConfigInput(config || {});
   }
 
   // If no explicit token, try to extract from config (first
@@ -457,6 +469,8 @@ async function listIntegrations(agentId) {
             decryptSensitiveConfig(row.provider, row.config),
             row.cron_job_id,
           )
+        : row.provider === "wecom"
+          ? normalizeWecomDisplayConfig(decryptSensitiveConfig(row.provider, row.config))
         : row.config;
     return {
       ...hydrated,
@@ -478,11 +492,17 @@ async function updateIntegration(integrationId, agentId, token, config = {}) {
   const provider = current.provider;
   const currentConfigRaw = decryptSensitiveConfig(provider, current.config);
   const currentConfig =
-    provider === "email" ? normalizeEmailConfigInput(currentConfigRaw) : currentConfigRaw;
+    provider === "email"
+      ? normalizeEmailConfigInput(currentConfigRaw)
+      : provider === "wecom"
+        ? normalizeWecomConfigInput(currentConfigRaw)
+        : currentConfigRaw;
   const patchConfig = expandDottedConfig(config || {});
   const mergedConfig =
     provider === "email"
       ? normalizeEmailConfigInput(mergeConfig(currentConfig, patchConfig))
+      : provider === "wecom"
+        ? normalizeWecomConfigInput(mergeConfig(currentConfig, patchConfig))
       : mergeConfig(currentConfig, patchConfig);
 
   let resolvedToken = token;
@@ -524,6 +544,8 @@ async function updateIntegration(integrationId, agentId, token, config = {}) {
       provider,
       provider === "email"
         ? normalizeEmailDisplayConfig(mergedConfig, updated.cron_job_id)
+        : provider === "wecom"
+          ? normalizeWecomDisplayConfig(mergedConfig)
         : mergedConfig,
     ),
   };
@@ -545,7 +567,7 @@ async function testIntegration(integrationId, agentId) {
   const integration = await repo.findIntegration({ integrationId, agentId });
   if (!integration) throw new Error("Integration not found");
 
-  if (!integration.access_token && integration.provider !== "email") {
+  if (!integration.access_token && !["email", "wecom"].includes(integration.provider)) {
     return { success: false, error: "No access token configured" };
   }
 
@@ -559,7 +581,11 @@ async function testIntegration(integrationId, agentId) {
   const token = refreshedRow.access_token ? decrypt(refreshedRow.access_token) : null;
   const decryptedConfigRaw = decryptSensitiveConfig(provider, refreshedRow.config);
   const decryptedConfig =
-    provider === "email" ? normalizeEmailConfigInput(decryptedConfigRaw) : decryptedConfigRaw;
+    provider === "email"
+      ? normalizeEmailConfigInput(decryptedConfigRaw)
+      : provider === "wecom"
+        ? normalizeWecomConfigInput(decryptedConfigRaw)
+        : decryptedConfigRaw;
 
   const ctx = {
     row: { ...refreshedRow, config: decryptedConfig },
@@ -568,6 +594,26 @@ async function testIntegration(integrationId, agentId) {
   };
 
   return providerRegistry.resolve(provider).test(ctx, providerDeps);
+}
+
+async function getDecryptedIntegration(integrationId, agentId) {
+  const row = await repo.findIntegration({ integrationId, agentId });
+  if (!row) return null;
+
+  const provider = row.provider || row.catalog_id;
+  const decryptedConfigRaw = decryptSensitiveConfig(provider, row.config);
+  const decryptedConfig =
+    provider === "email"
+      ? normalizeEmailConfigInput(decryptedConfigRaw)
+      : provider === "wecom"
+        ? normalizeWecomConfigInput(decryptedConfigRaw)
+        : decryptedConfigRaw;
+
+  return {
+    ...hydrateRow(row),
+    access_token: row.access_token ? decrypt(row.access_token) : null,
+    config: decryptedConfig,
+  };
 }
 
 // ── Sync + env ──────────────────────────────────────────
@@ -601,7 +647,11 @@ async function getIntegrationEnvVars(agentId) {
     const row = await refreshTwitterOAuthRowIfNeeded(rawRow);
     const decryptedConfigRaw = decryptSensitiveConfig(row.provider, row.config);
     const decryptedConfig =
-      row.provider === "email" ? normalizeEmailConfigInput(decryptedConfigRaw) : decryptedConfigRaw;
+      row.provider === "email"
+        ? normalizeEmailConfigInput(decryptedConfigRaw)
+        : row.provider === "wecom"
+          ? normalizeWecomConfigInput(decryptedConfigRaw)
+          : decryptedConfigRaw;
     const envMapping = providerRegistry
       .resolve(row.provider)
       .mapToEnv({ row, token: null, config: decryptedConfig });
@@ -633,6 +683,7 @@ module.exports = {
   // Email helpers
   normalizeEmailConfigInput,
   extractEmailPrimarySecret,
+  normalizeWecomConfigInput,
   // OAuth refresh
   refreshTwitterOAuthRowIfNeeded,
   // Sync entries
@@ -646,6 +697,7 @@ module.exports = {
   removeIntegration,
   updateIntegration,
   testIntegration,
+  getDecryptedIntegration,
   updateEmailCronJobId,
   findActiveEmailIntegrations,
   findActiveIntegrationByCronJobId,

--- a/backend-api/routes/integrations.ts
+++ b/backend-api/routes/integrations.ts
@@ -13,6 +13,11 @@ const { AGENT_RUNTIME_PORT } = require("../../agent-runtime/lib/contracts");
 const { runtimeUrlForAgent } = require("../../agent-runtime/lib/agentEndpoints");
 const { resolveAgentRuntimeFamily } = require("../agentRuntimeFields");
 const { normalizeEmailConfigInput } = require("../integrations");
+const {
+  activateWecomForOpenClawAgent,
+  deactivateWecomForOpenClawAgent,
+  verifyWecomForOpenClawAgent,
+} = require("../integrations/providers/wecomActivation");
 
 const router = express.Router();
 
@@ -23,6 +28,7 @@ const TWITTER_OAUTH_SCOPES = ["tweet.read", "users.read", "tweet.write", "offlin
 const TWITTER_OAUTH_STATE_TTL_MS = 10 * 60 * 1000;
 const DEFAULT_EMAIL_CRON_PROMPT =
   "Look for any new emails or calendar invites I should be aware of and summarize anything important for me.";
+const SINGLETON_INTEGRATION_PROVIDERS = new Set(["wecom"]);
 
 // Editor floor — integration configs include sensitive credentials, so viewers
 // don't see them. Per-route GET could be relaxed to viewer in a follow-up if
@@ -773,13 +779,58 @@ async function reconcileEmailCronJob(
   return nextCronJobId;
 }
 
+async function updateWecomActivationState(agentId, integrationId, activation) {
+  if (!integrationId || !activation || typeof activation !== "object") return null;
+  return integrations.updateIntegration(integrationId, agentId, null, {
+    activation,
+  });
+}
+
+async function activateWecomIntegration(agent, agentId, integrationId) {
+  const savedIntegration = await integrations.getDecryptedIntegration(integrationId, agentId);
+  if (!savedIntegration) {
+    const error = new Error("Saved WeCom integration could not be loaded for activation.");
+    error.statusCode = 500;
+    throw error;
+  }
+
+  try {
+    const outcome = await activateWecomForOpenClawAgent(agent, savedIntegration.config || {}, {
+      runContainerCommand,
+      rpcCall,
+    });
+    return (await updateWecomActivationState(agentId, integrationId, outcome.activation)) || savedIntegration;
+  } catch (error) {
+    const message =
+      String(error?.message || "WeCom activation failed.")
+        .trim()
+        .replace(/\s+/g, " ") || "WeCom activation failed.";
+    await updateWecomActivationState(agentId, integrationId, {
+      lifecycleStatus: "activation_failed",
+      readiness: "error",
+      lastError: message,
+      lastVerifiedAt: "",
+    }).catch(() => null);
+    const wrapped = new Error(message);
+    wrapped.statusCode = 502;
+    throw wrapped;
+  }
+}
+
 router.post("/agents/:id/integrations", async (req, res) => {
   try {
     const { provider, token, config } = req.body;
     if (!provider) return res.status(400).json({ error: "Provider required" });
     const agent = await getAgentIntegrationRuntimeTarget(req.params.id);
     const runtimeFamily = resolveAgentRuntimeFamily(agent || {});
-    const result = await integrations.connectIntegration(req.params.id, provider, token, config);
+    let result = SINGLETON_INTEGRATION_PROVIDERS.has(String(provider))
+      ? await integrations.replaceIntegration(req.params.id, provider, token, config)
+      : await integrations.connectIntegration(req.params.id, provider, token, config);
+
+    if (provider === "wecom" && runtimeFamily === "openclaw" && result?.id) {
+      const latestAgent = await getAgentIntegrationRuntimeTarget(req.params.id);
+      result = await activateWecomIntegration(latestAgent || agent, req.params.id, result.id);
+    }
 
     if (runtimeFamily === "hermes") {
       await syncIntegrationsToAgent(req.params.id, { strictHermes: true });
@@ -828,6 +879,10 @@ router.delete("/agents/:id/integrations/:iid", async (req, res) => {
       await removeEmailCronJobs(agent, [linkedCronJobId, ...runtimeCronJobIds]);
     }
 
+    if (current?.provider === "wecom" && runtimeFamily === "openclaw") {
+      await deactivateWecomForOpenClawAgent(agent, { rpcCall, runContainerCommand });
+    }
+
     const removed = await integrations.removeIntegration(req.params.iid, req.params.id);
 
     if (runtimeFamily === "hermes") {
@@ -862,12 +917,17 @@ router.put("/agents/:id/integrations/:iid", async (req, res) => {
       : null;
     if (!current) return res.status(404).json({ error: "Integration not found" });
 
-    const result = await integrations.updateIntegration(
+    let result = await integrations.updateIntegration(
       req.params.iid,
       req.params.id,
       req.body?.token,
       req.body?.config || {},
     );
+
+    if (result?.provider === "wecom" && runtimeFamily === "openclaw") {
+      const latestAgent = await getAgentIntegrationRuntimeTarget(req.params.id);
+      result = await activateWecomIntegration(latestAgent || agent, req.params.id, result.id);
+    }
 
     if (runtimeFamily === "hermes") {
       await syncIntegrationsToAgent(req.params.id, { strictHermes: true });
@@ -1031,7 +1091,29 @@ router.get("/integrations/twitter/oauth/callback", async (req, res) => {
 
 router.post("/agents/:id/integrations/:iid/test", async (req, res) => {
   try {
-    const result = await integrations.testIntegration(req.params.iid, req.params.id);
+    const agent = await getAgentIntegrationRuntimeTarget(req.params.id);
+    const runtimeFamily = resolveAgentRuntimeFamily(agent || {});
+    const existing = await integrations.listIntegrations(req.params.id);
+    const current = Array.isArray(existing)
+      ? existing.find((item) => String(item.id) === String(req.params.iid))
+      : null;
+    let result;
+
+    if (current?.provider === "wecom" && runtimeFamily === "openclaw") {
+      const savedIntegration = await integrations.getDecryptedIntegration(req.params.iid, req.params.id);
+      if (!savedIntegration) {
+        return res.status(404).json({ error: "Integration not found" });
+      }
+      result = await verifyWecomForOpenClawAgent(agent, savedIntegration.config || {}, {
+        runContainerCommand,
+        rpcCall,
+      });
+      if (result?.activation) {
+        await updateWecomActivationState(req.params.id, req.params.iid, result.activation).catch(() => null);
+      }
+    } else {
+      result = await integrations.testIntegration(req.params.iid, req.params.id);
+    }
     res.json(result);
   } catch (e) {
     res.status(e.statusCode || 500).json({ error: e.message });

--- a/backend-api/routes/integrations.ts
+++ b/backend-api/routes/integrations.ts
@@ -799,7 +799,10 @@ async function activateWecomIntegration(agent, agentId, integrationId) {
       runContainerCommand,
       rpcCall,
     });
-    return (await updateWecomActivationState(agentId, integrationId, outcome.activation)) || savedIntegration;
+    return (
+      (await updateWecomActivationState(agentId, integrationId, outcome.activation)) ||
+      savedIntegration
+    );
   } catch (error) {
     const message =
       String(error?.message || "WeCom activation failed.")
@@ -1100,7 +1103,10 @@ router.post("/agents/:id/integrations/:iid/test", async (req, res) => {
     let result;
 
     if (current?.provider === "wecom" && runtimeFamily === "openclaw") {
-      const savedIntegration = await integrations.getDecryptedIntegration(req.params.iid, req.params.id);
+      const savedIntegration = await integrations.getDecryptedIntegration(
+        req.params.iid,
+        req.params.id,
+      );
       if (!savedIntegration) {
         return res.status(404).json({ error: "Integration not found" });
       }
@@ -1109,7 +1115,9 @@ router.post("/agents/:id/integrations/:iid/test", async (req, res) => {
         rpcCall,
       });
       if (result?.activation) {
-        await updateWecomActivationState(req.params.id, req.params.iid, result.activation).catch(() => null);
+        await updateWecomActivationState(req.params.id, req.params.iid, result.activation).catch(
+          () => null,
+        );
       }
     } else {
       result = await integrations.testIntegration(req.params.iid, req.params.id);

--- a/frontend-dashboard/components/agents/ActiveIntegrationRow.tsx
+++ b/frontend-dashboard/components/agents/ActiveIntegrationRow.tsx
@@ -2,6 +2,7 @@ import { ChevronRight, Mail, Clock3 } from "lucide-react";
 
 export default function ActiveIntegrationRow({ integration, selected, onSelect }: any) {
   const providerName = integration.name || integration.catalog_name || integration.provider;
+  const isWecomIntegration = integration.provider === "wecom";
   const mailboxIdentity =
     integration.config?.auth?.username ||
     integration.config?.smtp?.fromAddress ||
@@ -9,9 +10,27 @@ export default function ActiveIntegrationRow({ integration, selected, onSelect }
     "Connected integration";
   const providerPreset = integration.config?.providerPreset || integration.provider;
   const cronEnabled = Boolean(integration?.config?.cron?.enabled && integration?.cron_job_id);
+  const wecomMode = integration?.config?.mode || "bot";
+  const wecomReadiness = integration?.config?.activation?.readiness || "pending_activation";
+  const wecomLifecycle = integration?.config?.activation?.lifecycleStatus || "saved";
   const statusText = cronEnabled
     ? `Reminder cron active every ${integration.config?.cron?.intervalMinutes || 60} minutes`
     : "No reminder cron configured";
+  const summaryText = isWecomIntegration
+    ? `${wecomMode.charAt(0).toUpperCase()}${wecomMode.slice(1)} mode`
+    : mailboxIdentity;
+  const detailText = isWecomIntegration
+    ? `${wecomLifecycle.replace(/_/g, " ")} • ${wecomReadiness.replace(/_/g, " ")}`
+    : statusText;
+  const stateDotClass = isWecomIntegration
+    ? wecomReadiness === "ready"
+      ? "bg-emerald-500"
+      : wecomReadiness === "error"
+        ? "bg-rose-500"
+        : "bg-amber-500"
+    : cronEnabled
+      ? "bg-blue-500"
+      : "bg-slate-300";
 
   return (
     <button
@@ -26,9 +45,7 @@ export default function ActiveIntegrationRow({ integration, selected, onSelect }
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0 flex-1">
           <div className="flex items-center gap-2">
-            <div
-              className={`h-2.5 w-2.5 rounded-full ${cronEnabled ? "bg-blue-500" : "bg-slate-300"}`}
-            />
+            <div className={`h-2.5 w-2.5 rounded-full ${stateDotClass}`} />
             <span className="truncate text-sm font-bold text-slate-900">{providerName}</span>
             <span className="rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide text-slate-500">
               {providerPreset}
@@ -36,11 +53,11 @@ export default function ActiveIntegrationRow({ integration, selected, onSelect }
           </div>
           <div className="mt-2 flex items-center gap-2 text-xs text-slate-500">
             <Mail size={12} />
-            <span className="truncate">{mailboxIdentity}</span>
+            <span className="truncate">{summaryText}</span>
           </div>
           <div className="mt-1 flex items-center gap-2 text-xs text-slate-500">
             <Clock3 size={12} />
-            <span className="truncate">{statusText}</span>
+            <span className="truncate">{detailText}</span>
           </div>
         </div>
         <ChevronRight size={16} className="mt-1 shrink-0 text-slate-400" />

--- a/frontend-dashboard/components/agents/IntegrationCard.tsx
+++ b/frontend-dashboard/components/agents/IntegrationCard.tsx
@@ -255,7 +255,9 @@ export default function IntegrationCard({
   });
   const isWecomIntegration = (item?.id || item?.provider || item?.catalog_id) === "wecom";
   const installedConfig =
-    item?.installed?.config && typeof item.installed.config === "object" ? item.installed.config : {};
+    item?.installed?.config && typeof item.installed.config === "object"
+      ? item.installed.config
+      : {};
   const wecomMode = (configValues as any).mode || (installedConfig as any).mode || "bot";
   const cronToggleField = isEmailIntegration
     ? configFields.find((field) => field.key === "cron.enabled")
@@ -345,9 +347,7 @@ export default function IntegrationCard({
 
     return (
       <div className="space-y-4">
-        {shared.length > 0 ? (
-          <div className="space-y-3">{shared.map(renderField)}</div>
-        ) : null}
+        {shared.length > 0 ? <div className="space-y-3">{shared.map(renderField)}</div> : null}
 
         <div className="space-y-4">
           <div className="rounded-lg border border-sky-200 bg-sky-50/70 p-3">
@@ -587,87 +587,88 @@ export default function IntegrationCard({
                   )}
                 </div>
               )}
-              {isWecomIntegration ? renderWecomModeSections(basicFields) : basicFields.map(renderField)}
+              {isWecomIntegration
+                ? renderWecomModeSections(basicFields)
+                : basicFields.map(renderField)}
 
-              {(advancedFields.length > 0 || (isEmailIntegration && (cronToggleField || cronConfigFields.length > 0))) && (
-                  <div className="rounded-xl border border-slate-200 bg-slate-50/70">
-                    <button
-                      type="button"
-                      onClick={() => setShowAdvanced((prev) => !prev)}
-                      className="w-full flex items-center justify-between px-3 py-2 text-left"
-                    >
-                      <div>
-                        <div className="text-[11px] font-bold text-slate-800">
-                          {isEmailIntegration
-                            ? "Advanced Connection & Cron Settings"
-                            : "Advanced Configuration"}
-                        </div>
-                        <div className="text-[10px] text-slate-500">
-                          {isEmailIntegration
-                            ? "Provider defaults are prefilled. Use this section for custom server overrides and the optional reminder cron."
-                            : "Optional provider-specific fields live here so the main connect flow stays focused on the default setup."}
-                        </div>
+              {(advancedFields.length > 0 ||
+                (isEmailIntegration && (cronToggleField || cronConfigFields.length > 0))) && (
+                <div className="rounded-xl border border-slate-200 bg-slate-50/70">
+                  <button
+                    type="button"
+                    onClick={() => setShowAdvanced((prev) => !prev)}
+                    className="w-full flex items-center justify-between px-3 py-2 text-left"
+                  >
+                    <div>
+                      <div className="text-[11px] font-bold text-slate-800">
+                        {isEmailIntegration
+                          ? "Advanced Connection & Cron Settings"
+                          : "Advanced Configuration"}
                       </div>
-                      <span className="text-[10px] font-bold text-slate-500">
-                        {showAdvanced ? "Hide" : "Show"}
-                      </span>
-                    </button>
-                    {showAdvanced && (
-                      <div className="border-t border-slate-200 p-3 space-y-3">
-                        {advancedFields.length > 0 && (
-                          <div className="space-y-3">
-                            <div>
-                              <div className="text-[11px] font-bold text-slate-800">
-                                {isEmailIntegration
-                                  ? "Connection Overrides"
-                                  : "Advanced Fields"}
-                              </div>
-                              <div className="mt-1 text-[10px] text-slate-500">
-                                {isEmailIntegration
-                                  ? "Adjust IMAP and SMTP host settings only if you need something other than the preset defaults."
-                                  : "These settings are optional and usually only needed for more customized provider behavior."}
-                              </div>
-                            </div>
-                            {isWecomIntegration ? (
-                              renderWecomModeSections(advancedFields)
-                            ) : (
-                              <div className="grid gap-3 md:grid-cols-2">
-                                {advancedFields.map(renderField)}
-                              </div>
-                            )}
-                          </div>
-                        )}
-
-                        {isEmailIntegration && (cronToggleField || cronConfigFields.length > 0) && (
-                          <div className="space-y-3 rounded-lg border border-slate-200 bg-white p-3">
-                            <div>
-                              <div className="text-[11px] font-bold text-slate-800">
-                                Reminder Cron
-                              </div>
-                              <div className="mt-1 text-[10px] text-slate-500">
-                                Nora can optionally create a normal scheduled agent turn seeded from
-                                this mailbox connection.
-                              </div>
-                            </div>
-
-                            {cronToggleField ? renderField(cronToggleField) : null}
-
-                            {cronEnabled ? (
-                              <div className="grid gap-3 md:grid-cols-2">
-                                {cronConfigFields.map(renderField)}
-                              </div>
-                            ) : (
-                              <div className="rounded-lg border border-dashed border-slate-200 bg-slate-50 px-3 py-2 text-[11px] text-slate-500">
-                                Turn on the reminder cron to choose how often it runs and what
-                                prompt it should use.
-                              </div>
-                            )}
-                          </div>
-                        )}
+                      <div className="text-[10px] text-slate-500">
+                        {isEmailIntegration
+                          ? "Provider defaults are prefilled. Use this section for custom server overrides and the optional reminder cron."
+                          : "Optional provider-specific fields live here so the main connect flow stays focused on the default setup."}
                       </div>
-                    )}
-                  </div>
-                )}
+                    </div>
+                    <span className="text-[10px] font-bold text-slate-500">
+                      {showAdvanced ? "Hide" : "Show"}
+                    </span>
+                  </button>
+                  {showAdvanced && (
+                    <div className="border-t border-slate-200 p-3 space-y-3">
+                      {advancedFields.length > 0 && (
+                        <div className="space-y-3">
+                          <div>
+                            <div className="text-[11px] font-bold text-slate-800">
+                              {isEmailIntegration ? "Connection Overrides" : "Advanced Fields"}
+                            </div>
+                            <div className="mt-1 text-[10px] text-slate-500">
+                              {isEmailIntegration
+                                ? "Adjust IMAP and SMTP host settings only if you need something other than the preset defaults."
+                                : "These settings are optional and usually only needed for more customized provider behavior."}
+                            </div>
+                          </div>
+                          {isWecomIntegration ? (
+                            renderWecomModeSections(advancedFields)
+                          ) : (
+                            <div className="grid gap-3 md:grid-cols-2">
+                              {advancedFields.map(renderField)}
+                            </div>
+                          )}
+                        </div>
+                      )}
+
+                      {isEmailIntegration && (cronToggleField || cronConfigFields.length > 0) && (
+                        <div className="space-y-3 rounded-lg border border-slate-200 bg-white p-3">
+                          <div>
+                            <div className="text-[11px] font-bold text-slate-800">
+                              Reminder Cron
+                            </div>
+                            <div className="mt-1 text-[10px] text-slate-500">
+                              Nora can optionally create a normal scheduled agent turn seeded from
+                              this mailbox connection.
+                            </div>
+                          </div>
+
+                          {cronToggleField ? renderField(cronToggleField) : null}
+
+                          {cronEnabled ? (
+                            <div className="grid gap-3 md:grid-cols-2">
+                              {cronConfigFields.map(renderField)}
+                            </div>
+                          ) : (
+                            <div className="rounded-lg border border-dashed border-slate-200 bg-slate-50 px-3 py-2 text-[11px] text-slate-500">
+                              Turn on the reminder cron to choose how often it runs and what prompt
+                              it should use.
+                            </div>
+                          )}
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
             </div>
             {/* Test result banner in modal */}
             {testResult && (

--- a/frontend-dashboard/components/agents/IntegrationCard.tsx
+++ b/frontend-dashboard/components/agents/IntegrationCard.tsx
@@ -11,6 +11,7 @@ import {
   ExternalLink,
   Cpu,
 } from "lucide-react";
+import { buildInitialValues, partitionVisibleFields } from "./integrationFormUtils";
 
 type IntegrationCardProps = {
   item: any;
@@ -64,6 +65,34 @@ const EMAIL_CONNECTION_ADVANCED_KEYS = new Set([
   "smtp.port",
   "smtp.secure",
 ]);
+
+function isWecomBotField(field: any) {
+  return typeof field?.key === "string" && field.key.startsWith("defaultAccount.bot.");
+}
+
+function isWecomAgentField(field: any) {
+  return typeof field?.key === "string" && field.key.startsWith("defaultAccount.agent.");
+}
+
+function partitionWecomModeFields(fields: any[]) {
+  const shared: any[] = [];
+  const bot: any[] = [];
+  const agent: any[] = [];
+
+  for (const field of fields || []) {
+    if (isWecomBotField(field)) {
+      bot.push(field);
+      continue;
+    }
+    if (isWecomAgentField(field)) {
+      agent.push(field);
+      continue;
+    }
+    shared.push(field);
+  }
+
+  return { shared, bot, agent };
+}
 
 const EMAIL_CRON_KEYS = new Set(["cron.enabled", "cron.intervalMinutes", "cron.prompt"]);
 
@@ -123,13 +152,7 @@ export default function IntegrationCard({
   }
 
   function buildInitialConfigValues() {
-    const initialValues = configFields.reduce(
-      (acc, field) => {
-        if (field.defaultValue !== undefined) acc[field.key] = field.defaultValue;
-        return acc;
-      },
-      {} as Record<string, any>,
-    );
+    const initialValues = buildInitialValues({}, configFields);
     return applyEmailPresetDefaults(initialValues);
   }
 
@@ -227,15 +250,13 @@ export default function IntegrationCard({
     }
   }
 
-  const basicFields = isEmailIntegration
-    ? configFields.filter(
-        (field) =>
-          !EMAIL_CONNECTION_ADVANCED_KEYS.has(field.key) && !EMAIL_CRON_KEYS.has(field.key),
-      )
-    : configFields;
-  const advancedConnectionFields = isEmailIntegration
-    ? configFields.filter((field) => EMAIL_CONNECTION_ADVANCED_KEYS.has(field.key))
-    : [];
+  const { basicFields, advancedFields } = partitionVisibleFields(configFields, configValues, {
+    advancedKeys: isEmailIntegration ? EMAIL_CONNECTION_ADVANCED_KEYS : undefined,
+  });
+  const isWecomIntegration = (item?.id || item?.provider || item?.catalog_id) === "wecom";
+  const installedConfig =
+    item?.installed?.config && typeof item.installed.config === "object" ? item.installed.config : {};
+  const wecomMode = (configValues as any).mode || (installedConfig as any).mode || "bot";
   const cronToggleField = isEmailIntegration
     ? configFields.find((field) => field.key === "cron.enabled")
     : null;
@@ -252,6 +273,9 @@ export default function IntegrationCard({
         <label className="text-[10px] text-slate-500 font-bold uppercase tracking-widest block mb-1">
           {field.label} {field.required && <span className="text-red-400">*</span>}
         </label>
+        {field.description ? (
+          <p className="mb-1 text-[10px] leading-relaxed text-slate-500">{field.description}</p>
+        ) : null}
         {field.type === "textarea" ? (
           <textarea
             value={configValues[field.key] || ""}
@@ -307,6 +331,45 @@ export default function IntegrationCard({
             className="w-full text-xs border border-slate-200 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
           />
         )}
+      </div>
+    );
+  }
+
+  function renderWecomModeSections(fields: any[]) {
+    const { shared, bot, agent } = partitionWecomModeFields(fields);
+    const shouldSeparate = wecomMode === "both" && bot.length > 0 && agent.length > 0;
+
+    if (!shouldSeparate) {
+      return <div className="space-y-3">{fields.map(renderField)}</div>;
+    }
+
+    return (
+      <div className="space-y-4">
+        {shared.length > 0 ? (
+          <div className="space-y-3">{shared.map(renderField)}</div>
+        ) : null}
+
+        <div className="space-y-4">
+          <div className="rounded-lg border border-sky-200 bg-sky-50/70 p-3">
+            <div className="mb-3">
+              <div className="text-[11px] font-bold text-sky-800">Bot Configuration</div>
+              <div className="mt-1 text-[10px] text-sky-900/75">
+                WebSocket bot settings and credentials used for the Bot channel path.
+              </div>
+            </div>
+            <div className="space-y-3">{bot.map(renderField)}</div>
+          </div>
+
+          <div className="rounded-lg border border-emerald-200 bg-emerald-50/70 p-3">
+            <div className="mb-3">
+              <div className="text-[11px] font-bold text-emerald-800">Agent Configuration</div>
+              <div className="mt-1 text-[10px] text-emerald-900/75">
+                Enterprise app credentials and callback settings used for Agent mode.
+              </div>
+            </div>
+            <div className="space-y-3">{agent.map(renderField)}</div>
+          </div>
+        </div>
       </div>
     );
   }
@@ -524,12 +587,9 @@ export default function IntegrationCard({
                   )}
                 </div>
               )}
-              {basicFields.map(renderField)}
+              {isWecomIntegration ? renderWecomModeSections(basicFields) : basicFields.map(renderField)}
 
-              {isEmailIntegration &&
-                (advancedConnectionFields.length > 0 ||
-                  cronToggleField ||
-                  cronConfigFields.length > 0) && (
+              {(advancedFields.length > 0 || (isEmailIntegration && (cronToggleField || cronConfigFields.length > 0))) && (
                   <div className="rounded-xl border border-slate-200 bg-slate-50/70">
                     <button
                       type="button"
@@ -538,11 +598,14 @@ export default function IntegrationCard({
                     >
                       <div>
                         <div className="text-[11px] font-bold text-slate-800">
-                          Advanced Connection & Cron Settings
+                          {isEmailIntegration
+                            ? "Advanced Connection & Cron Settings"
+                            : "Advanced Configuration"}
                         </div>
                         <div className="text-[10px] text-slate-500">
-                          Provider defaults are prefilled. Use this section for custom server
-                          overrides and the optional reminder cron.
+                          {isEmailIntegration
+                            ? "Provider defaults are prefilled. Use this section for custom server overrides and the optional reminder cron."
+                            : "Optional provider-specific fields live here so the main connect flow stays focused on the default setup."}
                         </div>
                       </div>
                       <span className="text-[10px] font-bold text-slate-500">
@@ -551,24 +614,31 @@ export default function IntegrationCard({
                     </button>
                     {showAdvanced && (
                       <div className="border-t border-slate-200 p-3 space-y-3">
-                        {advancedConnectionFields.length > 0 && (
+                        {advancedFields.length > 0 && (
                           <div className="space-y-3">
                             <div>
                               <div className="text-[11px] font-bold text-slate-800">
-                                Connection Overrides
+                                {isEmailIntegration
+                                  ? "Connection Overrides"
+                                  : "Advanced Fields"}
                               </div>
                               <div className="mt-1 text-[10px] text-slate-500">
-                                Adjust IMAP and SMTP host settings only if you need something other
-                                than the preset defaults.
+                                {isEmailIntegration
+                                  ? "Adjust IMAP and SMTP host settings only if you need something other than the preset defaults."
+                                  : "These settings are optional and usually only needed for more customized provider behavior."}
                               </div>
                             </div>
-                            <div className="grid gap-3 md:grid-cols-2">
-                              {advancedConnectionFields.map(renderField)}
-                            </div>
+                            {isWecomIntegration ? (
+                              renderWecomModeSections(advancedFields)
+                            ) : (
+                              <div className="grid gap-3 md:grid-cols-2">
+                                {advancedFields.map(renderField)}
+                              </div>
+                            )}
                           </div>
                         )}
 
-                        {(cronToggleField || cronConfigFields.length > 0) && (
+                        {isEmailIntegration && (cronToggleField || cronConfigFields.length > 0) && (
                           <div className="space-y-3 rounded-lg border border-slate-200 bg-white p-3">
                             <div>
                               <div className="text-[11px] font-bold text-slate-800">

--- a/frontend-dashboard/components/agents/IntegrationDetailPanel.tsx
+++ b/frontend-dashboard/components/agents/IntegrationDetailPanel.tsx
@@ -10,6 +10,12 @@ import {
   Link2,
   Loader2,
 } from "lucide-react";
+import {
+  buildInitialValues,
+  normalizeFieldValue,
+  partitionVisibleFields,
+  readFieldValue,
+} from "./integrationFormUtils";
 
 const REDACTED_SECRET = "[REDACTED]";
 const EMAIL_CONNECTION_ADVANCED_KEYS = new Set([
@@ -20,8 +26,7 @@ const EMAIL_CONNECTION_ADVANCED_KEYS = new Set([
   "smtp.port",
   "smtp.secure",
 ]);
-
-const EMAIL_CRON_KEYS = new Set(["cron.enabled", "cron.intervalMinutes", "cron.prompt"]);
+const DEFAULT_WECOM_AGENT_CALLBACK_PATH = "/plugins/wecom/agent/default";
 
 function connectionStatusLabel(integration: any) {
   return integration?.status || "active";
@@ -35,32 +40,32 @@ function providerPresetLabel(config: any, provider: string) {
   return config?.providerPreset || provider || "custom";
 }
 
-function readFieldValue(source: any, key: string) {
-  return key.split(".").reduce((acc, part) => (acc == null ? undefined : acc[part]), source);
+function isWecomBotField(field: any) {
+  return typeof field?.key === "string" && field.key.startsWith("defaultAccount.bot.");
 }
 
-function normalizeFieldValue(field: any, value: any) {
-  if (field.type === "checkbox") return Boolean(value ?? field.defaultValue ?? false);
-  if (field.type === "number") {
-    if (value == null || value === "") return "";
-    const parsed = Number(value);
-    return Number.isFinite(parsed) ? parsed : "";
+function isWecomAgentField(field: any) {
+  return typeof field?.key === "string" && field.key.startsWith("defaultAccount.agent.");
+}
+
+function partitionWecomModeFields(fields: any[]) {
+  const shared: any[] = [];
+  const bot: any[] = [];
+  const agent: any[] = [];
+
+  for (const field of fields || []) {
+    if (isWecomBotField(field)) {
+      bot.push(field);
+      continue;
+    }
+    if (isWecomAgentField(field)) {
+      agent.push(field);
+      continue;
+    }
+    shared.push(field);
   }
-  if (field.type === "password") return "";
-  return value ?? field.defaultValue ?? "";
-}
 
-function buildInitialValues(integration: any, configFields: any[]) {
-  return (configFields || []).reduce(
-    (acc, field) => {
-      acc[field.key] = normalizeFieldValue(
-        field,
-        readFieldValue(integration?.config || {}, field.key),
-      );
-      return acc;
-    },
-    {} as Record<string, any>,
-  );
+  return { shared, bot, agent };
 }
 
 export default function IntegrationDetailPanel({
@@ -84,7 +89,7 @@ export default function IntegrationDetailPanel({
       setFormValues({});
       return;
     }
-    setFormValues(buildInitialValues(integration, configFields));
+    setFormValues(buildInitialValues(integration?.config || {}, configFields));
     setConfigExpanded(false);
     setAdvancedExpanded(false);
   }, [integration, configFields]);
@@ -99,23 +104,29 @@ export default function IntegrationDetailPanel({
 
   const name = integration.name || integration.catalog_name || integration.provider;
   const config = integration.config || {};
-  const basicFields =
-    integration.provider === "email"
-      ? configFields.filter(
-          (field: any) =>
-            !EMAIL_CONNECTION_ADVANCED_KEYS.has(field.key) && !EMAIL_CRON_KEYS.has(field.key),
-        )
-      : configFields;
-  const advancedConnectionFields =
-    integration.provider === "email"
-      ? configFields.filter((field: any) => EMAIL_CONNECTION_ADVANCED_KEYS.has(field.key))
-      : [];
+  const isEmailIntegration = integration.provider === "email";
+  const isWecomIntegration = integration.provider === "wecom";
+  const wecomMode = config?.mode || "bot";
+  const wecomActivation = config?.activation || {};
+  const wecomCallbackPath =
+    config?.defaultAccount?.agent?.callbackPath || DEFAULT_WECOM_AGENT_CALLBACK_PATH;
+  const wecomCallbackUrl = useMemo(() => {
+    if (typeof window === "undefined" || !wecomCallbackPath) return "";
+    try {
+      return new URL(wecomCallbackPath, window.location.origin).toString();
+    } catch {
+      return wecomCallbackPath;
+    }
+  }, [wecomCallbackPath]);
+  const { basicFields, advancedFields } = partitionVisibleFields(configFields, formValues, {
+    advancedKeys: isEmailIntegration ? EMAIL_CONNECTION_ADVANCED_KEYS : undefined,
+  });
   const cronToggleField =
-    integration.provider === "email"
+    isEmailIntegration
       ? configFields.find((field: any) => field.key === "cron.enabled")
       : null;
   const cronConfigFields =
-    integration.provider === "email"
+    isEmailIntegration
       ? configFields.filter(
           (field: any) => field.key === "cron.intervalMinutes" || field.key === "cron.prompt",
         )
@@ -165,6 +176,9 @@ export default function IntegrationDetailPanel({
         <label className="mb-1 block text-xs font-bold text-slate-600">
           {field.label} {field.required ? <span className="text-rose-500">*</span> : null}
         </label>
+        {field.description ? (
+          <p className="mb-1 text-xs leading-relaxed text-slate-500">{field.description}</p>
+        ) : null}
         {field.type === "textarea" ? (
           <textarea
             value={value ?? ""}
@@ -232,6 +246,49 @@ export default function IntegrationDetailPanel({
     );
   }
 
+  function renderWecomModeSections(fields: any[]) {
+    const { shared, bot, agent } = partitionWecomModeFields(fields);
+    const shouldSeparate = wecomMode === "both" && bot.length > 0 && agent.length > 0;
+
+    if (!shouldSeparate) {
+      return <div className="grid gap-3 md:grid-cols-2">{fields.map(renderField)}</div>;
+    }
+
+    return (
+      <div className="space-y-4">
+        {shared.length > 0 ? (
+          <div className="grid gap-3 md:grid-cols-2">{shared.map(renderField)}</div>
+        ) : null}
+
+        <div className="grid gap-4 lg:grid-cols-2">
+          <div className="rounded-xl border border-sky-200 bg-sky-50/70 p-4">
+            <div className="mb-3">
+              <div className="text-xs font-bold uppercase tracking-wide text-sky-700">
+                Bot Configuration
+              </div>
+              <p className="mt-1 text-xs text-sky-900/75">
+                WebSocket bot credentials used for the Bot connection path.
+              </p>
+            </div>
+            <div className="space-y-3">{bot.map(renderField)}</div>
+          </div>
+
+          <div className="rounded-xl border border-emerald-200 bg-emerald-50/70 p-4">
+            <div className="mb-3">
+              <div className="text-xs font-bold uppercase tracking-wide text-emerald-700">
+                Agent Configuration
+              </div>
+              <p className="mt-1 text-xs text-emerald-900/75">
+                Enterprise app credentials and callback settings used for Agent mode.
+              </p>
+            </div>
+            <div className="space-y-3">{agent.map(renderField)}</div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
       <div className="flex items-start justify-between gap-3">
@@ -252,59 +309,193 @@ export default function IntegrationDetailPanel({
       </div>
 
       <div className="mt-6 grid gap-4 md:grid-cols-2">
-        <section className="rounded-xl border border-slate-100 bg-slate-50 p-4">
-          <div className="flex items-center gap-2 text-xs font-bold uppercase tracking-wide text-slate-500">
-            <Mail size={12} />
-            Mailbox Summary
-          </div>
-          <dl className="mt-3 space-y-2 text-sm">
-            <div>
-              <dt className="text-xs text-slate-500">Mailbox Identity</dt>
-              <dd className="font-medium text-slate-900">
-                {config?.auth?.username || config?.smtp?.fromAddress || "Not configured"}
-              </dd>
-            </div>
-            <div>
-              <dt className="text-xs text-slate-500">From Address</dt>
-              <dd className="font-medium text-slate-900">
-                {config?.smtp?.fromAddress || config?.from_address || "Not configured"}
-              </dd>
-            </div>
-            <div>
-              <dt className="text-xs text-slate-500">Auth Mode</dt>
-              <dd className="font-medium capitalize text-slate-900">{authModeLabel(config)}</dd>
-            </div>
-          </dl>
-        </section>
+        {isEmailIntegration ? (
+          <>
+            <section className="rounded-xl border border-slate-100 bg-slate-50 p-4">
+              <div className="flex items-center gap-2 text-xs font-bold uppercase tracking-wide text-slate-500">
+                <Mail size={12} />
+                Mailbox Summary
+              </div>
+              <dl className="mt-3 space-y-2 text-sm">
+                <div>
+                  <dt className="text-xs text-slate-500">Mailbox Identity</dt>
+                  <dd className="font-medium text-slate-900">
+                    {config?.auth?.username || config?.smtp?.fromAddress || "Not configured"}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-slate-500">From Address</dt>
+                  <dd className="font-medium text-slate-900">
+                    {config?.smtp?.fromAddress || config?.from_address || "Not configured"}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-slate-500">Auth Mode</dt>
+                  <dd className="font-medium capitalize text-slate-900">{authModeLabel(config)}</dd>
+                </div>
+              </dl>
+            </section>
 
-        <section className="rounded-xl border border-slate-100 bg-slate-50 p-4">
-          <div className="flex items-center gap-2 text-xs font-bold uppercase tracking-wide text-slate-500">
-            <Clock size={12} />
-            Cron Setup
-          </div>
-          <dl className="mt-3 space-y-2 text-sm">
-            <div>
-              <dt className="text-xs text-slate-500">Reminder Cron Enabled</dt>
-              <dd className="font-medium text-slate-900">{config?.cron?.enabled ? "Yes" : "No"}</dd>
+            <section className="rounded-xl border border-slate-100 bg-slate-50 p-4">
+              <div className="flex items-center gap-2 text-xs font-bold uppercase tracking-wide text-slate-500">
+                <Clock size={12} />
+                Cron Setup
+              </div>
+              <dl className="mt-3 space-y-2 text-sm">
+                <div>
+                  <dt className="text-xs text-slate-500">Reminder Cron Enabled</dt>
+                  <dd className="font-medium text-slate-900">
+                    {config?.cron?.enabled ? "Yes" : "No"}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-slate-500">Interval</dt>
+                  <dd className="font-medium text-slate-900">
+                    {config?.cron?.enabled
+                      ? config?.cron?.intervalMinutes
+                        ? `${config.cron.intervalMinutes} minutes`
+                        : "Not configured"
+                      : "Disabled"}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-slate-500">Prompt</dt>
+                  <dd className="font-medium text-slate-900">
+                    {config?.cron?.enabled ? config?.cron?.prompt || "Not configured" : "Disabled"}
+                  </dd>
+                </div>
+              </dl>
+            </section>
+          </>
+        ) : isWecomIntegration ? (
+          <>
+            <section className="rounded-xl border border-slate-100 bg-slate-50 p-4">
+              <div className="flex items-center gap-2 text-xs font-bold uppercase tracking-wide text-slate-500">
+                <Mail size={12} />
+                WeCom Summary
+              </div>
+              <dl className="mt-3 space-y-2 text-sm">
+                <div>
+                  <dt className="text-xs text-slate-500">Mode</dt>
+                  <dd className="font-medium capitalize text-slate-900">
+                    {config?.mode || "Not configured"}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-slate-500">Default Account</dt>
+                  <dd className="font-medium text-slate-900">
+                    {config?.defaultAccount?.label || "Default"}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-slate-500">Extra Accounts</dt>
+                  <dd className="font-medium text-slate-900">
+                    {Array.isArray(config?.accounts) ? config.accounts.length : 0}
+                  </dd>
+                </div>
+              </dl>
+            </section>
+
+            <section className="rounded-xl border border-slate-100 bg-slate-50 p-4">
+              <div className="flex items-center gap-2 text-xs font-bold uppercase tracking-wide text-slate-500">
+                <Clock size={12} />
+                Activation State
+              </div>
+              <dl className="mt-3 space-y-2 text-sm">
+                <div>
+                  <dt className="text-xs text-slate-500">Lifecycle</dt>
+                  <dd className="font-medium text-slate-900">
+                    {config?.activation?.lifecycleStatus || "saved"}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-slate-500">Readiness</dt>
+                  <dd className="font-medium text-slate-900">
+                    {config?.activation?.readiness || "pending_activation"}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-slate-500">Callback Path</dt>
+                  <dd className="font-medium text-slate-900">
+                    {wecomCallbackPath || "Not configured"}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-slate-500">Browser-Resolved Callback URL</dt>
+                  <dd className="break-all font-medium text-slate-900">
+                    {wecomCallbackUrl || "Not available in this browser context"}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-slate-500">Last Verified</dt>
+                  <dd className="font-medium text-slate-900">
+                    {wecomActivation?.lastVerifiedAt
+                      ? new Date(wecomActivation.lastVerifiedAt).toLocaleString()
+                      : "Not yet verified"}
+                  </dd>
+                </div>
+              </dl>
+            </section>
+
+            <section className="rounded-xl border border-slate-100 bg-slate-50 p-4 md:col-span-2">
+              <div className="flex items-center gap-2 text-xs font-bold uppercase tracking-wide text-slate-500">
+                <Shield size={12} />
+                Operator Guidance
+              </div>
+              <div className="mt-3 space-y-2 text-sm text-slate-700">
+                {wecomActivation?.lastError ? (
+                  <p className="rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-rose-700">
+                    {wecomActivation.lastError}
+                  </p>
+                ) : null}
+                {wecomActivation?.readiness === "pending_activation" ? (
+                  <p>
+                    Start the OpenClaw agent, then run <span className="font-medium">Test</span> to
+                    finish plugin verification and refresh the saved activation state.
+                  </p>
+                ) : null}
+                {(wecomMode === "agent" || wecomMode === "both") ? (
+                  <p>
+                    Agent mode still needs the WeCom admin console callback setup to use your public Nora/OpenClaw host with this path:
+                    {" "}
+                    <span className="font-mono text-xs">{wecomCallbackPath}</span>.
+                  </p>
+                ) : null}
+                {(wecomMode === "agent" || wecomMode === "both") && wecomCallbackUrl ? (
+                  <p className="text-xs text-slate-500">
+                    The browser-resolved URL above is only a preview based on the host you are currently using to access Nora. If WeCom reaches Nora through a tunnel or public domain, use that public base URL instead.
+                  </p>
+                ) : null}
+                {wecomActivation?.readiness === "ready" ? (
+                  <p>Runtime activation looks healthy. Re-run Test after any config change to confirm the gateway picked it up.</p>
+                ) : null}
+              </div>
+            </section>
+          </>
+        ) : (
+          <section className="rounded-xl border border-slate-100 bg-slate-50 p-4 md:col-span-2">
+            <div className="flex items-center gap-2 text-xs font-bold uppercase tracking-wide text-slate-500">
+              <Mail size={12} />
+              Integration Summary
             </div>
-            <div>
-              <dt className="text-xs text-slate-500">Interval</dt>
-              <dd className="font-medium text-slate-900">
-                {config?.cron?.enabled
-                  ? config?.cron?.intervalMinutes
-                    ? `${config.cron.intervalMinutes} minutes`
-                    : "Not configured"
-                  : "Disabled"}
-              </dd>
-            </div>
-            <div>
-              <dt className="text-xs text-slate-500">Prompt</dt>
-              <dd className="font-medium text-slate-900">
-                {config?.cron?.enabled ? config?.cron?.prompt || "Not configured" : "Disabled"}
-              </dd>
-            </div>
-          </dl>
-        </section>
+            <dl className="mt-3 grid gap-3 text-sm md:grid-cols-3">
+              <div>
+                <dt className="text-xs text-slate-500">Provider</dt>
+                <dd className="font-medium text-slate-900">{integration.provider}</dd>
+              </div>
+              <div>
+                <dt className="text-xs text-slate-500">Status</dt>
+                <dd className="font-medium text-slate-900">{connectionStatusLabel(integration)}</dd>
+              </div>
+              <div>
+                <dt className="text-xs text-slate-500">Preset</dt>
+                <dd className="font-medium text-slate-900">
+                  {providerPresetLabel(config, integration.provider)}
+                </dd>
+              </div>
+            </dl>
+          </section>
+        )}
 
         <section className="rounded-xl border border-slate-100 bg-slate-50 p-4">
           <div className="flex items-center gap-2 text-xs font-bold uppercase tracking-wide text-slate-500">
@@ -365,11 +556,15 @@ export default function IntegrationDetailPanel({
               />
             </button>
             {configExpanded ? (
-              <div className="mt-3 grid gap-3 md:grid-cols-2">{basicFields.map(renderField)}</div>
+              <div className="mt-3">
+                {isWecomIntegration ? renderWecomModeSections(basicFields) : (
+                  <div className="grid gap-3 md:grid-cols-2">{basicFields.map(renderField)}</div>
+                )}
+              </div>
             ) : null}
           </section>
 
-          {advancedConnectionFields.length > 0 || cronToggleField || cronConfigFields.length > 0 ? (
+          {advancedFields.length > 0 || (isEmailIntegration && (cronToggleField || cronConfigFields.length > 0)) ? (
             <section className="rounded-xl border border-slate-100 bg-slate-50 p-4">
               <button
                 type="button"
@@ -387,20 +582,25 @@ export default function IntegrationDetailPanel({
               </button>
               {advancedExpanded ? (
                 <div className="mt-3 space-y-4">
-                  {advancedConnectionFields.length > 0 ? (
+                  {advancedFields.length > 0 ? (
                     <div className="space-y-3">
                       <div>
                         <div className="text-xs font-bold uppercase tracking-wide text-slate-500">
-                          Connection Overrides
+                          {isEmailIntegration ? "Connection Overrides" : "Advanced Fields"}
                         </div>
                         <p className="mt-1 text-xs text-slate-500">
-                          Adjust IMAP and SMTP server settings only if you need something other than
-                          the provider preset defaults.
+                          {isEmailIntegration
+                            ? "Adjust IMAP and SMTP server settings only if you need something other than the provider preset defaults."
+                            : "Optional provider-specific fields that are usually only needed for a more customized setup."}
                         </p>
                       </div>
-                      <div className="grid gap-3 md:grid-cols-2">
-                        {advancedConnectionFields.map(renderField)}
-                      </div>
+                      {isWecomIntegration ? (
+                        renderWecomModeSections(advancedFields)
+                      ) : (
+                        <div className="grid gap-3 md:grid-cols-2">
+                          {advancedFields.map(renderField)}
+                        </div>
+                      )}
                     </div>
                   ) : null}
 

--- a/frontend-dashboard/components/agents/IntegrationDetailPanel.tsx
+++ b/frontend-dashboard/components/agents/IntegrationDetailPanel.tsx
@@ -121,16 +121,14 @@ export default function IntegrationDetailPanel({
   const { basicFields, advancedFields } = partitionVisibleFields(configFields, formValues, {
     advancedKeys: isEmailIntegration ? EMAIL_CONNECTION_ADVANCED_KEYS : undefined,
   });
-  const cronToggleField =
-    isEmailIntegration
-      ? configFields.find((field: any) => field.key === "cron.enabled")
-      : null;
-  const cronConfigFields =
-    isEmailIntegration
-      ? configFields.filter(
-          (field: any) => field.key === "cron.intervalMinutes" || field.key === "cron.prompt",
-        )
-      : [];
+  const cronToggleField = isEmailIntegration
+    ? configFields.find((field: any) => field.key === "cron.enabled")
+    : null;
+  const cronConfigFields = isEmailIntegration
+    ? configFields.filter(
+        (field: any) => field.key === "cron.intervalMinutes" || field.key === "cron.prompt",
+      )
+    : [];
   const hasCronAssociation = Boolean(integration?.cron_job_id);
   const cronEnabled = Boolean(formValues["cron.enabled"]);
 
@@ -454,20 +452,25 @@ export default function IntegrationDetailPanel({
                     finish plugin verification and refresh the saved activation state.
                   </p>
                 ) : null}
-                {(wecomMode === "agent" || wecomMode === "both") ? (
+                {wecomMode === "agent" || wecomMode === "both" ? (
                   <p>
-                    Agent mode still needs the WeCom admin console callback setup to use your public Nora/OpenClaw host with this path:
-                    {" "}
+                    Agent mode still needs the WeCom admin console callback setup to use your public
+                    Nora/OpenClaw host with this path:{" "}
                     <span className="font-mono text-xs">{wecomCallbackPath}</span>.
                   </p>
                 ) : null}
                 {(wecomMode === "agent" || wecomMode === "both") && wecomCallbackUrl ? (
                   <p className="text-xs text-slate-500">
-                    The browser-resolved URL above is only a preview based on the host you are currently using to access Nora. If WeCom reaches Nora through a tunnel or public domain, use that public base URL instead.
+                    The browser-resolved URL above is only a preview based on the host you are
+                    currently using to access Nora. If WeCom reaches Nora through a tunnel or public
+                    domain, use that public base URL instead.
                   </p>
                 ) : null}
                 {wecomActivation?.readiness === "ready" ? (
-                  <p>Runtime activation looks healthy. Re-run Test after any config change to confirm the gateway picked it up.</p>
+                  <p>
+                    Runtime activation looks healthy. Re-run Test after any config change to confirm
+                    the gateway picked it up.
+                  </p>
                 ) : null}
               </div>
             </section>
@@ -557,14 +560,17 @@ export default function IntegrationDetailPanel({
             </button>
             {configExpanded ? (
               <div className="mt-3">
-                {isWecomIntegration ? renderWecomModeSections(basicFields) : (
+                {isWecomIntegration ? (
+                  renderWecomModeSections(basicFields)
+                ) : (
                   <div className="grid gap-3 md:grid-cols-2">{basicFields.map(renderField)}</div>
                 )}
               </div>
             ) : null}
           </section>
 
-          {advancedFields.length > 0 || (isEmailIntegration && (cronToggleField || cronConfigFields.length > 0)) ? (
+          {advancedFields.length > 0 ||
+          (isEmailIntegration && (cronToggleField || cronConfigFields.length > 0)) ? (
             <section className="rounded-xl border border-slate-100 bg-slate-50 p-4">
               <button
                 type="button"

--- a/frontend-dashboard/components/agents/integrationFormUtils.ts
+++ b/frontend-dashboard/components/agents/integrationFormUtils.ts
@@ -1,0 +1,53 @@
+export function readFieldValue(source: any, key: string) {
+  return key.split(".").reduce((acc, part) => (acc == null ? undefined : acc[part]), source);
+}
+
+export function normalizeFieldValue(field: any, value: any) {
+  if (field.type === "checkbox") return Boolean(value ?? field.defaultValue ?? false);
+  if (field.type === "number") {
+    if (value == null || value === "") return "";
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : "";
+  }
+  if (field.type === "password") return "";
+  return value ?? field.defaultValue ?? "";
+}
+
+export function buildInitialValues(source: any, configFields: any[]) {
+  return (configFields || []).reduce(
+    (acc, field) => {
+      acc[field.key] = normalizeFieldValue(field, readFieldValue(source || {}, field.key));
+      return acc;
+    },
+    {} as Record<string, any>,
+  );
+}
+
+function matchesCondition(expected: any, actual: any) {
+  if (Array.isArray(expected)) return expected.includes(actual);
+  return actual === expected;
+}
+
+export function isFieldVisible(field: any, values: Record<string, any>) {
+  const rules = field?.visibleWhen;
+  if (!rules || typeof rules !== "object") return true;
+  return Object.entries(rules).every(([key, expected]) =>
+    matchesCondition(expected, values[key] ?? readFieldValue(values, key)),
+  );
+}
+
+export function partitionVisibleFields(
+  fields: any[],
+  values: Record<string, any>,
+  options: { advancedKeys?: Set<string> } = {},
+) {
+  const advancedKeys = options.advancedKeys || new Set<string>();
+  const visibleFields = (fields || []).filter((field) => isFieldVisible(field, values));
+  const basicFields = visibleFields.filter(
+    (field) => field.section !== "advanced" && !advancedKeys.has(field.key),
+  );
+  const advancedFields = visibleFields.filter(
+    (field) => field.section === "advanced" || advancedKeys.has(field.key),
+  );
+  return { basicFields, advancedFields };
+}

--- a/plans/wecom_integration/README.md
+++ b/plans/wecom_integration/README.md
@@ -1,0 +1,11 @@
+# WeCom Integration Plans
+
+- Canonical manifest: `wecom_integration_manifest.md`
+- Phased implementation plan: `wecom-integration-plan.md`
+
+Current locked direction:
+- Integration-first, OpenClaw-only for v1
+- Supports both Bot and Agent mode
+- One-click connect
+- Multi-account aware
+- Advanced/plugin-heavy options collapsed by default

--- a/plans/wecom_integration/wecom-integration-plan.md
+++ b/plans/wecom_integration/wecom-integration-plan.md
@@ -1,0 +1,218 @@
+# WeCom Integration Plan
+
+This plan breaks WeCom into small, testable phases with the same general Nora pattern used by the
+existing integration plans: backend contracts first, then operator UI, then runtime activation and
+status semantics. The source of truth for scope, ownership, reusable pieces, and open questions is
+[wecom_integration_manifest.md](/Users/justinchan/Desktop/repos/nora/plans/wecom_integration/wecom_integration_manifest.md).
+
+---
+
+## Phase 0: Scope Lock And Catalog Scaffolding
+### Goal
+Create the minimum catalog and backend scaffolding so WeCom can exist as a first-class integration
+without committing prematurely to every plugin capability.
+
+### Backend
+Files to create/modify:
+- `backend-api/integrations/catalog/catalog.json`
+- `backend-api/integrations/providers/wecom/index.ts`
+- `backend-api/integrations/index.ts`
+- `backend-api/integrations/services/integrationsService.ts`
+- `backend-api/routes/integrations.ts`
+
+Tasks:
+- Add a `wecom` catalog entry.
+- Add config fields for:
+  - top-level mode selector
+  - default account basics
+  - optional extra named accounts in a simple v1 shape
+  - Bot mode basics
+  - Agent mode basics
+  - default policy fields
+  - collapsed Advanced sections for media/network/dynamic-agent-style plugin options
+- Create a placeholder `wecomProvider` registration.
+- Reserve any WeCom-specific route stubs if needed for later activation/test status work.
+- Define an explicit draft activation-state model for WeCom that is stronger than Nora's current
+  generic “active integration row exists” behavior.
+
+Do NOT touch:
+- actual plugin install commands
+- rich multi-account account-card UX
+- dynamic agents as a Nora product feature
+- built-in WeCom skills as separate Nora product surfaces
+
+### Frontend
+Files to create/modify:
+- `frontend-dashboard/components/agents/IntegrationCard.tsx`
+- `frontend-dashboard/components/agents/IntegrationDetailPanel.tsx`
+
+Tasks:
+- Make the integration form capable of mode-first rendering:
+  - user picks Bot / Agent / Both
+  - mode-specific sections appear below
+- Support the agreed UX direction:
+  - advanced sections present but collapsed
+  - defaults prefilled
+- Keep the initial multi-account UX simple and compatible with the existing integrations form
+  pattern rather than introducing a large custom account-management UI.
+- Preserve generic catalog-driven behavior for all other integrations.
+
+### Acceptance Criteria
+- [ ] WeCom exists in the catalog and renders in the Integrations UI.
+- [ ] The UI can conditionally show mode-specific fields from a single WeCom integration entry.
+- [ ] A placeholder provider can be registered without breaking startup.
+- [ ] The plan for WeCom activation state is explicit enough to guide later backend/UI work.
+
+### ✅ Gate
+Do not proceed until the simple v1 multi-account shape and activation-state semantics are confirmed.
+
+---
+
+## Phase 1: Config Storage, Validation, And Redacted Readback
+### Goal
+Persist WeCom config cleanly through the existing integrations system.
+
+### Backend
+Files to create/modify:
+- `backend-api/integrations/providers/wecom/index.ts`
+- `backend-api/integrations/services/integrationsService.ts`
+- `backend-api/integrations/repository/integrationsRepository.ts`
+- `backend-api/__tests__/integrations.test.ts`
+
+Tasks:
+- Implement `normalizeWecomConfigInput(...)`.
+- Define which WeCom fields are secrets and ensure they are encrypted/redacted.
+- Support create, list, update, and disconnect through the existing integration pipeline.
+- Ensure stored config reads back in a UI-friendly nested shape.
+- Support the chosen simple multi-account shape without breaking generic form editing.
+- Introduce the backend representation for saved-vs-activation state if that does not fit cleanly
+  inside the current generic integration `status` semantics.
+
+### Frontend
+Files to create/modify:
+- `frontend-dashboard/components/agents/IntegrationsTab.tsx`
+- `frontend-dashboard/components/agents/IntegrationCard.tsx`
+- `frontend-dashboard/components/agents/IntegrationDetailPanel.tsx`
+
+Tasks:
+- Submit WeCom config through the existing connect/save flow.
+- Preserve password/secret field behavior on edit.
+- Keep the UX mode-first and default-prefilled.
+- Ensure the form can preserve/edit the simple multi-account shape without turning into a bespoke
+  WeCom-only management screen.
+
+### Acceptance Criteria
+- [ ] WeCom integrations can be created and updated through the generic integrations routes.
+- [ ] Sensitive WeCom config is encrypted at rest and redacted on read.
+- [ ] Mode-specific defaults render and persist correctly.
+- [ ] A saved-but-not-yet-activated state can be represented cleanly if activation later fails.
+
+### ✅ Gate
+Do not proceed until the saved config shape is stable.
+
+---
+
+## Phase 2: OpenClaw Plugin Installation And Activation
+### Goal
+Turn a saved WeCom integration into a live capability on OpenClaw agents.
+
+### Backend
+Files to create/modify:
+- `backend-api/routes/integrations.ts`
+- `backend-api/authSync.ts`
+- optional new helper:
+  - `backend-api/integrations/providers/wecom/install.ts`
+- `backend-api/__tests__/agents.test.ts`
+
+Tasks:
+- Add a WeCom-specific post-connect activation step.
+- Implement the locked install strategy:
+  - manual `openclaw plugins install @wecom/wecom-openclaw-plugin`
+  - explicit `openclaw config set ...` writes
+  - Nora-controlled restart/reload
+  - post-activation verification
+- Treat the official WeCom CLI installer and `openclaw channels add` as fallback/manual operator
+  tools rather than Nora's primary automation path.
+- Write the mode-specific OpenClaw config.
+- Restart/reload the gateway using a container-appropriate Nora strategy rather than assuming
+  `openclaw gateway restart` is the right primitive.
+- Return actionable operator errors when install/config verification fails.
+- Decide and implement what happens when persistence succeeds but activation fails:
+  - retain the integration as saved but inactive / activation-failed
+  - surface retryable status to the UI
+
+Do NOT touch:
+- Hermes support
+- rich multi-account routing/bindings UX beyond the chosen simple shape
+- full WeCom skill surfacing
+
+### Acceptance Criteria
+- [ ] Connecting WeCom on an OpenClaw agent can install/configure the plugin.
+- [ ] Updating the integration can reconcile the plugin config safely.
+- [ ] Disconnecting WeCom can disable or clean up the configured runtime state.
+- [ ] The one-click connect flow handles save + activation as a single operator action.
+- [ ] Activation failures produce a stable saved-but-inactive state rather than losing the stored config.
+- [ ] The implementation is validated against Nora's actual containerized OpenClaw environment.
+
+### ✅ Gate
+Do not proceed until a single-agent OpenClaw install flow is reliable.
+
+---
+
+## Phase 3: Status, Test, And Operator Guidance
+### Goal
+Make the integration understandable and supportable from the UI.
+
+### Backend
+Files to create/modify:
+- `backend-api/routes/integrations.ts`
+- optional status helper module(s)
+
+Tasks:
+- Add WeCom-specific test/status behavior if the generic test contract is insufficient.
+- Expose activation/install failures in a clean UI-facing shape.
+- Surface any follow-up instructions still required in the WeCom admin console.
+- Add stronger validation checks that aim beyond “record saved”, ideally including:
+  - plugin installed
+  - config written
+  - gateway healthy
+  - callback/config readiness where detectable
+- Make the activation state model explicit in backend responses and not just implicit in logs.
+
+### Frontend
+Files to create/modify:
+- `frontend-dashboard/components/agents/IntegrationDetailPanel.tsx`
+- `frontend-dashboard/components/agents/ActiveIntegrationRow.tsx`
+
+Tasks:
+- Show mode and activation status clearly.
+- Show any required follow-up steps or callback URL hints.
+- Make it obvious whether the integration is merely saved vs actually active in OpenClaw.
+- Preserve the current Integrations detail-panel look and feel while adding WeCom-specific status
+  cards/summary content.
+
+### Acceptance Criteria
+- [ ] Operators can distinguish saved config from active plugin state.
+- [ ] Errors are clear enough to fix setup without reading backend logs.
+- [ ] Callback URL guidance and readiness hints are visible enough to complete Agent mode setup.
+
+### ✅ Gate
+Do not proceed until the support/debug story is acceptable.
+
+---
+
+## Phase 4: Optional Capability Expansion
+### Goal
+Decide how much of the plugin surface Nora should expose after basic activation works.
+
+Possible follow-up areas:
+- richer policy editing
+- cron/announce patterns for WeCom delivery
+- selected plugin capabilities surfaced intentionally in Nora
+- richer multi-account routing/bindings UX
+- dynamic agent routing
+
+Explicitly not required for MVP:
+- individually modeled plugin-bundled WeCom skills
+- dynamic agents as a Nora-managed product surface
+- advanced media/network tuning as deeply supported Nora features

--- a/plans/wecom_integration/wecom_integration_manifest.md
+++ b/plans/wecom_integration/wecom_integration_manifest.md
@@ -1,0 +1,328 @@
+# WeCom Integration Manifest
+
+## Overview
+
+Add WeCom to Nora as an integration-first feature for OpenClaw agents. The initial scope is
+configuration, installation, and activation of the official WeCom OpenClaw plugin from Nora's
+integrations surface, with messaging treated as a capability of the integration rather than as a
+standalone Nora channel.
+
+The intended operator experience should match Nora's current integrations UX closely. WeCom should
+feel like a first-class catalog integration inside the existing Integrations tab, not like a
+special-case wizard or a separate channel-management screen.
+
+## Ownership
+
+| Layer | Owns |
+|---|---|
+| **Integration** | WeCom connection mode selection, plugin config shape, credential storage, setup/test UX |
+| **Nora** | Integration catalog/UI, secret storage, connect/update/remove flows, plugin install/config orchestration, runtime sync, operator visibility |
+| **OpenClaw plugin** | WeCom protocol handling, callback/websocket handling, delivery behavior, policy enforcement, built-in WeCom capabilities |
+| **Agent** | Uses WeCom messaging and future WeCom tool capabilities once the plugin is installed and configured |
+
+## Locked Decisions
+
+- WeCom should be modeled as an **integration-first** feature, not as a Telegram/WhatsApp-style Nora-native channel.
+- The first setup surface should ask the user which **connection mode** they want:
+  - Bot
+  - Agent
+  - Both
+- The frontend should use catalog-driven fields and prefilled defaults where practical.
+- The first implementation target should be **OpenClaw agents only**.
+- Nora should install/configure the official WeCom OpenClaw plugin rather than reimplementing the WeCom transport itself.
+- V1 should support **both Bot and Agent mode** in the same integration.
+- V1 should live in **Integrations only**, not as a separate Nora Channels feature.
+- Connect should be a **one-click connect** flow: save + install/configure in one action.
+- V1 should allow **multiple WeCom accounts/config entries** within the integration shape.
+- Advanced/plugin-heavy options should be present but **collapsed under Advanced** by default.
+- V1 testing should aim for a **thorough activation check**, not just “config saved”.
+- The WeCom setup and edit experience should follow the **existing Nora integrations look and
+  feel exactly**, using the same catalog card, connect form, active-integrations list, and
+  right-side detail panel patterns rather than introducing a bespoke WeCom-specific screen.
+- Nora's primary automation path should use:
+  - manual plugin install
+  - explicit `openclaw config set ...` writes
+  - Nora-managed restart/reload + verification
+  rather than relying on the interactive WeCom CLI installer as the main one-click path.
+- Plugin-bundled WeCom skills should be treated as **inherited plugin capability content** in v1,
+  not as individually modeled Nora features.
+
+## Current Repo State
+
+| Status | Item |
+|---|---|
+| Exists | Generic integration catalog/UI flow via `integration_catalog`, `catalog.json`, `IntegrationsTab.tsx`, `IntegrationCard.tsx`, and `IntegrationDetailPanel.tsx` |
+| Exists | Generic integration CRUD + sync orchestration via `routes/integrations.ts` and `integrationsService.ts` |
+| Exists | Backend command execution helpers via `runContainerCommand()` and `runRuntimeCommand()` in `backend-api/authSync.ts` |
+| Exists | Worker-side command execution helper via `runProvisionerExecCommand()` in `workers/provisioner/worker.ts` |
+| Exists | Runtime metadata sync endpoint `POST /integrations/sync` in `agent-runtime/lib/server.ts` |
+| Exists | OpenClaw plugin-install precedent in `backend-api/channels/openclaw.ts` |
+| Exists | Current Nora integrations are effectively treated as “connected” once an active integration row is persisted; there is no strong generic activation-state model today |
+| Missing | `wecom` integration catalog entry |
+| Missing | `backend-api/integrations/providers/wecom/` provider module |
+| Missing | WeCom-specific post-connect install/config orchestration |
+| Missing | Clear product decision on whether Nora exposes any WeCom capability beyond connection/messaging/status in v1 |
+
+## Reusable Nora Pieces
+
+### Catalog + UI
+- `backend-api/integrations/catalog/catalog.json`
+- `backend-api/integrations/catalog/catalogLoader.ts`
+- `frontend-dashboard/components/agents/IntegrationsTab.tsx`
+- `frontend-dashboard/components/agents/IntegrationCard.tsx`
+- `frontend-dashboard/components/agents/IntegrationDetailPanel.tsx`
+
+### Persistence + service orchestration
+- `backend-api/integrations/repository/integrationsRepository.ts`
+- `backend-api/integrations/services/integrationsService.ts`
+- `backend-api/routes/integrations.ts`
+
+### Runtime / agent-side installation execution
+- `backend-api/authSync.ts`
+  - `runContainerCommand()`
+  - `runRuntimeCommand()`
+- `workers/provisioner/worker.ts`
+  - `runProvisionerExecCommand()`
+- `backend-api/channels/openclaw.ts`
+  - existing OpenClaw plugin enable/install command patterns
+
+## Frontend UX Contract
+
+The WeCom integration should preserve the same operator interaction model that Nora already uses
+for integrations today.
+
+### Catalog Browse Surface
+
+- WeCom should appear as a normal item in the catalog grid within the Integrations tab.
+- It should participate in the same search/category filtering behavior as other integrations.
+- Clicking the WeCom card should open the same connect/config surface used by existing
+  integrations.
+
+### Connect Surface
+
+- WeCom should use the existing `IntegrationCard`-style setup flow rather than a separate page or
+  wizard.
+- The first visible section should establish **Connection Mode**:
+  - Bot
+  - Agent
+  - Both
+- After mode selection, only the relevant configuration groups should be shown.
+- Defaults should be prefilled where the plugin/README gives clear defaults.
+- Plugin-heavy or less-common settings should appear under the same **collapsed Advanced**
+  treatment already used elsewhere in Nora.
+- The connect action should remain a single operator action: **Connect** should save, attempt
+  activation, and then surface test/activation results inline.
+
+### Active Integration Surface
+
+- Once connected, WeCom should appear in the existing **Active Integrations** master/detail
+  layout.
+- The left side should remain a selectable list of active integrations.
+- The right side should remain the editable detail panel for the selected integration.
+- WeCom should not introduce a separate management page for status/config unless the generic Nora
+  integration layout proves insufficient.
+
+### Detail Panel Expectations
+
+- The right-side detail panel should preserve the same Nora visual structure:
+  - status / summary information at the top
+  - editable configuration below
+  - advanced sections collapsed by default
+  - save / test / disconnect actions in the same general action area
+- WeCom-specific state should be expressed within that existing pattern, for example:
+  - selected mode
+  - activation/install status
+  - callback/setup readiness hints
+  - account summary
+
+### Explicit Non-Goals For V1
+
+- No standalone WeCom onboarding page
+- No separate WeCom-specific channel management surface
+- No custom visual design language that breaks from current Integrations tab behavior
+- No requirement for the operator to leave the Integrations tab to perform ordinary config/edit
+  tasks
+
+## Backend Contract
+
+The backend should treat WeCom as a normal Nora integration record plus a WeCom-specific
+activation/orchestration layer for OpenClaw agents.
+
+### Catalog And Schema Ownership
+
+- The WeCom integration definition should live in
+  `backend-api/integrations/catalog/catalog.json`.
+- The catalog entry should drive the frontend form shape through the existing catalog loader and
+  integration UI pipeline.
+- Mode-specific and advanced WeCom fields should be described in the same catalog-driven way as
+  other integrations rather than through a hardcoded frontend-only form.
+
+### Provider Module Responsibilities
+
+The WeCom provider module should own configuration semantics, not runtime side effects.
+
+Expected responsibilities:
+- normalize the stored config shape
+- validate mode-specific requirements
+- define which fields are secret/sensitive
+- redact secret fields on read
+- optionally map config into runtime-facing env/config representations
+- optionally perform provider-level validation or test logic when feasible
+
+Expected non-responsibilities:
+- direct container exec
+- plugin installation
+- gateway restart/reload
+- long-running orchestration or recovery flows
+
+### Persistence Model
+
+- The connected WeCom integration record should be stored in the existing `integrations` table.
+- The UI/schema metadata should continue to come from `integration_catalog`.
+- The initial WeCom implementation should not require a separate bespoke WeCom table if the config
+  can live cleanly inside `integrations.config`.
+- Multi-account support should be modeled in the integration config shape itself unless a later
+  phase proves that a relational account table is necessary.
+
+### Connect And Update Flow
+
+- `POST /api/agents/:agentId/integrations` should remain the primary entry point for a new WeCom
+  connection.
+- `PUT /api/agents/:agentId/integrations/:integrationId` should remain the primary entry point
+  for WeCom config edits.
+- The generic integrations flow should:
+  1. normalize and validate config
+  2. encrypt/store secrets
+  3. persist the integration row
+  4. trigger WeCom-specific activation work for OpenClaw agents
+
+### Activation / Installation Flow
+
+- Nora should perform activation as part of the one-click connect flow.
+- The activation layer should be responsible for:
+  - ensuring the WeCom plugin is installed
+  - writing the OpenClaw config needed for Bot / Agent / Both mode
+  - restarting or reloading the gateway if required
+  - verifying whether the agent has become activation-ready
+- The activation layer should live in backend orchestration code, not inside the provider's
+  pure config helpers.
+- The preferred automation path should be:
+  1. install the plugin with `openclaw plugins install @wecom/wecom-openclaw-plugin`
+  2. write config explicitly with `openclaw config set channels.wecom...`
+  3. perform a Nora-controlled restart/reload strategy suitable for containerized OpenClaw agents
+  4. verify post-activation readiness/status
+- The official WeCom CLI installer and interactive `openclaw channels add` flow should be treated
+  as manual/operator fallback tools rather than Nora's primary backend automation path.
+
+### Runtime Sync Expectations
+
+- Nora should continue to use the existing integrations sync machinery to send non-sensitive
+  integration metadata into the runtime.
+- If the plugin needs additional runtime-resident config beyond normal metadata sync, that should
+  be treated as part of activation/orchestration rather than as an entirely separate Nora product
+  surface.
+- The runtime sync path should not become the primary owner of WeCom setup semantics; it should
+  remain a secondary propagation mechanism.
+
+### Testing And Verification Expectations
+
+- The backend contract should support a stronger notion of success than “record saved”.
+- Desired verification signals include, where practical:
+  - integration row persisted
+  - plugin installed
+  - config written successfully
+  - gateway restarted/reloaded successfully
+  - runtime/gateway returns healthy status
+  - callback/webhook readiness can be inferred or surfaced when relevant
+- The install path should be validated against Nora's actual containerized OpenClaw environment,
+  not only against the README, because some documented OpenClaw service commands (for example,
+  `openclaw gateway restart`) may not be the right primitive inside Nora-managed containers.
+
+### Explicit Non-Goals For V1
+
+- No Hermes runtime support
+- No reimplementation of the WeCom protocol in Nora
+- No separate Nora-native channel system for WeCom
+- No requirement for WeCom-specific persistence tables unless the integration config shape proves
+  insufficient
+- No individual Nora product surfaces for each plugin-bundled WeCom skill
+
+## Expected System Flow
+
+1. Operator chooses WeCom in the Integrations tab.
+2. Operator selects connection mode:
+   - Bot
+   - Agent
+   - Both
+3. UI reveals the mode-specific config fields with defaults.
+4. Frontend posts the integration config to `POST /api/agents/:agentId/integrations`.
+5. Backend normalizes, validates, encrypts, and stores the integration record in `integrations`.
+6. Backend runs a WeCom-specific post-connect installer/configurator against the target OpenClaw agent.
+7. Backend syncs integration metadata to the runtime.
+8. Backend returns success/error plus any setup guidance that still must be completed in the WeCom admin console.
+
+## Candidate Stored Config Shape
+
+This is a draft shape, not final.
+
+```json
+{
+  "mode": "bot",
+  "bot": {
+    "connectionMode": "websocket",
+    "name": "企业微信",
+    "botId": "xxx",
+    "secret": "encrypted",
+    "websocketUrl": "wss://openws.work.weixin.qq.com",
+    "sendThinkingMessage": true
+  },
+  "agent": {
+    "corpId": "ww1234567890abcdef",
+    "corpSecret": "encrypted",
+    "agentId": 1000002,
+    "token": "encrypted",
+    "encodingAESKey": "encrypted"
+  },
+  "policies": {
+    "dmPolicy": "open",
+    "allowFrom": [],
+    "groupPolicy": "open",
+    "groupAllowFrom": []
+  }
+}
+```
+
+## Plugin-Bundled Skills
+
+The WeCom plugin repository ships a `skills/` directory containing OpenClaw skill folders built
+around `SKILL.md` files and reference material. In this integration, those skills should be
+understood as **plugin-bundled OpenClaw skills** that become available when the plugin is
+installed/enabled, not as separate Nora-managed integrations or standalone Nora product modules.
+
+Implications for v1:
+
+- Nora does not need to model each WeCom skill as a separate integration or UI surface.
+- Nora's main responsibility is to install/configure the plugin correctly so those bundled skills
+  are available to OpenClaw as intended.
+- Some skills may still depend on real plugin/runtime capabilities (for example MCP-backed or
+  channel-backed operations), so they are more than passive docs, but Nora does not need to
+  productize them individually in the MVP.
+
+## Install / Configure Boundary
+
+The most likely Nora boundary is:
+
+- provider module:
+  - normalize config
+  - validate mode-specific requirements
+  - redact / map env values
+  - optional test logic
+
+- route-level installer:
+  - install/update plugin
+  - write OpenClaw config
+  - restart/reload gateway if required
+  - sync integration metadata back to the runtime
+
+This keeps provider logic declarative and puts side-effect-heavy runtime orchestration in the same
+layer that already owns integration sync and OpenClaw-specific runtime behavior.


### PR DESCRIPTION
## Summary

This PR adds a first full WeCom integration flow to Nora, scoped to a clean v1 product surface.

It introduces:
- WeCom as a supported integration in the Nora catalog
- Bot, Agent, and Both connection modes
- OpenClaw activation, verification, and disconnect handling for the official WeCom plugin
- Runtime-aware WeCom testing and activation status in the UI
- Curated WeCom policy controls, including DM allowlists, group allowlists, and per-group sender allowlists
- A simplified WebSocket-only Bot story for this version

## What Changed

### Backend
- Added a dedicated WeCom provider and normalization layer
- Added WeCom activation/deactivation helpers for OpenClaw
- Wired WeCom connect, update, disconnect, and test flows through the integrations routes
- Added runtime verification that checks the live `channels.wecom` config against Nora’s saved config
- Added targeted backend coverage for WeCom config parsing, activation behavior, mode switching, and verification

### Frontend
- Added WeCom-specific integration UI behavior in the connect modal and detail panel
- Improved `both` mode by visually separating Bot and Agent configuration
- Added WeCom activation/readiness state to the active integrations list
- Added operator guidance for Agent callback setup and runtime verification
- Updated callback guidance so the UI treats the full callback URL as a browser-resolved preview and points operators to use their public Nora/OpenClaw host plus the saved callback path

## Product Decisions In This PR
- Bot webhook support was intentionally removed from this version
- Bot mode is WebSocket-only for v1
- Phase 4 stayed curated and limited to reasonable operator controls rather than exposing the full upstream plugin surface

## Validation
- `docker compose exec backend-api npm test -- --runInBand __tests__/integrations.test.ts`
- `docker compose exec backend-api npx tsc --noEmit`
- `docker compose exec frontend-dashboard npx tsc --noEmit`