### PR TITLE
Add ClawHub skill deletion flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -236,3 +236,8 @@ TLS_KEY_PATH=
 AWS_S3_BUCKET=<REPLACE_WITH_S3_BUCKET_NAME>
 AWS_ACCESS_KEY_ID=<REPLACE_WITH_AWS_ACCESS_KEY>
 AWS_SECRET_ACCESS_KEY=<REPLACE_WITH_AWS_SECRET_KEY>
+
+# When true, the provisioner reconciler uninstalls ClawHub skills present in a runtime
+# container but not tracked in the agents table. OFF by default — leaving it unset only
+# surfaces such drift as "orphaned" in the UI; operators remove orphans explicitly.
+CLAWHUB_PRUNE_ORPHANED_SKILLS=false

--- a/agent-runtime/lib/clawhubReconciliation.js
+++ b/agent-runtime/lib/clawhubReconciliation.js
@@ -20,6 +20,15 @@ function normalizeSavedSkillEntry(slug, entry = {}) {
   };
 }
 
+function normalizeInstalledSkillEntries(entries = []) {
+  return (Array.isArray(entries) ? entries : [])
+    .map((entry) => ({
+      slug: String(entry?.slug || "").trim(),
+      version: String(entry?.version || "").trim(),
+    }))
+    .filter((entry) => entry.slug);
+}
+
 function normalizeSavedSkillEntries(entries = []) {
   const deduped = new Map();
   for (const entry of Array.isArray(entries) ? entries : []) {
@@ -35,16 +44,88 @@ function normalizeSavedSkillEntries(entries = []) {
 
 function computeMissingSavedSkills(savedSkills = [], installedSkills = []) {
   const normalizedSaved = normalizeSavedSkillEntries(savedSkills);
-  const installedSlugs = new Set(
-    (Array.isArray(installedSkills) ? installedSkills : [])
-      .map((entry) => String(entry?.slug || "").trim())
-      .filter(Boolean),
-  );
+  const installedSlugs = new Set(normalizeInstalledSkillEntries(installedSkills).map((entry) => entry.slug));
   return normalizedSaved.filter((entry) => !installedSlugs.has(entry.installSlug));
+}
+
+function computeOrphanedInstalledSkills(savedSkills = [], installedSkills = []) {
+  const normalizedSaved = normalizeSavedSkillEntries(savedSkills);
+  const savedSlugs = new Set(normalizedSaved.map((entry) => entry.installSlug));
+  return normalizeInstalledSkillEntries(installedSkills).filter((entry) => !savedSlugs.has(entry.slug));
+}
+
+function removeSavedSkillEntry(entries = [], slug, author = "") {
+  const normalizedSlug = String(slug || "").trim();
+  const normalizedAuthor = String(author || "").trim();
+  if (!normalizedSlug) {
+    return normalizeSavedSkillEntries(entries);
+  }
+
+  return normalizeSavedSkillEntries(entries).filter((entry) => {
+    if (entry.installSlug !== normalizedSlug) return true;
+    if (!normalizedAuthor) return false;
+    return entry.author !== normalizedAuthor;
+  });
+}
+
+function mergeClawhubSkillState(savedSkills = [], installedSkills = [], pendingJobs = []) {
+  const normalizedSaved = normalizeSavedSkillEntries(savedSkills);
+  const normalizedInstalled = normalizeInstalledSkillEntries(installedSkills);
+  const installedBySlug = new Map(normalizedInstalled.map((entry) => [entry.slug, entry]));
+  const pendingBySlug = new Map(
+    (Array.isArray(pendingJobs) ? pendingJobs : [])
+      .map((job) => [String(job?.slug || "").trim(), job])
+      .filter(([slug]) => slug),
+  );
+  const merged = [];
+
+  for (const saved of normalizedSaved) {
+    const installed = installedBySlug.get(saved.installSlug);
+    const pending = pendingBySlug.get(saved.installSlug);
+    merged.push({
+      slug: saved.installSlug,
+      version: installed?.version || "",
+      saved: true,
+      installed: Boolean(installed),
+      source: "clawhub",
+      author: saved.author,
+      pagePath: saved.pagePath,
+      installedAt: saved.installedAt || null,
+      status: pending?.operation === "delete"
+        ? "pending_delete"
+        : pending?.operation === "install"
+          ? "pending_install"
+          : installed
+            ? "healthy"
+            : "missing_runtime",
+    });
+    installedBySlug.delete(saved.installSlug);
+  }
+
+  for (const installed of installedBySlug.values()) {
+    const pending = pendingBySlug.get(installed.slug);
+    merged.push({
+      slug: installed.slug,
+      version: installed.version || "",
+      saved: false,
+      installed: true,
+      source: "clawhub",
+      author: "",
+      pagePath: installed.slug,
+      installedAt: null,
+      status: pending?.operation === "delete" ? "pending_delete" : "orphaned_runtime",
+    });
+  }
+
+  return merged.sort((a, b) => a.slug.localeCompare(b.slug));
 }
 
 module.exports = {
   computeMissingSavedSkills,
+  computeOrphanedInstalledSkills,
+  mergeClawhubSkillState,
+  normalizeInstalledSkillEntries,
+  removeSavedSkillEntry,
   normalizeSavedSkillEntries,
   normalizeSavedSkillEntry,
 };

--- a/backend-api/__tests__/clawhub.test.ts
+++ b/backend-api/__tests__/clawhub.test.ts
@@ -8,18 +8,18 @@ jest.mock("../authSync", () => ({
 }));
 
 jest.mock("../redisQueue", () => ({
-  addClawhubInstallJob: jest.fn(),
-  findInFlightClawhubInstallJob: jest.fn(),
-  getClawhubInstallJobStatus: jest.fn(),
+  addClawhubJob: jest.fn(),
+  findInFlightClawhubJob: jest.fn(),
+  getClawhubJobStatus: jest.fn(),
 }));
 
 const { normalizeSkillDetailPayload, parseSkillMarkdown } = require("../clawhubClient");
 const db = require("../db");
 const { runContainerCommand } = require("../authSync");
 const {
-  addClawhubInstallJob,
-  findInFlightClawhubInstallJob,
-  getClawhubInstallJobStatus,
+  addClawhubJob,
+  findInFlightClawhubJob,
+  getClawhubJobStatus,
 } = require("../redisQueue");
 const router = require("../routes/clawhub");
 
@@ -290,7 +290,7 @@ Install and manage repos.
     });
   });
 
-  it("returns installed skills normalized from the agent lockfile", async () => {
+  it("returns merged saved/runtime skill state", async () => {
     const handler = getRouteHandler("/agents/:agentId/skills");
     db.query.mockResolvedValueOnce({
       rows: [
@@ -303,7 +303,7 @@ Install and manage repos.
           runtime_family: "openclaw",
           deploy_target: "docker",
           sandbox_profile: "standard",
-          clawhub_skills: [],
+          clawhub_skills: [{ installSlug: "github", author: "steipete", pagePath: "steipete/github" }],
         },
       ],
     });
@@ -324,8 +324,28 @@ Install and manage repos.
     expect(res.statusCode).toBe(200);
     expect(res.body).toEqual({
       skills: [
-        { slug: "github", version: "2.1.0" },
-        { slug: "notion", version: "1.0.0" },
+        {
+          slug: "github",
+          version: "2.1.0",
+          saved: true,
+          installed: true,
+          source: "clawhub",
+          author: "steipete",
+          pagePath: "steipete/github",
+          installedAt: expect.any(String),
+          status: "healthy",
+        },
+        {
+          slug: "notion",
+          version: "1.0.0",
+          saved: false,
+          installed: true,
+          source: "clawhub",
+          author: "",
+          pagePath: "notion",
+          installedAt: null,
+          status: "orphaned_runtime",
+        },
       ],
     });
   });
@@ -357,7 +377,7 @@ Install and manage repos.
     expect(res.statusCode).toBe(409);
     expect(res.body).toEqual({
       error: "unsupported_runtime",
-      message: "ClawHub installs are only available for OpenClaw agents.",
+      message: "ClawHub mutations are only available for OpenClaw agents.",
     });
   });
 
@@ -388,7 +408,7 @@ Install and manage repos.
     expect(res.statusCode).toBe(409);
     expect(res.body).toEqual({
       error: "container_not_running",
-      message: "Start the agent before installing skills.",
+      message: "Start the agent before managing ClawHub skills.",
     });
   });
 
@@ -440,11 +460,12 @@ Install and manage repos.
       ],
     });
     runContainerCommand.mockResolvedValueOnce({ output: "" });
-    findInFlightClawhubInstallJob.mockResolvedValueOnce({ id: "job-1" });
-    getClawhubInstallJobStatus.mockResolvedValueOnce({
+    findInFlightClawhubJob.mockResolvedValueOnce({ id: "job-1" });
+    getClawhubJobStatus.mockResolvedValueOnce({
       jobId: "job-1",
       agentId: "agent-1",
       slug: "github",
+      operation: "install",
       status: "running",
       error: null,
       completedAt: null,
@@ -463,9 +484,10 @@ Install and manage repos.
       jobId: "job-1",
       agentId: "agent-1",
       slug: "github",
+      operation: "install",
       status: "running",
     });
-    expect(addClawhubInstallJob).not.toHaveBeenCalled();
+    expect(addClawhubJob).not.toHaveBeenCalled();
   });
 
   it("enqueues a new install job and marks persistOnSuccess false when already saved", async () => {
@@ -484,8 +506,8 @@ Install and manage repos.
       ],
     });
     runContainerCommand.mockResolvedValueOnce({ output: "" });
