### PR TITLE
feat(mcp): control-plane MCP server (@nora/mcp-server) + nora mcp CLI alias

### DIFF
--- a/.github/workflows/ci-compose.yml
+++ b/.github/workflows/ci-compose.yml
@@ -18,6 +18,7 @@ on:
       - "backend-api/**"
       - "agent-runtime/**"
       - "workers/provisioner/**"
+      - "mcp-server/**"
       - "e2e/**"
   push:
     branches:
@@ -65,6 +66,24 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
           cache-dependency-path: agent-runtime/package-lock.json
+      - run: npm ci
+      - run: npm test
+
+  mcp-server-unit-tests:
+    name: mcp-server unit tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: mcp-server
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: mcp-server/package-lock.json
       - run: npm ci
       - run: npm test
 

--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -21,6 +21,7 @@ on:
       - "agent-runtime/**"
       - "workers/provisioner/**"
       - "e2e/**"
+      - "mcp-server/**"
   push:
     branches:
       - master
@@ -42,6 +43,7 @@ jobs:
           - frontend-marketing
           - backend-api
           - workers/provisioner
+          - mcp-server
         check:
           - eslint
           - prettier
@@ -126,6 +128,7 @@ jobs:
           - agent-runtime
           - workers/provisioner
           - e2e
+          - mcp-server
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -40,6 +40,7 @@ jobs:
           - agent-runtime
           - workers/provisioner
           - e2e
+          - mcp-server
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -68,6 +69,7 @@ jobs:
           - agent-runtime
           - workers/provisioner
           - e2e
+          - mcp-server
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,6 +121,7 @@ Each folder has its own `AGENTS.md` that narrows ownership, data-flow rules, and
 
 - `backend-api/` — primary integration hub: control-plane APIs, persistence, queue, auth, monitoring, Agent Hub, gateway proxy, runtime coordination
 - `cli/` — packaged command-line client for Nora's public REST APIs, workspace config, token auth, and operator automation commands
+- `mcp-server/` — `@nora/mcp-server`, standalone MCP (Model Context Protocol) stdio server exposing the public REST API as tools for Claude Code/Desktop/Cursor; pure API client authenticated by workspace API keys, no backend coupling
 - `workers/provisioner/` — async provisioning worker; `workers/provisioner/backends/` holds adapter implementations (shared with backend-api via volume mount)
 - `agent-runtime/` — shared runtime contracts (mounted read-only into backend-api and worker)
 - `frontend-dashboard/` — operator UI at `/app`; coordinates with backend-api for API + WebSocket contracts

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Full architecture write-up — system map, queue/worker boundaries, RBAC, migrat
 | Provisioning backends | Docker and k3s/Kubernetes (GA); NemoClaw (experimental sandbox); Proxmox (planned) |
 | Secrets at rest       | AES-256-GCM (provider keys, integrations, backups)                                 |
 
-## Public REST API and CLI
+## Public REST API, CLI, and MCP
 
 Workspace-scoped API keys (bearer-only, prefixed `nora_`, HMAC-hashed at rest, scope-based) drive a stable subset of the REST surface. Issue keys at `/app/workspaces/<id>/api-keys`.
 
