### PR TITLE
feat(infra): official Helm chart for installing Nora on Kubernetes

### DIFF
--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -105,6 +105,8 @@ jobs:
             dockerfile: backend-api/Dockerfile.prod
           - image: nora-worker-provisioner
             dockerfile: workers/provisioner/Dockerfile.prod
+          - image: nora-worker-backup
+            dockerfile: workers/backup/Dockerfile.prod
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/scripts/validate-infra.mjs
+++ b/.github/workflows/scripts/validate-infra.mjs
@@ -93,10 +93,56 @@ function validateKindConfig(filePath) {
   }
 }
 
+// Dummy values so charts that `fail` on missing required secrets still render
+// in CI. Never reuse these anywhere real.
+const HELM_CI_VALUES = [
+  "--set",
+  "secrets.jwtSecret=ci-validate-dummy-jwt-secret-0000000000",
+  "--set",
+  "secrets.encryptionKey=ci-validate-dummy-encryption-key-00000000",
+  "--set",
+  "secrets.backupEncryptionKey=ci-validate-dummy-backup-key-000000000",
+  "--set",
+  "secrets.apiKeyHashSecret=ci-validate-dummy-hash-secret-0000000000",
+  "--set",
+  "secrets.dbPassword=ci-validate-dummy-db-password",
+];
+
+function runCapture(command, args) {
+  return execFileSync(command, args, { cwd: repoRoot, encoding: "utf8" });
+}
+
 function validateHelmCharts(chartFiles) {
   for (const chartFile of chartFiles) {
     const chartDir = path.dirname(chartFile);
-    run("helm", ["lint", chartDir]);
+    run("helm", ["lint", chartDir, ...HELM_CI_VALUES]);
+
+    // kubeconform the *rendered* manifests — raw template files are not YAML.
+    const rendered = runCapture("helm", ["template", "nora-ci", chartDir, ...HELM_CI_VALUES]);
+    const renderedPath = path.join(repoRoot, ".helm-rendered-ci.yaml");
+    fs.writeFileSync(renderedPath, rendered);
+    try {
+      run("kubeconform", ["-summary", "-strict", path.relative(repoRoot, renderedPath)]);
+    } finally {
+      fs.unlinkSync(renderedPath);
+    }
+
+    // The nora chart vendors backend-api/db_schema.sql for postgres initdb;
+    // fail loudly when the copies drift.
+    const vendoredSchema = path.join(chartDir, "files", "db_schema.sql");
+    if (fs.existsSync(vendoredSchema)) {
+      const canonical = fs.readFileSync(
+        path.join(repoRoot, "backend-api", "db_schema.sql"),
+        "utf8",
+      );
+      if (fs.readFileSync(vendoredSchema, "utf8") !== canonical) {
+        throw new Error(
+          `${path.relative(repoRoot, vendoredSchema)} is out of sync with backend-api/db_schema.sql — ` +
+            "run: cp backend-api/db_schema.sql " +
+            path.relative(repoRoot, vendoredSchema),
+        );
+      }
+    }
   }
 }
 