-    findInFlightClawhubInstallJob.mockResolvedValueOnce(null);
-    addClawhubInstallJob.mockResolvedValueOnce({ id: "job-2" });
+    findInFlightClawhubJob.mockResolvedValueOnce(null);
+    addClawhubJob.mockResolvedValueOnce({ id: "job-2" });
 
     const req = {
       params: { agentId: "agent-1", slug: "github" },
@@ -499,9 +521,10 @@ Install and manage repos.
     const res = createMockRes();
     await handler(req, res);
 
-    expect(addClawhubInstallJob).toHaveBeenCalledWith({
+    expect(addClawhubJob).toHaveBeenCalledWith({
       agentId: "agent-1",
       slug: "github",
+      operation: "install",
       skillEntry: {
         source: "clawhub",
         installSlug: "github",
@@ -516,13 +539,150 @@ Install and manage repos.
       jobId: "job-2",
       agentId: "agent-1",
       slug: "github",
+      operation: "install",
+      status: "pending",
+    });
+  });
+
+  it("reuses an in-flight delete job when one already exists", async () => {
+    const handler = getRouteHandler("/agents/:agentId/skills/:slug/delete", "post");
+    db.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: "agent-1",
+          user_id: "user-1",
+          status: "running",
+          container_id: "container-1",
+          backend_type: "docker",
+          runtime_family: "openclaw",
+          clawhub_skills: [],
+        },
+      ],
+    });
+    findInFlightClawhubJob.mockResolvedValueOnce({ id: "job-del-1" });
+    getClawhubJobStatus.mockResolvedValueOnce({
+      jobId: "job-del-1",
+      agentId: "agent-1",
+      slug: "github",
+      operation: "delete",
+      status: "running",
+      error: null,
+      completedAt: null,
+    });
+
+    const req = {
+      params: { agentId: "agent-1", slug: "github" },
+      user: { id: "user-1" },
+      body: {},
+    };
+    const res = createMockRes();
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(202);
+    expect(res.body).toEqual({
+      jobId: "job-del-1",
+      agentId: "agent-1",
+      slug: "github",
+      operation: "delete",
+      status: "running",
+    });
+  });
+
+  it("blocks delete when an install job is already in progress", async () => {
+    const handler = getRouteHandler("/agents/:agentId/skills/:slug/delete", "post");
+    db.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: "agent-1",
+          user_id: "user-1",
+          status: "running",
+          container_id: "container-1",
+          backend_type: "docker",
+          runtime_family: "openclaw",
+          clawhub_skills: [],
+        },
+      ],
+    });
+    findInFlightClawhubJob.mockResolvedValueOnce({ id: "job-inst-1" });
+    getClawhubJobStatus.mockResolvedValueOnce({
+      jobId: "job-inst-1",
+      agentId: "agent-1",
+      slug: "github",
+      operation: "install",
+      status: "running",
+      error: null,
+      completedAt: null,
+    });
+
+    const req = {
+      params: { agentId: "agent-1", slug: "github" },
+      user: { id: "user-1" },
+      body: {},
+    };
+    const res = createMockRes();
+    await handler(req, res);
+
+    expect(res.statusCode).toBe(409);
+    expect(res.body).toEqual({
+      error: "conflicting_job",
+      message: "A ClawHub install job is already in progress for this skill.",
+      jobId: "job-inst-1",
+      operation: "install",
+    });
+  });
+
+  it("enqueues a delete job for an orphaned runtime skill", async () => {
+    const handler = getRouteHandler("/agents/:agentId/skills/:slug/delete", "post");
+    db.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: "agent-1",
+          user_id: "user-1",
+          status: "running",
+          container_id: "container-1",
+          backend_type: "docker",
+          runtime_family: "openclaw",
+          clawhub_skills: [],
+        },
+      ],
+    });
+    findInFlightClawhubJob.mockResolvedValueOnce(null);
+    addClawhubJob.mockResolvedValueOnce({ id: "job-del-2" });
+
+    const req = {
+      params: { agentId: "agent-1", slug: "notion" },
+      user: { id: "user-1" },
+      body: { pagePath: "notion" },
+    };
+    const res = createMockRes();
+    await handler(req, res);
+
+    expect(addClawhubJob).toHaveBeenCalledWith({
+      agentId: "agent-1",
+      slug: "notion",
+      operation: "delete",
+      skillEntry: {
+        source: "clawhub",
+        installSlug: "notion",
+        author: "",
+        pagePath: "notion",
+        installedAt: expect.any(String),
+      },
+      removeSavedEntryOnSuccess: true,
+    });
+    expect(res.statusCode).toBe(202);
+    expect(res.body).toEqual({
+      jobId: "job-del-2",
+      agentId: "agent-1",
+      slug: "notion",
+      operation: "delete",
       status: "pending",
     });
   });
 
   it("returns job_not_found when the install job lookup misses", async () => {
     const handler = getRouteHandler("/jobs/:jobId");
-    getClawhubInstallJobStatus.mockResolvedValueOnce(null);
+    getClawhubJobStatus.mockResolvedValueOnce(null);
 
     const req = { params: { jobId: "missing-job" } };
     const res = createMockRes();
@@ -534,16 +694,20 @@ Install and manage repos.
 
   it("returns normalized install job status when the job exists", async () => {
     const handler = getRouteHandler("/jobs/:jobId");
-    getClawhubInstallJobStatus.mockResolvedValueOnce({
+    getClawhubJobStatus.mockResolvedValueOnce({
       jobId: "job-3",
       agentId: "agent-1",
       slug: "github",
+      operation: "install",
       status: "success",
       error: null,
       completedAt: "2026-04-21T01:00:00.000Z",
     });
+    db.query.mockResolvedValueOnce({
+      rows: [{ id: "agent-1", user_id: "user-1" }],
+    });
 
-    const req = { params: { jobId: "job-3" } };
+    const req = { params: { jobId: "job-3" }, user: { id: "user-1" } };
     const res = createMockRes();
     await handler(req, res);
 
@@ -552,6 +716,7 @@ Install and manage repos.
       jobId: "job-3",
       agentId: "agent-1",
       slug: "github",
+      operation: "install",
       status: "success",
       error: null,
       completedAt: "2026-04-21T01:00:00.000Z",

--- a/backend-api/__tests__/clawhub.test.ts
+++ b/backend-api/__tests__/clawhub.test.ts
@@ -16,11 +16,7 @@ jest.mock("../redisQueue", () => ({
 const { normalizeSkillDetailPayload, parseSkillMarkdown } = require("../clawhubClient");
 const db = require("../db");
 const { runContainerCommand } = require("../authSync");
-const {
-  addClawhubJob,
-  findInFlightClawhubJob,
-  getClawhubJobStatus,
-} = require("../redisQueue");
+const { addClawhubJob, findInFlightClawhubJob, getClawhubJobStatus } = require("../redisQueue");
 const router = require("../routes/clawhub");
 
 function mockJsonResponse(status, payload) {
@@ -303,7 +299,9 @@ Install and manage repos.
           runtime_family: "openclaw",
           deploy_target: "docker",
           sandbox_profile: "standard",
-          clawhub_skills: [{ installSlug: "github", author: "steipete", pagePath: "steipete/github" }],
+          clawhub_skills: [
+            { installSlug: "github", author: "steipete", pagePath: "steipete/github" },
+          ],
         },
       ],
     });

--- a/backend-api/redisQueue.ts
+++ b/backend-api/redisQueue.ts
@@ -44,7 +44,7 @@ const deployQueue = new Queue("deployments", {
   },
 });
 
-const clawhubInstallsQueue = new Queue("clawhub-installs", {
+const clawhubJobsQueue = new Queue("clawhub-jobs", {
   connection,
   defaultJobOptions: {
     attempts: 1,
@@ -96,9 +96,10 @@ async function addAlertDeliveryJob(payload) {
   );
 }
 
-async function addClawhubInstallJob(payload) {
+async function addClawhubJob(payload) {
   const jobId = payload?.jobId || randomUUID();
-  return clawhubInstallsQueue.add("install-skill", { ...payload, jobId }, { jobId });
+  const operation = String(payload?.operation || "").trim() || "install";
+  return clawhubJobsQueue.add(`${operation}-skill`, { ...payload, operation, jobId }, { jobId });
 }
 
 async function addBackupJob(payload) {
@@ -106,10 +107,10 @@ async function addBackupJob(payload) {
   return backupsQueue.add("run-backup", { ...payload, jobId }, { jobId });
 }
 
-async function findInFlightClawhubInstallJob(agentId, slug) {
+async function findInFlightClawhubJob(agentId, slug, operation) {
   if (!agentId || !slug) return null;
 
-  const jobs = await clawhubInstallsQueue.getJobs([
+  const jobs = await clawhubJobsQueue.getJobs([
     "active",
     "waiting",
     "waiting-children",
@@ -124,7 +125,10 @@ async function findInFlightClawhubInstallJob(agentId, slug) {
     if (!job) continue;
     const matchesAgent = String(job.data?.agentId || "") === normalizedAgentId;
     const matchesSlug = String(job.data?.slug || "").trim() === normalizedSlug;
-    if (matchesAgent && matchesSlug) {
+    const matchesOperation = operation
+      ? String(job.data?.operation || "").trim() === String(operation).trim()
+      : true;
+    if (matchesAgent && matchesSlug && matchesOperation) {
       return job;
     }
   }
@@ -149,13 +153,13 @@ function mapClawhubJobState(state) {
   }
 }
 
-async function getClawhubInstallJob(jobId) {
+async function getClawhubJob(jobId) {
   if (!jobId) return null;
-  return clawhubInstallsQueue.getJob(jobId);
+  return clawhubJobsQueue.getJob(jobId);
 }
 
-async function getClawhubInstallJobStatus(jobId) {
-  const job = await getClawhubInstallJob(jobId);
+async function getClawhubJobStatus(jobId) {
+  const job = await getClawhubJob(jobId);
   if (!job) return null;
 
   const state = await job.getState();
@@ -168,10 +172,29 @@ async function getClawhubInstallJobStatus(jobId) {
     jobId: String(job.id),
     agentId: job.data?.agentId || null,
     slug: job.data?.slug || null,
+    operation: job.data?.operation || "install",
     status: mapClawhubJobState(state),
     error: failedReason,
     completedAt: job.finishedOn ? new Date(job.finishedOn).toISOString() : null,
   };
+}
+
+async function addClawhubInstallJob(payload) {
+  return addClawhubJob({ ...payload, operation: "install" });
+}
+
+async function findInFlightClawhubInstallJob(agentId, slug) {
+  return findInFlightClawhubJob(agentId, slug, "install");
+}
+
+async function getClawhubInstallJob(jobId) {
+  const job = await getClawhubJob(jobId);
+  return job && String(job.data?.operation || "install") === "install" ? job : null;
+}
+
+async function getClawhubInstallJobStatus(jobId) {
+  const status = await getClawhubJobStatus(jobId);
+  return status && status.operation === "install" ? status : null;
 }
 
 /** Retrieve failed jobs (dead letter queue) for inspection. */
@@ -189,14 +212,18 @@ async function retryDLQJob(jobId) {
 
 module.exports = {
   deployQueue,
-  clawhubInstallsQueue,
+  clawhubJobsQueue,
   backupsQueue,
   alertDeliveryQueue,
   addDeploymentJob,
+  addClawhubJob,
   addClawhubInstallJob,
   addBackupJob,
   addAlertDeliveryJob,
+  findInFlightClawhubJob,
   findInFlightClawhubInstallJob,
+  getClawhubJob,
+  getClawhubJobStatus,
   getClawhubInstallJob,
   getClawhubInstallJobStatus,
   getDLQJobs,

--- a/backend-api/routes/clawhub.ts
+++ b/backend-api/routes/clawhub.ts
@@ -2,12 +2,16 @@
 const express = require("express");
 const { getSkillDetail, listSkills, searchSkills } = require("../clawhubClient");
 const {
-  addClawhubInstallJob,
-  findInFlightClawhubInstallJob,
-  getClawhubInstallJobStatus,
+  addClawhubJob,
+  findInFlightClawhubJob,
+  getClawhubJobStatus,
 } = require("../redisQueue");
 const db = require("../db");
 const { runContainerCommand } = require("../authSync");
+const {
+  mergeClawhubSkillState,
+  normalizeSavedSkillEntry,
+} = require("../../agent-runtime/lib/clawhubReconciliation");
 
 const router = express.Router();
 const OPENCLAW_WORKSPACE_PATH = "/root/.openclaw/workspace";
@@ -69,7 +73,7 @@ function normalizeInstalledSkillsLockfile(parsed) {
     .filter((entry) => entry.slug && entry.version);
 }
 
-function validateInstallableAgent(agent) {
+function validateClawhubMutableAgent(agent) {
   if (!agent) {
     const error = new Error("agent_not_found");
     error.statusCode = 404;
@@ -78,54 +82,28 @@ function validateInstallableAgent(agent) {
   }
 
   if (agent.runtime_family !== "openclaw") {
-    const error = new Error("ClawHub installs are only available for OpenClaw agents.");
+    const error = new Error("ClawHub mutations are only available for OpenClaw agents.");
     error.statusCode = 409;
     error.code = "unsupported_runtime";
     throw error;
   }
 
   if (agent.status !== "running" && agent.status !== "warning") {
-    const error = new Error("Start the agent before installing skills.");
+    const error = new Error("Start the agent before managing ClawHub skills.");
     error.statusCode = 409;
     error.code = "container_not_running";
     throw error;
   }
 
   if (!agent.container_id) {
-    const error = new Error("Start the agent before installing skills.");
+    const error = new Error("Start the agent before managing ClawHub skills.");
     error.statusCode = 409;
     error.code = "container_not_running";
     throw error;
   }
 }
 
-function normalizeSavedSkillEntry(slug, input = {}) {
-  const installSlug = typeof slug === "string" ? slug.trim() : "";
-  if (!installSlug) return null;
-
-  const author = typeof input.author === "string" ? input.author.trim() : "";
-  const pagePath =
-    typeof input.pagePath === "string" && input.pagePath.trim()
-      ? input.pagePath.trim()
-      : author
-        ? `${author}/${installSlug}`
-        : installSlug;
-  const installedAtRaw = typeof input.installedAt === "string" ? input.installedAt.trim() : "";
-  const installedAt =
-    installedAtRaw && !Number.isNaN(new Date(installedAtRaw).getTime())
-      ? new Date(installedAtRaw).toISOString()
-      : new Date().toISOString();
-
-  return {
-    source: "clawhub",
-    installSlug,
-    author,
-    pagePath,
-    installedAt,
-  };
-}
-
-function sendInstallError(res, error) {
+function sendClawhubMutationError(res, error) {
   if (error?.statusCode === 404 || error?.code === "agent_not_found") {
     return res.status(404).json({ error: "agent_not_found" });
   }
@@ -133,14 +111,14 @@ function sendInstallError(res, error) {
   if (error?.code === "container_not_running") {
     return res.status(409).json({
       error: "container_not_running",
-      message: "Start the agent before installing skills.",
+      message: "Start the agent before managing ClawHub skills.",
     });
   }
 
   if (error?.code === "unsupported_runtime") {
     return res.status(409).json({
       error: "unsupported_runtime",
-      message: "ClawHub installs are only available for OpenClaw agents.",
+      message: "ClawHub mutations are only available for OpenClaw agents.",
     });
   }
 
@@ -152,7 +130,7 @@ function sendInstallError(res, error) {
   }
 
   return res.status(error?.statusCode || 500).json({
-    error: error?.code || "install_failed",
+    error: error?.code || "clawhub_mutation_failed",
     message: error?.message || "Unexpected error",
   });
 }
@@ -218,7 +196,7 @@ router.get("/skills/:slug", async (req, res) => {
 router.get("/agents/:agentId/skills", async (req, res) => {
   try {
     const agent = await loadOwnedAgent(req.params.agentId, req.user.id);
-    validateInstallableAgent(agent);
+    validateClawhubMutableAgent(agent);
     const { output } = await runContainerCommand(
       agent,
       `if [ -f ${JSON.stringify(CLAWHUB_LOCKFILE_PATH)} ]; then cat ${JSON.stringify(
@@ -227,17 +205,20 @@ router.get("/agents/:agentId/skills", async (req, res) => {
     );
     const parsed = JSON.parse(output || '{"version":1,"skills":{}}');
     return res.json({
-      skills: normalizeInstalledSkillsLockfile(parsed),
+      skills: mergeClawhubSkillState(
+        Array.isArray(agent.clawhub_skills) ? agent.clawhub_skills : [],
+        normalizeInstalledSkillsLockfile(parsed),
+      ),
     });
   } catch (error) {
-    return sendInstallError(res, error);
+    return sendClawhubMutationError(res, error);
   }
 });
 
 router.post("/agents/:agentId/skills/:slug/install", async (req, res) => {
   try {
     const agent = await loadOwnedAgent(req.params.agentId, req.user.id);
-    validateInstallableAgent(agent);
+    validateClawhubMutableAgent(agent);
     const slug = typeof req.params.slug === "string" ? req.params.slug.trim() : "";
     if (!slug) {
       return res.status(404).json({
@@ -273,20 +254,30 @@ router.post("/agents/:agentId/skills/:slug/install", async (req, res) => {
       throw error;
     }
 
-    const existingJob = await findInFlightClawhubInstallJob(agent.id, slug);
+    const existingJob = await findInFlightClawhubJob(agent.id, slug);
     if (existingJob) {
-      const existingStatus = await getClawhubInstallJobStatus(existingJob.id);
+      const existingStatus = await getClawhubJobStatus(existingJob.id);
+      if (existingStatus?.operation === "delete") {
+        return res.status(409).json({
+          error: "conflicting_job",
+          message: "A ClawHub delete job is already in progress for this skill.",
+          jobId: String(existingJob.id),
+          operation: "delete",
+        });
+      }
       return res.status(202).json({
         jobId: String(existingJob.id),
         agentId: agent.id,
         slug,
+        operation: "install",
         status: existingStatus?.status || "pending",
       });
     }
 
-    const job = await addClawhubInstallJob({
+    const job = await addClawhubJob({
       agentId: agent.id,
       slug,
+      operation: "install",
       skillEntry,
       persistOnSuccess: !existingSaved,
     });
@@ -295,10 +286,64 @@ router.post("/agents/:agentId/skills/:slug/install", async (req, res) => {
       jobId: String(job.id),
       agentId: agent.id,
       slug,
+      operation: "install",
       status: "pending",
     });
   } catch (error) {
-    return sendInstallError(res, error);
+    return sendClawhubMutationError(res, error);
+  }
+});
+
+router.post("/agents/:agentId/skills/:slug/delete", async (req, res) => {
+  try {
+    const agent = await loadOwnedAgent(req.params.agentId, req.user.id);
+    validateClawhubMutableAgent(agent);
+    const slug = typeof req.params.slug === "string" ? req.params.slug.trim() : "";
+    if (!slug) {
+      return res.status(404).json({
+        error: "skill_not_found",
+        message: "No skill found with slug: unknown",
+      });
+    }
+
+    const skillEntry = normalizeSavedSkillEntry(slug, req.body || {});
+    const existingJob = await findInFlightClawhubJob(agent.id, slug);
+    if (existingJob) {
+      const existingStatus = await getClawhubJobStatus(existingJob.id);
+      if (existingStatus?.operation === "delete") {
+        return res.status(202).json({
+          jobId: String(existingJob.id),
+          agentId: agent.id,
+          slug,
+          operation: "delete",
+          status: existingStatus?.status || "pending",
+        });
+      }
+      return res.status(409).json({
+        error: "conflicting_job",
+        message: "A ClawHub install job is already in progress for this skill.",
+        jobId: String(existingJob.id),
+        operation: "install",
+      });
+    }
+
+    const job = await addClawhubJob({
+      agentId: agent.id,
+      slug,
+      operation: "delete",
+      skillEntry,
+      removeSavedEntryOnSuccess: true,
+    });
+
+    return res.status(202).json({
+      jobId: String(job.id),
+      agentId: agent.id,
+      slug,
+      operation: "delete",
+      status: "pending",
+    });
+  } catch (error) {
+    return sendClawhubMutationError(res, error);
   }
 });
 
@@ -308,8 +353,13 @@ router.get("/jobs/:jobId", async (req, res) => {
     return res.status(404).json({ error: "job_not_found" });
   }
 
-  const status = await getClawhubInstallJobStatus(jobId);
+  const status = await getClawhubJobStatus(jobId);
   if (!status) {
+    return res.status(404).json({ error: "job_not_found" });
+  }
+
+  const agent = await loadOwnedAgent(status.agentId, req.user.id);
+  if (!agent) {
     return res.status(404).json({ error: "job_not_found" });
   }
 

--- a/backend-api/routes/clawhub.ts
+++ b/backend-api/routes/clawhub.ts
@@ -1,11 +1,7 @@
 // @ts-nocheck
 const express = require("express");
 const { getSkillDetail, listSkills, searchSkills } = require("../clawhubClient");
-const {
-  addClawhubJob,
-  findInFlightClawhubJob,
-  getClawhubJobStatus,
-} = require("../redisQueue");
+const { addClawhubJob, findInFlightClawhubJob, getClawhubJobStatus } = require("../redisQueue");
 const db = require("../db");
 const { runContainerCommand } = require("../authSync");
 const {

--- a/frontend-dashboard/components/agents/openclaw/ClawHubTab.tsx
+++ b/frontend-dashboard/components/agents/openclaw/ClawHubTab.tsx
@@ -550,7 +550,9 @@ export default function ClawHubTab({ agentId, refreshToken, onInstallSuccess }: 
               onInstallSuccess?.();
             } else {
               removeSelectedDeleteSkill({ slug: data.slug });
-              toast.success(`${data.slug} deleted. Restart your agent session to activate it.`);
+              toast.success(
+                `${data.slug} deleted. Restart your agent session to apply the removal.`,
+              );
             }
           }
 

--- a/frontend-dashboard/components/agents/openclaw/ClawHubTab.tsx
+++ b/frontend-dashboard/components/agents/openclaw/ClawHubTab.tsx
@@ -53,7 +53,9 @@ export default function ClawHubTab({ agentId, refreshToken, onInstallSuccess }: 
   const [error, setError] = useState<string | null>(null);
   const [selectedSkill, setSelectedSkill] = useState<SkillSummary | null>(null);
   const [selectedSkillDetail, setSelectedSkillDetail] = useState<SkillDetail | null>(null);
-  const [selectedSkillContext, setSelectedSkillContext] = useState<"catalog" | "installed">("catalog");
+  const [selectedSkillContext, setSelectedSkillContext] = useState<"catalog" | "installed">(
+    "catalog",
+  );
   const [detailLoading, setDetailLoading] = useState(false);
   const [detailError, setDetailError] = useState<string | null>(null);
   const [selectedInstallSkills, setSelectedInstallSkills] = useState<SkillDetail[]>([]);
@@ -99,7 +101,11 @@ export default function ClawHubTab({ agentId, refreshToken, onInstallSuccess }: 
     [selectedInstallSkills],
   );
   const displayedSelectedInstallSlugs = useMemo(
-    () => new Set([...pendingInstallSelectionSlugs, ...selectedInstallSkills.map((skill) => skill.slug)]),
+    () =>
+      new Set([
+        ...pendingInstallSelectionSlugs,
+        ...selectedInstallSkills.map((skill) => skill.slug),
+      ]),
     [pendingInstallSelectionSlugs, selectedInstallSkills],
   );
   const selectedDeleteSlugs = useMemo(
@@ -573,8 +579,8 @@ export default function ClawHubTab({ agentId, refreshToken, onInstallSuccess }: 
             </div>
             <h3 className="text-2xl font-black text-slate-900">Manage skills on this agent</h3>
             <p className="max-w-2xl text-sm leading-6 text-slate-600">
-              Review installed ClawHub skills, remove skills from the running agent, and browse
-              the public registry to queue new installs.
+              Review installed ClawHub skills, remove skills from the running agent, and browse the
+              public registry to queue new installs.
             </p>
           </div>
 
@@ -621,7 +627,8 @@ export default function ClawHubTab({ agentId, refreshToken, onInstallSuccess }: 
                 Selected Skills
               </div>
               <p className="text-sm font-semibold text-slate-900">
-                {selectedInstallSkills.length} skill{selectedInstallSkills.length === 1 ? "" : "s"} selected for install.
+                {selectedInstallSkills.length} skill{selectedInstallSkills.length === 1 ? "" : "s"}{" "}
+                selected for install.
               </p>
               <div className="flex flex-wrap gap-2">
                 {selectedInstallSkills.map((skill) => (
@@ -641,7 +648,9 @@ export default function ClawHubTab({ agentId, refreshToken, onInstallSuccess }: 
                   </span>
                 ))}
               </div>
-              {installError ? <p className="text-sm font-medium text-red-600">{installError}</p> : null}
+              {installError ? (
+                <p className="text-sm font-medium text-red-600">{installError}</p>
+              ) : null}
             </div>
 
             <div className="flex flex-col gap-3 sm:flex-row">

--- a/frontend-dashboard/components/agents/openclaw/ClawHubTab.tsx
+++ b/frontend-dashboard/components/agents/openclaw/ClawHubTab.tsx
@@ -1,13 +1,12 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Boxes, RefreshCw } from "lucide-react";
+import { Boxes, RefreshCw, Rocket, X } from "lucide-react";
 import { useToast } from "../../Toast";
 import { fetchWithAuth } from "../../../lib/api";
-import SkillDetailPanel, { SkillDetail, SkillDetailActionState } from "./SkillDetailPanel";
+import SkillDetailPanel, { SkillDetail } from "./SkillDetailPanel";
 import SkillGrid from "./SkillGrid";
+import InstalledSkillsPanel, { AgentClawhubSkill } from "./InstalledSkillsPanel";
 import SkillSearchBar from "./SkillSearchBar";
-import SkillSelectionTray from "./SkillSelectionTray";
 import { SkillSummary } from "./SkillCard";
-import { DeployClawHubSkill } from "../../../lib/clawhubDeploy";
 
 type ClawHubTabProps = {
   agentId: string;
@@ -22,44 +21,29 @@ type SkillListResponse = {
   message?: string;
 };
 
-type InstalledSkill = {
-  slug: string;
-  version: string;
-};
-
 type InstalledSkillsResponse = {
-  skills?: InstalledSkill[];
+  skills?: AgentClawhubSkill[];
   error?: string;
   message?: string;
 };
 
-type InstallJobResponse = {
+type ClawhubJobResponse = {
   jobId: string;
   agentId: string;
   slug: string;
+  operation: "install" | "delete";
   status: "pending" | "running" | "success" | "failed";
 };
 
-type InstallJobStatus = {
+type ClawhubJobStatus = {
   jobId: string;
   agentId: string;
   slug: string;
+  operation: "install" | "delete";
   status: "pending" | "running" | "success" | "failed";
   error: string | null;
   completedAt: string | null;
 };
-
-function buildSelectedSkill(detail: SkillDetail): DeployClawHubSkill {
-  return {
-    source: "clawhub",
-    installSlug: detail.slug,
-    author: detail.author || "",
-    pagePath: detail.pagePath || (detail.author ? `${detail.author}/${detail.slug}` : detail.slug),
-    installedAt: new Date().toISOString(),
-    name: detail.name,
-    description: detail.description,
-  };
-}
 
 export default function ClawHubTab({ agentId, refreshToken, onInstallSuccess }: ClawHubTabProps) {
   const toast = useToast();
@@ -69,38 +53,89 @@ export default function ClawHubTab({ agentId, refreshToken, onInstallSuccess }: 
   const [error, setError] = useState<string | null>(null);
   const [selectedSkill, setSelectedSkill] = useState<SkillSummary | null>(null);
   const [selectedSkillDetail, setSelectedSkillDetail] = useState<SkillDetail | null>(null);
+  const [selectedSkillContext, setSelectedSkillContext] = useState<"catalog" | "installed">("catalog");
   const [detailLoading, setDetailLoading] = useState(false);
   const [detailError, setDetailError] = useState<string | null>(null);
-  const [selectedSkills, setSelectedSkills] = useState<DeployClawHubSkill[]>([]);
+  const [selectedInstallSkills, setSelectedInstallSkills] = useState<SkillDetail[]>([]);
+  const [pendingInstallSelectionSlugs, setPendingInstallSelectionSlugs] = useState<string[]>([]);
+  const [selectedDeleteSkills, setSelectedDeleteSkills] = useState<AgentClawhubSkill[]>([]);
   const [selectionBusySlug, setSelectionBusySlug] = useState<string | null>(null);
-  const [jobStatuses, setJobStatuses] = useState<Record<string, InstallJobStatus>>({});
+  const [installBusySlug, setInstallBusySlug] = useState<string | null>(null);
+  const [deleteBusySlug, setDeleteBusySlug] = useState<string | null>(null);
+  const [jobStatuses, setJobStatuses] = useState<Record<string, ClawhubJobStatus>>({});
   const [installError, setInstallError] = useState<string | null>(null);
-  const [installedSkills, setInstalledSkills] = useState<InstalledSkill[]>([]);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [agentSkills, setAgentSkills] = useState<AgentClawhubSkill[]>([]);
   const requestIdRef = useRef(0);
   const detailCacheRef = useRef<Record<string, SkillDetail>>({});
 
   const showingDefaultBrowseEmptyState = !query.trim() && !loading && !error && skills.length === 0;
+  const displayedAgentSkills = useMemo(
+    () =>
+      agentSkills.map((skill) => {
+        const pending = jobStatuses[skill.slug];
+        if (!pending || (pending.status !== "pending" && pending.status !== "running")) {
+          return skill;
+        }
+        if (pending.operation === "delete") {
+          return {
+            ...skill,
+            status: "pending_delete" as const,
+          };
+        }
+        return {
+          ...skill,
+          status: "pending_install" as const,
+        };
+      }),
+    [agentSkills, jobStatuses],
+  );
   const installedSlugs = useMemo(
-    () => new Set(installedSkills.map((skill) => skill.slug)),
-    [installedSkills],
+    () => new Set(agentSkills.filter((skill) => skill.installed).map((skill) => skill.slug)),
+    [agentSkills],
   );
-  const selectedSkillKeys = useMemo(
-    () => new Set(selectedSkills.map((skill) => `${skill.author}:${skill.installSlug}`)),
-    [selectedSkills],
+  const selectedInstallSlugs = useMemo(
+    () => new Set(selectedInstallSkills.map((skill) => skill.slug)),
+    [selectedInstallSkills],
   );
-  const selectedSkillSlugs = useMemo(
-    () => new Set(selectedSkills.map((skill) => skill.installSlug)),
-    [selectedSkills],
+  const displayedSelectedInstallSlugs = useMemo(
+    () => new Set([...pendingInstallSelectionSlugs, ...selectedInstallSkills.map((skill) => skill.slug)]),
+    [pendingInstallSelectionSlugs, selectedInstallSkills],
   );
-  const selectedCurrentSkill = selectedSkillDetail
-    ? selectedSkillKeys.has(`${selectedSkillDetail.author || ""}:${selectedSkillDetail.slug}`)
+  const selectedDeleteSlugs = useMemo(
+    () => new Set(selectedDeleteSkills.map((skill) => skill.slug)),
+    [selectedDeleteSkills],
+  );
+  const selectedCatalogSkill = selectedSkillDetail
+    ? selectedInstallSlugs.has(selectedSkillDetail.slug)
     : false;
   const activeInstallCount = useMemo(
     () =>
       Object.values(jobStatuses).filter(
-        (status) => status.status === "pending" || status.status === "running",
+        (status) =>
+          status.operation === "install" &&
+          (status.status === "pending" || status.status === "running"),
       ).length,
     [jobStatuses],
+  );
+  const activeDeleteCount = useMemo(
+    () =>
+      Object.values(jobStatuses).filter(
+        (status) =>
+          status.operation === "delete" &&
+          (status.status === "pending" || status.status === "running"),
+      ).length,
+    [jobStatuses],
+  );
+  const installedSectionSkills = useMemo(
+    () =>
+      displayedAgentSkills.filter(
+        (skill) =>
+          skill.installed ||
+          skill.status === "orphaned_runtime" ||
+          skill.status === "pending_delete",
+      ),
+    [displayedAgentSkills],
   );
 
   async function loadInstalledSkills() {
@@ -110,7 +145,7 @@ export default function ClawHubTab({ agentId, refreshToken, onInstallSuccess }: 
       if (!res.ok) {
         throw new Error(data.message || data.error || "Could not load installed skills.");
       }
-      setInstalledSkills(Array.isArray(data.skills) ? data.skills : []);
+      setAgentSkills(Array.isArray(data.skills) ? data.skills : []);
     } catch (err: any) {
       console.error(err);
     }
@@ -197,7 +232,11 @@ export default function ClawHubTab({ agentId, refreshToken, onInstallSuccess }: 
     return data as SkillDetail;
   }
 
-  async function loadSkillDetail(skill: SkillSummary) {
+  async function loadSkillDetail(
+    skill: SkillSummary,
+    context: "catalog" | "installed" = "catalog",
+  ) {
+    setSelectedSkillContext(context);
     setSelectedSkill(skill);
     setSelectedSkillDetail(detailCacheRef.current[skill.slug] || null);
     setDetailError(null);
@@ -235,59 +274,135 @@ export default function ClawHubTab({ agentId, refreshToken, onInstallSuccess }: 
     }
   }
 
-  function addSelectedSkill(detail: SkillDetail) {
-    const nextSkill = buildSelectedSkill(detail);
-    const nextKey = `${nextSkill.author}:${nextSkill.installSlug}`;
-    setSelectedSkills((current) => {
-      if (current.some((skill) => `${skill.author}:${skill.installSlug}` === nextKey)) {
-        return current;
-      }
-      return [...current, nextSkill];
+  function toggleInstalledSkillSelection(skill: AgentClawhubSkill) {
+    toggleDeleteSelection(skill);
+  }
+
+  function addSelectedInstallSkill(skill: SkillDetail) {
+    setPendingInstallSelectionSlugs((current) => current.filter((slug) => slug !== skill.slug));
+    setSelectedInstallSkills((current) => {
+      if (current.some((entry) => entry.slug === skill.slug)) return current;
+      return [...current, skill];
     });
   }
 
-  function removeSelectedSkill(skill: SkillSummary | DeployClawHubSkill | SkillDetail) {
-    const installSlug = "installSlug" in skill ? skill.installSlug : skill.slug;
-    const author = "author" in skill ? skill.author || "" : "";
-    setSelectedSkills((current) =>
-      current.filter((entry) => !(entry.installSlug === installSlug && entry.author === author)),
-    );
+  function removeSelectedInstallSkill(skill: Pick<SkillDetail, "slug">) {
+    setPendingInstallSelectionSlugs((current) => current.filter((slug) => slug !== skill.slug));
+    setSelectedInstallSkills((current) => current.filter((entry) => entry.slug !== skill.slug));
   }
 
-  function removeSelectedSkillBySlug(slug: string) {
-    setSelectedSkills((current) => current.filter((entry) => entry.installSlug !== slug));
+  function clearSelectedInstallSkills() {
+    setPendingInstallSelectionSlugs([]);
+    setSelectedInstallSkills([]);
   }
 
-  function clearSelectedSkills() {
-    setSelectedSkills([]);
+  function addSelectedDeleteSkill(skill: AgentClawhubSkill) {
+    setSelectedDeleteSkills((current) => {
+      if (current.some((entry) => entry.slug === skill.slug)) return current;
+      return [...current, skill];
+    });
+  }
+
+  function removeSelectedDeleteSkill(skill: Pick<AgentClawhubSkill, "slug">) {
+    setSelectedDeleteSkills((current) => current.filter((entry) => entry.slug !== skill.slug));
+  }
+
+  function clearSelectedDeleteSkills() {
+    setSelectedDeleteSkills([]);
+  }
+
+  function toggleDeleteSelection(skill: AgentClawhubSkill) {
+    setDeleteBusySlug(skill.slug);
+    try {
+      if (selectedDeleteSlugs.has(skill.slug)) {
+        removeSelectedDeleteSkill(skill);
+      } else {
+        addSelectedDeleteSkill(skill);
+      }
+    } finally {
+      setDeleteBusySlug(null);
+    }
   }
 
   async function toggleSkillSelection(skill: SkillSummary) {
     const cached = detailCacheRef.current[skill.slug];
-    const cachedKey = `${cached?.author || ""}:${skill.slug}`;
-    if (cached && selectedSkillKeys.has(cachedKey)) {
-      removeSelectedSkill(cached);
+    if (displayedSelectedInstallSlugs.has(skill.slug)) {
+      setPendingInstallSelectionSlugs((current) => current.filter((slug) => slug !== skill.slug));
+      if (cached) {
+        removeSelectedInstallSkill(cached);
+      } else {
+        setSelectedInstallSkills((current) => current.filter((entry) => entry.slug !== skill.slug));
+      }
       return;
     }
 
+    setPendingInstallSelectionSlugs((current) =>
+      current.includes(skill.slug) ? current : [...current, skill.slug],
+    );
     setSelectionBusySlug(skill.slug);
     try {
       const detail = cached || (await fetchSkillDetail(skill));
-      const detailKey = `${detail.author || ""}:${detail.slug}`;
-      if (selectedSkillKeys.has(detailKey)) {
-        removeSelectedSkill(detail);
-      } else {
-        addSelectedSkill(detail);
+      if (!selectedInstallSlugs.has(detail.slug)) {
+        addSelectedInstallSkill(detail);
       }
+      setSelectedSkillContext("catalog");
+      setSelectedSkill({
+        slug: detail.slug,
+        name: detail.name,
+        description: detail.description,
+        downloads: detail.downloads,
+        stars: detail.stars,
+        updatedAt: detail.updatedAt || null,
+      });
+      setSelectedSkillDetail(detail);
+      setDetailError(null);
     } catch (err: any) {
+      setPendingInstallSelectionSlugs((current) => current.filter((slug) => slug !== skill.slug));
       toast.error(err?.message || "Could not update that selection.");
     } finally {
       setSelectionBusySlug(null);
     }
   }
 
+  async function queueInstall(detail: SkillDetail) {
+    if (installedSlugs.has(detail.slug)) {
+      return;
+    }
+    const res = await fetchWithAuth(
+      `/api/clawhub/agents/${agentId}/skills/${encodeURIComponent(detail.slug)}/install`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          source: "clawhub",
+          author: detail.author || "",
+          pagePath:
+            detail.pagePath || (detail.author ? `${detail.author}/${detail.slug}` : detail.slug),
+          installedAt: detail.installedAt || new Date().toISOString(),
+        }),
+      },
+    );
+    const data: ClawhubJobResponse & { error?: string; message?: string } = await res.json();
+    if (!res.ok) {
+      throw new Error(data.message || data.error || "Could not queue install.");
+    }
+
+    setJobStatuses((current) => ({
+      ...current,
+      [detail.slug]: {
+        jobId: data.jobId,
+        agentId: data.agentId,
+        slug: data.slug,
+        operation: "install",
+        status: data.status,
+        error: null,
+        completedAt: null,
+      },
+    }));
+  }
+
   async function handleInstallSelected() {
-    const installable = selectedSkills.filter((skill) => !installedSlugs.has(skill.installSlug));
+    const installable = selectedInstallSkills.filter((skill) => !installedSlugs.has(skill.slug));
     if (!installable.length) {
       setInstallError("All selected skills are already installed.");
       return;
@@ -296,9 +411,40 @@ export default function ClawHubTab({ agentId, refreshToken, onInstallSuccess }: 
     setInstallError(null);
 
     for (const skill of installable) {
+      setInstallBusySlug(skill.slug);
+      try {
+        await queueInstall(skill);
+      } catch (err: any) {
+        setJobStatuses((current) => ({
+          ...current,
+          [skill.slug]: {
+            jobId: current[skill.slug]?.jobId || `${skill.slug}-failed`,
+            agentId,
+            slug: skill.slug,
+            operation: "install",
+            status: "failed",
+            error: err?.message || "Could not queue install.",
+            completedAt: null,
+          },
+        }));
+      } finally {
+        setInstallBusySlug(null);
+      }
+    }
+  }
+
+  async function handleDeleteSelected() {
+    if (!selectedDeleteSkills.length) {
+      setDeleteError("No installed skills selected for delete.");
+      return;
+    }
+
+    setDeleteError(null);
+
+    for (const skill of selectedDeleteSkills) {
       try {
         const res = await fetchWithAuth(
-          `/api/clawhub/agents/${agentId}/skills/${encodeURIComponent(skill.installSlug)}/install`,
+          `/api/clawhub/agents/${agentId}/skills/${encodeURIComponent(skill.slug)}/delete`,
           {
             method: "POST",
             headers: { "Content-Type": "application/json" },
@@ -310,17 +456,18 @@ export default function ClawHubTab({ agentId, refreshToken, onInstallSuccess }: 
             }),
           },
         );
-        const data: InstallJobResponse & { error?: string; message?: string } = await res.json();
+        const data: ClawhubJobResponse & { error?: string; message?: string } = await res.json();
         if (!res.ok) {
-          throw new Error(data.message || data.error || "Could not queue install.");
+          throw new Error(data.message || data.error || "Could not queue delete.");
         }
 
         setJobStatuses((current) => ({
           ...current,
-          [skill.installSlug]: {
+          [skill.slug]: {
             jobId: data.jobId,
             agentId: data.agentId,
             slug: data.slug,
+            operation: "delete",
             status: data.status,
             error: null,
             completedAt: null,
@@ -329,12 +476,13 @@ export default function ClawHubTab({ agentId, refreshToken, onInstallSuccess }: 
       } catch (err: any) {
         setJobStatuses((current) => ({
           ...current,
-          [skill.installSlug]: {
-            jobId: current[skill.installSlug]?.jobId || `${skill.installSlug}-failed`,
+          [skill.slug]: {
+            jobId: current[skill.slug]?.jobId || `${skill.slug}-delete-failed`,
             agentId,
-            slug: skill.installSlug,
+            slug: skill.slug,
+            operation: "delete",
             status: "failed",
-            error: err?.message || "Could not queue install.",
+            error: err?.message || "Could not queue delete.",
             completedAt: null,
           },
         }));
@@ -378,7 +526,7 @@ export default function ClawHubTab({ agentId, refreshToken, onInstallSuccess }: 
       for (const job of activeJobs) {
         try {
           const res = await fetchWithAuth(`/api/clawhub/jobs/${encodeURIComponent(job.jobId)}`);
-          const data: InstallJobStatus & { error?: string } = await res.json();
+          const data: ClawhubJobStatus & { error?: string } = await res.json();
           if (!res.ok) {
             continue;
           }
@@ -390,9 +538,14 @@ export default function ClawHubTab({ agentId, refreshToken, onInstallSuccess }: 
 
           if (data.status === "success") {
             await loadInstalledSkills();
-            removeSelectedSkillBySlug(data.slug);
-            toast.success(`${data.slug} installed. Restart your agent session to activate it.`);
-            onInstallSuccess?.();
+            if (data.operation === "install") {
+              removeSelectedInstallSkill({ slug: data.slug });
+              toast.success(`${data.slug} installed. Restart your agent session to activate it.`);
+              onInstallSuccess?.();
+            } else {
+              removeSelectedDeleteSkill({ slug: data.slug });
+              toast.success(`${data.slug} deleted. Restart your agent session to activate it.`);
+            }
           }
 
           if (data.status === "failed" && data.error) {
@@ -409,26 +562,6 @@ export default function ClawHubTab({ agentId, refreshToken, onInstallSuccess }: 
     };
   }, [agentId, jobStatuses, onInstallSuccess, toast]);
 
-  const detailActionState: SkillDetailActionState | undefined = selectedSkillDetail
-    ? installedSlugs.has(selectedSkillDetail.slug)
-      ? {
-          label: "Installed",
-          disabled: true,
-        }
-      : {
-          label: selectedCurrentSkill ? "Remove from selection" : "Add to selection",
-          disabled: Boolean(selectionBusySlug && selectionBusySlug !== selectedSkillDetail.slug),
-          loading: selectionBusySlug === selectedSkillDetail.slug,
-          onClick: () => {
-            if (selectedCurrentSkill) {
-              removeSelectedSkill(selectedSkillDetail);
-              return;
-            }
-            addSelectedSkill(selectedSkillDetail);
-          },
-        }
-    : undefined;
-
   return (
     <div className="space-y-4">
       <div className="rounded-3xl border border-slate-200 bg-gradient-to-r from-white via-slate-50 to-blue-50 p-5 shadow-sm">
@@ -438,10 +571,10 @@ export default function ClawHubTab({ agentId, refreshToken, onInstallSuccess }: 
               <Boxes size={12} />
               ClawHub Catalog
             </div>
-            <h3 className="text-2xl font-black text-slate-900">Install skills on this agent</h3>
+            <h3 className="text-2xl font-black text-slate-900">Manage skills on this agent</h3>
             <p className="max-w-2xl text-sm leading-6 text-slate-600">
-              Browse the public ClawHub registry from Nora, select one or more skills, and queue
-              runtime installs for this running agent.
+              Review installed ClawHub skills, remove skills from the running agent, and browse
+              the public registry to queue new installs.
             </p>
           </div>
 
@@ -460,20 +593,17 @@ export default function ClawHubTab({ agentId, refreshToken, onInstallSuccess }: 
         </div>
       </div>
 
-      <SkillSelectionTray
-        skills={selectedSkills}
-        mode="install"
-        installLabel={
-          activeInstallCount
-            ? `Installing ${activeInstallCount} skill${activeInstallCount === 1 ? "" : "s"}...`
-            : `Install ${selectedSkills.length || 0} Skill${selectedSkills.length === 1 ? "" : "s"}`
-        }
-        installDisabled={!selectedSkills.length || activeInstallCount > 0}
-        installError={installError}
-        onInstall={handleInstallSelected}
-        onRemoveSkill={removeSelectedSkill}
-        onClearAll={clearSelectedSkills}
-      />
+      <div className="space-y-3">
+        <InstalledSkillsPanel
+          skills={installedSectionSkills}
+          selectedDeleteSlugs={selectedDeleteSlugs}
+          deleting={activeDeleteCount > 0}
+          deleteError={deleteError}
+          onToggleDelete={toggleInstalledSkillSelection}
+          onDeleteSelected={handleDeleteSelected}
+          onClearSelection={clearSelectedDeleteSkills}
+        />
+      </div>
 
       <SkillSearchBar
         query={query}
@@ -483,6 +613,61 @@ export default function ClawHubTab({ agentId, refreshToken, onInstallSuccess }: 
         onClear={handleClearSearch}
       />
 
+      {selectedInstallSkills.length ? (
+        <div className="rounded-3xl border border-slate-200 bg-white p-4 shadow-sm">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div className="space-y-2">
+              <div className="text-xs font-black uppercase tracking-[0.18em] text-slate-500">
+                Selected Skills
+              </div>
+              <p className="text-sm font-semibold text-slate-900">
+                {selectedInstallSkills.length} skill{selectedInstallSkills.length === 1 ? "" : "s"} selected for install.
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {selectedInstallSkills.map((skill) => (
+                  <span
+                    key={skill.slug}
+                    className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-bold text-slate-800"
+                  >
+                    {skill.name || skill.slug}
+                    <button
+                      type="button"
+                      onClick={() => removeSelectedInstallSkill(skill)}
+                      className="inline-flex h-4 w-4 items-center justify-center rounded-full text-slate-500 transition-colors hover:bg-slate-200 hover:text-slate-800"
+                      aria-label={`Remove ${skill.name || skill.slug} from install selection`}
+                    >
+                      <X size={12} />
+                    </button>
+                  </span>
+                ))}
+              </div>
+              {installError ? <p className="text-sm font-medium text-red-600">{installError}</p> : null}
+            </div>
+
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <button
+                type="button"
+                onClick={clearSelectedInstallSkills}
+                className="inline-flex items-center justify-center gap-2 rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm font-black text-slate-700 transition-colors hover:bg-slate-50"
+              >
+                Clear
+              </button>
+              <button
+                type="button"
+                onClick={handleInstallSelected}
+                disabled={activeInstallCount > 0}
+                className="inline-flex items-center justify-center gap-2 rounded-2xl bg-emerald-600 px-5 py-3 text-sm font-black text-white transition-colors hover:bg-emerald-700 disabled:opacity-60"
+              >
+                <Rocket size={16} />
+                {activeInstallCount
+                  ? `Installing ${activeInstallCount} skill${activeInstallCount === 1 ? "" : "s"}...`
+                  : `Install Selected (${selectedInstallSkills.length})`}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
       <div className="grid grid-cols-1 gap-4 2xl:grid-cols-[minmax(0,1.4fr)_minmax(360px,0.9fr)]">
         <div className="min-w-0">
           <SkillGrid
@@ -490,9 +675,9 @@ export default function ClawHubTab({ agentId, refreshToken, onInstallSuccess }: 
             loading={loading}
             error={error}
             query={query}
-            selectedSlug={selectedSkill?.slug || null}
+            selectedSlug={null}
             installedSlugs={installedSlugs}
-            selectedSkillSlugs={selectedSkillSlugs}
+            selectedSkillSlugs={displayedSelectedInstallSlugs}
             selectionBusySlug={selectionBusySlug}
             onSelect={loadSkillDetail}
             onToggleSelection={toggleSkillSelection}
@@ -515,7 +700,6 @@ export default function ClawHubTab({ agentId, refreshToken, onInstallSuccess }: 
             detail={selectedSkillDetail}
             loading={detailLoading}
             error={detailError}
-            action={detailActionState}
             onClose={() => {
               setSelectedSkill(null);
               setSelectedSkillDetail(null);

--- a/frontend-dashboard/components/agents/openclaw/InstalledSkillsPanel.tsx
+++ b/frontend-dashboard/components/agents/openclaw/InstalledSkillsPanel.tsx
@@ -1,0 +1,167 @@
+import { AlertTriangle, CheckCircle2, Trash2 } from "lucide-react";
+
+export type AgentClawhubSkill = {
+  slug: string;
+  version: string;
+  saved: boolean;
+  installed: boolean;
+  source: "clawhub";
+  author: string;
+  pagePath: string;
+  installedAt: string | null;
+  status: "healthy" | "missing_runtime" | "orphaned_runtime" | "pending_install" | "pending_delete";
+};
+
+type InstalledSkillsPanelProps = {
+  skills: AgentClawhubSkill[];
+  selectedDeleteSlugs?: Set<string>;
+  deleting?: boolean;
+  deleteError?: string | null;
+  onToggleDelete: (skill: AgentClawhubSkill) => void;
+  onDeleteSelected: () => void;
+  onClearSelection?: () => void;
+};
+
+function statusPill(skill: AgentClawhubSkill) {
+  switch (skill.status) {
+    case "orphaned_runtime":
+      return {
+        label: "Orphaned",
+        className: "bg-amber-100 text-amber-800",
+        icon: AlertTriangle,
+      };
+    case "pending_delete":
+      return {
+        label: "Deleting",
+        className: "bg-rose-100 text-rose-800",
+        icon: Trash2,
+      };
+    case "pending_install":
+      return {
+        label: "Installing",
+        className: "bg-blue-100 text-blue-800",
+        icon: CheckCircle2,
+      };
+    default:
+      return {
+        label: "Installed",
+        className: "bg-emerald-100 text-emerald-800",
+        icon: CheckCircle2,
+      };
+  }
+}
+
+export default function InstalledSkillsPanel({
+  skills,
+  selectedDeleteSlugs = new Set(),
+  deleting = false,
+  deleteError = null,
+  onToggleDelete,
+  onDeleteSelected,
+  onClearSelection,
+}: InstalledSkillsPanelProps) {
+  const selectedCount = selectedDeleteSlugs.size;
+
+  if (!skills.length) {
+    return (
+      <div className="rounded-3xl border border-dashed border-slate-300 bg-slate-50 px-5 py-8 text-center">
+        <p className="text-sm font-bold text-slate-700">No ClawHub skills currently installed.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
+      <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-between">
+        <div className="space-y-3">
+          <div className="text-xs font-black uppercase tracking-[0.18em] text-slate-500">
+            Installed Skills
+          </div>
+          <div className="flex items-center gap-2 text-2xl font-black text-slate-900">
+            <CheckCircle2 size={20} className="text-emerald-500" />
+            {skills.length} installed
+          </div>
+          <p className="text-sm text-slate-600">Select a skill to delete it from this agent.</p>
+          {selectedCount ? (
+            <div className="flex flex-wrap items-center gap-2">
+              <p className="text-xs font-medium text-slate-500">
+                {selectedCount} skill{selectedCount === 1 ? "" : "s"} selected for delete.
+              </p>
+              {onClearSelection ? (
+                <button
+                  type="button"
+                  onClick={onClearSelection}
+                  className="text-xs font-black text-slate-500 transition-colors hover:text-slate-700"
+                >
+                  Clear selection
+                </button>
+              ) : null}
+            </div>
+          ) : null}
+          {deleteError ? <p className="text-sm font-medium text-red-600">{deleteError}</p> : null}
+        </div>
+
+        {selectedCount ? (
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <button
+              type="button"
+              onClick={() => onClearSelection?.()}
+              className="inline-flex items-center justify-center gap-2 self-start rounded-2xl border border-slate-200 bg-white px-5 py-3 text-sm font-black text-slate-700 transition-colors hover:bg-slate-50"
+            >
+              Clear
+            </button>
+            <button
+              type="button"
+              onClick={onDeleteSelected}
+              disabled={deleting}
+              className="inline-flex items-center justify-center gap-2 self-start rounded-2xl bg-rose-600 px-5 py-3 text-sm font-black text-white transition-colors hover:bg-rose-700 disabled:opacity-60"
+            >
+              <Trash2 size={16} />
+              {deleting
+                ? `Deleting ${selectedCount} skill${selectedCount === 1 ? "" : "s"}...`
+                : `Delete Selected (${selectedCount})`}
+            </button>
+          </div>
+        ) : null}
+      </div>
+
+      <div className="mt-5 flex flex-wrap gap-3">
+        {skills.map((skill) => {
+          const selectedForDelete = selectedDeleteSlugs.has(skill.slug);
+          const pill = statusPill(skill);
+          const StatusIcon = pill.icon;
+
+          return (
+            <button
+              type="button"
+              onClick={() => onToggleDelete(skill)}
+              disabled={deleting || skill.status === "pending_delete"}
+              key={`${skill.author}:${skill.slug}`}
+              className={`inline-flex max-w-full items-center gap-2 rounded-2xl border px-3 py-2 text-left shadow-sm transition-all ${
+                selectedForDelete
+                  ? "border-rose-300 bg-rose-50/80"
+                  : "border-slate-200 bg-slate-50 hover:border-slate-300"
+              } disabled:opacity-60`}
+            >
+              <div className="flex min-w-0 flex-wrap items-center gap-2">
+                <span className="truncate text-sm font-black text-slate-900">{skill.slug}</span>
+                <span
+                  className={`inline-flex items-center gap-1 rounded-full px-2 py-1 text-[10px] font-black uppercase tracking-[0.18em] ${pill.className}`}
+                >
+                  <StatusIcon size={10} />
+                  {pill.label}
+                </span>
+                {skill.version ? (
+                  <span className="text-xs font-semibold text-slate-500">v{skill.version}</span>
+                ) : null}
+              </div>
+              <div className="truncate text-xs text-slate-500">
+                {skill.pagePath || (skill.author ? `${skill.author}/${skill.slug}` : skill.slug)}
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend-dashboard/components/agents/openclaw/SkillCard.tsx
+++ b/frontend-dashboard/components/agents/openclaw/SkillCard.tsx
@@ -1,4 +1,4 @@
-import { ArrowUpRight, Check, Download, Plus, Star } from "lucide-react";
+import { ArrowUpRight, Download, Star } from "lucide-react";
 
 export type SkillSummary = {
   slug: string;
@@ -45,20 +45,27 @@ export default function SkillCard({
   onToggleSelection,
 }: SkillCardProps) {
   const showStats = typeof skill.downloads === "number" || typeof skill.stars === "number";
+  const handleClick = () => {
+    if (selectable && onToggleSelection) {
+      onToggleSelection(skill);
+    }
+    onSelect(skill);
+  };
 
   return (
-    <div
+    <button
+      type="button"
+      onClick={handleClick}
+      disabled={selectionBusy}
       className={`group flex h-full flex-col rounded-2xl border p-4 text-left shadow-sm transition-all ${
         selected
           ? "border-blue-300 bg-blue-50/70"
-          : "border-slate-200 bg-white hover:-translate-y-0.5 hover:border-blue-200 hover:shadow-md"
-      }`}
+          : selectedForAction
+            ? "border-emerald-300 bg-emerald-50/80"
+            : "border-slate-200 bg-white hover:-translate-y-0.5 hover:border-blue-200 hover:shadow-md"
+      } disabled:opacity-60`}
     >
-      <button
-        type="button"
-        onClick={() => onSelect(skill)}
-        className="flex flex-1 flex-col text-left"
-      >
+      <div className="flex flex-1 flex-col text-left">
         <div className="flex items-start justify-between gap-3">
           <div className="space-y-1">
             <div className="text-sm font-black text-slate-900">{skill.name || skill.slug}</div>
@@ -67,6 +74,11 @@ export default function SkillCard({
             </div>
           </div>
           <div className="flex items-center gap-2">
+            {selectedForAction ? (
+              <span className="rounded-full bg-emerald-100 px-2 py-1 text-[10px] font-black uppercase tracking-[0.18em] text-emerald-700">
+                Selected
+              </span>
+            ) : null}
             {installed ? (
               <span className="rounded-full bg-emerald-100 px-2 py-1 text-[10px] font-black uppercase tracking-[0.18em] text-emerald-700">
                 Installed
@@ -101,23 +113,7 @@ export default function SkillCard({
         ) : null}
 
         <div className="mt-4 text-xs text-slate-400">{formatUpdatedAt(skill.updatedAt)}</div>
-      </button>
-
-      {selectable && onToggleSelection ? (
-        <button
-          type="button"
-          onClick={() => onToggleSelection(skill)}
-          disabled={selectionBusy}
-          className={`mt-4 inline-flex items-center justify-center gap-2 rounded-xl px-3 py-2 text-sm font-black transition-colors ${
-            selectedForAction
-              ? "bg-emerald-100 text-emerald-800 hover:bg-emerald-200"
-              : "bg-slate-100 text-slate-700 hover:bg-slate-200"
-          } disabled:opacity-60`}
-        >
-          {selectedForAction ? <Check size={14} /> : <Plus size={14} />}
-          {selectionBusy ? "Updating..." : selectedForAction ? "Selected" : "Add to selection"}
-        </button>
-      ) : null}
-    </div>
+      </div>
+    </button>
   );
 }

--- a/frontend-dashboard/components/agents/openclaw/SkillDetailPanel.tsx
+++ b/frontend-dashboard/components/agents/openclaw/SkillDetailPanel.tsx
@@ -6,10 +6,7 @@ import {
   Box,
   Cpu,
   FileText,
-  Lock,
   CircleAlert,
-  Check,
-  Plus,
 } from "lucide-react";
 
 export type SkillRequirementItem = {
@@ -39,21 +36,12 @@ export type SkillDetail = {
   requirements?: SkillRequirements | null;
 };
 
-export type SkillDetailActionState = {
-  label: string;
-  disabled?: boolean;
-  loading?: boolean;
-  onClick?: () => void;
-  onAction?: () => void;
-};
-
 type SkillDetailPanelProps = {
   skill: SkillDetail | null;
   detail?: SkillDetail | null;
   loading: boolean;
   error: string | null;
   onClose: () => void;
-  action?: SkillDetailActionState;
 };
 
 function formatCount(value: number | undefined) {
@@ -268,14 +256,8 @@ export default function SkillDetailPanel({
   loading,
   error,
   onClose,
-  action,
 }: SkillDetailPanelProps) {
   const activeSkill = detail || skill;
-  const helperText = action
-    ? action.label.toLowerCase().includes("selection")
-      ? "Use this action to add or remove the skill from the deploy selection."
-      : "This action is controlled by the current flow."
-    : "Install is disabled in Phase 1. This panel is read-only while we finish the browse and detail experience.";
 
   return (
     <aside className="lg:sticky lg:top-5">
@@ -308,8 +290,7 @@ export default function SkillDetailPanel({
               Pick a card to open the README and requirements.
             </p>
             <p className="mt-1 text-xs leading-5 text-slate-500">
-              The detail panel is read-only in Phase 1. Install actions will unlock in a later
-              phase.
+              This panel is read-only and focused on the skill's details.
             </p>
           </div>
         ) : (
@@ -331,48 +312,6 @@ export default function SkillDetailPanel({
               <p className="text-sm leading-6 text-slate-600">
                 {activeSkill.description || "No description provided."}
               </p>
-            </div>
-
-            <div className="rounded-2xl border border-slate-200 bg-slate-50 p-4">
-              <div className="flex items-center gap-2 text-sm font-bold text-slate-700">
-                <Lock size={14} className="text-slate-400" />
-                Install
-              </div>
-              <p className="mt-2 text-xs leading-5 text-slate-500">{helperText}</p>
-              <button
-                type="button"
-                onClick={action?.onClick || action?.onAction}
-                disabled={action ? action.disabled || action.loading : true}
-                className="mt-4 inline-flex items-center gap-1.5 rounded-lg px-3 py-2 text-xs font-bold transition disabled:cursor-not-allowed disabled:opacity-80 bg-slate-300 text-slate-500"
-              >
-                {action?.loading ? (
-                  <span className="inline-flex items-center gap-1.5">
-                    <span className="h-3 w-3 animate-spin rounded-full border-2 border-current border-t-transparent" />
-                    {action.label}
-                  </span>
-                ) : action ? (
-                  action.disabled ? (
-                    <>
-                      <Lock size={12} />
-                      {action.label}
-                    </>
-                  ) : (
-                    <>
-                      {action.label === "Add to selection" ? (
-                        <Plus size={12} />
-                      ) : (
-                        <Check size={12} />
-                      )}
-                      {action.label}
-                    </>
-                  )
-                ) : (
-                  <>
-                    <Lock size={12} />
-                    Install
-                  </>
-                )}
-              </button>
             </div>
 
             {error ? (

--- a/frontend-dashboard/components/agents/openclaw/SkillDetailPanel.tsx
+++ b/frontend-dashboard/components/agents/openclaw/SkillDetailPanel.tsx
@@ -1,13 +1,5 @@
 import type { ReactNode } from "react";
-import {
-  ChevronLeft,
-  Download,
-  Star,
-  Box,
-  Cpu,
-  FileText,
-  CircleAlert,
-} from "lucide-react";
+import { ChevronLeft, Download, Star, Box, Cpu, FileText, CircleAlert } from "lucide-react";
 
 export type SkillRequirementItem = {
   kind?: string;

--- a/frontend-dashboard/components/agents/openclaw/SkillSelectionTray.tsx
+++ b/frontend-dashboard/components/agents/openclaw/SkillSelectionTray.tsx
@@ -1,9 +1,9 @@
-import { CheckCircle2, ChevronLeft, Rocket, X } from "lucide-react";
+import { CheckCircle2, ChevronLeft, Rocket, Trash2, X } from "lucide-react";
 import { DeployClawHubSkill } from "../../../lib/clawhubDeploy";
 
 type SkillSelectionTrayProps = {
   skills: DeployClawHubSkill[];
-  mode?: "deploy" | "install";
+  mode?: "deploy" | "install" | "delete";
   deploying?: boolean;
   installLabel?: string;
   installDisabled?: boolean;
@@ -29,6 +29,9 @@ export default function SkillSelectionTray({
   onClearAll,
 }: SkillSelectionTrayProps) {
   const isDeployMode = mode === "deploy";
+  const isDeleteMode = mode === "delete";
+  const actionIcon = isDeleteMode ? Trash2 : Rocket;
+  const ActionIcon = actionIcon;
 
   return (
     <div className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
@@ -39,12 +42,19 @@ export default function SkillSelectionTray({
           </div>
           <div className="flex items-center gap-2 text-2xl font-black text-slate-900">
             <CheckCircle2 size={20} className="text-emerald-500" />
-            {skills.length} {isDeployMode ? "chosen for this deploy" : "selected for install"}
+            {skills.length}{" "}
+            {isDeployMode
+              ? "chosen for this deploy"
+              : isDeleteMode
+                ? "selected for delete"
+                : "selected for install"}
           </div>
           <p className="max-w-2xl text-sm leading-6 text-slate-600">
             {isDeployMode
               ? "These skills will be saved onto the new agent record when you click deploy. Runtime installation happens later in the deploy lifecycle, not on this page."
-              : "Queue one install job per selected skill for this running agent. Successful installs will update the saved ClawHub skill list and prompt a session restart."}
+              : isDeleteMode
+                ? "Queue one delete job per selected skill for this running agent. Successful deletes will update the ClawHub runtime state and prompt the same restart recommendation used for installs."
+                : "Queue one install job per selected skill for this running agent. Successful installs will update the saved ClawHub skill list and prompt a session restart."}
           </p>
           {skills.length ? (
             <div className="space-y-2">
@@ -87,7 +97,9 @@ export default function SkillSelectionTray({
             <p className="text-sm text-slate-500">
               {isDeployMode
                 ? "No ClawHub skills selected. You can still continue and deploy the agent without any."
-                : "No ClawHub skills selected yet. Pick one or more cards to queue installs."}
+                : isDeleteMode
+                  ? "No ClawHub skills selected for delete yet. Pick one or more installed skills above."
+                  : "No ClawHub skills selected yet. Pick one or more cards to queue installs."}
             </p>
           )}
           {installError ? <p className="text-sm font-medium text-red-600">{installError}</p> : null}
@@ -109,14 +121,16 @@ export default function SkillSelectionTray({
             type="button"
             onClick={isDeployMode ? onDeploy : onInstall}
             disabled={deploying || (!isDeployMode && installDisabled)}
-            className="inline-flex items-center justify-center gap-2 rounded-2xl bg-blue-600 px-5 py-3 text-sm font-black text-white transition-colors hover:bg-blue-700 disabled:opacity-60"
+            className={`inline-flex items-center justify-center gap-2 rounded-2xl px-5 py-3 text-sm font-black text-white transition-colors disabled:opacity-60 ${
+              isDeleteMode ? "bg-rose-600 hover:bg-rose-700" : "bg-blue-600 hover:bg-blue-700"
+            }`}
           >
-            <Rocket size={16} />
+            <ActionIcon size={16} />
             {isDeployMode
               ? deploying
                 ? "Deploying..."
                 : "Deploy Agent & Open Validation"
-              : installLabel || "Install Selected Skills"}
+              : installLabel || (isDeleteMode ? "Delete Selected Skills" : "Install Selected Skills")}
           </button>
         </div>
       </div>

--- a/frontend-dashboard/components/agents/openclaw/SkillSelectionTray.tsx
+++ b/frontend-dashboard/components/agents/openclaw/SkillSelectionTray.tsx
@@ -130,7 +130,8 @@ export default function SkillSelectionTray({
               ? deploying
                 ? "Deploying..."
                 : "Deploy Agent & Open Validation"
-              : installLabel || (isDeleteMode ? "Delete Selected Skills" : "Install Selected Skills")}
+              : installLabel ||
+                (isDeleteMode ? "Delete Selected Skills" : "Install Selected Skills")}
           </button>
         </div>
       </div>

--- a/frontend-dashboard/pages/clawhub/index.tsx
+++ b/frontend-dashboard/pages/clawhub/index.tsx
@@ -12,10 +12,7 @@ import {
   normalizeDeployDraftResources,
   saveDeployDraft,
 } from "../../lib/clawhubDeploy";
-import SkillDetailPanel, {
-  SkillDetail,
-  SkillDetailActionState,
-} from "../../components/agents/openclaw/SkillDetailPanel";
+import SkillDetailPanel, { SkillDetail } from "../../components/agents/openclaw/SkillDetailPanel";
 import SkillGrid from "../../components/agents/openclaw/SkillGrid";
 import SkillSearchBar from "../../components/agents/openclaw/SkillSearchBar";
 import SkillSelectionTray from "../../components/agents/openclaw/SkillSelectionTray";
@@ -342,21 +339,6 @@ export default function ClawHubDeployPage() {
     loadBrowseResults();
   }, [draft]);
 
-  const detailActionState: SkillDetailActionState | undefined = selectedSkillDetail
-    ? {
-        label: selectedCurrentSkill ? "Remove from selection" : "Add to selection",
-        disabled: Boolean(selectionBusySlug && selectionBusySlug !== selectedSkillDetail.slug),
-        loading: selectionBusySlug === selectedSkillDetail.slug,
-        onClick: () => {
-          if (selectedCurrentSkill) {
-            removeSelectedSkill(selectedSkillDetail);
-            return;
-          }
-          addSelectedSkill(selectedSkillDetail);
-        },
-      }
-    : undefined;
-
   return (
     <Layout>
       <div className="space-y-6">
@@ -436,7 +418,6 @@ export default function ClawHubDeployPage() {
               detail={selectedSkillDetail}
               loading={detailLoading}
               error={detailError}
-              action={detailActionState}
               onClose={() => {
                 setSelectedSkill(null);
                 setSelectedSkillDetail(null);

--- a/plans/clawhub_deletion/clawhub-deletion-implementation-plan.md
+++ b/plans/clawhub_deletion/clawhub-deletion-implementation-plan.md
@@ -1,0 +1,780 @@
+# ClawHub Deletion Implementation Plan
+
+## Purpose
+
+This document translates the product plan in `plans/clawhub_deletion/clawhub-deletion-plan.md` into an engineer-facing implementation sequence. It is intended to be detailed enough that an engineer new to this codepath can use it as a working skeleton for the feature.
+
+The feature has two goals:
+
+1. Add runtime deletion of ClawHub skills, including orphaned runtime skills.
+2. Update the ClawHub UI so operators can see installed/drifted skills and delete them with the same overall interaction model used for install.
+
+## Existing Code To Reuse
+
+### Backend
+
+- `backend-api/routes/clawhub.ts`
+  Owns ClawHub REST routes, route-level validation, and install job enqueueing.
+- `backend-api/redisQueue.ts`
+  Owns the shared BullMQ ClawHub mutation queue and job lookup helpers.
+- `workers/provisioner/worker.ts`
+  Owns the install worker, runtime exec helpers, and restart-time reconciliation.
+- `agent-runtime/lib/clawhubReconciliation.js`
+  Owns normalization helpers for saved skills and the current "DB saved but runtime missing" computation.
+- `backend-api/__tests__/clawhub.test.ts`
+  Route tests for browse/detail/install/job polling.
+- `backend-api/__tests__/clawhubReconciliation.test.ts`
+  Reconciliation helper tests.
+
+### Frontend
+
+- `frontend-dashboard/components/agents/openclaw/ClawHubTab.tsx`
+  Main stateful ClawHub agent tab.
+- `frontend-dashboard/components/agents/openclaw/SkillGrid.tsx`
+  Catalog grid.
+- `frontend-dashboard/components/agents/openclaw/SkillCard.tsx`
+  Catalog card UI, already supports `installed`.
+- `frontend-dashboard/components/agents/openclaw/SkillDetailPanel.tsx`
+  Detail/review panel.
+- `frontend-dashboard/components/agents/openclaw/SkillSelectionTray.tsx`
+  Existing install tray to extend for delete mode.
+- `frontend-dashboard/components/agents/OpenClawTab.tsx`
+  OpenClaw shell; use current branch and `pr-174` as references for tab framing.
+- `frontend-dashboard/pages/agents/[id].tsx`
+  Contains the current "ClawHub Install Complete" restart banner shown after install success.
+
+### `pr-174` UI Reference
+
+The current branch already contains most of the catalog internals. The local `pr-174` branch is mainly useful as a reference for the broader OpenClaw tab shell and surrounding agent-page presentation.
+
+Files to compare while implementing:
+
+- `frontend-dashboard/components/agents/OpenClawTab.tsx`
+- `frontend-dashboard/pages/agents/[id].tsx`
+- `frontend-dashboard/components/agents/openclaw/ChatPanel.tsx`
+
+Do not expect to port large chunks from `pr-174` for the catalog internals; the current branch already has those.
+
+## Phase 1: Normalize The Backend Data Model
+
+### Objective
+
+Create one shared notion of ClawHub skill state that can answer:
+
+- what Nora thinks should exist,
+- what is actually installed,
+- whether the skill is healthy, missing from runtime, or orphaned in runtime.
+
+### Files
+
+- `agent-runtime/lib/clawhubReconciliation.js`
+- `backend-api/routes/clawhub.ts`
+- `workers/provisioner/worker.ts`
+- optionally a new helper file under `backend-api/` or `agent-runtime/lib/` if the merged-state logic feels too large for `routes/clawhub.ts`
+
+### Changes
+
+1. Expand the reconciliation helper module.
+
+Add functions alongside:
+
+- `normalizeSavedSkillEntry`
+- `normalizeSavedSkillEntries`
+- `computeMissingSavedSkills`
+
+New helpers should include something close to:
+
+- `mapInstalledClawhubSkills(lockfileEntries)`
+- `computeOrphanedInstalledSkills(savedSkills, installedSkills)`
+- `mergeClawhubSkillState(savedSkills, installedSkills, pendingJobs?)`
+- `removeSavedClawhubSkillEntry(entries, slug, author?)`
+
+The merged output shape should match the product plan:
+
+```ts
+type MergedClawhubSkillState = {
+  slug: string;
+  version: string;
+  saved: boolean;
+  installed: boolean;
+  source: "clawhub";
+  author: string;
+  pagePath: string;
+  installedAt: string | null;
+  status: "healthy" | "missing_runtime" | "orphaned_runtime";
+};
+```
+
+2. Keep normalization logic centralized.
+
+Do not duplicate saved-entry normalization in both:
+
+- `backend-api/routes/clawhub.ts`
+- `workers/provisioner/worker.ts`
+
+Instead, route code and worker code should both lean on the shared helper module.
+
+3. Preserve richer skill identity than `slug` alone.
+
+Even if runtime install/uninstall remains slug-driven, Nora should continue to preserve:
+
+- `author`
+- `pagePath`
+
+for saved metadata and UI matching.
+
+Implementation guidance:
+
+- runtime mutation commands may continue to use `slug`,
+- saved-state mutation and UI display should preserve `author + slug` and `pagePath` when available.
+
+4. Add DB mutation helper(s) for saved state.
+
+Today `workers/provisioner/worker.ts` has:
+
+- `appendSavedClawhubSkill(agentId, slug, skillEntry)`
+
+Add the inverse helper, likely in the same file first and then extract later if it grows:
+
+- `removeSavedClawhubSkill(agentId, slug, skillEntry?)`
+
+This helper should:
+
+- load `agents.clawhub_skills`,
+- normalize entries,
+- remove the matching entry if present,
+- no-op cleanly if no saved entry exists.
+
+That no-op behavior is what enables orphaned runtime deletion to use the same delete flow.
+
+### Tests
+
+Extend `backend-api/__tests__/clawhubReconciliation.test.ts` with cases for:
+
+- orphaned runtime skills,
+- merged healthy/missing/orphaned states,
+- removing a saved skill entry,
+- duplicate saved entries collapsing correctly before delete.
+
+## Phase 2: Expand The ClawHub API Contract
+
+### Objective
+
+Change the agent-skills endpoint from "raw runtime lockfile list" into "operator-facing merged health view," and add delete enqueueing.
+
+### Files
+
+- `backend-api/routes/clawhub.ts`
+- `backend-api/__tests__/clawhub.test.ts`
+
+### Changes
+
+1. Refactor route-local helper naming.
+
+`validateInstallableAgent(agent)` is now doing generic OpenClaw runtime validation, not just install validation. Rename it to something like:
+
+- `validateClawhubMutableAgent(agent)`
+
+and reuse it for both install and delete.
+
+2. Replace the current `GET /agents/:agentId/skills` response.
+
+Current behavior:
+
+- loads the agent row,
+- reads `.clawhub/lock.json` via `runContainerCommand`,
+- returns only `skills: normalizeInstalledSkillsLockfile(parsed)`.
+
+New behavior:
+
+- load the agent row,
+- normalize `agent.clawhub_skills`,
+- read installed lockfile skills,
+- return merged skill state.
+
+Implementation note:
+
+Keep this endpoint focused on stable skill health state. Temporary pending install/delete UI state should come from job polling and be overlaid in the frontend rather than embedded into the stable skills response.
+
+3. Add `POST /agents/:agentId/skills/:slug/delete`.
+
+This should mirror the install route structure:
+
+- load owned agent,
+- validate runtime eligibility,
+- normalize slug,
+- ensure ClawHub CLI exists if we want symmetry with install and uninstall depends on the CLI,
+- check for in-flight delete job,
+- block or coalesce conflicting install job,
+- enqueue delete job.
+
+The payload can stay minimal:
+
+```json
+{
+  "author": "steipete",
+  "pagePath": "steipete/github"
+}
+```
+
+but the route should not require that the DB contain the entry.
+
+4. Extend `GET /jobs/:jobId`.
+
+Current job status payload has:
+
+- `jobId`
+- `agentId`
+- `slug`
+- `status`
+- `error`
+- `completedAt`
+
+Extend it to include:
+
+- `operation: "install" | "delete"`
+
+That lets the frontend reuse one polling loop for both job types. Because install and delete now share the same queue, a bare `jobId` can be resolved from one place.
+
+Add an ownership check:
+
+- load the job,
+- confirm the job's `agentId` belongs to `req.user.id`,
+- only then return job status.
+
+5. Split error handling cleanly.
+
+`sendInstallError` should either be generalized to `sendClawhubMutationError`, or a delete-specific sibling should be added. Avoid install-only wording in delete responses.
+
+### Tests
+
+Add route tests for:
+
+- merged skills response with healthy and orphaned entries,
+- delete route rejects non-running / non-openclaw agents,
+- delete route reuses existing in-flight delete job,
+- delete route blocks or coalesces against conflicting install job,
+- delete route enqueues successfully for an orphaned runtime skill,
+- job status response returns `operation`.
+
+## Phase 3: Generalize The Shared ClawHub Queue And Queue Lookup Helpers
+
+### Objective
+
+Turn the current install-only queue into a shared ClawHub mutation queue with explicit operation typing and conflict detection.
+
+### Files
+
+- `backend-api/redisQueue.ts`
+- `backend-api/routes/clawhub.ts`
+- `workers/provisioner/worker.ts`
+
+### Changes
+
+1. Replace the install-only queue with a shared ClawHub mutation queue.
+
+Current queue:
+
+- `const clawhubInstallsQueue = new Queue("clawhub-installs", ...)`
+
+Replace it with a shared queue:
+
+- `const clawhubJobsQueue = new Queue("clawhub-jobs", ...)`
+
+Use the current install timeout defaults initially unless delete proves to need a different one.
+
+2. Generalize queue helpers around `operation`.
+
+Current helpers:
+
+- `addClawhubInstallJob`
+- `findInFlightClawhubInstallJob`
+- `getClawhubInstallJob`
+- `getClawhubInstallJobStatus`
+
+Replace or generalize them into something like:
+
+- `addClawhubJob(payload)`
+- `findInFlightClawhubJob(agentId, slug, operation?)`
+- `getClawhubJob(jobId)`
+- `getClawhubJobStatus(jobId)`
+
+`findInFlightClawhubJob(agentId, slug, operation?)` should be able to return either:
+
+- only same-operation jobs when `operation` is provided,
+- or any in-flight mutation for the same `(agentId, slug)` when the route wants conflict detection.
+
+Its result should include:
+
+- operation,
+- job id,
+- status.
+
+3. Keep job payloads parallel.
+
+Install payload today:
+
+- `agentId`
+- `slug`
+- `skillEntry`
+- `persistOnSuccess`
+
+Shared ClawHub job payload should look like:
+
+- `agentId`
+- `slug`
+- `operation`
+- `skillEntry`
+- `persistOnSuccess` for install jobs
+- `removeSavedEntryOnSuccess` for delete jobs
+
+For orphaned runtime skills, `removeSavedEntryOnSuccess` can remain `true`; the worker helper will no-op if there is no saved entry.
+
+### Tests
+
+Add unit coverage in `backend-api/__tests__/clawhub.test.ts` via mocked `redisQueue` exports. If `redisQueue.ts` has direct tests elsewhere, add queue lookup tests there too.
+
+## Phase 4: Implement The Delete Worker
+
+### Objective
+
+Add the runtime delete worker with the same verify-before-persist guarantees as install.
+
+### Files
+
+- `workers/provisioner/worker.ts`
+- `backend-api/redisQueue.ts`
+
+### Changes
+
+1. Extract shared ClawHub runtime helpers.
+
+The following are already present in `workers/provisioner/worker.ts` and should be reused:
+
+- `readInstalledClawhubSkills`
+- `ensureClawhubCli`
+- `createClawhubInstallLogger` (rename/generalize)
+
+Refactor `createClawhubInstallLogger` into something like:
+
+- `createClawhubSkillJobLogger({ jobId, agentId, slug, operation })`
+
+so install and delete share the same logging shape.
+
+2. Add runtime uninstall helper.
+
+Add a helper near the install helper block:
+
+- `uninstallClawhubSkill(provisioner, containerId, slug)`
+
+Implementation:
+
+- `await ensureClawhubCli(...)`
+- run `cd /root/.openclaw/workspace && clawhub uninstall <slug> --no-input` if supported
+- if the CLI does not accept `--no-input`, use the simplest non-interactive uninstall invocation confirmed in manual verification
+- use the same timeout and env flags as install unless uninstall needs its own constant
+- after uninstall returns, re-read and verify installed skills with the same retry-friendly lockfile read helper rather than a single immediate check
+
+3. Add delete worker.
+
+Generalize the install worker into a shared ClawHub mutation worker:
+
+- queue name: `clawhub-jobs`
+- concurrency: `1`
+- lock duration / renew time: parallel to the current install worker
+
+Suggested structure:
+
+```ts
+const clawhubJobsWorker = new Worker("clawhub-jobs", async (job) => {
+  // validate job payload
+  // branch on job.data.operation
+  // load agent
+  // validate runtime family + running state
+  // load provisioner
+  // run install or delete flow
+  // verify lockfile state
+  // persist DB mutation if needed
+  // return operation result
+});
+```
+
+4. Keep install and delete subflows explicit within the shared worker.
+
+Do not collapse install/delete behavior into one unreadable block. Use helpers or per-operation branches such as:
+
+- `runClawhubInstallJob(...)`
+- `runClawhubDeleteJob(...)`
+
+The shared worker should mainly:
+
+- validate payload,
+- load the agent/runtime,
+- dispatch by `operation`,
+- emit consistent logging/status payloads.
+
+Treat this as the implementation decision, not just a suggestion: one shared worker with explicit install/delete helper branches.
+
+5. Make delete tolerant of orphaned runtime skills.
+
+The worker must not fail just because the DB has no matching `clawhub_skills` entry. That is expected for an orphaned runtime deletion.
+
+6. Extend job completion/failure logging.
+
+Install currently has:
+
+- `clawhubInstallWorker.on("failed", ...)`
+- `clawhubInstallWorker.on("completed", ...)`
+
+Replace those with shared worker listeners keyed off `operation` in the log payload.
+
+### Verification Cases
+
+Manual verification should cover:
+
+- saved + installed skill delete,
+- runtime-only orphaned skill delete,
+- delete when skill is already absent,
+- failed uninstall leaving DB untouched,
+- successful uninstall removing lockfile entry and DB entry.
+
+## Phase 5: Extend Reconciliation
+
+### Objective
+
+Keep restart/provision reconciliation aligned with DB truth without causing destructive surprises during normal page viewing.
+
+### Files
+
+- `agent-runtime/lib/clawhubReconciliation.js`
+- `workers/provisioner/worker.ts`
+- possibly `backend-api/routes/clawhub.ts` if a future manual sync action is added later
+
+### Changes
+
+1. Expand reconciliation computation.
+
+Current worker path only does:
+
+- `computeMissingSavedSkills(savedSkills, installedSkills)`
+
+Add orphan detection:
+
+- `computeOrphanedInstalledSkills(savedSkills, installedSkills)`
+
+2. Update `reconcileSavedClawhubSkills`.
+
+This function should be renamed because it will no longer only install saved skills. Suggested rename:
+
+- `reconcileClawhubSkills`
+
+New behavior:
+
+- if DB-only skills exist, install them,
+- if runtime-only skills exist, uninstall them,
+- keep logging explicit about which path ran.
+
+3. Keep reconciliation at restart/provision boundaries.
+
+Do not add automatic reconciliation on page load. The existing provisioner call site is already the right place to begin:
+
+- after a fresh deploy,
+- after agent restart if a restart path later calls into the same helper.
+
+4. Preserve best-effort semantics.
+
+If one orphan uninstall fails during reconciliation, log it and continue processing other skills just like the current install reconciliation loop.
+
+### Tests
+
+Extend `backend-api/__tests__/clawhubReconciliation.test.ts` and add worker-level tests if there is an existing pattern for `workers/provisioner/worker.ts`. At minimum ensure helper coverage exists for both missing-saved and orphaned-runtime sets.
+
+## Phase 6: Implement Frontend Data Model Changes
+
+### Objective
+
+Teach the ClawHub tab to render merged runtime/DB health data rather than only raw installed slug lists.
+
+### Files
+
+- `frontend-dashboard/components/agents/openclaw/ClawHubTab.tsx`
+- `frontend-dashboard/components/agents/openclaw/SkillCard.tsx`
+- `frontend-dashboard/components/agents/openclaw/SkillGrid.tsx`
+- `frontend-dashboard/components/agents/openclaw/SkillSelectionTray.tsx`
+- optionally add a new component such as `InstalledSkillGrid.tsx` or `InstalledSkillList.tsx`
+
+### Changes
+
+1. Replace the current installed-skill state type.
+
+Current local types in `ClawHubTab.tsx`:
+
+- `type InstalledSkill = { slug: string; version: string }`
+- `type InstalledSkillsResponse = { skills?: InstalledSkill[] }`
+
+Replace with a merged type, e.g.:
+
+```ts
+type AgentClawhubSkill = {
+  slug: string;
+  version: string;
+  saved: boolean;
+  installed: boolean;
+  source: "clawhub";
+  author: string;
+  pagePath: string;
+  installedAt: string | null;
+  status: "healthy" | "missing_runtime" | "orphaned_runtime";
+};
+```
+
+2. Split install and delete selection state.
+
+Current selection state is install-only:
+
+- `selectedSkills`
+- `selectionBusySlug`
+- `jobStatuses`
+- `installError`
+
+Add delete-specific state:
+
+- `selectedDeleteSkills`
+- `deleteBusySlug`
+- `deleteError`
+
+Keep install and delete isolated so one flow does not pollute the other.
+
+3. Generalize job tracking.
+
+Current `InstallJobStatus` should become a generic ClawHub mutation job type with:
+
+- `operation`
+- `status`
+- `error`
+- `completedAt`
+
+The polling effect should update both install and delete UI by reading from the shared ClawHub jobs endpoint.
+
+Important boundary:
+
+- stable skill state comes from `GET /api/clawhub/agents/:agentId/skills`
+- temporary pending state comes from the local job-status map populated by polling
+
+4. Derive view models in `ClawHubTab.tsx`.
+
+From the merged API response compute:
+
+- `healthyInstalledSkills`
+- `orphanedRuntimeSkills`
+- `catalogInstalledSlugs`
+
+Those three derived sets are what drive:
+
+- installed section,
+- drift badges,
+- disabled install selection in the catalog.
+
+## Phase 7: Build The Installed Skills UI And Delete Flow
+
+### Objective
+
+Add the installed-skills section above the catalog and wire explicit deletion.
+
+### Files
+
+- `frontend-dashboard/components/agents/openclaw/ClawHubTab.tsx`
+- `frontend-dashboard/components/agents/openclaw/SkillSelectionTray.tsx`
+- `frontend-dashboard/components/agents/openclaw/SkillCard.tsx`
+- optionally new installed-skill-specific components under `frontend-dashboard/components/agents/openclaw/`
+
+### Changes
+
+1. Add an installed skills surface above the existing catalog.
+
+This can be:
+
+- a new `InstalledSkillsPanel` component, or
+- a small section rendered inline in `ClawHubTab.tsx`
+
+Responsibilities:
+
+- render healthy installed skills,
+- render orphaned runtime skills with drift styling,
+- allow selection for delete,
+- open the existing detail panel when clicked.
+
+2. Reuse `SkillDetailPanel` for delete review.
+
+`SkillDetailActionState` already exists. Extend action labels and callbacks for delete mode:
+
+- `Delete skill`
+- `Remove from delete selection`
+- `Installed`
+
+No new detail panel pattern should be introduced.
+
+3. Extend `SkillSelectionTray` with delete mode.
+
+Current prop:
+
+- `mode?: "deploy" | "install"`
+
+Change it to something like:
+
+- `mode?: "deploy" | "install" | "delete"`
+
+Then add delete-specific copy:
+
+- tray title/count,
+- action button label,
+- destructive styling if desired,
+- text that uses the same restart recommendation as install.
+
+4. Decide whether to reuse `SkillCard` or add a sibling for installed items.
+
+`SkillCard.tsx` already knows how to render an `Installed` pill for catalog entries.
+
+Recommendation:
+
+- keep `SkillCard` for catalog browsing,
+- create a lightweight installed-skill row/card component for the top section so delete affordances and drift states stay explicit.
+
+5. Add delete handlers in `ClawHubTab.tsx`.
+
+Suggested new handlers:
+
+- `toggleDeleteSelection(skill)`
+- `removeDeleteSelectionBySlug(slug)`
+- `clearDeleteSelections()`
+- `handleDeleteSelected()`
+
+`handleDeleteSelected()` should:
+
+- POST `/api/clawhub/agents/:agentId/skills/:slug/delete`
+- update job state map,
+- poll until success/failure,
+- reload installed skills,
+- remove the deleted skill from selection,
+- call the same restart-success callback pattern already used for install.
+
+6. Keep restart messaging identical in tone to install.
+
+Current install UX references:
+
+- `frontend-dashboard/components/agents/openclaw/SkillSelectionTray.tsx`
+- `frontend-dashboard/components/agents/openclaw/ClawHubTab.tsx`
+- `frontend-dashboard/pages/agents/[id].tsx`
+
+Delete success should set the same "restart your agent session" recommendation, just with delete-specific copy.
+
+## Phase 8: Reuse Existing Restart Recommendation Pattern
+
+### Objective
+
+Do not invent a second restart recommendation pattern for delete.
+
+### Files
+
+- `frontend-dashboard/components/agents/OpenClawTab.tsx`
+- `frontend-dashboard/pages/agents/[id].tsx`
+- `frontend-dashboard/components/agents/openclaw/ClawHubTab.tsx`
+
+### Changes
+
+1. Inspect the current callback path.
+
+Today:
+
+- `ClawHubTab` calls `onInstallSuccess?.()`
+- `OpenClawTab` forwards `onClawhubInstallSuccess`
+- `pages/agents/[id].tsx` shows the "ClawHub Install Complete" banner
+
+2. Keep the success notification path aligned with install.
+
+At minimum:
+
+- delete success should show the same upper-right notification/toast recommendation as install,
+- install and delete should share restart recommendation wording.
+
+If engineers choose to generalize the callback path as part of that cleanup, rename install-specific props to mutation-neutral ones:
+
+- `onClawhubInstallSuccess` -> `onClawhubMutationSuccess`
+- `onInstallSuccess` -> `onMutationSuccess`
+
+3. Treat the page-level banner as optional cleanup, not a requirement for v1.
+
+If product wants stronger parity later, the page-level banner in `pages/agents/[id].tsx` can be generalized, but the required behavior for this feature is the same restart recommendation toast/notification pattern as installation.
+
+## Phase 9: Test Plan
+
+### Backend Tests
+
+- `backend-api/__tests__/clawhub.test.ts`
+  Add route coverage for merged skill state and delete enqueueing.
+- `backend-api/__tests__/clawhubReconciliation.test.ts`
+  Add merged-state and orphan computation coverage.
+- add worker tests if a suitable test pattern exists for `workers/provisioner/worker.ts`
+
+Must-cover backend scenarios:
+
+- healthy merged skill state,
+- missing runtime state,
+- orphaned runtime state,
+- delete queued for saved skill,
+- delete queued for orphaned runtime skill,
+- duplicate in-flight delete job reused,
+- conflicting install job blocks delete,
+- delete success removes DB entry if present,
+- delete success keeps DB stable if no entry exists,
+- delete failure leaves DB untouched.
+- job status lookup rejects jobs for agents the current user does not own.
+
+### Frontend Tests
+
+Add tests wherever the current frontend test strategy for `frontend-dashboard` lives. If there are no component tests for this area yet, add focused render/interaction tests around the new installed-skill surface and keep them narrow.
+
+Must-cover frontend scenarios:
+
+- installed skills section renders above catalog,
+- healthy installed catalog skills remain non-selectable for install,
+- orphaned runtime skills render with drift state and are deletable,
+- delete tray mode uses delete-specific labels,
+- successful delete triggers the same restart recommendation path as install,
+- failed delete shows an error without dropping local state.
+- pending install/delete state is derived from polled job status, not embedded into the stable skills response.
+
+### Manual Verification
+
+1. Install a skill and confirm current behavior still works.
+2. Delete a healthy saved+installed skill.
+3. Delete an orphaned runtime skill.
+4. Restart the agent and confirm reconciliation installs DB-only skills.
+5. Restart the agent and confirm reconciliation removes runtime-only orphaned skills.
+6. Confirm the agent page banner uses the same restart recommendation for install and delete.
+6. Confirm delete success uses the same upper-right notification/toast restart recommendation as install.
+
+## Phase 10: Suggested Delivery Order
+
+Implement in this order to minimize thrash:
+
+1. Shared reconciliation helpers and merged-state computation.
+2. Route changes for merged skill state.
+3. Queue additions and delete route enqueueing.
+4. Delete worker.
+5. Restart/provision reconciliation expansion.
+6. Frontend type changes in `ClawHubTab.tsx`.
+7. Installed-skill UI section and delete tray mode.
+8. Restart banner generalization.
+9. Backend tests.
+10. Frontend tests and manual validation.
+
+## Out Of Scope For This Pass
+
+- aggressive cleanup of non-ClawHub-owned side effects,
+- adoption workflows beyond explicit orphan delete,
+- automatic drift repair on tab load,
+- redesigning the broader OpenClaw tab shell beyond the `pr-174` alignment already captured on this branch.
+Use the same upper-right notification/toast pattern as install for delete success.
+
+Do not require a new page-level banner for delete unless product later decides both install and delete should share one larger agent-page restart banner.

--- a/plans/clawhub_deletion/clawhub-deletion-plan.md
+++ b/plans/clawhub_deletion/clawhub-deletion-plan.md
@@ -1,0 +1,275 @@
+# ClawHub Deletion Plan
+
+## Goal
+
+Add safe ClawHub skill deletion for existing OpenClaw agents while reusing the `pr-174` UI direction for installed-skill visibility, disabled install selection for already-installed skills, and multi-select deletion.
+
+## Working Model
+
+Treat `agents.clawhub_skills` as Nora's desired-state source of truth and the OpenClaw workspace as the reconciled runtime state.
+
+- Database:
+  `agents.clawhub_skills` is the list Nora believes should exist for the agent.
+- Runtime:
+  The workspace filesystem plus `.clawhub/lock.json` is the actual installed-state snapshot inside the running container.
+- Reconciliation:
+  Workers drive runtime toward the database, not the other way around.
+
+This already matches the install flow in spirit:
+
+1. An install job runs `clawhub install <slug>`.
+2. The worker verifies the slug appears in `.clawhub/lock.json`.
+3. The worker persists the skill into `agents.clawhub_skills`.
+4. Reconciliation installs any DB-saved skills that are missing from runtime.
+
+Deletion should mirror that:
+
+1. A delete request targets one or more saved or runtime-present skills.
+2. The worker runs `clawhub uninstall <slug>` in the runtime.
+3. The worker verifies the slug is absent from `.clawhub/lock.json`.
+4. The worker removes the entry from `agents.clawhub_skills`.
+
+## Frontend
+
+### Baseline To Reuse
+
+- `frontend-dashboard/components/agents/openclaw/ClawHubTab.tsx`
+  Keep the current catalog/search/detail shell and align the deletion UX with the `pr-174` treatment of installed skills.
+- `frontend-dashboard/components/agents/openclaw/SkillGrid.tsx`
+  Keep this for catalog browsing.
+- `frontend-dashboard/components/agents/openclaw/SkillDetailPanel.tsx`
+  Reuse this for review/confirmation before delete.
+- `frontend-dashboard/components/agents/openclaw/SkillSelectionTray.tsx`
+  Extend this for delete mode instead of introducing a second tray pattern.
+
+### UI Structure
+
+The ClawHub tab should be organized into two clear surfaces:
+
+1. Installed skills section:
+   Shows skills already present on the agent and is the only place where delete selection is allowed.
+2. Catalog section:
+   Shows registry skills for browsing and install, with already-installed skills clearly marked and not selectable for install.
+
+### Intended User Flow
+
+1. User opens the ClawHub tab.
+2. Installed skills appear in a dedicated section above the browse/search catalog.
+3. User selects one or more installed skills for deletion.
+4. Selected skills appear in the existing tray pattern, now in delete mode.
+5. User confirms the destructive action.
+6. Nora queues delete jobs and shows per-skill job state.
+7. On success, the installed list refreshes and the UI prompts for restart or revalidation if needed.
+
+### Frontend Requirements
+
+- Match `pr-174` as closely as practical for installed-skill display and disabled install selection.
+- Do not allow install selection for skills already in a healthy installed state.
+- Keep install and delete selections visually distinct if both modes can exist in the same view.
+- Show per-skill pending/running/success/failed status.
+- Surface drift states instead of hiding them.
+- Surface `orphaned_runtime` as drift, but still allow the operator to explicitly delete it.
+- Preserve the existing detail panel pattern so README/requirements remain inspectable before delete.
+
+### Frontend Data Contract
+
+This contract is not just for rendering a list of skills. It is meant to tell the Nora operator whether each ClawHub skill on an agent is healthy relative to Nora's database state.
+
+The frontend therefore needs a merged DB/runtime view rather than only the raw lockfile view returned today.
+
+- DB view:
+  What Nora believes should exist for the agent.
+- Runtime view:
+  What is actually installed in the running OpenClaw workspace.
+- Merged view:
+  The operator-facing health view that compares those two sources and makes drift visible.
+
+Without that merged view, the UI can show a list of skills, but it cannot accurately tell the operator whether Nora and the live agent agree on the current state of those skills.
+
+```json
+{
+  "skills": [
+    {
+      "slug": "github",
+      "version": "2.1.0",
+      "saved": true,
+      "installed": true,
+      "source": "clawhub",
+      "author": "steipete",
+      "pagePath": "steipete/github",
+      "installedAt": "2026-04-21T00:00:00.000Z",
+      "status": "healthy"
+    }
+  ]
+}
+```
+
+Status values:
+
+- `healthy`
+- `missing_runtime`
+- `orphaned_runtime`
+- `pending_install`
+- `pending_delete`
+
+This gives the UI enough information to:
+
+- render installed skills separately,
+- disable install selection for already-installed skills,
+- show the operator when a skill is healthy versus out of sync,
+- show drift explicitly when the agent runtime and DB do not match,
+- decide when delete should be allowed, including explicit deletion of orphaned runtime skills.
+
+## Backend
+
+### Runtime Delete Command
+
+Assume the runtime removal command is `clawhub uninstall <slug>`.
+
+The backend should still verify the outcome instead of trusting the command blindly:
+
+1. Run `clawhub uninstall <slug>`.
+2. Re-read `.clawhub/lock.json`.
+3. Confirm the slug is absent.
+4. Only then mutate `agents.clawhub_skills`.
+
+This keeps the delete semantics aligned with install, where Nora verifies the lockfile before persisting state.
+
+### Reconciliation Rules
+
+Use the same rules in startup reconciliation, repair flows, and install/delete job handling:
+
+- DB has skill, runtime has skill:
+  No-op.
+- DB has skill, runtime is missing skill:
+  Install it into runtime.
+- DB is missing skill, runtime has skill:
+  Mark it as `orphaned_runtime` in the UI. The operator may explicitly delete it, and restart/provision reconciliation may also clean it up.
+- DB is missing skill, runtime is missing skill:
+  No-op.
+
+That keeps the database as the deciding authority without making the ClawHub tab itself feel destructively surprising.
+
+### Delete Worker Semantics
+
+The delete worker should use a verify-before-persist flow:
+
+1. Load and validate the agent.
+2. Read current runtime skills from `.clawhub/lock.json`.
+3. If the slug is already absent from runtime:
+   Treat runtime deletion as already satisfied.
+4. Otherwise run `clawhub uninstall <slug>`.
+5. Re-read installed skills from `.clawhub/lock.json`.
+6. If the slug is still present:
+   Fail the job and keep the DB row unchanged.
+7. Once runtime is confirmed clean:
+   Remove the normalized entry from `agents.clawhub_skills` if one exists.
+
+This means orphaned runtime skills can follow the normal delete path too. The only difference is that the final DB-removal step becomes a no-op because there is no saved entry to delete.
+
+That ordering matches the intended normal case: runtime first, database second.
+
+### API Contract
+
+Keep the install shape and add matching delete primitives.
+
+- `GET /api/clawhub/agents/:agentId/skills`
+  Return merged DB/runtime state for each skill. This endpoint should return stable skill health data; temporary pending install/delete UI state can be overlaid by the frontend from job polling rather than embedded in the stable response.
+- `POST /api/clawhub/agents/:agentId/skills/:slug/delete`
+  Queue a delete job for a single skill and return the job handle.
+- `GET /api/clawhub/jobs/:jobId`
+  Reuse the existing polling endpoint, but include `operation: "install" | "delete"` once both job types exist. Job polling must remain user-scoped so a user can only read the status of ClawHub jobs tied to agents they own.
+
+### Skill Identity
+
+Do not assume bare `slug` is the only stable identifier Nora should preserve.
+
+- Runtime operations and current ClawHub CLI flows are still slug-driven: `clawhub install <slug>`, `clawhub uninstall <slug>`.
+- ClawHub also exposes canonical page URLs in `owner/slug` form and has explicitly added owner handles to search results so duplicate/common slugs are easier to disambiguate.
+
+Product guidance:
+
+- keep using `slug` for runtime install/uninstall commands,
+- preserve `author` and `pagePath` in Nora's saved metadata and UI state,
+- treat `author + slug` / canonical `pagePath` as the richer identity for display and saved-state matching when available.
+
+### Queue / Worker Behavior
+
+- Use a single BullMQ queue for all ClawHub mutations: `clawhub-jobs`.
+- Each job carries `operation: "install" | "delete"`.
+- Reject or coalesce duplicate in-flight jobs for the same `(agentId, slug, operation)`.
+- Block conflicting install/delete jobs for the same `(agentId, slug)`.
+- The shared queue is also the main serialization mechanism so multiple ClawHub jobs cannot race against the same lockfile.
+- Reuse the existing install-worker patterns for runtime validation, logging, timeout handling, and post-job polling.
+
+Jobs should serialize because they mutate shared runtime state for the same agent:
+
+- the same workspace,
+- the same `.clawhub/lock.json`,
+- potentially the same skill directory.
+
+Without serialization, install/delete jobs can race each other and leave the runtime or lockfile in an inconsistent state.
+
+### Drift Handling
+
+Because the DB is ground truth, the backend should manage drift deliberately rather than silently as a side effect of opening the UI.
+
+- `missing_runtime`:
+  Backend installs the skill into runtime during reconciliation.
+- `orphaned_runtime`:
+  Backend surfaces the drift in the UI, allows the operator to explicitly delete it, and may also remove it during restart/provision reconciliation rather than immediately on page load.
+
+Recommended timing for repair:
+
+- Automatic repair:
+  Run drift reconciliation on restart/provision, where operators already expect state to be brought back in sync.
+- Optional manual repair:
+  A future `Sync ClawHub state` action in the UI could trigger the same reconciliation intentionally.
+
+This avoids destructive surprises while still letting Nora converge the runtime back to the DB-owned state.
+
+### Cleanup Scope
+
+The first version of deletion should focus on the ClawHub install footprint only.
+
+- Run `clawhub uninstall <slug>`.
+- Remove the skill from the ClawHub-managed workspace/lockfile footprint.
+- Do not attempt aggressive cleanup of arbitrary files a skill may have created outside that footprint.
+
+If a skill writes side effects elsewhere, that is a harder cleanup problem and should be treated as out of scope for v1 unless the runtime offers stronger ownership metadata.
+
+### Restart / Refresh Behavior
+
+Use the same restart recommendation as installation and assume install/delete require a restart or session refresh for the change to fully take effect.
+
+This matches the current ClawHub install UX in Nora, which already tells the user to restart the agent session after a successful install.
+
+Product guidance for now:
+
+- show a success state when the job completes,
+- refresh the ClawHub tab data,
+- show the same upper-right notification/toast pattern used by installation,
+- prompt the operator to restart or reload the agent/session so the change is activated.
+
+For background reconciliation:
+
+- keep the repair itself in the background,
+- show a completion notification when reconciliation installs or removes ClawHub skills.
+
+## Open Questions
+
+- Should restart messaging be a passive recommendation, or should the delete/install success UI more strongly direct the operator into a restart action?
+
+## Suggested Implementation Order
+
+1. Expand the installed-skills API into a merged DB/runtime state endpoint.
+2. Add shared helpers for merged-state computation and `agents.clawhub_skills` mutation.
+3. Implement delete queueing and the delete worker using `clawhub uninstall <slug>` plus lockfile verification.
+4. Extend reconciliation so DB-only skills are installed and runtime-only skills are cleaned up at restart/provision boundaries.
+5. Add delete mode to the current ClawHub tab components.
+6. Add tests for mixed install/delete job states, drift reporting, and post-delete refresh behavior.
+
+## Scope On This Branch
+
+- Reuse the prior branch's OpenClaw tab shell update where it helps the deletion UX.
+- Keep the plan explicit about frontend and backend contracts before implementing destructive behavior.

--- a/workers/provisioner/worker.ts
+++ b/workers/provisioner/worker.ts
@@ -973,10 +973,14 @@ async function removeSavedClawhubSkill(agentId, slug, skillEntry) {
 
 async function installClawhubSkill(provisioner, containerId, slug) {
   await ensureClawhubCli(provisioner, containerId);
+  // Keep the install invocation unwrapped (no nested in-container `timeout ... /bin/sh -lc ...`).
+  // A nested timeout caused Nora-driven ClawHub installs to hang even though the same CLI command
+  // completed quickly when run directly in the container. The outer exec timeout below is the single
+  // guardrail. `slug` is shell-quoted (single quotes) so it cannot inject into the container shell.
   await runProvisionerExecCommand(
     provisioner,
     containerId,
-    `cd ${JSON.stringify(OPENCLAW_WORKSPACE_PATH)} && clawhub install ${JSON.stringify(
+    `cd ${JSON.stringify(OPENCLAW_WORKSPACE_PATH)} && clawhub install ${shellSingleQuote(
       slug,
     )} --no-input`,
     {
@@ -989,10 +993,11 @@ async function installClawhubSkill(provisioner, containerId, slug) {
 
 async function uninstallClawhubSkill(provisioner, containerId, slug) {
   await ensureClawhubCli(provisioner, containerId);
+  // `slug` is shell-quoted (single quotes) so it cannot inject into the container shell.
   await runProvisionerExecCommand(
     provisioner,
     containerId,
-    `cd ${JSON.stringify(OPENCLAW_WORKSPACE_PATH)} && clawhub uninstall ${JSON.stringify(
+    `cd ${JSON.stringify(OPENCLAW_WORKSPACE_PATH)} && clawhub uninstall ${shellSingleQuote(
       slug,
     )} --yes`,
     {
@@ -1072,26 +1077,40 @@ async function reconcileClawhubSkills({
     }
   }
 
-  if (orphanedSkills.length) {
-    console.log(
-      `${logPrefix} agent=${agentId} Reconciling ${orphanedSkills.length} orphaned ClawHub skill(s)`,
+  // Pruning orphaned runtime skills (installed in the container but not tracked in the agents
+  // table) is destructive and OFF by default: it would silently delete skills an operator
+  // installed manually inside the container. Drift is always surfaced in the merged skill view
+  // and can be removed explicitly via the delete route; set CLAWHUB_PRUNE_ORPHANED_SKILLS=true
+  // to opt into automatic pruning during reconciliation.
+  const pruneOrphans = process.env.CLAWHUB_PRUNE_ORPHANED_SKILLS === "true";
+
+  if (orphanedSkills.length && !pruneOrphans) {
+    console.warn(
+      `${logPrefix} agent=${agentId} Detected ${orphanedSkills.length} orphaned ClawHub skill(s) not in saved state; ` +
+        `automatic pruning is disabled (set CLAWHUB_PRUNE_ORPHANED_SKILLS=true to enable). ` +
+        `Leaving runtime skills in place: ${orphanedSkills.map((skill) => skill.slug).join(", ")}`,
     );
   }
 
-  for (const skill of orphanedSkills) {
-    try {
-      console.log(
-        `${logPrefix} agent=${agentId} slug=${skill.slug} Removing orphaned runtime skill`,
-      );
-      await uninstallClawhubSkill(provisioner, containerId, skill.slug);
-      console.log(
-        `${logPrefix} agent=${agentId} slug=${skill.slug} Reconciliation uninstall completed`,
-      );
-    } catch (error) {
-      const message = String(error?.message || "");
-      console.warn(
-        `${logPrefix} agent=${agentId} slug=${skill.slug} Reconciliation uninstall failed: ${message}`,
-      );
+  if (orphanedSkills.length && pruneOrphans) {
+    console.warn(
+      `${logPrefix} agent=${agentId} Pruning ${orphanedSkills.length} orphaned ClawHub skill(s) (CLAWHUB_PRUNE_ORPHANED_SKILLS=true)`,
+    );
+    for (const skill of orphanedSkills) {
+      try {
+        console.warn(
+          `${logPrefix} agent=${agentId} slug=${skill.slug} Removing orphaned runtime skill`,
+        );
+        await uninstallClawhubSkill(provisioner, containerId, skill.slug);
+        console.warn(
+          `${logPrefix} agent=${agentId} slug=${skill.slug} Reconciliation uninstall completed`,
+        );
+      } catch (error) {
+        const message = String(error?.message || "");
+        console.warn(
+          `${logPrefix} agent=${agentId} slug=${skill.slug} Reconciliation uninstall failed: ${message}`,
+        );
+      }
     }
   }
 }

--- a/workers/provisioner/worker.ts
+++ b/workers/provisioner/worker.ts
@@ -44,6 +44,8 @@ const { buildReadinessWarningDetail, persistReadinessWarning } = require("./read
 const { shellSingleQuote } = require("../../agent-runtime/lib/containerCommand");
 const {
   computeMissingSavedSkills,
+  computeOrphanedInstalledSkills,
+  removeSavedSkillEntry,
   normalizeSavedSkillEntry: normalizeSavedClawhubSkillEntry,
 } = require("../../agent-runtime/lib/clawhubReconciliation");
 
@@ -690,14 +692,14 @@ function wrapCommandWithContainerTimeout(command, timeoutMs) {
   ].join(" ");
 }
 
-function createClawhubInstallLogger({ jobId, agentId, slug }) {
+function createClawhubSkillJobLogger({ jobId, agentId, slug, operation }) {
   const startedAt = Date.now();
 
   return (step, message, extra = null) => {
     const elapsedMs = Date.now() - startedAt;
     const suffix = extra ? ` ${JSON.stringify(extra)}` : "";
     console.log(
-      `[clawhub-installs] job=${jobId} agent=${agentId} slug=${slug} step=${step} elapsedMs=${elapsedMs} ${message}${suffix}`,
+      `[clawhub-jobs] operation=${operation} job=${jobId} agent=${agentId} slug=${slug} step=${step} elapsedMs=${elapsedMs} ${message}${suffix}`,
     );
   };
 }
@@ -950,7 +952,58 @@ async function appendSavedClawhubSkill(agentId, slug, skillEntry) {
   ]);
 }
 
-async function reconcileSavedClawhubSkills({
+async function removeSavedClawhubSkill(agentId, slug, skillEntry) {
+  const normalizedEntry = normalizeSavedClawhubSkillEntry(slug, skillEntry);
+  const result = await db.query("SELECT clawhub_skills FROM agents WHERE id = $1 LIMIT 1", [
+    agentId,
+  ]);
+  const current = Array.isArray(result.rows[0]?.clawhub_skills)
+    ? result.rows[0].clawhub_skills
+    : [];
+  const next = removeSavedSkillEntry(
+    current,
+    normalizedEntry?.installSlug || slug,
+    normalizedEntry?.author || "",
+  );
+  await db.query("UPDATE agents SET clawhub_skills = $2::jsonb WHERE id = $1", [
+    agentId,
+    JSON.stringify(next),
+  ]);
+}
+
+async function installClawhubSkill(provisioner, containerId, slug) {
+  await ensureClawhubCli(provisioner, containerId);
+  await runProvisionerExecCommand(
+    provisioner,
+    containerId,
+    `cd ${JSON.stringify(OPENCLAW_WORKSPACE_PATH)} && clawhub install ${JSON.stringify(
+      slug,
+    )} --no-input`,
+    {
+      timeout: CLAWHUB_INSTALL_TIMEOUT_MS + 10000,
+      maxOutputBytes: 32768,
+      env: ["TERM=dumb", "CI=1", "NO_COLOR=1", "CLICOLOR=0"],
+    },
+  );
+}
+
+async function uninstallClawhubSkill(provisioner, containerId, slug) {
+  await ensureClawhubCli(provisioner, containerId);
+  await runProvisionerExecCommand(
+    provisioner,
+    containerId,
+    `cd ${JSON.stringify(OPENCLAW_WORKSPACE_PATH)} && clawhub uninstall ${JSON.stringify(
+      slug,
+    )} --yes`,
+    {
+      timeout: CLAWHUB_INSTALL_TIMEOUT_MS + 10000,
+      maxOutputBytes: 32768,
+      env: ["TERM=dumb", "CI=1", "NO_COLOR=1", "CLICOLOR=0"],
+    },
+  );
+}
+
+async function reconcileClawhubSkills({
   agentId,
   containerId,
   provisioner,
@@ -972,11 +1025,6 @@ async function reconcileSavedClawhubSkills({
 
   const savedSkills = Array.isArray(agent.clawhub_skills) ? agent.clawhub_skills : [];
 
-  if (!savedSkills.length) {
-    console.log(`${logPrefix} agent=${agentId} No saved ClawHub skills to reconcile`);
-    return;
-  }
-
   let installedSkills = [];
   try {
     installedSkills = await readInstalledClawhubSkills(provisioner, containerId);
@@ -988,34 +1036,25 @@ async function reconcileSavedClawhubSkills({
   }
 
   const missingSkills = computeMissingSavedSkills(savedSkills, installedSkills);
+  const orphanedSkills = computeOrphanedInstalledSkills(savedSkills, installedSkills);
 
-  if (!missingSkills.length) {
-    console.log(`${logPrefix} agent=${agentId} All saved ClawHub skills already present`);
+  if (!missingSkills.length && !orphanedSkills.length) {
+    console.log(`${logPrefix} agent=${agentId} ClawHub runtime already matches saved state`);
     return;
   }
 
-  console.log(
-    `${logPrefix} agent=${agentId} Reconciling ${missingSkills.length} missing ClawHub skill(s)`,
-  );
+  if (missingSkills.length) {
+    console.log(
+      `${logPrefix} agent=${agentId} Reconciling ${missingSkills.length} missing ClawHub skill(s)`,
+    );
+  }
 
   for (const skill of missingSkills) {
     try {
       console.log(
         `${logPrefix} agent=${agentId} slug=${skill.installSlug} Installing missing saved skill`,
       );
-      await ensureClawhubCli(provisioner, containerId);
-      await runProvisionerExecCommand(
-        provisioner,
-        containerId,
-        `cd ${JSON.stringify(OPENCLAW_WORKSPACE_PATH)} && clawhub install ${JSON.stringify(
-          skill.installSlug,
-        )} --no-input`,
-        {
-          timeout: CLAWHUB_INSTALL_TIMEOUT_MS + 10000,
-          maxOutputBytes: 32768,
-          env: ["TERM=dumb", "CI=1", "NO_COLOR=1", "CLICOLOR=0"],
-        },
-      );
+      await installClawhubSkill(provisioner, containerId, skill.installSlug);
       console.log(
         `${logPrefix} agent=${agentId} slug=${skill.installSlug} Reconciliation install completed`,
       );
@@ -1029,6 +1068,29 @@ async function reconcileSavedClawhubSkills({
       }
       console.warn(
         `${logPrefix} agent=${agentId} slug=${skill.installSlug} Reconciliation install failed: ${message}`,
+      );
+    }
+  }
+
+  if (orphanedSkills.length) {
+    console.log(
+      `${logPrefix} agent=${agentId} Reconciling ${orphanedSkills.length} orphaned ClawHub skill(s)`,
+    );
+  }
+
+  for (const skill of orphanedSkills) {
+    try {
+      console.log(
+        `${logPrefix} agent=${agentId} slug=${skill.slug} Removing orphaned runtime skill`,
+      );
+      await uninstallClawhubSkill(provisioner, containerId, skill.slug);
+      console.log(
+        `${logPrefix} agent=${agentId} slug=${skill.slug} Reconciliation uninstall completed`,
+      );
+    } catch (error) {
+      const message = String(error?.message || "");
+      console.warn(
+        `${logPrefix} agent=${agentId} slug=${skill.slug} Reconciliation uninstall failed: ${message}`,
       );
     }
   }
@@ -1752,7 +1814,7 @@ const worker = new Worker(
 
         if (resolvedRuntimeFields.runtime_family === "openclaw" && containerId) {
           try {
-            await reconcileSavedClawhubSkills({
+            await reconcileClawhubSkills({
               agentId: id,
               containerId,
               provisioner,
@@ -1843,121 +1905,209 @@ worker.on("completed", (job) => {
   console.log(`Job ${job.id} completed successfully`);
 });
 
-const clawhubInstallWorker = new Worker(
-  "clawhub-installs",
-  async (job) => {
-    const { agentId, slug, skillEntry, persistOnSuccess = true } = job.data || {};
-    const normalizedSlug = String(slug || "").trim();
-    if (!agentId || !normalizedSlug) {
-      throw new Error("ClawHub install job is missing agentId or slug");
+async function loadClawhubJobAgent(agentId) {
+  const result = await db.query(
+    `SELECT id, name, status, container_id, backend_type, runtime_family, deploy_target,
+            execution_target_id, sandbox_profile, clawhub_skills
+       FROM agents
+      WHERE id = $1
+      LIMIT 1`,
+    [agentId],
+  );
+  const agent = result.rows[0];
+  if (!agent) {
+    throw new Error(`Agent not found: ${agentId}`);
+  }
+  if (agent.runtime_family !== "openclaw") {
+    throw new Error("ClawHub mutations are only available for OpenClaw agents.");
+  }
+  if (!agent.container_id || (agent.status !== "running" && agent.status !== "warning")) {
+    throw new Error("Start the agent before managing ClawHub skills.");
+  }
+  return agent;
+}
+
+async function runClawhubInstallJob({
+  agentId,
+  slug,
+  skillEntry,
+  persistOnSuccess = true,
+  provisioner,
+  containerId,
+  logJob,
+}) {
+  logJob("cli-check", "Ensuring clawhub CLI is available");
+  await ensureClawhubCli(provisioner, containerId);
+  logJob("cli-check", "Clawhub CLI is ready");
+
+  logJob("precheck", "Reading installed skills before install");
+  const installedBefore = await readInstalledClawhubSkills(provisioner, containerId);
+  logJob("precheck", "Read installed skills before install", {
+    installedCount: installedBefore.length,
+  });
+  if (installedBefore.some((entry) => entry.slug === slug)) {
+    logJob("precheck", "Skill already installed before command");
+    if (persistOnSuccess) {
+      logJob("persist", "Persisting already-installed skill to agents table");
+      await appendSavedClawhubSkill(agentId, slug, skillEntry);
+      logJob("persist", "Persisted already-installed skill");
     }
-    const logInstall = createClawhubInstallLogger({
+    return {
+      agentId,
+      slug,
+      operation: "install",
+      installedSkills: installedBefore,
+    };
+  }
+
+  try {
+    logJob("install", "Running clawhub install command", {
+      timeoutMs: CLAWHUB_INSTALL_TIMEOUT_MS,
+    });
+    await installClawhubSkill(provisioner, containerId, slug);
+    logJob("install", "Clawhub install command finished");
+  } catch (error) {
+    const message = String(error?.message || "");
+    if (!message.includes("Already installed")) {
+      logJob("install", "Clawhub install command failed", {
+        error: message,
+      });
+      throw error;
+    }
+    logJob("install", "Clawhub reported skill already installed");
+  }
+
+  logJob("verify", "Reading installed skills after install");
+  const installedSkills = await readInstalledClawhubSkills(provisioner, containerId);
+  logJob("verify", "Read installed skills after install", {
+    installedCount: installedSkills.length,
+  });
+  if (!installedSkills.some((entry) => entry.slug === slug)) {
+    logJob("verify", "Lockfile missing expected slug after install");
+    throw new Error(`ClawHub install completed but ${slug} was not found in lockfile`);
+  }
+
+  if (persistOnSuccess) {
+    logJob("persist", "Persisting successful install to agents table");
+    await appendSavedClawhubSkill(agentId, slug, skillEntry);
+    logJob("persist", "Persisted successful install");
+  }
+
+  return {
+    agentId,
+    slug,
+    operation: "install",
+    installedSkills,
+  };
+}
+
+async function runClawhubDeleteJob({
+  agentId,
+  slug,
+  skillEntry,
+  removeSavedEntryOnSuccess = true,
+  provisioner,
+  containerId,
+  logJob,
+}) {
+  logJob("cli-check", "Ensuring clawhub CLI is available");
+  await ensureClawhubCli(provisioner, containerId);
+  logJob("cli-check", "Clawhub CLI is ready");
+
+  logJob("precheck", "Reading installed skills before delete");
+  const installedBefore = await readInstalledClawhubSkills(provisioner, containerId);
+  logJob("precheck", "Read installed skills before delete", {
+    installedCount: installedBefore.length,
+  });
+
+  if (installedBefore.some((entry) => entry.slug === slug)) {
+    logJob("delete", "Running clawhub uninstall command", {
+      timeoutMs: CLAWHUB_INSTALL_TIMEOUT_MS,
+    });
+    await uninstallClawhubSkill(provisioner, containerId, slug);
+    logJob("delete", "Clawhub uninstall command finished");
+  } else {
+    logJob("precheck", "Skill already absent before delete");
+  }
+
+  logJob("verify", "Reading installed skills after delete");
+  const installedSkills = await readInstalledClawhubSkills(provisioner, containerId);
+  logJob("verify", "Read installed skills after delete", {
+    installedCount: installedSkills.length,
+  });
+  if (installedSkills.some((entry) => entry.slug === slug)) {
+    logJob("verify", "Lockfile still contains slug after delete");
+    throw new Error(`ClawHub uninstall completed but ${slug} is still present in lockfile`);
+  }
+
+  if (removeSavedEntryOnSuccess) {
+    logJob("persist", "Removing saved ClawHub skill from agents table if present");
+    await removeSavedClawhubSkill(agentId, slug, skillEntry);
+    logJob("persist", "Removed saved ClawHub skill from agents table if present");
+  }
+
+  return {
+    agentId,
+    slug,
+    operation: "delete",
+    installedSkills,
+  };
+}
+
+const clawhubJobsWorker = new Worker(
+  "clawhub-jobs",
+  async (job) => {
+    const {
+      agentId,
+      slug,
+      operation = "install",
+      skillEntry,
+      persistOnSuccess = true,
+      removeSavedEntryOnSuccess = true,
+    } = job.data || {};
+    const normalizedSlug = String(slug || "").trim();
+    const normalizedOperation = String(operation || "").trim() || "install";
+    if (!agentId || !normalizedSlug) {
+      throw new Error("ClawHub job is missing agentId or slug");
+    }
+    if (!["install", "delete"].includes(normalizedOperation)) {
+      throw new Error(`Unsupported ClawHub operation: ${normalizedOperation}`);
+    }
+
+    const logJob = createClawhubSkillJobLogger({
       jobId: job.id,
       agentId,
       slug: normalizedSlug,
+      operation: normalizedOperation,
     });
-
-    const result = await db.query(
-      `SELECT id, name, status, container_id, backend_type, runtime_family, deploy_target,
-              execution_target_id, sandbox_profile, clawhub_skills
-         FROM agents
-        WHERE id = $1
-        LIMIT 1`,
-      [agentId],
-    );
-    const agent = result.rows[0];
-    if (!agent) {
-      throw new Error(`Agent not found: ${agentId}`);
-    }
-    if (agent.runtime_family !== "openclaw") {
-      throw new Error("ClawHub installs are only available for OpenClaw agents.");
-    }
-    if (!agent.container_id || (agent.status !== "running" && agent.status !== "warning")) {
-      throw new Error("Start the agent before installing skills.");
-    }
+    const agent = await loadClawhubJobAgent(agentId);
     const provisioner = await loadBackend(buildAgentRuntimeFields(agent));
 
-    logInstall("start", "Starting install job");
+    logJob("start", `Starting ${normalizedOperation} job`);
 
-    logInstall("cli-check", "Ensuring clawhub CLI is available");
-    await ensureClawhubCli(provisioner, agent.container_id);
-    logInstall("cli-check", "Clawhub CLI is ready");
+    const result =
+      normalizedOperation === "install"
+        ? await runClawhubInstallJob({
+            agentId,
+            slug: normalizedSlug,
+            skillEntry,
+            persistOnSuccess,
+            provisioner,
+            containerId: agent.container_id,
+            logJob,
+          })
+        : await runClawhubDeleteJob({
+            agentId,
+            slug: normalizedSlug,
+            skillEntry,
+            removeSavedEntryOnSuccess,
+            provisioner,
+            containerId: agent.container_id,
+            logJob,
+          });
 
-    logInstall("precheck", "Reading installed skills before install");
-    const installedBefore = await readInstalledClawhubSkills(provisioner, agent.container_id);
-    logInstall("precheck", "Read installed skills before install", {
-      installedCount: installedBefore.length,
-    });
-    if (installedBefore.some((entry) => entry.slug === normalizedSlug)) {
-      logInstall("precheck", "Skill already installed before command");
-      if (persistOnSuccess) {
-        logInstall("persist", "Persisting already-installed skill to agents table");
-        await appendSavedClawhubSkill(agentId, normalizedSlug, skillEntry);
-        logInstall("persist", "Persisted already-installed skill");
-      }
-      logInstall("done", "Install job completed without running clawhub install");
-      return {
-        agentId,
-        slug: normalizedSlug,
-        installedSkills: installedBefore,
-      };
-    }
-
-    try {
-      logInstall("install", "Running clawhub install command", {
-        timeoutMs: CLAWHUB_INSTALL_TIMEOUT_MS,
-      });
-      // Keep the install invocation unwrapped. A nested in-container `timeout ... /bin/sh -lc ...`
-      // caused Nora-driven ClawHub installs to hang/time out even though the same CLI command
-      // completed quickly when run directly in the container. The outer exec timeout remains the
-      // single guardrail for this path.
-      await runProvisionerExecCommand(
-        provisioner,
-        agent.container_id,
-        `cd ${JSON.stringify(OPENCLAW_WORKSPACE_PATH)} && clawhub install ${JSON.stringify(
-          normalizedSlug,
-        )} --no-input`,
-        {
-          timeout: CLAWHUB_INSTALL_TIMEOUT_MS + 10000,
-          maxOutputBytes: 32768,
-          env: ["TERM=dumb", "CI=1", "NO_COLOR=1", "CLICOLOR=0"],
-        },
-      );
-      logInstall("install", "Clawhub install command finished");
-    } catch (error) {
-      const message = String(error?.message || "");
-      if (!message.includes("Already installed")) {
-        logInstall("install", "Clawhub install command failed", {
-          error: message,
-        });
-        throw error;
-      }
-      logInstall("install", "Clawhub reported skill already installed");
-    }
-
-    logInstall("verify", "Reading installed skills after install");
-    const installedSkills = await readInstalledClawhubSkills(provisioner, agent.container_id);
-    logInstall("verify", "Read installed skills after install", {
-      installedCount: installedSkills.length,
-    });
-    const installed = installedSkills.some((entry) => entry.slug === normalizedSlug);
-    if (!installed) {
-      logInstall("verify", "Lockfile missing expected slug after install");
-      throw new Error(`ClawHub install completed but ${normalizedSlug} was not found in lockfile`);
-    }
-
-    if (persistOnSuccess) {
-      logInstall("persist", "Persisting successful install to agents table");
-      await appendSavedClawhubSkill(agentId, normalizedSlug, skillEntry);
-      logInstall("persist", "Persisted successful install");
-    }
-
-    logInstall("done", "Install job completed successfully");
-    return {
-      agentId,
-      slug: normalizedSlug,
-      installedSkills,
-    };
+    logJob("done", `${normalizedOperation} job completed successfully`);
+    return result;
   },
   {
     connection,
@@ -1969,12 +2119,16 @@ const clawhubInstallWorker = new Worker(
   },
 );
 
-clawhubInstallWorker.on("failed", (job, err) => {
-  console.error(`[clawhub-installs] Job ${job?.id} failed: ${err.message}`);
+clawhubJobsWorker.on("failed", (job, err) => {
+  console.error(
+    `[clawhub-jobs] operation=${job?.data?.operation || "unknown"} job=${job?.id} failed: ${err.message}`,
+  );
 });
 
-clawhubInstallWorker.on("completed", (job) => {
-  console.log(`[clawhub-installs] Job ${job.id} completed successfully`);
+clawhubJobsWorker.on("completed", (job) => {
+  console.log(
+    `[clawhub-jobs] operation=${job?.data?.operation || "unknown"} job=${job.id} completed successfully`,
+  );
 });
 
 // ── Alert Delivery Worker ────────────────────────────────────────
@@ -2024,7 +2178,7 @@ const HEALTH_PORT = parseInt(process.env.WORKER_HEALTH_PORT || "4001");
 const healthServer = http.createServer((req, res) => {
   if (req.url === "/health") {
     const isReady =
-      worker.isRunning() && clawhubInstallWorker.isRunning() && alertDeliveryWorker.isRunning();
+      worker.isRunning() && clawhubJobsWorker.isRunning() && alertDeliveryWorker.isRunning();
     res.writeHead(isReady ? 200 : 503, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ status: isReady ? "ok" : "not_ready", uptime: process.uptime() }));
   } else {


### PR DESCRIPTION
## Summary

This PR adds the ClawHub skill deletion flow for OpenClaw agents and updates the ClawHub tab so operators can see installed skills, detect drift between Nora DB state and runtime state, and delete skills directly from the installed-skills surface.

The feature now treats `agents.clawhub_skills` as desired state, uses runtime state as the live installed view, and supports explicit cleanup of orphaned runtime skills.

## What Changed

### Backend

- Added shared ClawHub skill-state reconciliation helpers
  - merged saved/runtime skill state
  - orphaned runtime detection
  - saved skill removal helper
- Updated ClawHub API routes to support:
  - merged `GET /clawhub/agents/:agentId/skills`
  - `POST /clawhub/agents/:agentId/skills/:slug/delete`
  - shared job polling with `operation: "install" | "delete"`
  - user-scoped job status lookup
- Generalized the queue contract from install-only to shared `clawhub-jobs`
- Updated the provisioner worker to:
  - process both install and delete jobs
  - run `clawhub uninstall <slug> --yes` for deletion
  - verify runtime state before removing the saved DB entry
  - reconcile both:
    - DB-only skills => install
    - runtime-only skills => removable orphaned state

### Frontend

- Added an installed-skills panel to the ClawHub tab
- Installed skills can now be selected directly for delete
- Orphaned runtime skills are surfaced in the installed panel as drift
- Catalog cards support whole-card selection for install and turn green immediately
- Restored install multi-select action behavior for catalog skills
- Simplified the detail panel to be read-only skill information
- Restricted the detail panel to catalog browsing only
- Removed installed-skill interactions from the detail flow
- Refined installed-skills copy and actions so the surface is cleaner and more focused

### Docs

- Added:
  - `plans/clawhub_deletion/clawhub-deletion-plan.md`
  - `plans/clawhub_deletion/clawhub-deletion-implementation-plan.md`

## Operator Behavior

- Saved + installed skills show as healthy
- Runtime-only skills show as orphaned drift
- Orphaned skills can still be explicitly deleted by the operator
- Delete uses the same restart recommendation pattern as install

## Verification

### Backend

Ran focused backend tests inside the running backend container:

```bash
docker exec nora-backend-api-1 sh -lc 'cd /nora-host-repo/backend-api && npm test -- --runInBand __tests__/clawhubReconciliation.test.ts __tests__/clawhub.test.ts'