@@ -129,6 +129,17 @@ curl -H "Authorization: Bearer $NORA_TOKEN" https://your-nora.example.com/api/ag
 ```
 
 A small CLI lives in [`cli/`](./cli) (`@nora/cli`) and wraps the same surface for `nora workspaces`, `nora agents`, and `nora monitoring`. See the [API reference](https://noradocs.solomontsao.com/api/overview) for the supported endpoints and scopes.
+
+**Operate Nora from Claude Code, Claude Desktop, or Cursor:** the [`mcp-server/`](./mcp-server) package (`@nora/mcp-server`) exposes the same API as [Model Context Protocol](https://modelcontextprotocol.io) tools — deploy agents, control their lifecycle, and read fleet metrics, events, and per-agent cost from any MCP client. Destructive deletion stays disabled unless explicitly opted in.
+
+```bash
+claude mcp add nora \
+  --env NORA_API_URL=https://your-nora.example.com \
+  --env NORA_API_KEY=nora_... \
+  -- npx -y @nora/mcp-server
+```
+
+See the [MCP guide](https://noradocs.solomontsao.com/guides/mcp-server) for Claude Desktop/Cursor config, the tool list, and security notes.
 
 ## Roadmap
 

--- a/cli/src/commands/mcp.js
+++ b/cli/src/commands/mcp.js
@@ -1,0 +1,49 @@
+// `nora mcp` — run the Nora MCP server (stdio) so MCP clients like Claude
+// Code, Claude Desktop, or Cursor can operate this control plane. The server
+// itself lives in the separate @nora/mcp-server package; this command resolves
+// it (local checkout first, then npx) and hands over stdio. Host + token come
+// from the same config `nora login` writes, exported as env for the child.
+
+const { spawn } = require("node:child_process");
+const fs = require("node:fs");
+const path = require("node:path");
+const { load } = require("../config");
+
+function localServerEntrypoint() {
+  // Monorepo layout: cli/src/commands/mcp.js -> ../../../mcp-server/src/index.js
+  const candidate = path.join(__dirname, "..", "..", "..", "mcp-server", "src", "index.js");
+  return fs.existsSync(candidate) ? candidate : null;
+}
+
+async function run(args, flags) {
+  const config = load();
+  const env = { ...process.env };
+  if (config.host && !env.NORA_API_URL) env.NORA_API_URL = config.host;
+  if (config.token && !env.NORA_API_KEY) env.NORA_API_KEY = config.token;
+  if (flags["allow-destructive"]) env.NORA_MCP_ALLOW_DESTRUCTIVE = "true";
+
+  const local = localServerEntrypoint();
+  const [command, commandArgs] = local
+    ? [process.execPath, [local]]
+    : ["npx", ["--yes", "@nora/mcp-server"]];
+
+  // stdio is the MCP transport — inherit all three streams untouched.
+  const child = spawn(command, commandArgs, { env, stdio: "inherit" });
+  const code = await new Promise((resolve) => {
+    child.on("close", resolve);
+    child.on("error", (error) => {
+      console.error(`Failed to start MCP server: ${error.message}`);
+      resolve(1);
+    });
+  });
+  if (code) {
+    const error = new Error(`MCP server exited with code ${code}`);
+    error.status = code;
+    throw error;
+  }
+}
+
+module.exports = {
+  describe: "Run the Nora MCP server on stdio (for Claude Code, Claude Desktop, Cursor)",
+  run,
+};

--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -9,6 +9,7 @@ const commands = {
   workspaces: require("./commands/workspaces"),
   agents: require("./commands/agents"),
   monitoring: require("./commands/monitoring"),
+  mcp: require("./commands/mcp"),
 };
 
 function printRootHelp() {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -145,6 +145,7 @@
             ]
           },
           "guides/channels",
+          "guides/mcp-server",
           "guides/monitoring",
           "guides/alert-rules",
           "guides/backups",

--- a/docs/guides/mcp-server.mdx
+++ b/docs/guides/mcp-server.mdx
@@ -1,0 +1,96 @@
+# Operate Nora over MCP
+
+> Run the Nora MCP server so Claude Code, Claude Desktop, Cursor, or any MCP client can deploy, inspect, and operate your agent fleet — "Claude, why is my agent stopped?" becomes a tool call against your own control plane.
+
+The `@nora/mcp-server` package exposes Nora's public REST API as [Model Context Protocol](https://modelcontextprotocol.io) tools over stdio. It authenticates with the same workspace API keys the REST API and CLI use, so workspace scoping and scope-based permissions apply unchanged.
+
+## Prerequisites
+
+1. A running Nora control plane reachable over HTTPS.
+2. A workspace API key (Workspace → API Keys, or via the admin API). Scopes determine what the MCP tools can do:
+   - `agents:read` + `monitoring:read` — all read tools
+   - `agents:write` — deploy and lifecycle tools
+3. Node.js 20+ on the machine running the MCP client.
+
+## Connect a client
+
+<CodeGroup>
+
+```bash Claude Code
+claude mcp add nora \
+  --env NORA_API_URL=https://nora.example.com \
+  --env NORA_API_KEY=nora_xxxxxxxx \
+  -- npx -y @nora/mcp-server
+```
+
+```json Claude Desktop / Cursor
+{
+  "mcpServers": {
+    "nora": {
+      "command": "npx",
+      "args": ["-y", "@nora/mcp-server"],
+      "env": {
+        "NORA_API_URL": "https://nora.example.com",
+        "NORA_API_KEY": "nora_xxxxxxxx"
+      }
+    }
+  }
+}
+```
+
+```bash Via the Nora CLI
+# Reuses the host + token saved by `nora login`
+nora login --host https://nora.example.com --token nora_xxxxxxxx
+nora mcp
+```
+
+</CodeGroup>
+
+## Configuration
+
+| Variable | Required | Purpose |
+| --- | --- | --- |
+| `NORA_API_URL` | yes | Base URL of your Nora deployment (the public origin, e.g. `https://nora.example.com`) |
+| `NORA_API_KEY` | yes | Workspace API key (`nora_…`) |
+| `NORA_MCP_ALLOW_DESTRUCTIVE` | no | Set `true` to register the `delete_agent` tool. Off by default. |
+
+When `NORA_API_URL`/`NORA_API_KEY` are unset, the server falls back to `NORA_HOST`/`NORA_TOKEN` and then to the CLI's `~/.nora/config.json`, so `nora login` is sufficient setup for local use.
+
+## Tools
+
+**Read** (require `agents:read` / `monitoring:read`):
+
+| Tool | What it returns |
+| --- | --- |
+| `list_agents` | All agents in the key's workspace with status, runtime family, deploy target, resources |
+| `get_agent` | One agent with live-reconciled container status |
+| `get_agent_versions` | Configuration version history |
+| `get_platform_metrics` | Fleet counts by status plus provisioning queue depth |
+| `list_monitoring_events` | Recent platform/agent events with type, search, and time filters |
+| `get_agent_metrics` | Time-series CPU/memory/network/disk/token metrics |
+| `get_agent_metrics_summary` | Aggregated metrics for one agent |
+| `get_agent_cost` | Pricing-aware token-cost rollup (default last 30 days) |
+
+**Write** (require `agents:write`):
+
+| Tool | Effect |
+| --- | --- |
+| `deploy_agent` | Provision a new runtime (name, runtime family, deploy target, sandbox profile, vCPU/RAM/disk) |
+| `start_agent` / `stop_agent` / `restart_agent` | Lifecycle control |
+| `redeploy_agent` | Re-provision the container with current config |
+| `delete_agent` | Permanent removal — only registered when `NORA_MCP_ALLOW_DESTRUCTIVE=true` |
+
+Tool output is the raw REST JSON, so anything the [API reference](/api/overview) documents is available to the model.
+
+## Example prompts
+
+- "List my agents and tell me which ones aren't running."
+- "Deploy an OpenClaw agent named research-assistant with 2 vCPU and 4 GB RAM, then watch it until it's running."
+- "What did agent X cost in the last 7 days, and what model was the spend on?"
+- "Show the last 20 events for the fleet and summarize anything unusual."
+
+## Security notes
+
+- The MCP server is a pure client of the REST API — it adds no endpoints and stores nothing. Revoking the API key cuts off access immediately.
+- Use a key with only the scopes you need; a read-only key (`agents:read`, `monitoring:read`) makes every tool safe.
+- `delete_agent` stays unregistered unless explicitly enabled, so a model can't be talked into destroying an agent by default.

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,0 +1,50 @@
+# @nora/mcp-server
+
+MCP server for [Nora](https://github.com/solomon2773/nora), the self-hosted AI agent ops platform. Connect Claude Code, Claude Desktop, Cursor, or any [Model Context Protocol](https://modelcontextprotocol.io) client to your Nora control plane and operate your agent fleet in natural language: deploy runtimes, start/stop/restart them, tail fleet status, and pull metrics, events, and per-agent cost.
+
+```bash
+claude mcp add nora \
+  --env NORA_API_URL=https://nora.example.com \
+  --env NORA_API_KEY=nora_xxxxxxxx \
+  -- npx -y @nora/mcp-server
+```
+
+Or in any MCP client's JSON config:
+
+```json
+{
+  "mcpServers": {
+    "nora": {
+      "command": "npx",
+      "args": ["-y", "@nora/mcp-server"],
+      "env": {
+        "NORA_API_URL": "https://nora.example.com",
+        "NORA_API_KEY": "nora_xxxxxxxx"
+      }
+    }
+  }
+}
+```
+
+## Auth
+
+Uses Nora workspace API keys (create one under Workspace → API Keys). Scopes apply unchanged:
+
+- `agents:read` + `monitoring:read` → read tools
+- `agents:write` → deploy/lifecycle tools
+
+Fallbacks: `NORA_HOST`/`NORA_TOKEN` env vars, then the Nora CLI's `~/.nora/config.json` — so after `nora login`, `nora mcp` (or plain `npx @nora/mcp-server`) just works.
+
+## Tools
+
+Read: `list_agents`, `get_agent`, `get_agent_versions`, `get_platform_metrics`, `list_monitoring_events`, `get_agent_metrics`, `get_agent_metrics_summary`, `get_agent_cost`.
+
+Write: `deploy_agent`, `start_agent`, `stop_agent`, `restart_agent`, `redeploy_agent` — and `delete_agent`, which is only registered when `NORA_MCP_ALLOW_DESTRUCTIVE=true`.
+
+Tool output is the raw Nora REST JSON; the server is a pure API client and stores nothing.
+
+Full guide: [noradocs.solomontsao.com/guides/mcp-server](https://noradocs.solomontsao.com/guides/mcp-server)
+
+## License
+
+Apache-2.0

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,0 +1,1198 @@
+{
+  "name": "@nora/mcp-server",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@nora/mcp-server",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.4.3"
+      },
+      "bin": {
+        "nora-mcp": "src/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^25.9.3",
+        "typescript": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "25.9.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.3.tgz",
+      "integrity": "sha512-603BddQMv3pUcr4U2dhujk83N2tTDVr/34wII2B6bJy6g+8WD6yUb11jszNs0gdi4PesVWl7ABt8nYMVpnLUcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.3.tgz",
+      "integrity": "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@nora/mcp-server",
+  "version": "0.1.0",
+  "description": "MCP server for the Nora agent ops control plane — operate your agent fleet from Claude Code, Claude Desktop, Cursor, or any MCP client.",
+  "license": "Apache-2.0",
+  "type": "module",
+  "bin": {
+    "nora-mcp": "./src/index.js"
+  },
+  "files": [
+    "src/**/*.js",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "start": "node src/index.js",
+    "test": "node --test",
+    "typecheck": "tsc --noEmit"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/solomon2773/nora.git",
+    "directory": "mcp-server"
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "nora",
+    "agents",
+    "openclaw",
+    "hermes",
+    "ops"
+  ],
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.29.0",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^25.9.3",
+    "typescript": "^6.0.3"
+  }
+}

--- a/mcp-server/src/client.js
+++ b/mcp-server/src/client.js
@@ -1,0 +1,66 @@
+// Thin wrapper around the Nora public REST API, mirroring cli/src/client.js.
+// Paths are absolute including the `/api` prefix (the public nginx contract).
+// Throws ApiError on non-2xx with the server's error message preserved.
+
+import { requireConnection } from "./config.js";
+
+export class ApiError extends Error {
+  constructor(status, message, code) {
+    super(message);
+    this.status = status;
+    this.code = code;
+  }
+}
+
+export function createApi({ baseUrl, apiKey, fetchImpl } = {}) {
+  const resolved =
+    baseUrl && apiKey
+      ? { baseUrl, apiKey }
+      : { ...requireConnection(), ...(baseUrl ? { baseUrl } : {}) };
+  const doFetch = fetchImpl || fetch;
+
+  async function request(method, path, { body, query } = {}) {
+    const url = new URL(path, resolved.baseUrl);
+    if (query) {
+      for (const [key, value] of Object.entries(query)) {
+        if (value !== undefined && value !== null) url.searchParams.set(key, String(value));
+      }
+    }
+    const response = await doFetch(url, {
+      method,
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${resolved.apiKey}`,
+        "User-Agent": "nora-mcp-server/0.1.0",
+      },
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+    const text = await response.text();
+    let parsed = null;
+    if (text) {
+      try {
+        parsed = JSON.parse(text);
+      } catch {
+        parsed = text;
+      }
+    }
+    if (!response.ok) {
+      const message =
+        (parsed && typeof parsed === "object" && parsed.error) ||
+        (typeof parsed === "string" && parsed) ||
+        `Request failed (${response.status})`;
+      const code =
+        parsed && typeof parsed === "object" && typeof parsed.code === "string"
+          ? parsed.code
+          : null;
+      throw new ApiError(response.status, message, code);
+    }
+    return parsed;
+  }
+
+  return {
+    get: (path, opts) => request("GET", path, opts),
+    post: (path, body, opts) => request("POST", path, { ...(opts || {}), body }),
+    delete: (path, opts) => request("DELETE", path, opts),
+  };
+}

--- a/mcp-server/src/client.js
+++ b/mcp-server/src/client.js
@@ -21,6 +21,13 @@ export function createApi({ baseUrl, apiKey, fetchImpl } = {}) {
 
   async function request(method, path, { body, query } = {}) {
     const url = new URL(path, resolved.baseUrl);
+    // Defense in depth: every tool path is under `/api/`. URL normalization
+    // collapses any `..` segment that slipped through a tool's input schema, so
+    // refuse a request whose normalized path escaped the API prefix rather than
+    // silently calling an unintended endpoint.
+    if (!url.pathname.startsWith("/api/")) {
+      throw new ApiError(0, `Refusing request to non-API path: ${url.pathname}`, "invalid_path");
+    }
     if (query) {
       for (const [key, value] of Object.entries(query)) {
         if (value !== undefined && value !== null) url.searchParams.set(key, String(value));

--- a/mcp-server/src/config.js
+++ b/mcp-server/src/config.js
@@ -38,5 +38,16 @@ export function requireConnection(env = process.env) {
       "No Nora API key found. Set NORA_API_KEY to a workspace API key (nora_...) or run `nora login --token nora_...`.",
     );
   }
+  // The API key is sent as a bearer token on every request. Warn (to stderr —
+  // stdout is the MCP protocol channel) if it would travel in cleartext over a
+  // non-local http:// origin. Loopback is exempt for local development.
+  if (
+    /^http:\/\//i.test(baseUrl) &&
+    !/^http:\/\/(localhost|127\.0\.0\.1|\[::1\])(:|\/|$)/i.test(baseUrl)
+  ) {
+    process.stderr.write(
+      `[nora-mcp] WARNING: ${baseUrl} uses http://; your API key will be sent unencrypted. Use https://.\n`,
+    );
+  }
   return { baseUrl, apiKey };
 }

--- a/mcp-server/src/config.js
+++ b/mcp-server/src/config.js
@@ -1,0 +1,42 @@
+// Connection resolution for the Nora MCP server.
+//
+// Precedence: explicit MCP env vars (NORA_API_URL / NORA_API_KEY), then the
+// CLI-compatible env vars (NORA_HOST / NORA_TOKEN), then the CLI's on-disk
+// config at ~/.nora/config.json — so `nora login` is all the setup an MCP
+// client needs.
+
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+export const CONFIG_PATH = path.join(os.homedir(), ".nora", "config.json");
+
+function readCliConfig() {
+  try {
+    return JSON.parse(fs.readFileSync(CONFIG_PATH, "utf8"));
+  } catch {
+    return {};
+  }
+}
+
+export function loadConnection(env = process.env) {
+  const disk = readCliConfig();
+  const baseUrl = env.NORA_API_URL || env.NORA_HOST || disk.host || null;
+  const apiKey = env.NORA_API_KEY || env.NORA_TOKEN || disk.token || null;
+  return { baseUrl, apiKey };
+}
+
+export function requireConnection(env = process.env) {
+  const { baseUrl, apiKey } = loadConnection(env);
+  if (!baseUrl) {
+    throw new Error(
+      "Nora host is not configured. Set NORA_API_URL (e.g. https://nora.example.com) or run `nora login --host https://...`.",
+    );
+  }
+  if (!apiKey) {
+    throw new Error(
+      "No Nora API key found. Set NORA_API_KEY to a workspace API key (nora_...) or run `nora login --token nora_...`.",
+    );
+  }
+  return { baseUrl, apiKey };
+}

--- a/mcp-server/src/index.js
+++ b/mcp-server/src/index.js
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+// Nora MCP server — operate a Nora agent fleet from any MCP client.
+//
+// Stdio transport: stdout belongs to the protocol. Anything human-facing goes
+// to stderr; never console.log in this process.
+
+import { pathToFileURL } from "node:url";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { createApi } from "./client.js";
+import { registerAgentTools } from "./tools/agents.js";
+import { registerMonitoringTools } from "./tools/monitoring.js";
+
+export const SERVER_INFO = { name: "nora", version: "0.1.0" };
+
+export function createServer({ api, env = process.env } = {}) {
+  const server = new McpServer(SERVER_INFO, {
+    instructions:
+      "Tools for operating a Nora self-hosted agent ops control plane: list, deploy, start/stop, and inspect agent runtimes (OpenClaw, Hermes), and read fleet metrics, events, and per-agent cost. Mutating tools require an API key with the agents:write scope; reads require agents:read / monitoring:read.",
+  });
+  const client = api || createApi();
+  const allowDestructive = String(env.NORA_MCP_ALLOW_DESTRUCTIVE || "").toLowerCase() === "true";
+  registerAgentTools(server, client, { allowDestructive });
+  registerMonitoringTools(server, client);
+  return server;
+}
+
+export async function main() {
+  let server;
+  try {
+    server = createServer();
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error("Nora MCP server ready (stdio)");
+}
+
+const isDirectRun = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isDirectRun) {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/mcp-server/src/tools/agents.js
+++ b/mcp-server/src/tools/agents.js
@@ -5,7 +5,11 @@
 import { z } from "zod";
 import { jsonResult, withApi } from "./shared.js";
 
-const agentId = z.string().describe("Agent id (UUID)");
+// Validate as a UUID: agent ids are UUIDs (db_schema agents.id), and the value
+// is interpolated into the request path. A loose z.string() would let a crafted
+// id like ".." collapse `/api/agents/../stop` to `/api/stop` via URL
+// normalization and reach endpoints the tool never advertised.
+const agentId = z.string().uuid().describe("Agent id (UUID)");
 
 export function registerAgentTools(server, api, { allowDestructive = false } = {}) {
   server.registerTool(
@@ -79,7 +83,14 @@ export function registerAgentTools(server, api, { allowDestructive = false } = {
           .optional()
           .describe("Sandbox profile (nemoclaw is experimental)"),
         vcpu: z.number().int().min(1).optional().describe("vCPU cores"),
-        ram_mb: z.number().int().min(256).optional().describe("RAM in MB"),
+        ram_mb: z
+          .number()
+          .int()
+          .min(512)
+          .optional()
+          .describe(
+            "RAM in MB (self-hosted minimum 512; ignored in PaaS mode where the operator sets resources)",
+          ),
         disk_gb: z.number().int().min(1).optional().describe("Disk in GB"),
       },
       annotations: { destructiveHint: false, idempotentHint: false },
@@ -126,7 +137,7 @@ export function registerAgentTools(server, api, { allowDestructive = false } = {
     {
       title: "Redeploy agent",
       description:
-        "Tear down and re-provision the agent's runtime container with its current configuration. Use after config changes that need a fresh container.",
+        "Tear down and re-provision the agent's runtime container with its current configuration. Only valid when the agent is stopped, in warning, or in error state — stop a running agent first.",
       inputSchema: { id: agentId },
       annotations: { destructiveHint: true, idempotentHint: false },
     },

--- a/mcp-server/src/tools/agents.js
+++ b/mcp-server/src/tools/agents.js
@@ -1,0 +1,149 @@
+// Agent lifecycle tools — wrap the existing /api/agents endpoints. Auth and
+// workspace scoping come from the API key (agents:read / agents:write scopes);
+// the server adds no policy of its own beyond gating delete_agent.
+
+import { z } from "zod";
+import { jsonResult, withApi } from "./shared.js";
+
+const agentId = z.string().describe("Agent id (UUID)");
+
+export function registerAgentTools(server, api, { allowDestructive = false } = {}) {
+  server.registerTool(
+    "list_agents",
+    {
+      title: "List agents",
+      description:
+        "List all agents accessible to the API key's workspace, with status, runtime family, deploy target, resources, and placement.",
+      inputSchema: {
+        scope: z
+          .enum(["accessible", "owned"])
+          .optional()
+          .describe("'owned' restricts to agents created by the key's issuing user"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    withApi(async ({ scope }) => jsonResult(await api.get("/api/agents", { query: { scope } }))),
+  );
+
+  server.registerTool(
+    "get_agent",
+    {
+      title: "Get agent details",
+      description:
+        "Fetch one agent with live-reconciled status and runtime details (container state, gateway info, resources).",
+      inputSchema: { id: agentId },
+      annotations: { readOnlyHint: true },
+    },
+    withApi(async ({ id }) => jsonResult(await api.get(`/api/agents/${id}`))),
+  );
+
+  server.registerTool(
+    "get_agent_versions",
+    {
+      title: "List agent config versions",
+      description:
+        "List an agent's configuration version history (snapshots taken on config changes; usable with the dashboard's rollback).",
+      inputSchema: {
+        id: agentId,
+        limit: z.number().int().min(1).max(200).optional(),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    withApi(async ({ id, limit }) =>
+      jsonResult(await api.get(`/api/agents/${id}/versions`, { query: { limit } })),
+    ),
+  );
+
+  server.registerTool(
+    "deploy_agent",
+    {
+      title: "Deploy a new agent",
+      description:
+        "Provision and deploy a new agent runtime. Queues the deployment and returns the created agent; poll get_agent until status is 'running'.",
+      inputSchema: {
+        name: z.string().min(1).max(100).describe("Agent display name"),
+        runtime_family: z
+          .enum(["openclaw", "hermes"])
+          .optional()
+          .describe("Runtime family (default: control plane's default, usually openclaw)"),
+        deploy_target: z
+          .string()
+          .optional()
+          .describe("Deploy target, e.g. 'docker' or 'k8s' (default: control plane default)"),
+        execution_target_id: z
+          .string()
+          .optional()
+          .describe("Specific execution target id (e.g. a registered Kubernetes cluster)"),
+        sandbox_profile: z
+          .enum(["standard", "nemoclaw"])
+          .optional()
+          .describe("Sandbox profile (nemoclaw is experimental)"),
+        vcpu: z.number().int().min(1).optional().describe("vCPU cores"),
+        ram_mb: z.number().int().min(256).optional().describe("RAM in MB"),
+        disk_gb: z.number().int().min(1).optional().describe("Disk in GB"),
+      },
+      annotations: { destructiveHint: false, idempotentHint: false },
+    },
+    withApi(async (body) => jsonResult(await api.post("/api/agents/deploy", body))),
+  );
+
+  server.registerTool(
+    "start_agent",
+    {
+      title: "Start agent",
+      description: "Start a stopped agent runtime.",
+      inputSchema: { id: agentId },
+      annotations: { destructiveHint: false, idempotentHint: true },
+    },
+    withApi(async ({ id }) => jsonResult(await api.post(`/api/agents/${id}/start`))),
+  );
+
+  server.registerTool(
+    "stop_agent",
+    {
+      title: "Stop agent",
+      description:
+        "Stop a running agent runtime. The agent keeps its state and can be started again.",
+      inputSchema: { id: agentId },
+      annotations: { destructiveHint: true, idempotentHint: true },
+    },
+    withApi(async ({ id }) => jsonResult(await api.post(`/api/agents/${id}/stop`))),
+  );
+
+  server.registerTool(
+    "restart_agent",
+    {
+      title: "Restart agent",
+      description: "Restart a running agent runtime in place.",
+      inputSchema: { id: agentId },
+      annotations: { destructiveHint: true, idempotentHint: true },
+    },
+    withApi(async ({ id }) => jsonResult(await api.post(`/api/agents/${id}/restart`))),
+  );
+
+  server.registerTool(
+    "redeploy_agent",
+    {
+      title: "Redeploy agent",
+      description:
+        "Tear down and re-provision the agent's runtime container with its current configuration. Use after config changes that need a fresh container.",
+      inputSchema: { id: agentId },
+      annotations: { destructiveHint: true, idempotentHint: false },
+    },
+    withApi(async ({ id }) => jsonResult(await api.post(`/api/agents/${id}/redeploy`))),
+  );
+
+  if (allowDestructive) {
+    server.registerTool(
+      "delete_agent",
+      {
+        title: "Delete agent",
+        description:
+          "Permanently delete an agent and its runtime container. Irreversible. Only registered because NORA_MCP_ALLOW_DESTRUCTIVE=true.",
+        inputSchema: { id: agentId },
+        annotations: { destructiveHint: true, idempotentHint: true },
+      },
+      withApi(async ({ id }) => jsonResult(await api.delete(`/api/agents/${id}`))),
+    );
+  }
+}

--- a/mcp-server/src/tools/monitoring.js
+++ b/mcp-server/src/tools/monitoring.js
@@ -1,0 +1,89 @@
+// Monitoring and cost tools — wrap the existing /api/monitoring and per-agent
+// observability endpoints (monitoring:read scope).
+
+import { z } from "zod";
+import { jsonResult, withApi } from "./shared.js";
+
+const agentId = z.string().describe("Agent id (UUID)");
+
+export function registerMonitoringTools(server, api) {
+  server.registerTool(
+    "get_platform_metrics",
+    {
+      title: "Get platform metrics",
+      description:
+        "Fleet-level metrics for the workspace: agent counts by status (active/deploying/warning/error/queued/stopped), total deployments, and provisioning queue depth.",
+      inputSchema: {},
+      annotations: { readOnlyHint: true },
+    },
+    withApi(async () => jsonResult(await api.get("/api/monitoring/metrics"))),
+  );
+
+  server.registerTool(
+    "list_monitoring_events",
+    {
+      title: "List monitoring events",
+      description:
+        "Recent platform/agent events (deploys, lifecycle changes, alerts, budget crossings). Filter by agent, type, free-text search, or time range.",
+      inputSchema: {
+        agentId: z.string().optional().describe("Scope to one agent"),
+        limit: z.number().int().min(1).max(100).optional(),
+        type: z.string().optional().describe("Event type filter, e.g. 'agent.deployed'"),
+        search: z.string().optional().describe("Free-text search in event messages"),
+        from: z.string().optional().describe("ISO timestamp lower bound"),
+        to: z.string().optional().describe("ISO timestamp upper bound"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    withApi(async (args) => jsonResult(await api.get("/api/monitoring/events", { query: args }))),
+  );
+
+  server.registerTool(
+    "get_agent_metrics",
+    {
+      title: "Get agent metrics",
+      description:
+        "Time-series usage metrics for one agent (CPU, memory, network, disk, tokens) over a time window. Defaults to the last 24h.",
+      inputSchema: {
+        id: agentId,
+        type: z.string().optional().describe("Metric type filter, e.g. 'token_usage'"),
+        since: z.string().optional().describe("ISO timestamp lower bound (default: 24h ago)"),
+        until: z.string().optional().describe("ISO timestamp upper bound (default: now)"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    withApi(async ({ id, ...query }) =>
+      jsonResult(await api.get(`/api/agents/${id}/metrics`, { query })),
+    ),
+  );
+
+  server.registerTool(
+    "get_agent_metrics_summary",
+    {
+      title: "Get agent metrics summary",
+      description: "Aggregated metrics summary for one agent (totals and latest samples).",
+      inputSchema: { id: agentId },
+      annotations: { readOnlyHint: true },
+    },
+    withApi(async ({ id }) => jsonResult(await api.get(`/api/agents/${id}/metrics/summary`))),
+  );
+
+  server.registerTool(
+    "get_agent_cost",
+    {
+      title: "Get agent cost",
+      description:
+        "Token-cost rollup for one agent (input/output/total tokens and USD cost, pricing-aware per model). Defaults to the last 30 days.",
+      inputSchema: {
+        id: agentId,
+        periodDays: z.number().int().min(1).max(365).optional(),
+        periodStart: z.string().optional().describe("ISO date overriding periodDays"),
+        periodEnd: z.string().optional().describe("ISO date overriding periodDays"),
+      },
+      annotations: { readOnlyHint: true },
+    },
+    withApi(async ({ id, ...query }) =>
+      jsonResult(await api.get(`/api/agents/${id}/cost`, { query })),
+    ),
+  );
+}

--- a/mcp-server/src/tools/monitoring.js
+++ b/mcp-server/src/tools/monitoring.js
@@ -4,7 +4,8 @@
 import { z } from "zod";
 import { jsonResult, withApi } from "./shared.js";
 
-const agentId = z.string().describe("Agent id (UUID)");
+// UUID-validated: interpolated into the request path (see agents.js note).
+const agentId = z.string().uuid().describe("Agent id (UUID)");
 
 export function registerMonitoringTools(server, api) {
   server.registerTool(

--- a/mcp-server/src/tools/shared.js
+++ b/mcp-server/src/tools/shared.js
@@ -1,0 +1,32 @@
+// Result helpers shared by all Nora MCP tools. Tool output is the raw REST
+// JSON, pretty-printed — the API's serializers are the contract, so the tools
+// never reshape fields.
+
+import { ApiError } from "../client.js";
+
+export function jsonResult(data) {
+  return {
+    content: [{ type: "text", text: JSON.stringify(data, null, 2) }],
+  };
+}
+
+export function errorResult(error) {
+  const message =
+    error instanceof ApiError
+      ? `Nora API error ${error.status}: ${error.message}${error.code ? ` (${error.code})` : ""}`
+      : `Error: ${error?.message || String(error)}`;
+  return {
+    isError: true,
+    content: [{ type: "text", text: message }],
+  };
+}
+
+export function withApi(handler) {
+  return async (args, extra) => {
+    try {
+      return await handler(args, extra);
+    } catch (error) {
+      return errorResult(error);
+    }
+  };
+}

--- a/mcp-server/test/tools.test.js
+++ b/mcp-server/test/tools.test.js
@@ -1,0 +1,137 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createServer } from "../src/index.js";
+import { ApiError } from "../src/client.js";
+
+// Records calls and replays canned responses keyed by "METHOD path".
+function mockApi(responses = {}) {
+  const calls = [];
+  function respond(method, path, opts) {
+    calls.push({ method, path, opts });
+    const key = `${method} ${path}`;
+    if (key in responses) {
+      const value = responses[key];
+      if (value instanceof Error) return Promise.reject(value);
+      return Promise.resolve(value);
+    }
+    return Promise.resolve({ ok: true, key });
+  }
+  return {
+    calls,
+    get: (path, opts) => respond("GET", path, opts),
+    post: (path, body, opts) => respond("POST", path, { ...(opts || {}), body }),
+    delete: (path, opts) => respond("DELETE", path, opts),
+  };
+}
+
+async function connect(server) {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "test-client", version: "0.0.0" });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return client;
+}
+
+test("registers read and write tools; delete_agent only when destructive is allowed", async () => {
+  const api = mockApi();
+  const safe = await connect(createServer({ api, env: {} }));
+  const safeNames = (await safe.listTools()).tools.map((t) => t.name).sort();
+  assert.ok(safeNames.includes("list_agents"));
+  assert.ok(safeNames.includes("deploy_agent"));
+  assert.ok(safeNames.includes("get_agent_cost"));
+  assert.ok(!safeNames.includes("delete_agent"));
+
+  const destructive = await connect(
+    createServer({ api, env: { NORA_MCP_ALLOW_DESTRUCTIVE: "true" } }),
+  );
+  const destructiveNames = (await destructive.listTools()).tools.map((t) => t.name);
+  assert.ok(destructiveNames.includes("delete_agent"));
+});
+
+test("list_agents returns raw API JSON and passes scope", async () => {
+  const agents = [{ id: "a1", name: "Ops", status: "running" }];
+  const api = mockApi({ "GET /api/agents": agents });
+  const client = await connect(createServer({ api, env: {} }));
+  const result = await client.callTool({ name: "list_agents", arguments: { scope: "owned" } });
+  assert.equal(result.isError, undefined);
+  assert.deepEqual(JSON.parse(result.content[0].text), agents);
+  assert.deepEqual(api.calls[0], {
+    method: "GET",
+    path: "/api/agents",
+    opts: { query: { scope: "owned" } },
+  });
+});
+
+test("deploy_agent forwards the request body to /api/agents/deploy", async () => {
+  const api = mockApi({ "POST /api/agents/deploy": { id: "new", status: "queued" } });
+  const client = await connect(createServer({ api, env: {} }));
+  const result = await client.callTool({
+    name: "deploy_agent",
+    arguments: { name: "Researcher", runtime_family: "openclaw", vcpu: 2, ram_mb: 4096 },
+  });
+  assert.deepEqual(JSON.parse(result.content[0].text), { id: "new", status: "queued" });
+  assert.equal(api.calls[0].path, "/api/agents/deploy");
+  assert.deepEqual(api.calls[0].opts.body, {
+    name: "Researcher",
+    runtime_family: "openclaw",
+    vcpu: 2,
+    ram_mb: 4096,
+  });
+});
+
+test("lifecycle tools hit the expected endpoints", async () => {
+  const api = mockApi();
+  const client = await connect(createServer({ api, env: { NORA_MCP_ALLOW_DESTRUCTIVE: "true" } }));
+  await client.callTool({ name: "start_agent", arguments: { id: "a1" } });
+  await client.callTool({ name: "stop_agent", arguments: { id: "a1" } });
+  await client.callTool({ name: "restart_agent", arguments: { id: "a1" } });
+  await client.callTool({ name: "redeploy_agent", arguments: { id: "a1" } });
+  await client.callTool({ name: "delete_agent", arguments: { id: "a1" } });
+  assert.deepEqual(
+    api.calls.map((c) => `${c.method} ${c.path}`),
+    [
+      "POST /api/agents/a1/start",
+      "POST /api/agents/a1/stop",
+      "POST /api/agents/a1/restart",
+      "POST /api/agents/a1/redeploy",
+      "DELETE /api/agents/a1",
+    ],
+  );
+});
+
+test("per-agent observability tools use the /api/agents/:id paths", async () => {
+  const api = mockApi();
+  const client = await connect(createServer({ api, env: {} }));
+  await client.callTool({
+    name: "get_agent_metrics",
+    arguments: { id: "a1", type: "token_usage" },
+  });
+  await client.callTool({ name: "get_agent_metrics_summary", arguments: { id: "a1" } });
+  await client.callTool({ name: "get_agent_cost", arguments: { id: "a1", periodDays: 7 } });
+  assert.equal(api.calls[0].path, "/api/agents/a1/metrics");
+  assert.deepEqual(api.calls[0].opts.query, { type: "token_usage" });
+  assert.equal(api.calls[1].path, "/api/agents/a1/metrics/summary");
+  assert.equal(api.calls[2].path, "/api/agents/a1/cost");
+  assert.deepEqual(api.calls[2].opts.query, { periodDays: 7 });
+});
+
+test("API errors surface as isError tool results with status and message", async () => {
+  const api = mockApi({
+    "GET /api/agents/missing": new ApiError(404, "Agent not found"),
+  });
+  const client = await connect(createServer({ api, env: {} }));
+  const result = await client.callTool({ name: "get_agent", arguments: { id: "missing" } });
+  assert.equal(result.isError, true);
+  assert.match(result.content[0].text, /Nora API error 404: Agent not found/);
+});
+
+test("tool annotations mark reads read-only and destructive writes destructive", async () => {
+  const client = await connect(createServer({ api: mockApi(), env: {} }));
+  const tools = (await client.listTools()).tools;
+  const byName = Object.fromEntries(tools.map((t) => [t.name, t]));
+  assert.equal(byName.list_agents.annotations.readOnlyHint, true);
+  assert.equal(byName.get_platform_metrics.annotations.readOnlyHint, true);
+  assert.equal(byName.stop_agent.annotations.destructiveHint, true);
+  assert.equal(byName.deploy_agent.annotations.destructiveHint, false);
+});

--- a/mcp-server/test/tools.test.js
+++ b/mcp-server/test/tools.test.js
@@ -3,7 +3,10 @@ import assert from "node:assert/strict";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { createServer } from "../src/index.js";
-import { ApiError } from "../src/client.js";
+import { ApiError, createApi } from "../src/client.js";
+
+// A valid UUID for tools whose `id` input is now uuid-validated.
+const AID = "123e4567-e89b-12d3-a456-426614174000";
 
 // Records calls and replays canned responses keyed by "METHOD path".
 function mockApi(responses = {}) {
@@ -83,21 +86,61 @@ test("deploy_agent forwards the request body to /api/agents/deploy", async () =>
 test("lifecycle tools hit the expected endpoints", async () => {
   const api = mockApi();
   const client = await connect(createServer({ api, env: { NORA_MCP_ALLOW_DESTRUCTIVE: "true" } }));
-  await client.callTool({ name: "start_agent", arguments: { id: "a1" } });
-  await client.callTool({ name: "stop_agent", arguments: { id: "a1" } });
-  await client.callTool({ name: "restart_agent", arguments: { id: "a1" } });
-  await client.callTool({ name: "redeploy_agent", arguments: { id: "a1" } });
-  await client.callTool({ name: "delete_agent", arguments: { id: "a1" } });
+  await client.callTool({ name: "start_agent", arguments: { id: AID } });
+  await client.callTool({ name: "stop_agent", arguments: { id: AID } });
+  await client.callTool({ name: "restart_agent", arguments: { id: AID } });
+  await client.callTool({ name: "redeploy_agent", arguments: { id: AID } });
+  await client.callTool({ name: "delete_agent", arguments: { id: AID } });
   assert.deepEqual(
     api.calls.map((c) => `${c.method} ${c.path}`),
     [
-      "POST /api/agents/a1/start",
-      "POST /api/agents/a1/stop",
-      "POST /api/agents/a1/restart",
-      "POST /api/agents/a1/redeploy",
-      "DELETE /api/agents/a1",
+      `POST /api/agents/${AID}/start`,
+      `POST /api/agents/${AID}/stop`,
+      `POST /api/agents/${AID}/restart`,
+      `POST /api/agents/${AID}/redeploy`,
+      `DELETE /api/agents/${AID}`,
     ],
   );
+});
+
+test("a non-UUID agent id is rejected before any request is made", async () => {
+  const api = mockApi();
+  const client = await connect(createServer({ api, env: {} }));
+  const result = await client.callTool({
+    name: "get_agent",
+    arguments: { id: "../billing/subscription" },
+  });
+  assert.equal(result.isError, true);
+  assert.equal(api.calls.length, 0);
+});
+
+test("the HTTP client refuses a path that escapes the /api/ prefix", async () => {
+  const fetchImpl = () => assert.fail("fetch must not be called for an escaped path");
+  const api = createApi({ baseUrl: "https://nora.example.com", apiKey: "nora_test", fetchImpl });
+  // `..` segments that walk out of /api/ entirely (e.g. /api/agents/../../admin
+  // -> /admin) are refused by the client as a backstop to schema validation.
+  await assert.rejects(
+    () => api.get("/api/../admin/users"),
+    (err) => {
+      assert.ok(err instanceof ApiError);
+      assert.equal(err.code, "invalid_path");
+      return true;
+    },
+  );
+});
+
+test("the HTTP client sends bearer auth and parses JSON for a valid path", async () => {
+  const seen = {};
+  const fetchImpl = async (url, opts) => {
+    seen.url = url.toString();
+    seen.auth = opts.headers.Authorization;
+    return { ok: true, status: 200, text: async () => JSON.stringify({ id: AID }) };
+  };
+  const api = createApi({ baseUrl: "https://nora.example.com", apiKey: "nora_test", fetchImpl });
+  const body = await api.get(`/api/agents/${AID}`);
+  assert.deepEqual(body, { id: AID });
+  assert.equal(seen.url, `https://nora.example.com/api/agents/${AID}`);
+  assert.equal(seen.auth, "Bearer nora_test");
 });
 
 test("per-agent observability tools use the /api/agents/:id paths", async () => {
@@ -105,23 +148,23 @@ test("per-agent observability tools use the /api/agents/:id paths", async () => 
   const client = await connect(createServer({ api, env: {} }));
   await client.callTool({
     name: "get_agent_metrics",
-    arguments: { id: "a1", type: "token_usage" },
+    arguments: { id: AID, type: "token_usage" },
   });
-  await client.callTool({ name: "get_agent_metrics_summary", arguments: { id: "a1" } });
-  await client.callTool({ name: "get_agent_cost", arguments: { id: "a1", periodDays: 7 } });
-  assert.equal(api.calls[0].path, "/api/agents/a1/metrics");
+  await client.callTool({ name: "get_agent_metrics_summary", arguments: { id: AID } });
+  await client.callTool({ name: "get_agent_cost", arguments: { id: AID, periodDays: 7 } });
+  assert.equal(api.calls[0].path, `/api/agents/${AID}/metrics`);
   assert.deepEqual(api.calls[0].opts.query, { type: "token_usage" });
-  assert.equal(api.calls[1].path, "/api/agents/a1/metrics/summary");
-  assert.equal(api.calls[2].path, "/api/agents/a1/cost");
+  assert.equal(api.calls[1].path, `/api/agents/${AID}/metrics/summary`);
+  assert.equal(api.calls[2].path, `/api/agents/${AID}/cost`);
   assert.deepEqual(api.calls[2].opts.query, { periodDays: 7 });
 });
 
 test("API errors surface as isError tool results with status and message", async () => {
   const api = mockApi({
-    "GET /api/agents/missing": new ApiError(404, "Agent not found"),
+    [`GET /api/agents/${AID}`]: new ApiError(404, "Agent not found"),
   });
   const client = await connect(createServer({ api, env: {} }));
-  const result = await client.callTool({ name: "get_agent", arguments: { id: "missing" } });
+  const result = await client.callTool({ name: "get_agent", arguments: { id: AID } });
   assert.equal(result.isError, true);
   assert.match(result.content[0].text, /Nora API error 404: Agent not found/);
 });

--- a/mcp-server/tsconfig.json
+++ b/mcp-server/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["es2023"],
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "incremental": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.js", "test/**/*.js"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## What

Ships the #1 verified pre-launch gap from the 2026-06-11 market research: a first-party MCP surface for Nora.

- **`mcp-server/`** — new standalone `@nora/mcp-server` package (ESM, stdio, `@modelcontextprotocol/sdk`). Exposes the existing public REST API as MCP tools so Claude Code / Claude Desktop / Cursor can operate the fleet:
  - **Read** (`agents:read` / `monitoring:read`): `list_agents`, `get_agent`, `get_agent_versions`, `get_platform_metrics`, `list_monitoring_events`, `get_agent_metrics`, `get_agent_metrics_summary`, `get_agent_cost`
  - **Write** (`agents:write`): `deploy_agent`, `start_agent`, `stop_agent`, `restart_agent`, `redeploy_agent` — plus `delete_agent`, registered **only** when `NORA_MCP_ALLOW_DESTRUCTIVE=true`
- **`nora mcp`** — new CLI command spawning the server over stdio, reusing `~/.nora/config.json` credentials from `nora login`
- **CI** — `mcp-server` added to quality (eslint/prettier/typecheck) and security (npm audit/license policy) matrices + path filters
- **Docs** — new guide `docs/guides/mcp-server.mdx` (client config, tool table, security notes) + README "Operate Nora from Claude Code" section

## Design notes

- Pure API client: no new endpoints, no state, no backend coupling. Workspace scoping + scope enforcement happen server-side via the existing API-key middleware — revoking the key cuts off the MCP surface instantly.
- Tool output is the raw REST JSON (the API serializers are the contract).
- Honest MCP annotations (`readOnlyHint`/`destructiveHint`) so clients can build confirmation UX.
- npm publish is manual for now (no publish workflow exists yet); deferred along with the `tail_logs` streaming tool and a ghcr image.

## Verification

- `mcp-server`: 7-test suite over the SDK's in-memory transport (registration/gating, path+body contracts, error mapping, annotations) — green; `tsc --noEmit` green; eslint/prettier green; `cli` tests still green.
- Live end-to-end over stdio against a running stack with a real scoped key: tool listing, fleet metrics, workspace-scoped `list_agents`, 404→`isError` mapping, and the full **deploy → poll-to-running → stop → delete** loop.
- Docs nav linter: no missing pages, no orphans. Temporary verification key revoked after testing.

Part of the 9-item pre-launch plan (PR-1 of 9; market research: `.private/docs/launch/market-research-2026-06-11.md`).