@@ -112,12 +158,19 @@ function validateKubernetesManifests(manifestFiles) {
 validateComposeFiles();
 
 const chartFiles = walk(infraDir, (fullPath) => path.basename(fullPath) === "Chart.yaml");
+const chartDirs = chartFiles.map((chartFile) => path.dirname(chartFile));
 const yamlFiles = walk(infraDir, (fullPath) => /\.(ya?ml)$/i.test(fullPath));
 const manifestFiles = [];
 
 for (const yamlFile of yamlFiles) {
   const relativePath = path.relative(repoRoot, yamlFile);
   if (relativePath.startsWith("infra/docker-compose.")) {
+    continue;
+  }
+
+  // Helm chart contents (templates, values, Chart.yaml) are validated through
+  // helm lint + helm template above, not as raw manifests.
+  if (chartDirs.some((chartDir) => yamlFile.startsWith(chartDir + path.sep))) {
     continue;
   }
 

--- a/.github/workflows/scripts/validate-infra.mjs
+++ b/.github/workflows/scripts/validate-infra.mjs
@@ -108,8 +108,61 @@ const HELM_CI_VALUES = [
   "secrets.dbPassword=ci-validate-dummy-db-password",
 ];
 
+// A second permutation so the default render isn't the only thing validated:
+// turns on Ingress and points DB/Redis at external services (exercising the
+// external.* branches and the ingress template, none of which render by default).
+const HELM_CI_ALT_VALUES = [
+  ...HELM_CI_VALUES,
+  "--set",
+  "ingress.enabled=true",
+  "--set",
+  "ingress.host=nora.ci.example.com",
+  "--set",
+  "postgresql.enabled=false",
+  "--set",
+  "postgresql.external.host=db.ci.example.com",
+  "--set",
+  "redis.enabled=false",
+  "--set",
+  "redis.external.host=redis.ci.example.com",
+  "--set",
+  "nginx.service.type=NodePort",
+];
+
+// Pin the Kubernetes schema version kubeconform validates against, instead of
+// the floating (latest dev) "master" schemas it uses by default.
+const KUBECONFORM_K8S_VERSION = "1.30.0";
+
 function runCapture(command, args) {
   return execFileSync(command, args, { cwd: repoRoot, encoding: "utf8" });
+}
+
+function kubeconformRendered(rendered, label) {
+  const renderedPath = path.join(repoRoot, `.helm-rendered-ci-${label}.yaml`);
+  fs.writeFileSync(renderedPath, rendered);
+  try {
+    run("kubeconform", [
+      "-summary",
+      "-strict",
+      "-kubernetes-version",
+      KUBECONFORM_K8S_VERSION,
+      path.relative(repoRoot, renderedPath),
+    ]);
+  } finally {
+    fs.unlinkSync(renderedPath);
+  }
+}
+
+// Walk a chart's template files and report whether any of them reads the given
+// `.Files.Get "<relPath>"` — used to make the drift guard fail closed when a
+// referenced vendored file is deleted (Helm's .Files.Get silently returns "").
+function chartReferencesFile(chartDir, relPath) {
+  const templatesDir = path.join(chartDir, "templates");
+  if (!fs.existsSync(templatesDir)) return false;
+  const needle = `.Files.Get "${relPath}"`;
+  return walk(templatesDir, (p) => /\.(ya?ml|tpl)$/i.test(p)).some((p) =>
+    fs.readFileSync(p, "utf8").includes(needle),
+  );
 }
 
 function validateHelmCharts(chartFiles) {
@@ -118,18 +171,29 @@ function validateHelmCharts(chartFiles) {
     run("helm", ["lint", chartDir, ...HELM_CI_VALUES]);
 
     // kubeconform the *rendered* manifests — raw template files are not YAML.
-    const rendered = runCapture("helm", ["template", "nora-ci", chartDir, ...HELM_CI_VALUES]);
-    const renderedPath = path.join(repoRoot, ".helm-rendered-ci.yaml");
-    fs.writeFileSync(renderedPath, rendered);
-    try {
-      run("kubeconform", ["-summary", "-strict", path.relative(repoRoot, renderedPath)]);
-    } finally {
-      fs.unlinkSync(renderedPath);
-    }
+    // Validate both the default values and the alternate permutation so the
+    // Ingress and external-DB/Redis branches don't ship unvalidated.
+    kubeconformRendered(
+      runCapture("helm", ["template", "nora-ci", chartDir, ...HELM_CI_VALUES]),
+      "default",
+    );
+    kubeconformRendered(
+      runCapture("helm", ["template", "nora-ci", chartDir, ...HELM_CI_ALT_VALUES]),
+      "alt",
+    );
 
-    // The nora chart vendors backend-api/db_schema.sql for postgres initdb;
-    // fail loudly when the copies drift.
+    // The nora chart vendors backend-api/db_schema.sql for postgres initdb. Fail
+    // loudly when the copies drift — and fail closed when a referenced vendored
+    // file is missing entirely (an empty .Files.Get would otherwise pass green).
     const vendoredSchema = path.join(chartDir, "files", "db_schema.sql");
+    if (chartReferencesFile(chartDir, "files/db_schema.sql") && !fs.existsSync(vendoredSchema)) {
+      throw new Error(
+        `${path.relative(repoRoot, chartDir)} references files/db_schema.sql via .Files.Get but ` +
+          `${path.relative(repoRoot, vendoredSchema)} is missing — ` +
+          "run: cp backend-api/db_schema.sql " +
+          path.relative(repoRoot, vendoredSchema),
+      );
+    }
     if (fs.existsSync(vendoredSchema)) {
       const canonical = fs.readFileSync(
         path.join(repoRoot, "backend-api", "db_schema.sql"),

--- a/docs/self-hosting.mdx
+++ b/docs/self-hosting.mdx
@@ -137,6 +137,30 @@ Use manual setup when you want full control over every configuration value befor
   </Step>
 </Steps>
 
+## Kubernetes (Helm)
+
+Run Nora itself on a Kubernetes cluster with the official chart in [`infra/helm/nora`](https://github.com/solomon2773/nora/tree/master/infra/helm/nora). The chart deploys the full control plane (nginx edge, the three frontends, backend API, provisioner and backup workers) with in-chart PostgreSQL and Redis by default, or external data stores via values.
+
+```bash
+git clone https://github.com/solomon2773/nora.git && cd nora
+helm install nora ./infra/helm/nora \
+  --namespace nora --create-namespace \
+  --set secrets.jwtSecret="$(openssl rand -hex 32)" \
+  --set secrets.encryptionKey="$(openssl rand -hex 32)" \
+  --set secrets.backupEncryptionKey="$(openssl rand -hex 32)" \
+  --set secrets.apiKeyHashSecret="$(openssl rand -hex 32)" \
+  --set secrets.dbPassword="$(openssl rand -hex 24)"
+kubectl -n nora port-forward svc/nora-nginx 8080:80
+```
+
+The chart refuses to install without real secrets — there are no insecure defaults. For a public deployment set `publicUrl`, enable `ingress.*`, and terminate TLS at your Ingress controller.
+
+<Warning>
+  A cluster-hosted control plane deploys agents to **Kubernetes targets only** (`ENABLED_BACKENDS=k8s`): pods have no Docker socket, so the Docker deploy target is unavailable. Register agent clusters under Admin → Kubernetes and mount their kubeconfigs with `kubeconfigs.existingSecret`. In-place release upgrades from the Admin UI are a Docker Compose feature — upgrade with `helm upgrade` instead.
+</Warning>
+
+See the [chart README](https://github.com/solomon2773/nora/blob/master/infra/helm/nora/README.md) for all values, design notes, and the local Kind smoke test.
+
 ## Accessing the dashboard
 
 After installation, the following URLs are available in local mode. Public-domain mode uses the same paths on your configured origin.

--- a/infra/helm/nora/Chart.yaml
+++ b/infra/helm/nora/Chart.yaml
@@ -1,0 +1,22 @@
+apiVersion: v2
+name: nora
+description: >-
+  Nora — the self-hosted AI agent ops platform. Deploys the full control plane
+  (nginx edge, marketing/operator/admin frontends, backend API, provisioner and
+  backup workers) plus optional in-chart PostgreSQL and Redis.
+type: application
+version: 0.1.0
+appVersion: "1.10.1"
+home: https://github.com/solomon2773/nora
+sources:
+  - https://github.com/solomon2773/nora
+maintainers:
+  - name: solomon2773
+    url: https://github.com/solomon2773
+keywords:
+  - ai
+  - agents
+  - openclaw
+  - hermes
+  - control-plane
+  - self-hosted

--- a/infra/helm/nora/README.md
+++ b/infra/helm/nora/README.md
@@ -24,6 +24,14 @@ secrets are provided (or `secrets.existingSecret` points at a Secret carrying
 `JWT_SECRET`, `ENCRYPTION_KEY`, `NORA_BACKUP_ENCRYPTION_KEY`,
 `NORA_API_KEY_HASH_SECRET`, `DB_PASSWORD`).
 
+> **Save your secrets.** The `--set` form above generates secrets that live only
+> inside the release. `helm uninstall` deletes the generated Secret, but the
+> postgres data PVC and the `nora-backups` PVC are retained
+> (`helm.sh/resource-policy: keep`). A reinstall then generates *new* secrets
+> that cannot decrypt the retained data or match the kept DB password. For any
+> install you intend to keep, manage the five secrets yourself and pass them via
+> `secrets.existingSecret`, or back up the generated Secret immediately.
+
 Without an Ingress: `kubectl -n nora port-forward svc/nora-nginx 8080:80` and
 open http://localhost:8080. The first user to sign up becomes the platform
 admin.

--- a/infra/helm/nora/README.md
+++ b/infra/helm/nora/README.md
@@ -1,0 +1,79 @@
+# Nora Helm Chart
+
+Installs the full Nora control plane on Kubernetes: the nginx edge, the three
+Next.js frontends (marketing, operator dashboard, admin), the backend API, the
+provisioner and backup workers, and — by default — in-chart PostgreSQL 15 and
+Redis 7 built on the official images.
+
+## Quick start
+
+```bash
+helm install nora ./infra/helm/nora \
+  --namespace nora --create-namespace \
+  --set secrets.jwtSecret="$(openssl rand -hex 32)" \
+  --set secrets.encryptionKey="$(openssl rand -hex 32)" \
+  --set secrets.backupEncryptionKey="$(openssl rand -hex 32)" \
+  --set secrets.apiKeyHashSecret="$(openssl rand -hex 32)" \
+  --set secrets.dbPassword="$(openssl rand -hex 24)" \
+  --set publicUrl="https://nora.example.com" \
+  --set ingress.enabled=true --set ingress.host="nora.example.com"
+```
+
+No insecure defaults ship in the chart: installs fail fast until the five
+secrets are provided (or `secrets.existingSecret` points at a Secret carrying
+`JWT_SECRET`, `ENCRYPTION_KEY`, `NORA_BACKUP_ENCRYPTION_KEY`,
+`NORA_API_KEY_HASH_SECRET`, `DB_PASSWORD`).
+
+Without an Ingress: `kubectl -n nora port-forward svc/nora-nginx 8080:80` and
+open http://localhost:8080. The first user to sign up becomes the platform
+admin.
+
+## Key values
+
+| Value | Default | Meaning |
+| --- | --- | --- |
+| `global.imageRegistry` | `ghcr.io/solomon2773` | Registry for the published `nora-*` images |
+| `global.imageTag` | `v<appVersion>` | Image tag for all Nora services |
+| `publicUrl` | `http://localhost:8080` | Public origin; feeds `NEXTAUTH_URL` + `CORS_ORIGINS` |
+| `enabledBackends` | `k8s` | Agent deploy targets (see limitations) |
+| `secrets.*` / `secrets.existingSecret` | — | Required credentials (see above) |
+| `backendEnv` | `{}` | Extra env for backend-api + workers (anything from `.env.example`) |
+| `kubeconfigs.existingSecret` | `""` | Secret of kubeconfig files mounted at `/kubeconfigs` for agent deploy targets |
+| `postgresql.enabled` / `redis.enabled` | `true` | In-chart data stores; disable and fill `*.external.*` to bring your own |
+| `backupsVolume.*` | RWO 10Gi | Shared volume for managed local backups |
+| `ingress.*` | disabled | Ingress in front of the `nora-nginx` Service |
+| `nginx.service.type` | `ClusterIP` | Switch to `LoadBalancer`/`NodePort` to expose directly |
+
+## Design notes
+
+- **One release per namespace.** Services use fixed compose-parity names
+  (`backend-api`, `postgres`, `redis`, `frontend-dashboard`, …) so the bundled
+  nginx config and the app's connection defaults work unchanged.
+- **`files/nginx-k8s.conf`** mirrors the repo-root `nginx.conf` routing with
+  static Service upstreams. When `nginx.conf` routing changes, update it in the
+  same PR.
+- **`files/db_schema.sql`** is a vendored copy of `backend-api/db_schema.sql`
+  used by the in-chart postgres initdb. CI (`npm run ci:validate-infra`) fails
+  when the copies drift; refresh with
+  `cp backend-api/db_schema.sql infra/helm/nora/files/db_schema.sql`.
+
+## Limitations on Kubernetes
+
+- **Docker deploy target is unavailable** — the provisioner has no Docker
+  socket in a pod. `ENABLED_BACKENDS` defaults to `k8s`; register clusters
+  under Admin → Kubernetes and mount their kubeconfigs via
+  `kubeconfigs.existingSecret`.
+- **In-place release upgrades (Admin UI) are a Docker Compose feature.**
+  Upgrade with `helm upgrade nora <chart> --reuse-values` instead.
+- **Local backup storage** uses one PVC shared by backend-api and
+  worker-backup. `ReadWriteOnce` only works when both pods schedule onto the
+  same node (k3s/Kind/single-node). On multi-node clusters use a
+  `ReadWriteMany` storage class or configure S3/SSH backup storage and set
+  `backupsVolume.enabled=false`.
+
+## Validation
+
+- `npm run ci:validate-infra` — helm lint + `helm template | kubeconform
+  -strict` + schema drift guard (runs in CI Security on every PR).
+- `infra/helm/scripts/kind-smoke.sh` — full install on a local Kind cluster
+  with edge probes (`/api/health`, `/`, `/app`, `/admin`).

--- a/infra/helm/nora/files/db_schema.sql
+++ b/infra/helm/nora/files/db_schema.sql
@@ -45,6 +45,7 @@ CREATE TABLE IF NOT EXISTS agents (
   vcpu INTEGER DEFAULT 1,
   ram_mb INTEGER DEFAULT 1024,
   disk_gb INTEGER DEFAULT 10,
+  paused_reason TEXT,
   created_at TIMESTAMP DEFAULT NOW()
 );
 
@@ -478,6 +479,25 @@ CREATE TABLE IF NOT EXISTS workspace_budgets (
   updated_at TIMESTAMPTZ DEFAULT NOW(),
   UNIQUE(workspace_id, period)
 );
+
+-- Per-agent LLM spend budgets. Soft crossings emit alert events; hard
+-- crossings additionally pause the runtime (agents.paused_reason records why).
+CREATE TABLE IF NOT EXISTS agent_budgets (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  period TEXT NOT NULL DEFAULT 'monthly'
+    CHECK (period IN ('daily', 'weekly', 'monthly')),
+  limit_usd NUMERIC(12, 2) NOT NULL,
+  soft_threshold_pct INTEGER NOT NULL DEFAULT 80
+    CHECK (soft_threshold_pct BETWEEN 0 AND 100),
+  last_alerted_at TIMESTAMPTZ,
+  last_alerted_pct INTEGER,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(agent_id, period)
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_budgets_agent ON agent_budgets(agent_id);
 
 CREATE TABLE IF NOT EXISTS integration_catalog (
   id VARCHAR(50) PRIMARY KEY,

--- a/infra/helm/nora/files/db_schema.sql
+++ b/infra/helm/nora/files/db_schema.sql
@@ -1,0 +1,671 @@
+-- PostgreSQL initial schema
+
+CREATE TABLE IF NOT EXISTS users (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  email TEXT UNIQUE NOT NULL,
+  password_hash TEXT,
+  role TEXT DEFAULT 'user',
+  name TEXT,
+  preferred_locale TEXT,
+  agent_limit_override INTEGER,
+  managed_backups_enabled_override BOOLEAN,
+  backup_limit_per_agent_override INTEGER,
+  backup_storage_mb_override INTEGER,
+  backup_retention_days_override INTEGER,
+  provider TEXT,
+  provider_id TEXT,
+  stripe_customer_id TEXT,
+  created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS agents (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+  name TEXT,
+  status TEXT DEFAULT 'queued',
+  backend_type VARCHAR(20) NOT NULL DEFAULT 'docker',
+  sandbox_type VARCHAR(20) DEFAULT 'standard',
+  runtime_family VARCHAR(20) NOT NULL DEFAULT 'openclaw',
+  deploy_target VARCHAR(20) NOT NULL DEFAULT 'docker',
+  execution_target_id TEXT NOT NULL DEFAULT 'docker',
+  sandbox_profile VARCHAR(20) NOT NULL DEFAULT 'standard',
+  node TEXT,
+  host TEXT,
+  runtime_host TEXT,
+  runtime_port INTEGER,
+  gateway_host TEXT,
+  gateway_port INTEGER,
+  gateway_host_port INTEGER,
+  gateway_token TEXT,
+  container_id TEXT,
+  container_name TEXT,
+  image TEXT,
+  template_payload JSONB DEFAULT '{}',
+  clawhub_skills JSONB DEFAULT '[]',
+  vcpu INTEGER DEFAULT 1,
+  ram_mb INTEGER DEFAULT 1024,
+  disk_gb INTEGER DEFAULT 10,
+  created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS kubernetes_clusters (
+  id TEXT PRIMARY KEY,
+  label TEXT NOT NULL,
+  provider TEXT NOT NULL DEFAULT 'kubernetes',
+  cluster_name TEXT NOT NULL DEFAULT '',
+  enabled BOOLEAN NOT NULL DEFAULT true,
+  is_default BOOLEAN NOT NULL DEFAULT false,
+  credential_mode TEXT NOT NULL DEFAULT 'mounted_path',
+  kubeconfig_path TEXT NOT NULL DEFAULT '',
+  kubeconfig_encrypted TEXT,
+  kube_context TEXT NOT NULL DEFAULT '',
+  namespace TEXT NOT NULL DEFAULT 'openclaw-agents',
+  openclaw_namespace TEXT NOT NULL DEFAULT '',
+  hermes_namespace TEXT NOT NULL DEFAULT '',
+  exposure_mode TEXT NOT NULL DEFAULT 'cluster-ip',
+  runtime_host TEXT NOT NULL DEFAULT '',
+  runtime_node_port INTEGER,
+  gateway_node_port INTEGER,
+  service_annotations JSONB NOT NULL DEFAULT '{}'::jsonb,
+  load_balancer_source_ranges TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+  load_balancer_class TEXT NOT NULL DEFAULT '',
+  load_balancer_ready_timeout_ms INTEGER NOT NULL DEFAULT 600000,
+  load_balancer_ready_interval_ms INTEGER NOT NULL DEFAULT 5000,
+  last_test_status TEXT,
+  last_test_message TEXT,
+  last_tested_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_kubernetes_clusters_enabled
+  ON kubernetes_clusters(enabled, is_default, label);
+
+CREATE TABLE IF NOT EXISTS deployments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id UUID REFERENCES agents(id) ON DELETE CASCADE,
+  status TEXT,
+  created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS agent_migrations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+  deployed_agent_id UUID REFERENCES agents(id) ON DELETE SET NULL,
+  name TEXT NOT NULL,
+  runtime_family VARCHAR(20) NOT NULL DEFAULT 'openclaw',
+  source_kind TEXT NOT NULL DEFAULT 'upload',
+  source_transport TEXT,
+  status TEXT NOT NULL DEFAULT 'ready',
+  summary JSONB DEFAULT '{}',
+  warnings JSONB DEFAULT '[]',
+  encrypted_manifest TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  expires_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_migrations_user_created
+  ON agent_migrations(user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_agent_migrations_agent
+  ON agent_migrations(deployed_agent_id);
+
+CREATE TABLE IF NOT EXISTS agent_secret_overrides (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id UUID REFERENCES agents(id) ON DELETE CASCADE,
+  env_key TEXT NOT NULL,
+  env_value TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(agent_id, env_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_secret_overrides_agent
+  ON agent_secret_overrides(agent_id, env_key);
+
+CREATE TABLE IF NOT EXISTS hermes_runtime_state (
+  agent_id UUID PRIMARY KEY REFERENCES agents(id) ON DELETE CASCADE,
+  model_config JSONB DEFAULT '{}',
+  channel_configs JSONB DEFAULT '{}',
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS platform_settings (
+  singleton BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (singleton = TRUE),
+  default_vcpu INTEGER NOT NULL DEFAULT 1,
+  default_ram_mb INTEGER NOT NULL DEFAULT 1024,
+  default_disk_gb INTEGER NOT NULL DEFAULT 10,
+  default_locale TEXT NOT NULL DEFAULT 'en',
+  system_banner_enabled BOOLEAN NOT NULL DEFAULT false,
+  system_banner_severity TEXT NOT NULL DEFAULT 'warning',
+  system_banner_title TEXT NOT NULL DEFAULT '',
+  system_banner_message TEXT NOT NULL DEFAULT '',
+  agent_hub_default_share_target TEXT NOT NULL DEFAULT 'both',
+  agent_hub_url TEXT NOT NULL DEFAULT 'https://nora.solomontsao.com',
+  agent_hub_api_key_encrypted TEXT,
+  backup_storage_backend TEXT NOT NULL DEFAULT 'local',
+  backup_local_path TEXT NOT NULL DEFAULT '/var/lib/nora-backups',
+  backup_s3_bucket TEXT NOT NULL DEFAULT '',
+  backup_s3_region TEXT NOT NULL DEFAULT 'us-east-1',
+  backup_s3_endpoint TEXT NOT NULL DEFAULT '',
+  backup_s3_access_key_id_encrypted TEXT,
+  backup_s3_secret_access_key_encrypted TEXT,
+  backup_ssh_host TEXT NOT NULL DEFAULT '',
+  backup_ssh_port INTEGER NOT NULL DEFAULT 22,
+  backup_ssh_username TEXT NOT NULL DEFAULT '',
+  backup_ssh_remote_path TEXT NOT NULL DEFAULT '/backups/nora',
+  backup_ssh_private_key_encrypted TEXT,
+  backup_ssh_password_encrypted TEXT,
+  backup_installation_schedule_enabled BOOLEAN NOT NULL DEFAULT false,
+  backup_installation_schedule_frequency TEXT NOT NULL DEFAULT 'daily',
+  backup_installation_schedule_hour_utc INTEGER NOT NULL DEFAULT 2,
+  backup_installation_schedule_day_of_week INTEGER NOT NULL DEFAULT 0,
+  -- Platform-wide SMTP for invitation emails + alert email channels (Phase 6).
+  -- Encrypted password is AES-256-GCM via crypto.ts. The set is "configured"
+  -- iff host + port + from_address are populated (mailer.isConfigured()).
+  smtp_host TEXT NOT NULL DEFAULT '',
+  smtp_port INTEGER NOT NULL DEFAULT 587,
+  smtp_secure BOOLEAN NOT NULL DEFAULT false,
+  smtp_username TEXT NOT NULL DEFAULT '',
+  smtp_password_encrypted TEXT,
+  smtp_from_address TEXT NOT NULL DEFAULT '',
+  smtp_from_name TEXT NOT NULL DEFAULT 'Nora',
+  -- Per-tier defaults live in backend-api/platformSettings.ts
+  -- (DEFAULT_BACKUP_PLAN_LIMITS) and are applied per-key by
+  -- normalizeBackupPlanLimits on read. Keep the schema default empty so the
+  -- two stay in sync from a single source of truth.
+  backup_plan_limits JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW()
+);
+
+INSERT INTO platform_settings(singleton, default_vcpu, default_ram_mb, default_disk_gb)
+VALUES(TRUE, 1, 1024, 10)
+ON CONFLICT (singleton) DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS snapshots (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id UUID,
+  name TEXT NOT NULL,
+  description TEXT,
+  kind TEXT DEFAULT 'snapshot',
+  template_key TEXT,
+  built_in BOOLEAN DEFAULT false,
+  config JSONB DEFAULT '{}',
+  created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS agent_hub_listings (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  snapshot_id UUID REFERENCES snapshots(id) ON DELETE CASCADE,
+  owner_user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  name TEXT NOT NULL,
+  description TEXT,
+  price TEXT DEFAULT 'Free',
+  category TEXT DEFAULT 'General',
+  rating NUMERIC DEFAULT 0,
+  installs INTEGER DEFAULT 0,
+  downloads INTEGER DEFAULT 0,
+  built_in BOOLEAN DEFAULT false,
+  source_type TEXT DEFAULT 'platform',
+  status TEXT DEFAULT 'published',
+  visibility TEXT DEFAULT 'public',
+  share_target TEXT DEFAULT 'internal',
+  local_visibility TEXT DEFAULT 'internal',
+  central_share_status TEXT DEFAULT 'not_shared',
+  central_listing_id TEXT,
+  central_last_synced_at TIMESTAMP,
+  central_error TEXT,
+  slug TEXT,
+  current_version INTEGER DEFAULT 1,
+  published_at TIMESTAMP,
+  updated_at TIMESTAMP DEFAULT NOW(),
+  reviewed_at TIMESTAMP,
+  reviewed_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  review_notes TEXT,
+  created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_snapshots_template_key
+  ON snapshots(template_key);
+
+CREATE INDEX IF NOT EXISTS idx_agent_hub_listings_snapshot_id
+  ON agent_hub_listings(snapshot_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_hub_listings_slug_unique
+  ON agent_hub_listings(slug)
+  WHERE slug IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_agent_hub_listings_owner
+  ON agent_hub_listings(owner_user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_agent_hub_listings_source_status
+  ON agent_hub_listings(source_type, status, published_at DESC);
+
+CREATE TABLE IF NOT EXISTS agent_hub_api_keys (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+  label TEXT NOT NULL,
+  key_hash TEXT NOT NULL UNIQUE,
+  key_prefix TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'active',
+  last_used_at TIMESTAMP,
+  revoked_at TIMESTAMP,
+  created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_hub_api_keys_user
+  ON agent_hub_api_keys(user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_agent_hub_api_keys_hash_active
+  ON agent_hub_api_keys(key_hash)
+  WHERE status = 'active' AND revoked_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS agent_hub_listing_versions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  listing_id UUID REFERENCES agent_hub_listings(id) ON DELETE CASCADE,
+  snapshot_id UUID REFERENCES snapshots(id) ON DELETE CASCADE,
+  version_number INTEGER NOT NULL,
+  clone_mode TEXT DEFAULT 'files_only',
+  created_at TIMESTAMP DEFAULT NOW(),
+  UNIQUE(listing_id, version_number),
+  UNIQUE(listing_id, snapshot_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_hub_listing_versions_listing
+  ON agent_hub_listing_versions(listing_id, version_number DESC);
+
+CREATE TABLE IF NOT EXISTS agent_hub_reports (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  listing_id UUID REFERENCES agent_hub_listings(id) ON DELETE CASCADE,
+  reporter_user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  reason TEXT NOT NULL,
+  details TEXT,
+  status TEXT DEFAULT 'open',
+  reviewed_at TIMESTAMP,
+  reviewed_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_hub_reports_listing_status
+  ON agent_hub_reports(listing_id, status, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS workspaces (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS workspace_agents (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id UUID REFERENCES workspaces(id) ON DELETE CASCADE,
+  agent_id UUID REFERENCES agents(id) ON DELETE CASCADE,
+  role TEXT DEFAULT 'member',
+  created_at TIMESTAMP DEFAULT NOW(),
+  UNIQUE(workspace_id, agent_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_workspace_agents_agent
+  ON workspace_agents(agent_id);
+
+-- Per-workspace membership (Phase 0 of multi-tenant RBAC).
+-- workspaces.user_id remains as the creator denormalization; permission checks
+-- read from workspace_members.role instead.
+CREATE TABLE IF NOT EXISTS workspace_members (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  role TEXT NOT NULL DEFAULT 'viewer'
+    CHECK (role IN ('owner', 'admin', 'editor', 'viewer')),
+  invited_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(workspace_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_workspace_members_user
+  ON workspace_members(user_id);
+
+CREATE INDEX IF NOT EXISTS idx_workspace_members_workspace_role
+  ON workspace_members(workspace_id, role);
+
+-- Backfill: every existing workspace creator becomes the 'owner' member.
+INSERT INTO workspace_members (workspace_id, user_id, role)
+SELECT id, user_id, 'owner'
+  FROM workspaces
+ WHERE user_id IS NOT NULL
+ON CONFLICT (workspace_id, user_id) DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS workspace_invitations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  email TEXT NOT NULL,
+  role TEXT NOT NULL DEFAULT 'viewer'
+    CHECK (role IN ('admin', 'editor', 'viewer')),
+  token_hash TEXT NOT NULL UNIQUE,
+  invited_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'accepted', 'revoked', 'expired')),
+  accepted_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  accepted_at TIMESTAMPTZ,
+  expires_at TIMESTAMPTZ NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_workspace_invitations_workspace
+  ON workspace_invitations(workspace_id, status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_workspace_invitations_email_pending
+  ON workspace_invitations(email)
+  WHERE status = 'pending';
+
+-- General-purpose, workspace-scoped API keys (Phase 1 of the public REST API).
+-- Token format: "nora_" + base64url(random32). Stored as HMAC-SHA256 hash with a
+-- server-side secret; key_prefix shows first 18 chars for UI display. Scopes is
+-- a JSONB array of "resource:action" strings (e.g. "agents:read", "agents:write").
+CREATE TABLE IF NOT EXISTS api_keys (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  label TEXT NOT NULL,
+  key_hash TEXT NOT NULL UNIQUE,
+  key_prefix TEXT NOT NULL,
+  scopes JSONB NOT NULL DEFAULT '[]'::jsonb,
+  status TEXT NOT NULL DEFAULT 'active'
+    CHECK (status IN ('active', 'revoked')),
+  expires_at TIMESTAMPTZ,
+  last_used_at TIMESTAMPTZ,
+  revoked_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_api_keys_workspace
+  ON api_keys(workspace_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_api_keys_hash_active
+  ON api_keys(key_hash)
+  WHERE status = 'active' AND revoked_at IS NULL;
+
+-- Alert rules (Phase 2). Match emitted events by type pattern (literal or
+-- glob suffix like "agent.*") and deliver to one or more channels.
+-- "webhook" channels POST a JSON body via the alert-deliveries BullMQ queue
+-- with exponential-backoff retries (handled in workers/provisioner/worker.ts);
+-- "email" channels dispatch inline through the platform mailer. last_error
+-- holds the most recent terminal delivery failure.
+CREATE TABLE IF NOT EXISTS alert_rules (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  name TEXT NOT NULL,
+  event_pattern TEXT NOT NULL,
+  channels JSONB NOT NULL DEFAULT '[]'::jsonb,
+  enabled BOOLEAN NOT NULL DEFAULT true,
+  last_fired_at TIMESTAMPTZ,
+  last_error TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_alert_rules_workspace_enabled
+  ON alert_rules(workspace_id, enabled);
+
+CREATE INDEX IF NOT EXISTS idx_alert_rules_pattern_enabled
+  ON alert_rules(event_pattern)
+  WHERE enabled = true;
+
+-- Agent configuration history (Phase 3). Every save of an agent's
+-- template_payload writes a new row; rollback restores a prior config and
+-- triggers a redeploy. version_number is monotonic per agent; the latest row
+-- is the current configuration baseline.
+CREATE TABLE IF NOT EXISTS agent_versions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  version_number INTEGER NOT NULL,
+  config JSONB NOT NULL DEFAULT '{}',
+  created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  message TEXT,
+  source TEXT NOT NULL DEFAULT 'edit'
+    CHECK (source IN ('edit', 'deploy', 'redeploy', 'duplicate', 'hub-install', 'restore', 'rollback')),
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(agent_id, version_number)
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_versions_agent_recent
+  ON agent_versions(agent_id, version_number DESC);
+
+-- Fleet runtime migrations (Phase 5). Tracks bulk runtime transitions
+-- (e.g. moving every Hermes agent from Docker to Kubernetes) so progress is
+-- visible and pre-migration state is captured for rollback.
+CREATE TABLE IF NOT EXISTS fleet_migrations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  initiated_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'queued', 'in_progress', 'completed', 'partial_failure', 'rolled_back')),
+  source_selection JSONB NOT NULL DEFAULT '{}',
+  target_selection JSONB NOT NULL DEFAULT '{}',
+  agent_ids JSONB NOT NULL DEFAULT '[]',
+  before_state JSONB NOT NULL DEFAULT '{}',
+  after_state JSONB NOT NULL DEFAULT '{}',
+  errors JSONB NOT NULL DEFAULT '[]',
+  dry_run BOOLEAN NOT NULL DEFAULT false,
+  notes TEXT,
+  started_at TIMESTAMPTZ,
+  completed_at TIMESTAMPTZ,
+  rolled_back_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_fleet_migrations_status_created
+  ON fleet_migrations(status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_fleet_migrations_initiator
+  ON fleet_migrations(initiated_by, created_at DESC);
+
+-- Per-workspace usage budgets. When usage crosses the soft threshold (e.g.
+-- 80% of limit) or 100%, an event fires that the alert system can match.
+CREATE TABLE IF NOT EXISTS workspace_budgets (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+  period TEXT NOT NULL DEFAULT 'monthly'
+    CHECK (period IN ('daily', 'weekly', 'monthly')),
+  limit_usd NUMERIC(12, 2) NOT NULL,
+  soft_threshold_pct INTEGER NOT NULL DEFAULT 80
+    CHECK (soft_threshold_pct BETWEEN 0 AND 100),
+  last_alerted_at TIMESTAMPTZ,
+  last_alerted_pct INTEGER,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(workspace_id, period)
+);
+
+CREATE TABLE IF NOT EXISTS integration_catalog (
+  id VARCHAR(50) PRIMARY KEY,
+  name VARCHAR(100) NOT NULL,
+  icon VARCHAR(50),
+  category VARCHAR(50) NOT NULL,
+  description TEXT,
+  auth_type VARCHAR(20),
+  config_schema JSONB NOT NULL DEFAULT '{}',
+  enabled BOOLEAN DEFAULT true
+);
+
+CREATE TABLE IF NOT EXISTS integrations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id UUID REFERENCES agents(id) ON DELETE CASCADE,
+  provider TEXT NOT NULL,
+  catalog_id VARCHAR(50) REFERENCES integration_catalog(id),
+  access_token TEXT,
+  config JSONB DEFAULT '{}',
+  status VARCHAR(20) DEFAULT 'active',
+  cron_job_id TEXT,
+  mailbox_state JSONB DEFAULT NULL,
+  created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS integration_oauth_states (
+  state TEXT PRIMARY KEY,
+  provider VARCHAR(50) NOT NULL,
+  user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+  agent_id UUID REFERENCES agents(id) ON DELETE CASCADE,
+  code_verifier TEXT NOT NULL,
+  client_id TEXT,
+  client_secret TEXT,
+  config JSONB NOT NULL DEFAULT '{}',
+  redirect_path TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  expires_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_integration_oauth_states_expires
+  ON integration_oauth_states(expires_at);
+
+CREATE TABLE IF NOT EXISTS channels (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id UUID REFERENCES agents(id) ON DELETE CASCADE,
+  type VARCHAR(30) NOT NULL,
+  name VARCHAR(100) NOT NULL,
+  config JSONB NOT NULL DEFAULT '{}',
+  enabled BOOLEAN DEFAULT true,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS channel_messages (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  channel_id UUID REFERENCES channels(id) ON DELETE CASCADE,
+  direction VARCHAR(10) NOT NULL,
+  content TEXT NOT NULL,
+  metadata JSONB DEFAULT '{}',
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS usage_metrics (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id UUID REFERENCES agents(id) ON DELETE CASCADE,
+  user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+  metric_type VARCHAR(50) NOT NULL,
+  value NUMERIC NOT NULL DEFAULT 0,
+  metadata JSONB DEFAULT '{}',
+  recorded_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_usage_metrics_agent
+  ON usage_metrics(agent_id, recorded_at);
+
+CREATE INDEX IF NOT EXISTS idx_usage_metrics_user
+  ON usage_metrics(user_id, recorded_at);
+
+CREATE INDEX IF NOT EXISTS idx_usage_metrics_type
+  ON usage_metrics(metric_type, recorded_at);
+
+CREATE INDEX IF NOT EXISTS idx_usage_metrics_token_model
+  ON usage_metrics(metric_type, (metadata->>'model'), recorded_at);
+
+CREATE INDEX IF NOT EXISTS idx_usage_metrics_token_source
+  ON usage_metrics(metric_type, (metadata->>'source'), recorded_at);
+
+CREATE TABLE IF NOT EXISTS container_stats (
+  id BIGSERIAL PRIMARY KEY,
+  agent_id UUID REFERENCES agents(id) ON DELETE CASCADE,
+  cpu_percent NUMERIC NOT NULL DEFAULT 0,
+  memory_usage_mb INTEGER NOT NULL DEFAULT 0,
+  memory_limit_mb INTEGER NOT NULL DEFAULT 0,
+  memory_percent NUMERIC NOT NULL DEFAULT 0,
+  network_rx_mb NUMERIC NOT NULL DEFAULT 0,
+  network_tx_mb NUMERIC NOT NULL DEFAULT 0,
+  disk_read_mb NUMERIC NOT NULL DEFAULT 0,
+  disk_write_mb NUMERIC NOT NULL DEFAULT 0,
+  network_rx_rate_mbps NUMERIC NOT NULL DEFAULT 0,
+  network_tx_rate_mbps NUMERIC NOT NULL DEFAULT 0,
+  disk_read_rate_mbps NUMERIC NOT NULL DEFAULT 0,
+  disk_write_rate_mbps NUMERIC NOT NULL DEFAULT 0,
+  pids INTEGER NOT NULL DEFAULT 0,
+  recorded_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_container_stats_agent_time
+  ON container_stats(agent_id, recorded_at DESC);
+
+CREATE TABLE IF NOT EXISTS backups (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES users(id) ON DELETE SET NULL,
+  agent_id UUID REFERENCES agents(id) ON DELETE SET NULL,
+  kind TEXT NOT NULL DEFAULT 'agent' CHECK (kind IN ('agent', 'installation')),
+  status TEXT NOT NULL DEFAULT 'queued',
+  name TEXT NOT NULL,
+  storage_backend TEXT NOT NULL DEFAULT 'local',
+  storage_key TEXT,
+  storage_config JSONB DEFAULT '{}',
+  content_type TEXT NOT NULL DEFAULT 'application/gzip',
+  format TEXT NOT NULL DEFAULT 'nora-backup-archive/v1',
+  size_bytes BIGINT NOT NULL DEFAULT 0,
+  checksum_sha256 TEXT,
+  scope JSONB DEFAULT '{}',
+  summary JSONB DEFAULT '{}',
+  warnings JSONB DEFAULT '[]',
+  error TEXT,
+  restore_metadata JSONB DEFAULT '{}',
+  created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  expires_at TIMESTAMPTZ,
+  completed_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_backups_user_agent_created
+  ON backups(user_id, agent_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_backups_kind_created
+  ON backups(kind, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_backups_expires
+  ON backups(expires_at)
+  WHERE expires_at IS NOT NULL AND status <> 'deleted';
+
+CREATE TABLE IF NOT EXISTS backup_schedules (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  schedule_key TEXT NOT NULL UNIQUE,
+  kind TEXT NOT NULL DEFAULT 'agent' CHECK (kind IN ('agent', 'installation')),
+  user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+  agent_id UUID REFERENCES agents(id) ON DELETE CASCADE,
+  enabled BOOLEAN NOT NULL DEFAULT false,
+  name TEXT,
+  frequency TEXT NOT NULL DEFAULT 'daily',
+  hour_utc INTEGER NOT NULL DEFAULT 2,
+  day_of_week INTEGER NOT NULL DEFAULT 0,
+  next_run_at TIMESTAMPTZ,
+  last_run_at TIMESTAMPTZ,
+  last_backup_id UUID REFERENCES backups(id) ON DELETE SET NULL,
+  last_error TEXT,
+  created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_backup_schedules_due
+  ON backup_schedules(enabled, next_run_at)
+  WHERE enabled = true AND next_run_at IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  type TEXT NOT NULL,
+  message TEXT,
+  metadata JSONB DEFAULT '{}',
+  created_at TIMESTAMP DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS subscriptions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+  stripe_customer_id TEXT,
+  stripe_subscription_id TEXT UNIQUE,
+  plan TEXT DEFAULT 'free',
+  status TEXT DEFAULT 'active',
+  agent_limit INTEGER DEFAULT 3,
+  vcpu INTEGER DEFAULT 1,
+  ram_mb INTEGER DEFAULT 1024,
+  disk_gb INTEGER DEFAULT 10,
+  current_period_end TIMESTAMP,
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW()
+);

--- a/infra/helm/nora/files/nginx-k8s.conf
+++ b/infra/helm/nora/files/nginx-k8s.conf
@@ -1,0 +1,137 @@
+# Kubernetes flavor of the repo-root nginx.conf. Routing must stay in sync
+# with nginx.conf — same locations, same headers, same rate limits. Deltas:
+# no Docker-embedded resolver (cluster DNS resolves Service names at startup),
+# static proxy_pass upstreams, and TLS is terminated by the Ingress.
+
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    server_tokens off;
+
+    add_header X-Content-Type-Options nosniff always;
+    add_header X-Frame-Options DENY always;
+    add_header Referrer-Policy strict-origin-when-cross-origin always;
+    add_header Cross-Origin-Opener-Policy same-origin always;
+
+    large_client_header_buffers 4 32k;
+    proxy_buffer_size 16k;
+    proxy_buffers 4 16k;
+
+    map $http_upgrade $connection_upgrade {
+        default upgrade;
+        ''      close;
+    }
+
+    limit_req_zone $binary_remote_addr zone=auth_limit:10m rate=5r/s;
+    limit_req_zone $binary_remote_addr zone=api_limit:10m rate=30r/s;
+    limit_req_status 429;
+
+    server {
+        listen 80;
+        server_name _;
+
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        # 1a. WebSocket streams: logs & terminal (must be above /api/)
+        location /api/ws/ {
+            proxy_pass http://backend-api:4000/ws/;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_read_timeout 86400;
+        }
+
+        # 1b. Gateway SSE streams (chat) — disable buffering for real-time streaming
+        location ~ ^/api/(agents/[^/]+/gateway/chat)$ {
+            proxy_pass http://backend-api:4000/$1$is_args$args;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_read_timeout 300;
+            chunked_transfer_encoding off;
+            proxy_set_header Accept-Encoding "";
+        }
+
+        # 1c. Gateway UI proxy — HTML, JS/CSS assets, favicons, internal paths, embed
+        location ~ ^/api/(agents/[^/]+/gateway/(ui|assets|favicon|__openclaw__|embed).*)$ {
+            proxy_pass http://backend-api:4000/$1$is_args$args;
+            proxy_buffering off;
+            proxy_read_timeout 30;
+        }
+
+        # 1d. Auth surface — credential stuffing / brute-force shield
+        location ~ ^/api/auth/(login|signup|oauth-login|session-upgrade|logout) {
+            limit_req zone=auth_limit burst=10 nodelay;
+            rewrite ^/api/(.*)$ /$1 break;
+            proxy_pass http://backend-api:4000;
+        }
+
+        # 1e. Backend API (general)
+        location /api/ {
+            limit_req zone=api_limit burst=60 nodelay;
+            rewrite ^/api/(.*)$ /$1 break;
+            proxy_pass http://backend-api:4000;
+        }
+
+        # 2. Admin Dashboard
+        location /admin {
+            proxy_pass http://admin-dashboard:3000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+        }
+
+        location /admin/_next/ {
+            proxy_pass http://admin-dashboard:3000;
+            proxy_set_header Host $host;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+        }
+
+        # 3. App Dashboard (Unified base path)
+        location /app {
+            proxy_pass http://frontend-dashboard:3000;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+        }
+
+        # 3. Next.js Static Assets & HMR WebSocket
+        location /_next/ {
+            proxy_pass http://frontend-marketing:3000;
+            proxy_set_header Host $host;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+        }
+
+        location /app/_next/ {
+            proxy_pass http://frontend-dashboard:3000;
+            proxy_set_header Host $host;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection $connection_upgrade;
+        }
+
+        # 4. Marketing Pages (Root)
+        location / {
+            proxy_pass http://frontend-marketing:3000;
+        }
+    }
+}

--- a/infra/helm/nora/templates/NOTES.txt
+++ b/infra/helm/nora/templates/NOTES.txt
@@ -1,0 +1,31 @@
+Nora {{ .Chart.AppVersion }} is deploying into namespace {{ .Release.Namespace }}.
+
+1. Watch the rollout:
+
+     kubectl -n {{ .Release.Namespace }} get pods -w
+
+2. Reach the UI:
+{{- if .Values.ingress.enabled }}
+
+     Open {{ .Values.publicUrl }} (Ingress host: {{ .Values.ingress.host }})
+{{- else if eq .Values.nginx.service.type "LoadBalancer" }}
+
+     kubectl -n {{ .Release.Namespace }} get svc nora-nginx   # use the EXTERNAL-IP
+{{- else }}
+
+     kubectl -n {{ .Release.Namespace }} port-forward svc/nora-nginx 8080:{{ .Values.nginx.service.port }}
+     # then open http://localhost:8080
+{{- end }}
+
+3. First login: sign up at /signup — the first registered user becomes the
+   platform admin.
+
+Notes:
+  * Agent deploy target is Kubernetes (ENABLED_BACKENDS={{ .Values.enabledBackends }}).
+    Register clusters under Admin -> Kubernetes; mount their kubeconfigs via
+    kubeconfigs.existingSecret. The Docker deploy target is unavailable for a
+    cluster-hosted control plane (no Docker socket in pods).
+  * In-place release upgrades from the Admin UI are a Docker Compose feature;
+    on Kubernetes upgrade with: helm upgrade {{ .Release.Name }} <chart> --reuse-values
+  * Local backup storage uses the shared nora-backups PVC ({{ .Values.backupsVolume.accessModes | join "," }});
+    on multi-node clusters prefer S3/SSH backup storage or a ReadWriteMany class.

--- a/infra/helm/nora/templates/NOTES.txt
+++ b/infra/helm/nora/templates/NOTES.txt
@@ -29,3 +29,13 @@ Notes:
     on Kubernetes upgrade with: helm upgrade {{ .Release.Name }} <chart> --reuse-values
   * Local backup storage uses the shared nora-backups PVC ({{ .Values.backupsVolume.accessModes | join "," }});
     on multi-node clusters prefer S3/SSH backup storage or a ReadWriteMany class.
+{{- if not .Values.secrets.existingSecret }}
+  * IMPORTANT — record your secrets. This release generated JWT/encryption/
+    backup/API-key/DB secrets into the {{ include "nora.secretName" . }} Secret.
+    `helm uninstall` deletes that Secret, but the postgres pgdata PVC and the
+    nora-backups PVC are retained. A fresh reinstall generates NEW secrets that
+    cannot decrypt the retained data or match the kept DB password. Save them
+    now, or pass your own via secrets.existingSecret:
+
+      kubectl -n {{ .Release.Namespace }} get secret {{ include "nora.secretName" . }} -o yaml > nora-secrets-backup.yaml
+{{- end }}

--- a/infra/helm/nora/templates/_helpers.tpl
+++ b/infra/helm/nora/templates/_helpers.tpl
@@ -78,3 +78,37 @@ imagePullSecrets:
 {{- end }}
 {{- end }}
 {{- end -}}
+
+{{/*
+  initContainer that blocks a control-plane pod until the database accepts TCP.
+  Compose used `depends_on: condition: service_healthy`; Kubernetes Deployments
+  have no such gate, and the backend runs its one-shot migrateDB() at boot and
+  swallows failures — so without this a fresh install can win the race against
+  postgres and permanently skip the incremental migrations. Uses the already
+  present backend-api image (node) so no extra image is pulled; DB_HOST/DB_PORT
+  come from the nora-env ConfigMap and resolve for both bundled and external DB.
+*/}}
+{{- define "nora.waitForDbInit" -}}
+initContainers:
+  - name: wait-for-db
+    image: {{ include "nora.image" (dict "root" . "name" "nora-backend-api") }}
+    imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+    envFrom:
+      - configMapRef:
+          name: nora-env
+    command:
+      - node
+      - -e
+      - |
+        const net = require("net");
+        const host = process.env.DB_HOST, port = Number(process.env.DB_PORT);
+        (function attempt() {
+          const sock = net.connect(port, host);
+          sock.on("connect", () => { sock.end(); process.exit(0); });
+          sock.on("error", () => {
+            sock.destroy();
+            console.error(`waiting for database ${host}:${port}`);
+            setTimeout(attempt, 2000);
+          });
+        })();
+{{- end -}}

--- a/infra/helm/nora/templates/_helpers.tpl
+++ b/infra/helm/nora/templates/_helpers.tpl
@@ -1,0 +1,80 @@
+{{/* Image tag: explicit value or v<appVersion>. */}}
+{{- define "nora.imageTag" -}}
+{{- default (printf "v%s" .Chart.AppVersion) .Values.global.imageTag -}}
+{{- end -}}
+
+{{/* Fully-qualified Nora image for a component, e.g. (include "nora.image" (dict "root" . "name" "nora-backend-api")). */}}
+{{- define "nora.image" -}}
+{{- printf "%s/%s:%s" .root.Values.global.imageRegistry .name (include "nora.imageTag" .root) -}}
+{{- end -}}
+
+{{/* Common labels for a component; expects (dict "root" . "component" "backend-api"). */}}
+{{- define "nora.labels" -}}
+app.kubernetes.io/name: nora
+app.kubernetes.io/instance: {{ .root.Release.Name }}
+app.kubernetes.io/component: {{ .component }}
+app.kubernetes.io/version: {{ .root.Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .root.Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .root.Chart.Name .root.Chart.Version }}
+{{- end -}}
+
+{{/* Selector labels (stable subset). */}}
+{{- define "nora.selectorLabels" -}}
+app.kubernetes.io/name: nora
+app.kubernetes.io/instance: {{ .root.Release.Name }}
+app.kubernetes.io/component: {{ .component }}
+{{- end -}}
+
+{{/* Name of the Secret holding core credentials. */}}
+{{- define "nora.secretName" -}}
+{{- default "nora-secrets" .Values.secrets.existingSecret -}}
+{{- end -}}
+
+{{/* Effective database connection facts. */}}
+{{- define "nora.dbHost" -}}
+{{- if .Values.postgresql.enabled -}}postgres{{- else -}}{{ required "postgresql.external.host is required when postgresql.enabled=false" .Values.postgresql.external.host }}{{- end -}}
+{{- end -}}
+{{- define "nora.dbPort" -}}
+{{- if .Values.postgresql.enabled -}}5432{{- else -}}{{ .Values.postgresql.external.port }}{{- end -}}
+{{- end -}}
+{{- define "nora.dbUser" -}}
+{{- if .Values.postgresql.enabled -}}{{ .Values.postgresql.auth.username }}{{- else -}}{{ .Values.postgresql.external.username }}{{- end -}}
+{{- end -}}
+{{- define "nora.dbName" -}}
+{{- if .Values.postgresql.enabled -}}{{ .Values.postgresql.auth.database }}{{- else -}}{{ .Values.postgresql.external.database }}{{- end -}}
+{{- end -}}
+
+{{/* Effective Redis connection facts. */}}
+{{- define "nora.redisHost" -}}
+{{- if .Values.redis.enabled -}}redis{{- else -}}{{ required "redis.external.host is required when redis.enabled=false" .Values.redis.external.host }}{{- end -}}
+{{- end -}}
+{{- define "nora.redisPort" -}}
+{{- if .Values.redis.enabled -}}6379{{- else -}}{{ .Values.redis.external.port }}{{- end -}}
+{{- end -}}
+
+{{/* envFrom block shared by control-plane pods (backend-api, workers). */}}
+{{- define "nora.controlPlaneEnvFrom" -}}
+envFrom:
+  - configMapRef:
+      name: nora-env
+  - secretRef:
+      name: {{ include "nora.secretName" . }}
+{{- end -}}
+
+{{/* Extra env entries from commonEnv/backendEnv maps; expects (dict "root" . "extra" <map>). */}}
+{{- define "nora.extraEnv" -}}
+{{- range $key, $value := .extra }}
+- name: {{ $key }}
+  value: {{ $value | quote }}
+{{- end }}
+{{- end -}}
+
+{{/* imagePullSecrets block. */}}
+{{- define "nora.imagePullSecrets" -}}
+{{- with .Values.global.imagePullSecrets }}
+imagePullSecrets:
+{{- range . }}
+  - name: {{ . }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/infra/helm/nora/templates/backend-api.yaml
+++ b/infra/helm/nora/templates/backend-api.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nora-backend-api
+  labels:
+    {{- include "nora.labels" (dict "root" . "component" "backend-api") | nindent 4 }}
+spec:
+  replicas: {{ .Values.backendApi.replicas }}
+  selector:
+    matchLabels:
+      {{- include "nora.selectorLabels" (dict "root" . "component" "backend-api") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "nora.selectorLabels" (dict "root" . "component" "backend-api") | nindent 8 }}
+    spec:
+      {{- include "nora.imagePullSecrets" . | nindent 6 }}
+      containers:
+        - name: backend-api
+          image: {{ include "nora.image" (dict "root" . "name" "nora-backend-api") }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          ports:
+            - name: http
+              containerPort: 4000
+          {{- include "nora.controlPlaneEnvFrom" . | nindent 10 }}
+          env:
+            {{- include "nora.extraEnv" (dict "root" . "extra" .Values.commonEnv) | nindent 12 }}
+          volumeMounts:
+            {{- if .Values.backupsVolume.enabled }}
+            - name: nora-backups
+              mountPath: /var/lib/nora-backups
+            {{- end }}
+            {{- if .Values.kubeconfigs.existingSecret }}
+            - name: kubeconfigs
+              mountPath: /kubeconfigs
+              readOnly: true
+            {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          resources:
+            {{- toYaml .Values.backendApi.resources | nindent 12 }}
+      volumes:
+        {{- if .Values.backupsVolume.enabled }}
+        - name: nora-backups
+          persistentVolumeClaim:
+            claimName: nora-backups
+        {{- end }}
+        {{- if .Values.kubeconfigs.existingSecret }}
+        - name: kubeconfigs
+          secret:
+            secretName: {{ .Values.kubeconfigs.existingSecret }}
+        {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: backend-api
+  labels:
+    {{- include "nora.labels" (dict "root" . "component" "backend-api") | nindent 4 }}
+spec:
+  selector:
+    {{- include "nora.selectorLabels" (dict "root" . "component" "backend-api") | nindent 4 }}
+  ports:
+    - name: http
+      port: 4000
+      targetPort: http

--- a/infra/helm/nora/templates/backend-api.yaml
+++ b/infra/helm/nora/templates/backend-api.yaml
@@ -15,6 +15,7 @@ spec:
         {{- include "nora.selectorLabels" (dict "root" . "component" "backend-api") | nindent 8 }}
     spec:
       {{- include "nora.imagePullSecrets" . | nindent 6 }}
+      {{- include "nora.waitForDbInit" . | nindent 6 }}
       containers:
         - name: backend-api
           image: {{ include "nora.image" (dict "root" . "name" "nora-backend-api") }}

--- a/infra/helm/nora/templates/backups-pvc.yaml
+++ b/infra/helm/nora/templates/backups-pvc.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.backupsVolume.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: nora-backups
+  labels:
+    {{- include "nora.labels" (dict "root" . "component" "backups") | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.backupsVolume.accessModes | nindent 4 }}
+  {{- with .Values.backupsVolume.storageClass }}
+  storageClassName: {{ . }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.backupsVolume.size }}
+{{- end }}

--- a/infra/helm/nora/templates/backups-pvc.yaml
+++ b/infra/helm/nora/templates/backups-pvc.yaml
@@ -5,6 +5,12 @@ metadata:
   name: nora-backups
   labels:
     {{- include "nora.labels" (dict "root" . "component" "backups") | nindent 4 }}
+  annotations:
+    # Retain the backup archives across `helm uninstall` and across a
+    # `--set backupsVolume.enabled=false` (which the README recommends on
+    # multi-node clusters). Without this, Helm deletes the PVC and every local
+    # backup with it. Delete the PVC by hand if you truly want the data gone.
+    helm.sh/resource-policy: keep
 spec:
   accessModes:
     {{- toYaml .Values.backupsVolume.accessModes | nindent 4 }}

--- a/infra/helm/nora/templates/configmap-env.yaml
+++ b/infra/helm/nora/templates/configmap-env.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nora-env
+  labels:
+    {{- include "nora.labels" (dict "root" . "component" "config") | nindent 4 }}
+data:
+  NODE_ENV: production
+  PLATFORM_MODE: {{ .Values.platformMode | quote }}
+  ENABLED_BACKENDS: {{ .Values.enabledBackends | quote }}
+  ENABLED_RUNTIME_FAMILIES: {{ .Values.enabledRuntimeFamilies | quote }}
+  ENABLED_SANDBOX_PROFILES: {{ .Values.enabledSandboxProfiles | quote }}
+  NEXTAUTH_URL: {{ .Values.publicUrl | quote }}
+  CORS_ORIGINS: {{ .Values.publicUrl | quote }}
+  DB_HOST: {{ include "nora.dbHost" . | quote }}
+  DB_PORT: {{ include "nora.dbPort" . | quote }}
+  DB_USER: {{ include "nora.dbUser" . | quote }}
+  DB_NAME: {{ include "nora.dbName" . | quote }}
+  REDIS_HOST: {{ include "nora.redisHost" . | quote }}
+  REDIS_PORT: {{ include "nora.redisPort" . | quote }}
+  {{- range $key, $value := .Values.backendEnv }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}

--- a/infra/helm/nora/templates/configmap-nginx.yaml
+++ b/infra/helm/nora/templates/configmap-nginx.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nora-nginx-config
+  labels:
+    {{- include "nora.labels" (dict "root" . "component" "nginx") | nindent 4 }}
+data:
+  nginx.conf: |
+{{ .Files.Get "files/nginx-k8s.conf" | indent 4 }}

--- a/infra/helm/nora/templates/frontends.yaml
+++ b/infra/helm/nora/templates/frontends.yaml
@@ -1,0 +1,70 @@
+{{- $frontends := list
+      (dict "name" "frontend-marketing" "image" "nora-frontend-marketing" "values" .Values.frontendMarketing "probePath" "/")
+      (dict "name" "frontend-dashboard" "image" "nora-frontend-dashboard" "values" .Values.frontendDashboard "probePath" "/app")
+      (dict "name" "admin-dashboard" "image" "nora-admin-dashboard" "values" .Values.adminDashboard "probePath" "/admin")
+}}
+{{- range $frontend := $frontends }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nora-{{ $frontend.name }}
+  labels:
+    {{- include "nora.labels" (dict "root" $ "component" $frontend.name) | nindent 4 }}
+spec:
+  replicas: {{ $frontend.values.replicas }}
+  selector:
+    matchLabels:
+      {{- include "nora.selectorLabels" (dict "root" $ "component" $frontend.name) | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "nora.selectorLabels" (dict "root" $ "component" $frontend.name) | nindent 8 }}
+    spec:
+      {{- include "nora.imagePullSecrets" $ | nindent 6 }}
+      containers:
+        - name: {{ $frontend.name }}
+          image: {{ include "nora.image" (dict "root" $ "name" $frontend.image) }}
+          imagePullPolicy: {{ $.Values.global.imagePullPolicy }}
+          ports:
+            - name: http
+              containerPort: 3000
+          env:
+            - name: PORT
+              value: "3000"
+            - name: NODE_ENV
+              value: production
+            {{- if eq $frontend.name "frontend-marketing" }}
+            - name: PLATFORM_MODE
+              value: {{ $.Values.platformMode | quote }}
+            {{- end }}
+            {{- include "nora.extraEnv" (dict "root" $ "extra" $.Values.commonEnv) | nindent 12 }}
+          readinessProbe:
+            httpGet:
+              path: {{ $frontend.probePath }}
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: {{ $frontend.probePath }}
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          resources:
+            {{- toYaml $frontend.values.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $frontend.name }}
+  labels:
+    {{- include "nora.labels" (dict "root" $ "component" $frontend.name) | nindent 4 }}
+spec:
+  selector:
+    {{- include "nora.selectorLabels" (dict "root" $ "component" $frontend.name) | nindent 4 }}
+  ports:
+    - name: http
+      port: 3000
+      targetPort: http
+---
+{{- end }}

--- a/infra/helm/nora/templates/ingress.yaml
+++ b/infra/helm/nora/templates/ingress.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: nora
+  labels:
+    {{- include "nora.labels" (dict "root" . "component" "ingress") | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - host: {{ required "ingress.host is required when ingress.enabled=true" .Values.ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: nora-nginx
+                port:
+                  number: {{ .Values.nginx.service.port }}
+{{- end }}

--- a/infra/helm/nora/templates/nginx.yaml
+++ b/infra/helm/nora/templates/nginx.yaml
@@ -1,0 +1,63 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nora-nginx
+  labels:
+    {{- include "nora.labels" (dict "root" . "component" "nginx") | nindent 4 }}
+spec:
+  replicas: {{ .Values.nginx.replicas }}
+  selector:
+    matchLabels:
+      {{- include "nora.selectorLabels" (dict "root" . "component" "nginx") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "nora.selectorLabels" (dict "root" . "component" "nginx") | nindent 8 }}
+      annotations:
+        checksum/nginx-config: {{ .Files.Get "files/nginx-k8s.conf" | sha256sum }}
+    spec:
+      containers:
+        - name: nginx
+          image: {{ .Values.nginx.image }}
+          ports:
+            - name: http
+              containerPort: 80
+          volumeMounts:
+            - name: nginx-config
+              mountPath: /etc/nginx/nginx.conf
+              subPath: nginx.conf
+              readOnly: true
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 20
+          resources:
+            {{- toYaml .Values.nginx.resources | nindent 12 }}
+      volumes:
+        - name: nginx-config
+          configMap:
+            name: nora-nginx-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: nora-nginx
+  labels:
+    {{- include "nora.labels" (dict "root" . "component" "nginx") | nindent 4 }}
+spec:
+  type: {{ .Values.nginx.service.type }}
+  selector:
+    {{- include "nora.selectorLabels" (dict "root" . "component" "nginx") | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.nginx.service.port }}
+      targetPort: http
+      {{- if and (eq .Values.nginx.service.type "NodePort") .Values.nginx.service.nodePort }}
+      nodePort: {{ .Values.nginx.service.nodePort }}
+      {{- end }}

--- a/infra/helm/nora/templates/postgres.yaml
+++ b/infra/helm/nora/templates/postgres.yaml
@@ -1,0 +1,95 @@
+{{- if .Values.postgresql.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nora-db-schema
+  labels:
+    {{- include "nora.labels" (dict "root" . "component" "postgres") | nindent 4 }}
+data:
+  01_schema.sql: |
+{{ .Files.Get "files/db_schema.sql" | indent 4 }}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: nora-postgres
+  labels:
+    {{- include "nora.labels" (dict "root" . "component" "postgres") | nindent 4 }}
+spec:
+  serviceName: postgres
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "nora.selectorLabels" (dict "root" . "component" "postgres") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "nora.selectorLabels" (dict "root" . "component" "postgres") | nindent 8 }}
+    spec:
+      containers:
+        - name: postgres
+          image: {{ .Values.postgresql.image }}
+          ports:
+            - name: postgres
+              containerPort: 5432
+          env:
+            - name: POSTGRES_USER
+              value: {{ .Values.postgresql.auth.username | quote }}
+            - name: POSTGRES_DB
+              value: {{ .Values.postgresql.auth.database | quote }}
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "nora.secretName" . }}
+                  key: DB_PASSWORD
+            # Keep data out of the volume root so initdb tolerates lost+found.
+            - name: PGDATA
+              value: /var/lib/postgresql/data/pgdata
+          volumeMounts:
+            - name: pgdata
+              mountPath: /var/lib/postgresql/data
+            - name: db-schema
+              mountPath: /docker-entrypoint-initdb.d
+              readOnly: true
+          readinessProbe:
+            exec:
+              command: ["sh", "-c", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command: ["sh", "-c", "pg_isready -U $POSTGRES_USER -d $POSTGRES_DB"]
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          resources:
+            {{- toYaml .Values.postgresql.resources | nindent 12 }}
+      volumes:
+        - name: db-schema
+          configMap:
+            name: nora-db-schema
+  volumeClaimTemplates:
+    - metadata:
+        name: pgdata
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        {{- with .Values.postgresql.persistence.storageClass }}
+        storageClassName: {{ . }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.postgresql.persistence.size }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  labels:
+    {{- include "nora.labels" (dict "root" . "component" "postgres") | nindent 4 }}
+spec:
+  selector:
+    {{- include "nora.selectorLabels" (dict "root" . "component" "postgres") | nindent 4 }}
+  ports:
+    - name: postgres
+      port: 5432
+      targetPort: postgres
+{{- end }}

--- a/infra/helm/nora/templates/redis.yaml
+++ b/infra/helm/nora/templates/redis.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.redis.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nora-redis
+  labels:
+    {{- include "nora.labels" (dict "root" . "component" "redis") | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "nora.selectorLabels" (dict "root" . "component" "redis") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "nora.selectorLabels" (dict "root" . "component" "redis") | nindent 8 }}
+    spec:
+      containers:
+        - name: redis
+          image: {{ .Values.redis.image }}
+          ports:
+            - name: redis
+              containerPort: 6379
+          readinessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          livenessProbe:
+            exec:
+              command: ["redis-cli", "ping"]
+            initialDelaySeconds: 15
+            periodSeconds: 20
+          resources:
+            {{- toYaml .Values.redis.resources | nindent 12 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  labels:
+    {{- include "nora.labels" (dict "root" . "component" "redis") | nindent 4 }}
+spec:
+  selector:
+    {{- include "nora.selectorLabels" (dict "root" . "component" "redis") | nindent 4 }}
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: redis
+{{- end }}

--- a/infra/helm/nora/templates/secret-env.yaml
+++ b/infra/helm/nora/templates/secret-env.yaml
@@ -1,0 +1,26 @@
+{{- if not .Values.secrets.existingSecret }}
+{{- $required := dict
+      "jwtSecret" "secrets.jwtSecret"
+      "encryptionKey" "secrets.encryptionKey"
+      "backupEncryptionKey" "secrets.backupEncryptionKey"
+      "apiKeyHashSecret" "secrets.apiKeyHashSecret"
+      "dbPassword" "secrets.dbPassword" }}
+{{- range $field, $path := $required }}
+{{- if not (get $.Values.secrets $field) }}
+{{- fail (printf "%s is required (or set secrets.existingSecret). Generate with: openssl rand -hex 32" $path) }}
+{{- end }}
+{{- end }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nora-secrets
+  labels:
+    {{- include "nora.labels" (dict "root" . "component" "config") | nindent 4 }}
+type: Opaque
+stringData:
+  JWT_SECRET: {{ .Values.secrets.jwtSecret | quote }}
+  ENCRYPTION_KEY: {{ .Values.secrets.encryptionKey | quote }}
+  NORA_BACKUP_ENCRYPTION_KEY: {{ .Values.secrets.backupEncryptionKey | quote }}
+  NORA_API_KEY_HASH_SECRET: {{ .Values.secrets.apiKeyHashSecret | quote }}
+  DB_PASSWORD: {{ .Values.secrets.dbPassword | quote }}
+{{- end }}

--- a/infra/helm/nora/templates/workers.yaml
+++ b/infra/helm/nora/templates/workers.yaml
@@ -1,0 +1,114 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nora-worker-provisioner
+  labels:
+    {{- include "nora.labels" (dict "root" . "component" "worker-provisioner") | nindent 4 }}
+spec:
+  replicas: {{ .Values.workerProvisioner.replicas }}
+  selector:
+    matchLabels:
+      {{- include "nora.selectorLabels" (dict "root" . "component" "worker-provisioner") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "nora.selectorLabels" (dict "root" . "component" "worker-provisioner") | nindent 8 }}
+    spec:
+      {{- include "nora.imagePullSecrets" . | nindent 6 }}
+      containers:
+        - name: worker-provisioner
+          image: {{ include "nora.image" (dict "root" . "name" "nora-worker-provisioner") }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          ports:
+            - name: health
+              containerPort: 4001
+          {{- include "nora.controlPlaneEnvFrom" . | nindent 10 }}
+          env:
+            - name: DEPLOYMENT_WORKER_CONCURRENCY
+              value: {{ .Values.workerProvisioner.concurrency | quote }}
+            {{- include "nora.extraEnv" (dict "root" . "extra" .Values.commonEnv) | nindent 12 }}
+          {{- if .Values.kubeconfigs.existingSecret }}
+          volumeMounts:
+            - name: kubeconfigs
+              mountPath: /kubeconfigs
+              readOnly: true
+          {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: health
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: health
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          resources:
+            {{- toYaml .Values.workerProvisioner.resources | nindent 12 }}
+      {{- if .Values.kubeconfigs.existingSecret }}
+      volumes:
+        - name: kubeconfigs
+          secret:
+            secretName: {{ .Values.kubeconfigs.existingSecret }}
+      {{- end }}
+{{- if .Values.workerBackup.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nora-worker-backup
+  labels:
+    {{- include "nora.labels" (dict "root" . "component" "worker-backup") | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "nora.selectorLabels" (dict "root" . "component" "worker-backup") | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "nora.selectorLabels" (dict "root" . "component" "worker-backup") | nindent 8 }}
+    spec:
+      {{- include "nora.imagePullSecrets" . | nindent 6 }}
+      containers:
+        - name: worker-backup
+          image: {{ include "nora.image" (dict "root" . "name" "nora-worker-backup") }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          ports:
+            - name: health
+              containerPort: 4002
+          {{- include "nora.controlPlaneEnvFrom" . | nindent 10 }}
+          env:
+            - name: BACKUP_WORKER_CONCURRENCY
+              value: {{ .Values.workerBackup.concurrency | quote }}
+            - name: NODE_PATH
+              value: /app/node_modules
+            {{- include "nora.extraEnv" (dict "root" . "extra" .Values.commonEnv) | nindent 12 }}
+          {{- if .Values.backupsVolume.enabled }}
+          volumeMounts:
+            - name: nora-backups
+              mountPath: /var/lib/nora-backups
+          {{- end }}
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: health
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: health
+            initialDelaySeconds: 30
+            periodSeconds: 20
+          resources:
+            {{- toYaml .Values.workerBackup.resources | nindent 12 }}
+      {{- if .Values.backupsVolume.enabled }}
+      volumes:
+        - name: nora-backups
+          persistentVolumeClaim:
+            claimName: nora-backups
+      {{- end }}
+{{- end }}

--- a/infra/helm/nora/templates/workers.yaml
+++ b/infra/helm/nora/templates/workers.yaml
@@ -15,6 +15,7 @@ spec:
         {{- include "nora.selectorLabels" (dict "root" . "component" "worker-provisioner") | nindent 8 }}
     spec:
       {{- include "nora.imagePullSecrets" . | nindent 6 }}
+      {{- include "nora.waitForDbInit" . | nindent 6 }}
       containers:
         - name: worker-provisioner
           image: {{ include "nora.image" (dict "root" . "name" "nora-worker-provisioner") }}
@@ -72,6 +73,7 @@ spec:
         {{- include "nora.selectorLabels" (dict "root" . "component" "worker-backup") | nindent 8 }}
     spec:
       {{- include "nora.imagePullSecrets" . | nindent 6 }}
+      {{- include "nora.waitForDbInit" . | nindent 6 }}
       containers:
         - name: worker-backup
           image: {{ include "nora.image" (dict "root" . "name" "nora-worker-backup") }}

--- a/infra/helm/nora/values.yaml
+++ b/infra/helm/nora/values.yaml
@@ -1,0 +1,164 @@
+# Default values for the Nora chart.
+#
+# One Nora release per namespace: Services use fixed compose-parity names
+# (backend-api, postgres, redis, ...) so the bundled nginx config and the
+# application's connection defaults work unchanged.
+
+global:
+  # Registry prefix for the published Nora images.
+  imageRegistry: ghcr.io/solomon2773
+  # Image tag for all Nora services. Empty resolves to "v<chart appVersion>".
+  imageTag: ""
+  imagePullPolicy: IfNotPresent
+  imagePullSecrets: []
+
+# Public origin operators will reach Nora on. Feeds NEXTAUTH_URL and
+# CORS_ORIGINS. With ingress enabled, set this to https://<ingress host>.
+publicUrl: http://localhost:8080
+
+platformMode: selfhosted
+# Kubernetes is the only usable agent deploy target when Nora itself runs in a
+# pod: the provisioner has no Docker socket in-cluster (see chart README).
+enabledBackends: k8s
+enabledRuntimeFamilies: openclaw
+enabledSandboxProfiles: standard
+
+secrets:
+  # Name of an existing Secret carrying JWT_SECRET, ENCRYPTION_KEY,
+  # NORA_BACKUP_ENCRYPTION_KEY, NORA_API_KEY_HASH_SECRET, and DB_PASSWORD.
+  # Leave empty to let the chart create one from the values below.
+  existingSecret: ""
+  # Required when existingSecret is empty (no insecure defaults are shipped):
+  #   openssl rand -hex 32   # for each of the four keys below
+  jwtSecret: ""
+  encryptionKey: ""
+  backupEncryptionKey: ""
+  apiKeyHashSecret: ""
+  dbPassword: ""
+
+# Extra non-secret environment variables applied to backend-api and both
+# workers (the control-plane processes). See .env.example for the catalog.
+backendEnv: {}
+
+# Extra environment variables applied to every Nora pod.
+commonEnv: {}
+
+nginx:
+  image: nginx:1.29
+  replicas: 1
+  service:
+    # ClusterIP behind an Ingress; switch to LoadBalancer/NodePort to expose
+    # the edge directly.
+    type: ClusterIP
+    port: 80
+    nodePort: ""
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+
+ingress:
+  enabled: false
+  className: ""
+  host: nora.example.com
+  annotations: {}
+  tls: []
+  # tls:
+  #   - secretName: nora-tls
+  #     hosts: [nora.example.com]
+
+frontendMarketing:
+  replicas: 1
+  resources:
+    requests:
+      cpu: 50m
+      memory: 192Mi
+
+frontendDashboard:
+  replicas: 1
+  resources:
+    requests:
+      cpu: 50m
+      memory: 192Mi
+
+adminDashboard:
+  replicas: 1
+  resources:
+    requests:
+      cpu: 50m
+      memory: 192Mi
+
+backendApi:
+  replicas: 1
+  resources:
+    requests:
+      cpu: 250m
+      memory: 512Mi
+
+workerProvisioner:
+  replicas: 1
+  concurrency: 6
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+
+workerBackup:
+  enabled: true
+  concurrency: 2
+  resources:
+    requests:
+      cpu: 50m
+      memory: 192Mi
+
+# Kubeconfigs for agent deploy targets registered in Admin -> Kubernetes.
+# Point at an existing Secret whose keys are kubeconfig files; it is mounted
+# read-only at /kubeconfigs in backend-api and the provisioner.
+kubeconfigs:
+  existingSecret: ""
+
+# Shared volume for managed local backups (backend-api + worker-backup).
+# ReadWriteOnce only works when both pods land on one node (single-node
+# clusters such as k3s or Kind). On multi-node clusters use a ReadWriteMany
+# storage class here, or configure S3/SSH backup storage in Admin settings
+# and disable this volume.
+backupsVolume:
+  enabled: true
+  size: 10Gi
+  storageClass: ""
+  accessModes:
+    - ReadWriteOnce
+
+postgresql:
+  # In-chart PostgreSQL (official postgres image). Disable to bring your own;
+  # then fill in external.* below.
+  enabled: true
+  image: postgres:15
+  auth:
+    username: nora
+    database: nora
+  persistence:
+    size: 10Gi
+    storageClass: ""
+  resources:
+    requests:
+      cpu: 100m
+      memory: 256Mi
+  external:
+    host: ""
+    port: 5432
+    username: nora
+    database: nora
+
+redis:
+  # In-chart Redis (official redis image). Queue state is transient; no
+  # persistence by default. Disable to bring your own.
+  enabled: true
+  image: redis:7
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+  external:
+    host: ""
+    port: 6379

--- a/infra/helm/scripts/kind-smoke.sh
+++ b/infra/helm/scripts/kind-smoke.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Manual smoke test: install the Nora chart on a local Kind cluster, wait for
+# the stack to go Ready, and probe the edge. Mirrors what a first-time
+# `helm install` user experiences. Requires: kind, kubectl, helm, openssl.
+#
+# Usage: infra/helm/scripts/kind-smoke.sh [--keep]
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+CLUSTER_NAME="nora-helm-smoke"
+NAMESPACE="nora"
+KEEP="${1:-}"
+
+cleanup() {
+  if [ "$KEEP" != "--keep" ]; then
+    kind delete cluster --name "$CLUSTER_NAME" >/dev/null 2>&1 || true
+  else
+    echo "Cluster kept: kind export kubeconfig --name $CLUSTER_NAME"
+  fi
+}
+trap cleanup EXIT
+
+echo "==> Creating Kind cluster ($CLUSTER_NAME)"
+kind create cluster --name "$CLUSTER_NAME" --config "$REPO_ROOT/infra/kind/nora-kind.yaml" --wait 120s
+
+echo "==> Installing chart"
+helm install nora "$REPO_ROOT/infra/helm/nora" \
+  --namespace "$NAMESPACE" --create-namespace \
+  --set secrets.jwtSecret="$(openssl rand -hex 32)" \
+  --set secrets.encryptionKey="$(openssl rand -hex 32)" \
+  --set secrets.backupEncryptionKey="$(openssl rand -hex 32)" \
+  --set secrets.apiKeyHashSecret="$(openssl rand -hex 32)" \
+  --set secrets.dbPassword="$(openssl rand -hex 24)" \
+  --wait --timeout 10m
+
+echo "==> Pods"
+kubectl -n "$NAMESPACE" get pods
+
+echo "==> Probing the edge through nora-nginx"
+kubectl -n "$NAMESPACE" port-forward svc/nora-nginx 18080:80 >/dev/null 2>&1 &
+PF_PID=$!
+sleep 3
+
+fail=0
+probe() {
+  local path="$1" expect="$2"
+  local code
+  code=$(curl -s -o /dev/null -w "%{http_code}" "http://127.0.0.1:18080$path")
+  if [ "$code" = "$expect" ]; then
+    echo "  OK  $path -> $code"
+  else
+    echo "  FAIL $path -> $code (expected $expect)"
+    fail=1
+  fi
+}
+
+probe "/api/health" "200"
+probe "/" "200"
+probe "/app" "200"
+probe "/admin" "200"
+
+kill "$PF_PID" >/dev/null 2>&1 || true
+
+if [ "$fail" -ne 0 ]; then
+  echo "Smoke test FAILED"
+  exit 1
+fi
+echo "Smoke test passed."


### PR DESCRIPTION
## What

Closes the "it manages my cluster but won't run in it" incoherence for K8s-first evaluators — PR-2 of the 9-item pre-launch plan.

**`infra/helm/nora/`** deploys the full control plane: nginx edge, the three Next.js frontends, backend-api, worker-provisioner, worker-backup, plus optional in-chart **PostgreSQL 15 / Redis 7 on official images** (Bitnami deliberately avoided) with `*.external.*` toggles to bring your own.

```bash
helm install nora ./infra/helm/nora -n nora --create-namespace \
  --set secrets.jwtSecret=... (5 required secrets — no insecure defaults ship)
```

## Design

- **One release per namespace; compose-parity Service names** (`backend-api`, `postgres`, `redis`, …) so the bundled nginx routing and the app's connection defaults (`DB_HOST=postgres`, `REDIS_HOST=redis`) work unchanged.
- `files/nginx-k8s.conf` mirrors root `nginx.conf` routing with static Service upstreams (sync rule documented in the chart README).
- `files/db_schema.sql` is a vendored copy for postgres initdb — **CI-enforced drift guard** fails `ci:validate-infra` when it diverges from `backend-api/db_schema.sql`.
- Fail-fast secrets: install refuses without `secrets.*` or `secrets.existingSecret`.
- Honest K8s limitations baked into defaults + docs: `ENABLED_BACKENDS=k8s` (no Docker socket in pods), Admin-UI in-place upgrades replaced by `helm upgrade`, RWO backups-volume caveat on multi-node clusters (use RWX or S3/SSH backup storage).

## CI / validation

- `validate-infra.mjs` upgraded: helm-lints with CI dummy values, runs **kubeconform `-strict` on the rendered templates**, excludes chart internals from the raw-manifest walk, and enforces the schema drift guard. Activates automatically in the existing CI Security job — no workflow surgery.
- `release-docker.yml` gains the missing **`nora-worker-backup`** image (every chart-referenced image is now published).
- `infra/helm/scripts/kind-smoke.sh` — manual Kind install smoke test probing `/api/health`, `/`, `/app`, `/admin` through the edge.
- Docs: "Kubernetes (Helm)" section in `docs/self-hosting.mdx` + full chart README.

## Verified locally

- `helm lint` clean; default render → **21 resources, all kubeconform-strict valid**.
- Alternate-toggle render (external DB/Redis, Ingress on, NodePort, kubeconfigs secret, backup worker off) → 15 resources valid; `existingSecret` path renders without the in-chart Secret.
- Full `npm run ci:validate-infra` green including all three compose validations.
- Kind smoke script provided but not CI-gated yet (deferred per plan).