### PR TITLE
feat(budgets): per-agent LLM budget hard caps with auto-pause

### DIFF
--- a/backend-api/__tests__/agentBudgets.test.ts
+++ b/backend-api/__tests__/agentBudgets.test.ts
@@ -1,0 +1,258 @@
+// @ts-nocheck
+const agentBudgets = require("../agentBudgets");
+
+// Minimal dbClient fake that routes on SQL shape and records every call.
+function fakeDb({ budgets = [] } = {}) {
+  const calls = [];
+  return {
+    calls,
+    budgets,
+    query: jest.fn(async (sql, params) => {
+      calls.push({ sql, params });
+      if (sql.includes("FROM agent_budgets")) {
+        return { rows: budgets };
+      }
+      if (sql.includes("INSERT INTO agent_budgets")) {
+        return {
+          rows: [
+            {
+              id: "b-1",
+              agent_id: params[0],
+              period: params[1],
+              limit_usd: params[2],
+              soft_threshold_pct: params[3],
+              last_alerted_at: null,
+              last_alerted_pct: null,
+              created_at: "now",
+              updated_at: "now",
+            },
+          ],
+        };
+      }
+      if (sql.includes("DELETE FROM agent_budgets")) {
+        return { rows: params[0] === "exists" ? [{ id: "exists" }] : [] };
+      }
+      return { rows: [] };
+    }),
+  };
+}
+
+function budgetRow(overrides = {}) {
+  return {
+    id: "b-1",
+    agent_id: "a-1",
+    period: "monthly",
+    limit_usd: "10.00",
+    soft_threshold_pct: 80,
+    last_alerted_at: null,
+    last_alerted_pct: null,
+    created_at: "now",
+    updated_at: "now",
+    ...overrides,
+  };
+}
+
+function runningAgent(overrides = {}) {
+  return { id: "a-1", name: "Researcher", status: "running", ...overrides };
+}
+
+describe("upsertBudget validation", () => {
+  it("normalizes period, limit, and threshold", async () => {
+    const dbClient = fakeDb();
+    const budget = await agentBudgets.upsertBudget(
+      "a-1",
+      { period: "monthly", limit_usd: "12.349", soft_threshold_pct: "75" },
+      { dbClient },
+    );
+    expect(budget.limitUsd).toBe(12.35);
+    expect(budget.softThresholdPct).toBe(75);
+    expect(budget.period).toBe("monthly");
+  });
+
+  it("rejects unknown periods and non-positive limits", async () => {
+    const dbClient = fakeDb();
+    await expect(
+      agentBudgets.upsertBudget("a-1", { period: "hourly", limit_usd: 5 }, { dbClient }),
+    ).rejects.toMatchObject({ statusCode: 400 });
+    await expect(
+      agentBudgets.upsertBudget("a-1", { period: "daily", limit_usd: 0 }, { dbClient }),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+});
+
+describe("checkAndEnforce", () => {
+  it("does nothing when the agent has no budgets", async () => {
+    const dbClient = fakeDb({ budgets: [] });
+    const costResolver = jest.fn();
+    const result = await agentBudgets.checkAndEnforce(runningAgent(), { dbClient, costResolver });
+    expect(result).toEqual({ enforced: false, crossings: [] });
+    expect(costResolver).not.toHaveBeenCalled();
+  });
+
+  it("emits a soft alert once and dedupes repeats in the same bucket", async () => {
+    const logEvent = jest.fn();
+    const stopRuntime = jest.fn();
+    const costResolver = jest.fn().mockResolvedValue({ total_cost: 8.5 }); // 85%
+
+    const first = fakeDb({ budgets: [budgetRow()] });
+    await agentBudgets.checkAndEnforce(runningAgent(), {
+      dbClient: first,
+      costResolver,
+      stopRuntime,
+      logEvent,
+    });
+    expect(logEvent).toHaveBeenCalledWith(
+      "agent.budget_soft_exceeded",
+      expect.stringContaining("85%"),
+      expect.objectContaining({ agentId: "a-1", pct: 85 }),
+    );
+    expect(stopRuntime).not.toHaveBeenCalled();
+
+    // Same bucket already alerted -> silent.
+    logEvent.mockClear();
+    const second = fakeDb({ budgets: [budgetRow({ last_alerted_pct: 85 })] });
+    await agentBudgets.checkAndEnforce(runningAgent(), {
+      dbClient: second,
+      costResolver,
+      stopRuntime,
+      logEvent,
+    });
+    expect(logEvent).not.toHaveBeenCalled();
+  });
+
+  it("pauses the runtime on a hard crossing: reason first, stop, then status", async () => {
+    const dbClient = fakeDb({ budgets: [budgetRow()] });
+    const logEvent = jest.fn();
+    const stopRuntime = jest.fn().mockResolvedValue(undefined);
+    const costResolver = jest.fn().mockResolvedValue({ total_cost: 11 }); // 110%
+
+    const result = await agentBudgets.checkAndEnforce(runningAgent(), {
+      dbClient,
+      costResolver,
+      stopRuntime,
+      logEvent,
+    });
+
+    expect(result.enforced).toBe(true);
+    expect(stopRuntime).toHaveBeenCalledTimes(1);
+
+    const updates = dbClient.calls.filter((c) => c.sql.includes("UPDATE agents"));
+    expect(updates[0].sql).toContain("paused_reason");
+    expect(updates[0].params).toEqual(["budget_exceeded", "a-1"]);
+    expect(updates[1].sql).toContain("status = 'stopped'");
+
+    // The paused_reason write must come BEFORE the stop call so a failed stop
+    // still records intent.
+    const reasonIdx = dbClient.calls.findIndex((c) => c.sql.includes("paused_reason"));
+    expect(stopRuntime.mock.invocationCallOrder[0]).toBeGreaterThan(0);
+    expect(reasonIdx).toBeGreaterThanOrEqual(0);
+
+    expect(logEvent).toHaveBeenCalledWith(
+      "agent.budget_paused",
+      expect.stringContaining("paused"),
+      expect.objectContaining({ agentId: "a-1" }),
+    );
+  });
+
+  it("keeps the pause intent and reports failure when stop() throws", async () => {
+    const dbClient = fakeDb({ budgets: [budgetRow()] });
+    const logEvent = jest.fn();
+    const stopRuntime = jest.fn().mockRejectedValue(new Error("docker unreachable"));
+    const costResolver = jest.fn().mockResolvedValue({ total_cost: 20 });
+
+    const result = await agentBudgets.checkAndEnforce(runningAgent(), {
+      dbClient,
+      costResolver,
+      stopRuntime,
+      logEvent,
+    });
+
+    expect(result.enforced).toBe(false);
+    // paused_reason was written (intent recorded for the sweep retry)...
+    const updates = dbClient.calls.filter((c) => c.sql.includes("UPDATE agents"));
+    expect(updates).toHaveLength(1);
+    expect(updates[0].sql).toContain("paused_reason");
+    // ...but status was NOT flipped to stopped.
+    expect(updates.some((c) => c.sql.includes("status = 'stopped'"))).toBe(false);
+    expect(logEvent).toHaveBeenCalledWith(
+      "agent.budget_pause_failed",
+      expect.stringContaining("docker unreachable"),
+      expect.objectContaining({ agentId: "a-1" }),
+    );
+  });
+
+  it("re-enforces while over cap even when the alert is deduped (reconciler un-pause defense)", async () => {
+    // Scenario: enforcement already alerted at 110% (last_alerted_pct=110),
+    // the container kept running (failed stop or manual restart), so the
+    // status reconciler flipped the agent back to running. The next check
+    // must stop it again even though no new alert fires.
+    const dbClient = fakeDb({ budgets: [budgetRow({ last_alerted_pct: 110 })] });
+    const logEvent = jest.fn();
+    const stopRuntime = jest.fn().mockResolvedValue(undefined);
+    const costResolver = jest.fn().mockResolvedValue({ total_cost: 11 });
+
+    const result = await agentBudgets.checkAndEnforce(runningAgent(), {
+      dbClient,
+      costResolver,
+      stopRuntime,
+      logEvent,
+    });
+
+    expect(result.enforced).toBe(true);
+    expect(stopRuntime).toHaveBeenCalledTimes(1);
+    // Alert deduped: no new budget_exceeded event, but the pause event fires.
+    const types = logEvent.mock.calls.map((c) => c[0]);
+    expect(types).not.toContain("agent.budget_exceeded");
+    expect(types).toContain("agent.budget_paused");
+  });
+
+  it("does not try to stop agents that are not running", async () => {
+    const dbClient = fakeDb({ budgets: [budgetRow({ last_alerted_pct: 110 })] });
+    const stopRuntime = jest.fn();
+    const costResolver = jest.fn().mockResolvedValue({ total_cost: 11 });
+
+    const result = await agentBudgets.checkAndEnforce(runningAgent({ status: "stopped" }), {
+      dbClient,
+      costResolver,
+      stopRuntime,
+      logEvent: jest.fn(),
+    });
+
+    expect(result.enforced).toBe(false);
+    expect(stopRuntime).not.toHaveBeenCalled();
+  });
+});
+
+describe("sweepAgentBudgets", () => {
+  it("checks every budgeted live agent and isolates per-agent failures", async () => {
+    const agents = [
+      { id: "a-1", name: "One", status: "running" },
+      { id: "a-2", name: "Two", status: "warning" },
+    ];
+    const dbClient = {
+      query: jest.fn(async (sql) => {
+        if (sql.includes("JOIN agent_budgets")) return { rows: agents };
+        if (sql.includes("FROM agent_budgets")) {
+          throw new Error("listBudgets boom"); // forces per-agent failure path
+        }
+        return { rows: [] };
+      }),
+    };
+
+    await expect(agentBudgets.sweepAgentBudgets({ dbClient })).resolves.toBeUndefined();
+    // The sweep query ran and both agents were attempted despite failures.
+    const budgetListCalls = dbClient.query.mock.calls.filter(([sql]) =>
+      sql.includes("FROM agent_budgets"),
+    );
+    expect(budgetListCalls).toHaveLength(2);
+  });
+});
+
+describe("clearPausedReason", () => {
+  it("nulls the marker", async () => {
+    const dbClient = fakeDb();
+    await agentBudgets.clearPausedReason("a-1", { dbClient });
+    expect(dbClient.calls[0].sql).toContain("paused_reason = NULL");
+    expect(dbClient.calls[0].params).toEqual(["a-1"]);
+  });
+});

--- a/backend-api/agentBudgets.ts
+++ b/backend-api/agentBudgets.ts
@@ -1,0 +1,308 @@
+// @ts-nocheck
+// Per-agent LLM spend budgets with hard-cap enforcement. Mirrors
+// workspaceBudgets.ts for CRUD/alert-dedup semantics, and adds the part only
+// a provisioning control plane can do: when spend crosses 100% of a budget,
+// the runtime is stopped (status 'stopped' + paused_reason 'budget_exceeded').
+//
+// Enforcement runs from two directions:
+//   - inline, fire-and-forget after every recordTokenUsage in gatewayProxy;
+//   - sweepAgentBudgets on a 60s interval (covers usage recorded outside the
+//     gateway path, failed stops, and manual restarts while still over cap —
+//     the status reconciler flips stopped->running whenever the container is
+//     live, so re-enforcement is what makes the pause stick).
+//
+// Alert events (agent.budget_soft_exceeded / agent.budget_exceeded) are
+// deduped per bucket via last_alerted_pct, exactly like workspace budgets.
+// Enforcement itself is NOT deduped: while over the hard cap and running,
+// every check re-pauses.
+
+const db = require("./db");
+const metrics = require("./metrics");
+const containerManager = require("./containerManager");
+const monitoring = require("./monitoring");
+
+const VALID_PERIODS = new Set(["daily", "weekly", "monthly"]);
+const PERIOD_DAYS = { daily: 1, weekly: 7, monthly: 30 };
+const PAUSED_REASON_BUDGET = "budget_exceeded";
+
+function normalizePeriod(value) {
+  const period = String(value || "monthly").trim();
+  if (!VALID_PERIODS.has(period)) {
+    const error = new Error(`period must be one of: ${[...VALID_PERIODS].join(", ")}`);
+    error.statusCode = 400;
+    throw error;
+  }
+  return period;
+}
+
+function normalizeLimit(value) {
+  const num = Number(value);
+  if (!Number.isFinite(num) || num <= 0) {
+    const error = new Error("limit_usd must be a positive number");
+    error.statusCode = 400;
+    throw error;
+  }
+  return Math.round(num * 100) / 100;
+}
+
+function normalizeThreshold(value) {
+  if (value == null) return 80;
+  const num = Number(value);
+  if (!Number.isFinite(num) || num < 0 || num > 100) {
+    const error = new Error("soft_threshold_pct must be between 0 and 100");
+    error.statusCode = 400;
+    throw error;
+  }
+  return Math.round(num);
+}
+
+function serializeBudget(row) {
+  return {
+    id: row.id,
+    agentId: row.agent_id,
+    period: row.period,
+    limitUsd: Number(row.limit_usd),
+    softThresholdPct: row.soft_threshold_pct,
+    lastAlertedAt: row.last_alerted_at,
+    lastAlertedPct: row.last_alerted_pct,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+async function listBudgets(agentId, { dbClient = db } = {}) {
+  const result = await dbClient.query(
+    `SELECT id, agent_id, period, limit_usd, soft_threshold_pct,
+            last_alerted_at, last_alerted_pct, created_at, updated_at
+       FROM agent_budgets
+      WHERE agent_id = $1
+      ORDER BY period`,
+    [agentId],
+  );
+  return result.rows.map(serializeBudget);
+}
+
+async function upsertBudget(agentId, payload = {}, { dbClient = db } = {}) {
+  const period = normalizePeriod(payload.period);
+  const limitUsd = normalizeLimit(payload.limitUsd ?? payload.limit_usd);
+  const softThresholdPct = normalizeThreshold(
+    payload.softThresholdPct ?? payload.soft_threshold_pct,
+  );
+
+  const result = await dbClient.query(
+    `INSERT INTO agent_budgets (agent_id, period, limit_usd, soft_threshold_pct)
+     VALUES ($1, $2, $3, $4)
+     ON CONFLICT (agent_id, period) DO UPDATE
+       SET limit_usd = EXCLUDED.limit_usd,
+           soft_threshold_pct = EXCLUDED.soft_threshold_pct,
+           updated_at = NOW()
+     RETURNING id, agent_id, period, limit_usd, soft_threshold_pct,
+               last_alerted_at, last_alerted_pct, created_at, updated_at`,
+    [agentId, period, limitUsd, softThresholdPct],
+  );
+  return serializeBudget(result.rows[0]);
+}
+
+async function deleteBudget(budgetId, agentId, { dbClient = db } = {}) {
+  const result = await dbClient.query(
+    "DELETE FROM agent_budgets WHERE id = $1 AND agent_id = $2 RETURNING id",
+    [budgetId, agentId],
+  );
+  return Boolean(result.rows[0]);
+}
+
+async function recordBudgetAlert(budgetId, pct, { dbClient = db } = {}) {
+  await dbClient
+    .query(
+      `UPDATE agent_budgets
+          SET last_alerted_at = NOW(),
+              last_alerted_pct = $2,
+              updated_at = NOW()
+        WHERE id = $1`,
+      [budgetId, pct],
+    )
+    .catch((err) => console.error("Failed to record agent budget alert:", err.message));
+}
+
+function bucketFor(pct, softThresholdPct) {
+  if (pct >= 100) return "hard";
+  if (pct >= softThresholdPct) return "soft";
+  return "none";
+}
+
+// Attach current spend + crossing bucket to each budget. Pure read; used by
+// the budget API so the UI can render cap-vs-spend without extra calls.
+async function listBudgetsWithSpend(agentId, deps = {}) {
+  const { costResolver = metrics.getAgentCost } = deps;
+  const budgets = await listBudgets(agentId, deps);
+  const out = [];
+  for (const budget of budgets) {
+    const cost = await costResolver(agentId, { periodDays: PERIOD_DAYS[budget.period] });
+    const currentUsd = Number(cost?.total_cost || 0);
+    const pct = budget.limitUsd > 0 ? Math.floor((currentUsd / budget.limitUsd) * 100) : 0;
+    out.push({ ...budget, currentUsd, pct, bucket: bucketFor(pct, budget.softThresholdPct) });
+  }
+  return out;
+}
+
+// Evaluate budgets for an agent and enforce the hard cap. Alerts are deduped
+// per bucket (like workspace budgets); the stop action re-fires on every
+// check while the agent is over cap and its runtime is up.
+async function checkAndEnforce(agent, deps = {}) {
+  const {
+    dbClient = db,
+    costResolver = metrics.getAgentCost,
+    logEvent = (type, message, metadata) => monitoring.logEvent(type, message, metadata),
+  } = deps;
+
+  if (!agent?.id) return { enforced: false, crossings: [] };
+
+  const budgets = await listBudgets(agent.id, { dbClient });
+  if (budgets.length === 0) return { enforced: false, crossings: [] };
+
+  const crossings = [];
+  let enforced = false;
+
+  for (const budget of budgets) {
+    const cost = await costResolver(agent.id, { periodDays: PERIOD_DAYS[budget.period] });
+    const currentUsd = Number(cost?.total_cost || 0);
+    const pct = budget.limitUsd > 0 ? Math.floor((currentUsd / budget.limitUsd) * 100) : 0;
+    const bucket = bucketFor(pct, budget.softThresholdPct);
+    if (bucket === "none") continue;
+    crossings.push({ budget, bucket, currentUsd, pct });
+
+    const lastBucket =
+      budget.lastAlertedPct == null
+        ? "none"
+        : budget.lastAlertedPct >= 100
+          ? "hard"
+          : budget.lastAlertedPct >= budget.softThresholdPct
+            ? "soft"
+            : "none";
+    const shouldAlert = bucket === "hard" ? lastBucket !== "hard" : lastBucket === "none";
+
+    if (shouldAlert) {
+      const type = bucket === "hard" ? "agent.budget_exceeded" : "agent.budget_soft_exceeded";
+      const message =
+        bucket === "hard"
+          ? `Agent "${agent.name || agent.id}" exceeded its ${budget.period} budget ($${currentUsd.toFixed(2)} of $${budget.limitUsd.toFixed(2)})`
+          : `Agent "${agent.name || agent.id}" reached ${pct}% of its ${budget.period} budget ($${currentUsd.toFixed(2)} of $${budget.limitUsd.toFixed(2)})`;
+      await Promise.resolve(
+        logEvent(type, message, {
+          agentId: agent.id,
+          budgetId: budget.id,
+          period: budget.period,
+          limitUsd: budget.limitUsd,
+          currentUsd,
+          pct,
+        }),
+      ).catch(() => {});
+      await recordBudgetAlert(budget.id, pct, { dbClient });
+    }
+
+    if (bucket === "hard" && !enforced) {
+      enforced = await enforcePause(agent, { budget, currentUsd, pct }, deps);
+    }
+  }
+
+  return { enforced, crossings };
+}
+
+// Pause the runtime for a hard crossing. paused_reason is written first so
+// the intent survives a failed stop; status only flips once the stop call
+// succeeded. A failed stop is retried by the next sweep.
+async function enforcePause(agent, crossing, deps = {}) {
+  const {
+    dbClient = db,
+    stopRuntime = (target) => containerManager.stop(target),
+    logEvent = (type, message, metadata) => monitoring.logEvent(type, message, metadata),
+  } = deps;
+
+  if (!["running", "warning"].includes(agent.status)) return false;
+
+  await dbClient.query("UPDATE agents SET paused_reason = $1 WHERE id = $2", [
+    PAUSED_REASON_BUDGET,
+    agent.id,
+  ]);
+
+  try {
+    await stopRuntime(agent);
+  } catch (err) {
+    await Promise.resolve(
+      logEvent(
+        "agent.budget_pause_failed",
+        `Failed to stop agent "${agent.name || agent.id}" after budget hard cap: ${err.message}`,
+        { agentId: agent.id, budgetId: crossing.budget.id, error: err.message },
+      ),
+    ).catch(() => {});
+    return false;
+  }
+
+  await dbClient.query("UPDATE agents SET status = 'stopped' WHERE id = $1", [agent.id]);
+  await Promise.resolve(
+    logEvent(
+      "agent.budget_paused",
+      `Agent "${agent.name || agent.id}" was paused: ${crossing.budget.period} budget hard cap reached ($${crossing.currentUsd.toFixed(2)} of $${crossing.budget.limitUsd.toFixed(2)})`,
+      {
+        agentId: agent.id,
+        budgetId: crossing.budget.id,
+        period: crossing.budget.period,
+        limitUsd: crossing.budget.limitUsd,
+        currentUsd: crossing.currentUsd,
+        pct: crossing.pct,
+      },
+    ),
+  ).catch(() => {});
+  return true;
+}
+
+// Clear the budget pause marker (called when an operator manually starts the
+// agent — restarting is an explicit override; the sweep re-pauses on the next
+// cycle if the agent is still over its cap and the cap wasn't raised).
+async function clearPausedReason(agentId, { dbClient = db } = {}) {
+  await dbClient
+    .query("UPDATE agents SET paused_reason = NULL WHERE id = $1 AND paused_reason IS NOT NULL", [
+      agentId,
+    ])
+    .catch(() => {});
+}
+
+// Periodic re-enforcement over every agent that has a budget and a live-ish
+// runtime. Best-effort by design, like the other background tasks.
+async function sweepAgentBudgets(deps = {}) {
+  const { dbClient = db } = deps;
+  try {
+    const result = await dbClient.query(
+      `SELECT DISTINCT a.id, a.name, a.status, a.user_id, a.container_id, a.backend_type,
+              a.runtime_family, a.deploy_target, a.execution_target_id, a.sandbox_profile,
+              a.host, a.runtime_host, a.runtime_port, a.gateway_host, a.gateway_port
+         FROM agents a
+         JOIN agent_budgets b ON b.agent_id = a.id
+        WHERE a.status IN ('running', 'warning')`,
+    );
+    for (const agent of result.rows) {
+      try {
+        await checkAndEnforce(agent, deps);
+      } catch {
+        // Per-agent failures must not stop the sweep.
+      }
+    }
+  } catch {
+    // Budget sweeping is best-effort only.
+  }
+}
+
+module.exports = {
+  PAUSED_REASON_BUDGET,
+  PERIOD_DAYS,
+  VALID_PERIODS,
+  checkAndEnforce,
+  clearPausedReason,
+  deleteBudget,
+  listBudgets,
+  listBudgetsWithSpend,
+  recordBudgetAlert,
+  serializeBudget,
+  sweepAgentBudgets,
+  upsertBudget,
+};

--- a/backend-api/db_schema.sql
+++ b/backend-api/db_schema.sql
@@ -45,6 +45,7 @@ CREATE TABLE IF NOT EXISTS agents (
   vcpu INTEGER DEFAULT 1,
   ram_mb INTEGER DEFAULT 1024,
   disk_gb INTEGER DEFAULT 10,
+  paused_reason TEXT,
   created_at TIMESTAMP DEFAULT NOW()
 );
 
@@ -478,6 +479,25 @@ CREATE TABLE IF NOT EXISTS workspace_budgets (
   updated_at TIMESTAMPTZ DEFAULT NOW(),
   UNIQUE(workspace_id, period)
 );
+
+-- Per-agent LLM spend budgets. Soft crossings emit alert events; hard
+-- crossings additionally pause the runtime (agents.paused_reason records why).
+CREATE TABLE IF NOT EXISTS agent_budgets (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  period TEXT NOT NULL DEFAULT 'monthly'
+    CHECK (period IN ('daily', 'weekly', 'monthly')),
+  limit_usd NUMERIC(12, 2) NOT NULL,
+  soft_threshold_pct INTEGER NOT NULL DEFAULT 80
+    CHECK (soft_threshold_pct BETWEEN 0 AND 100),
+  last_alerted_at TIMESTAMPTZ,
+  last_alerted_pct INTEGER,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(agent_id, period)
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_budgets_agent ON agent_budgets(agent_id);
 
 CREATE TABLE IF NOT EXISTS integration_catalog (
   id VARCHAR(50) PRIMARY KEY,

--- a/backend-api/gatewayProxy.ts
+++ b/backend-api/gatewayProxy.ts
@@ -13,6 +13,7 @@ const integrations = require("./integrations");
 const { resolveAgentRuntimeFamily } = require("./agentRuntimeFields");
 
 const metrics = require("./metrics");
+const agentBudgets = require("./agentBudgets");
 const { OPENCLAW_GATEWAY_PORT } = require("../agent-runtime/lib/contracts");
 const {
   resolveGatewayAddress,
@@ -804,6 +805,7 @@ function createGatewayRouter() {
             sessionId: session_id || "main",
             requestId: idempotencyKey,
           })
+          .then(() => agentBudgets.checkAndEnforce(req.agent))
           .catch(() => {});
 
         res.write(`data: ${JSON.stringify({ type: "done", runId })}\n\n`);
@@ -820,6 +822,7 @@ function createGatewayRouter() {
             sessionId: session_id || "main",
             requestId: idempotencyKey,
           })
+          .then(() => agentBudgets.checkAndEnforce(req.agent))
           .catch(() => {});
         res.json(result);
       }

--- a/backend-api/routes/agents.ts
+++ b/backend-api/routes/agents.ts
@@ -10,6 +10,7 @@ const {
 } = require("../platformSettings");
 const scheduler = require("../scheduler");
 const containerManager = require("../containerManager");
+const agentBudgets = require("../agentBudgets");
 const monitoring = require("../monitoring");
 const metrics = require("../metrics");
 const workspaces = require("../workspaces");
@@ -1671,8 +1672,10 @@ router.post("/:id/start", async (req, res, next) => {
 
     await containerManager.start(agent);
 
+    // Manual start is an explicit operator override of a budget pause; the
+    // budget sweep re-pauses on its next cycle if the agent is still over cap.
     const updated = await db.query(
-      "UPDATE agents SET status = 'running' WHERE id = $1 RETURNING *",
+      "UPDATE agents SET status = 'running', paused_reason = NULL WHERE id = $1 RETURNING *",
       [agent.id],
     );
     try {
@@ -1939,6 +1942,49 @@ router.post("/:id/redeploy", async (req, res) => {
     res.status(e.statusCode || 500).json({ error: e.message });
   }
 });
+
+// ── Per-agent budget caps ────────────────────────────────────────────────────
+// Budgets pause the runtime when spend crosses 100% of a period's limit; the
+// list endpoint attaches current spend so the UI renders cap-vs-spend directly.
+
+router.get(
+  "/:id/budget",
+  asyncHandler(async (req, res) => {
+    const agent = await findAccessibleAgent(req.params.id, req.user.id, "viewer");
+    if (!agent) return res.status(404).json({ error: "Agent not found" });
+    res.json({
+      budgets: await agentBudgets.listBudgetsWithSpend(agent.id),
+      pausedReason: agent.paused_reason || null,
+    });
+  }),
+);
+
+router.put(
+  "/:id/budget",
+  asyncHandler(async (req, res) => {
+    const agent = await findAccessibleAgent(req.params.id, req.user.id, "editor");
+    if (!agent) return res.status(404).json({ error: "Agent not found" });
+    res.locals.auditContext = buildAgentContext(agent, {
+      ownerEmail: req.user.email || null,
+    });
+    const budget = await agentBudgets.upsertBudget(agent.id, req.body || {});
+    res.json(budget);
+  }),
+);
+
+router.delete(
+  "/:id/budget/:budgetId",
+  asyncHandler(async (req, res) => {
+    const agent = await findAccessibleAgent(req.params.id, req.user.id, "editor");
+    if (!agent) return res.status(404).json({ error: "Agent not found" });
+    res.locals.auditContext = buildAgentContext(agent, {
+      ownerEmail: req.user.email || null,
+    });
+    const deleted = await agentBudgets.deleteBudget(req.params.budgetId, agent.id);
+    if (!deleted) return res.status(404).json({ error: "Budget not found" });
+    res.json({ success: true });
+  }),
+);
 
 // ── Agent versions + rollback ────────────────────────────────────────────────
 

--- a/backend-api/routes/agents.ts
+++ b/backend-api/routes/agents.ts
@@ -1968,6 +1968,18 @@ router.put(
       ownerEmail: req.user.email || null,
     });
     const budget = await agentBudgets.upsertBudget(agent.id, req.body || {});
+    await monitoring.logEvent(
+      "agent.budget_updated",
+      `Budget set on agent "${agent.name}": $${budget.limitUsd.toFixed(2)}/${budget.period} (warn at ${budget.softThresholdPct}%)`,
+      agentAuditMetadata(req, agent, {
+        result: {
+          budgetId: budget.id,
+          period: budget.period,
+          limitUsd: budget.limitUsd,
+          softThresholdPct: budget.softThresholdPct,
+        },
+      }),
+    );
     res.json(budget);
   }),
 );
@@ -1982,6 +1994,11 @@ router.delete(
     });
     const deleted = await agentBudgets.deleteBudget(req.params.budgetId, agent.id);
     if (!deleted) return res.status(404).json({ error: "Budget not found" });
+    await monitoring.logEvent(
+      "agent.budget_removed",
+      `Budget removed from agent "${agent.name}"`,
+      agentAuditMetadata(req, agent, { result: { budgetId: req.params.budgetId } }),
+    );
     res.json({ success: true });
   }),
 );

--- a/backend-api/server.ts
+++ b/backend-api/server.ts
@@ -22,6 +22,7 @@ const {
   collectBackgroundTelemetry,
   reconcileBackgroundAgentStatuses,
 } = require("./backgroundTasks");
+const agentBudgets = require("./agentBudgets");
 const { listKubernetesExecutionTargets } = require("./kubernetesClusters");
 const { STARTER_TEMPLATES } = require("./starterTemplates");
 const { getBootstrapAdminSeedConfig } = require("./bootstrapAdmin");
@@ -1667,6 +1668,26 @@ async function migrateDB() {
        updated_at TIMESTAMPTZ DEFAULT NOW(),
        UNIQUE(workspace_id, period)
      )`,
+    // ─── Per-agent budgets with hard-cap auto-pause ─────────────────────
+    `CREATE TABLE IF NOT EXISTS agent_budgets (
+       id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+       agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+       period TEXT NOT NULL DEFAULT 'monthly'
+         CHECK (period IN ('daily', 'weekly', 'monthly')),
+       limit_usd NUMERIC(12, 2) NOT NULL,
+       soft_threshold_pct INTEGER NOT NULL DEFAULT 80
+         CHECK (soft_threshold_pct BETWEEN 0 AND 100),
+       last_alerted_at TIMESTAMPTZ,
+       last_alerted_pct INTEGER,
+       created_at TIMESTAMPTZ DEFAULT NOW(),
+       updated_at TIMESTAMPTZ DEFAULT NOW(),
+       UNIQUE(agent_id, period)
+     )`,
+    `CREATE INDEX IF NOT EXISTS idx_agent_budgets_agent ON agent_budgets(agent_id)`,
+    `DO $$ BEGIN
+       ALTER TABLE agents ADD COLUMN paused_reason TEXT;
+     EXCEPTION WHEN duplicate_column THEN NULL;
+     END $$`,
     // ─── Phase 3: agent configuration history ───────────────────────────
     `CREATE TABLE IF NOT EXISTS agent_versions (
        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -1873,6 +1894,14 @@ if (require.main === module) {
     setInterval(async () => {
       await reconcileBackgroundAgentStatuses({ dbClient: db });
     }, RECONCILE_INTERVAL);
+
+    // ── Budget sweep: re-enforce per-agent hard caps every 60s. The status
+    // reconciler above flips stopped->running whenever a container is live,
+    // so re-enforcement is what keeps a budget pause stuck. ──
+    const BUDGET_SWEEP_INTERVAL = 60000;
+    setInterval(async () => {
+      await agentBudgets.sweepAgentBudgets({ dbClient: db });
+    }, BUDGET_SWEEP_INTERVAL);
   });
 
   attachLogStream(server);

--- a/docs/api/agents.mdx
+++ b/docs/api/agents.mdx
@@ -23,14 +23,13 @@ GET /agents
 ### Query parameters
 
 <ParamField query="scope" type="string">
-  Optional. `accessible` (default) includes directly owned and workspace-shared agents. `owned` returns only directly owned agents.
+  Optional. `accessible` (default) includes directly owned and workspace-shared agents. `owned`
+  returns only directly owned agents.
 </ParamField>
 
 <CodeGroup>
-```bash curl theme={null}
-curl http://localhost:8080/api/agents \
-  -H "Authorization: Bearer $TOKEN"
-```
+  ```bash curl theme={null}
+  curl http://localhost:8080/api/agents \ -H "Authorization: Bearer $TOKEN" ```
 </CodeGroup>
 
 ```json theme={null}
@@ -179,10 +178,9 @@ GET /agents/:id
 </ParamField>
 
 <CodeGroup>
-```bash curl theme={null}
-curl http://localhost:8080/api/agents/a1b2c3d4-e5f6-7890-abcd-ef1234567890 \
-  -H "Authorization: Bearer $TOKEN"
-```
+  ```bash curl theme={null}
+  curl http://localhost:8080/api/agents/a1b2c3d4-e5f6-7890-abcd-ef1234567890 \ -H "Authorization:
+  Bearer $TOKEN" ```
 </CodeGroup>
 
 ```json theme={null}
@@ -220,10 +218,9 @@ POST /agents/:id/start
 Returns the updated agent record with `status: "running"`.
 
 <CodeGroup>
-```bash curl theme={null}
-curl -X POST http://localhost:8080/api/agents/a1b2c3d4-e5f6-7890-abcd-ef1234567890/start \
-  -H "Authorization: Bearer $TOKEN"
-```
+  ```bash curl theme={null}
+  curl -X POST http://localhost:8080/api/agents/a1b2c3d4-e5f6-7890-abcd-ef1234567890/start \ -H
+  "Authorization: Bearer $TOKEN" ```
 </CodeGroup>
 
 | Status | Condition                               |
@@ -250,10 +247,9 @@ POST /agents/:id/stop
 Returns the updated agent record with `status: "stopped"`.
 
 <CodeGroup>
-```bash curl theme={null}
-curl -X POST http://localhost:8080/api/agents/a1b2c3d4-e5f6-7890-abcd-ef1234567890/stop \
-  -H "Authorization: Bearer $TOKEN"
-```
+  ```bash curl theme={null}
+  curl -X POST http://localhost:8080/api/agents/a1b2c3d4-e5f6-7890-abcd-ef1234567890/stop \ -H
+  "Authorization: Bearer $TOKEN" ```
 </CodeGroup>
 
 ---
@@ -279,10 +275,9 @@ POST /agents/:id/restart
 </ResponseField>
 
 <CodeGroup>
-```bash curl theme={null}
-curl -X POST http://localhost:8080/api/agents/a1b2c3d4-e5f6-7890-abcd-ef1234567890/restart \
-  -H "Authorization: Bearer $TOKEN"
-```
+  ```bash curl theme={null}
+  curl -X POST http://localhost:8080/api/agents/a1b2c3d4-e5f6-7890-abcd-ef1234567890/restart \ -H
+  "Authorization: Bearer $TOKEN" ```
 </CodeGroup>
 
 ```json theme={null}
@@ -319,10 +314,9 @@ POST /agents/:id/redeploy
 </ResponseField>
 
 <CodeGroup>
-```bash curl theme={null}
-curl -X POST http://localhost:8080/api/agents/a1b2c3d4-e5f6-7890-abcd-ef1234567890/redeploy \
-  -H "Authorization: Bearer $TOKEN"
-```
+  ```bash curl theme={null}
+  curl -X POST http://localhost:8080/api/agents/a1b2c3d4-e5f6-7890-abcd-ef1234567890/redeploy \ -H
+  "Authorization: Bearer $TOKEN" ```
 </CodeGroup>
 
 ```json theme={null}
@@ -356,10 +350,9 @@ DELETE /agents/:id
 </ResponseField>
 
 <CodeGroup>
-```bash curl theme={null}
-curl -X DELETE http://localhost:8080/api/agents/a1b2c3d4-e5f6-7890-abcd-ef1234567890 \
-  -H "Authorization: Bearer $TOKEN"
-```
+  ```bash curl theme={null}
+  curl -X DELETE http://localhost:8080/api/agents/a1b2c3d4-e5f6-7890-abcd-ef1234567890 \ -H
+  "Authorization: Bearer $TOKEN" ```
 </CodeGroup>
 
 ```json theme={null}
@@ -424,10 +417,9 @@ GET /agents/:id/stats
 </ResponseField>
 
 <CodeGroup>
-```bash curl theme={null}
-curl http://localhost:8080/api/agents/a1b2c3d4-e5f6-7890-abcd-ef1234567890/stats \
-  -H "Authorization: Bearer $TOKEN"
-```
+  ```bash curl theme={null}
+  curl http://localhost:8080/api/agents/a1b2c3d4-e5f6-7890-abcd-ef1234567890/stats \ -H
+  "Authorization: Bearer $TOKEN" ```
 </CodeGroup>
 
 ```json theme={null}
@@ -571,10 +563,9 @@ GET /agents/:id/gateway-url
 </ResponseField>
 
 <CodeGroup>
-```bash curl theme={null}
-curl http://localhost:8080/api/agents/a1b2c3d4-e5f6-7890-abcd-ef1234567890/gateway-url \
-  -H "Authorization: Bearer $TOKEN"
-```
+  ```bash curl theme={null}
+  curl http://localhost:8080/api/agents/a1b2c3d4-e5f6-7890-abcd-ef1234567890/gateway-url \ -H
+  "Authorization: Bearer $TOKEN" ```
 </CodeGroup>
 
 ```json theme={null}
@@ -588,3 +579,52 @@ curl http://localhost:8080/api/agents/a1b2c3d4-e5f6-7890-abcd-ef1234567890/gatew
 | ------ | --------------------------------------------------- |
 | `409`  | Agent is not running, or has no container           |
 | `502`  | Could not inspect the container to resolve the port |
+
+## Get agent budget
+
+List an agent's LLM spend budgets with current spend attached. When spend crosses 100% of any cap, Nora pauses the runtime automatically (`paused_reason` becomes `budget_exceeded`); a warning event fires at the soft threshold.
+
+```
+GET /agents/:id/budget
+```
+
+### Response
+
+<ResponseField name="budgets" type="array">
+  One entry per period (`daily`, `weekly`, `monthly`) with `limitUsd`, `softThresholdPct`,
+  `currentUsd`, `pct`, and `bucket` (`none` | `soft` | `hard`).
+</ResponseField>
+
+<ResponseField name="pausedReason" type="string | null">
+  `budget_exceeded` while the agent is paused by a cap.
+</ResponseField>
+
+## Set agent budget
+
+Create or update the budget for one period. Requires the `agents:write` scope.
+
+```
+PUT /agents/:id/budget
+```
+
+### Request body
+
+<ParamField body="period" type="string" required>
+  `daily`, `weekly`, or `monthly`.
+</ParamField>
+
+<ParamField body="limit_usd" type="number" required>
+  Hard cap in USD. Crossing 100% pauses the runtime.
+</ParamField>
+
+<ParamField body="soft_threshold_pct" type="number">
+  Warning threshold percent (default `80`). Emits `agent.budget_soft_exceeded`.
+</ParamField>
+
+## Delete agent budget
+
+```
+DELETE /agents/:id/budget/:budgetId
+```
+
+Removes the cap. A paused agent stays stopped until started; manually starting an agent clears `paused_reason`, and the budget sweep re-pauses it within a minute if a cap is still exceeded.

--- a/frontend-dashboard/components/agents/BudgetSection.tsx
+++ b/frontend-dashboard/components/agents/BudgetSection.tsx
@@ -1,0 +1,191 @@
+import { useCallback, useEffect, useState } from "react";
+import { DollarSign, Loader2, Save, Trash2 } from "lucide-react";
+import { fetchWithAuth } from "../../lib/api";
+import { useToast } from "../Toast";
+
+const PERIOD_LABELS = { daily: "Daily", weekly: "Weekly", monthly: "Monthly" };
+
+// Per-agent LLM budget editor (Settings tab). One budget per period; when
+// spend crosses 100% of a limit Nora pauses the runtime automatically.
+export default function BudgetSection({ agentId }) {
+  const [budgets, setBudgets] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [period, setPeriod] = useState("monthly");
+  const [limitUsd, setLimitUsd] = useState("");
+  const [softPct, setSoftPct] = useState("80");
+  const toast = useToast();
+
+  const load = useCallback(async () => {
+    try {
+      const res = await fetchWithAuth(`/api/agents/${agentId}/budget`);
+      if (!res.ok) throw new Error("Failed to load budget");
+      const data = await res.json();
+      setBudgets(data.budgets || []);
+    } catch {
+      // Leave the editor usable even when the read fails.
+    } finally {
+      setLoading(false);
+    }
+  }, [agentId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function handleSave(e) {
+    e?.preventDefault();
+    const limit = Number(limitUsd);
+    if (!Number.isFinite(limit) || limit <= 0) {
+      toast.error("Budget limit must be a positive amount");
+      return;
+    }
+    setSaving(true);
+    try {
+      const res = await fetchWithAuth(`/api/agents/${agentId}/budget`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          period,
+          limit_usd: limit,
+          soft_threshold_pct: Number(softPct) || 80,
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || "Failed to save budget");
+      }
+      toast.success("Budget saved");
+      setLimitUsd("");
+      await load();
+    } catch (err) {
+      toast.error(err.message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleDelete(budget) {
+    try {
+      const res = await fetchWithAuth(`/api/agents/${agentId}/budget/${budget.id}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) throw new Error("Failed to remove budget");
+      toast.success("Budget removed");
+      await load();
+    } catch (err) {
+      toast.error(err.message);
+    }
+  }
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-2xl p-6">
+      <div className="flex items-center gap-3 mb-1">
+        <div className="w-9 h-9 bg-emerald-50 rounded-xl flex items-center justify-center">
+          <DollarSign size={16} className="text-emerald-600" />
+        </div>
+        <div>
+          <h3 className="text-sm font-bold text-gray-900">LLM budget caps</h3>
+          <p className="text-xs text-gray-500">
+            Nora pauses this agent automatically when spend crosses 100% of a cap. A warning event
+            fires at the soft threshold.
+          </p>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center gap-2 text-xs text-gray-500 py-4">
+          <Loader2 size={14} className="animate-spin" /> Loading budget…
+        </div>
+      ) : (
+        <>
+          {budgets.length > 0 && (
+            <div className="mt-4 space-y-2">
+              {budgets.map((budget) => {
+                const pct = Math.min(100, budget.pct || 0);
+                const over = budget.bucket === "hard";
+                const warn = budget.bucket === "soft";
+                return (
+                  <div
+                    key={budget.id}
+                    className="flex items-center gap-4 border border-gray-100 rounded-xl px-4 py-3"
+                  >
+                    <div className="flex-1">
+                      <div className="flex items-center justify-between text-xs font-semibold text-gray-700">
+                        <span>{PERIOD_LABELS[budget.period] || budget.period} cap</span>
+                        <span className={over ? "text-red-600" : warn ? "text-amber-600" : ""}>
+                          ${budget.currentUsd.toFixed(2)} / ${budget.limitUsd.toFixed(2)} (
+                          {budget.pct}
+                          %)
+                        </span>
+                      </div>
+                      <div className="mt-2 h-1.5 bg-gray-100 rounded-full overflow-hidden">
+                        <div
+                          className={`h-full rounded-full ${over ? "bg-red-500" : warn ? "bg-amber-400" : "bg-emerald-500"}`}
+                          style={{ width: `${pct}%` }}
+                        />
+                      </div>
+                    </div>
+                    <button
+                      onClick={() => handleDelete(budget)}
+                      className="text-gray-400 hover:text-red-600 transition-colors"
+                      title="Remove budget"
+                    >
+                      <Trash2 size={14} />
+                    </button>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          <form onSubmit={handleSave} className="mt-4 flex flex-wrap items-end gap-3">
+            <label className="text-xs font-semibold text-gray-600">
+              Period
+              <select
+                value={period}
+                onChange={(e) => setPeriod(e.target.value)}
+                className="mt-1 block border border-gray-200 rounded-xl px-3 py-2 text-xs"
+              >
+                <option value="daily">Daily</option>
+                <option value="weekly">Weekly</option>
+                <option value="monthly">Monthly</option>
+              </select>
+            </label>
+            <label className="text-xs font-semibold text-gray-600">
+              Hard cap (USD)
+              <input
+                type="number"
+                min="0.01"
+                step="0.01"
+                value={limitUsd}
+                onChange={(e) => setLimitUsd(e.target.value)}
+                placeholder="25.00"
+                className="mt-1 block w-28 border border-gray-200 rounded-xl px-3 py-2 text-xs"
+              />
+            </label>
+            <label className="text-xs font-semibold text-gray-600">
+              Warn at (%)
+              <input
+                type="number"
+                min="0"
+                max="100"
+                value={softPct}
+                onChange={(e) => setSoftPct(e.target.value)}
+                className="mt-1 block w-20 border border-gray-200 rounded-xl px-3 py-2 text-xs"
+              />
+            </label>
+            <button
+              type="submit"
+              disabled={saving}
+              className="flex items-center gap-2 px-4 py-2.5 bg-emerald-50 border border-emerald-200 text-emerald-700 hover:bg-emerald-100 text-xs font-bold rounded-xl transition-all disabled:opacity-50"
+            >
+              {saving ? <Loader2 size={14} className="animate-spin" /> : <Save size={14} />}
+              Save cap
+            </button>
+          </form>
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend-dashboard/components/agents/OverviewTab.tsx
+++ b/frontend-dashboard/components/agents/OverviewTab.tsx
@@ -187,6 +187,32 @@ export default function OverviewTab({
         </div>
       )}
 
+      {agent.status === "stopped" && agent.paused_reason === "budget_exceeded" && (
+        <div className="flex items-center gap-3 bg-amber-50 border border-amber-200 rounded-2xl px-5 py-3">
+          <AlertOctagon size={18} className="text-amber-600 shrink-0" />
+          <div className="flex-1">
+            <p className="text-sm font-bold text-amber-800">Paused — budget cap reached</p>
+            <p className="text-xs text-amber-600">
+              This agent hit its LLM spend cap and was stopped automatically. Raise or remove the
+              cap in Settings, then start the agent; restarting without changing the cap re-pauses
+              it on the next check.
+            </p>
+          </div>
+          <button
+            onClick={onStart}
+            disabled={!!actionLoading}
+            className="flex items-center gap-1.5 px-3 py-1.5 bg-amber-600 text-white text-xs font-bold rounded-lg hover:bg-amber-700 transition-colors disabled:opacity-50 shrink-0"
+          >
+            {actionLoading === "start" ? (
+              <Loader2 size={12} className="animate-spin" />
+            ) : (
+              <Power size={12} />
+            )}
+            Resume
+          </button>
+        </div>
+      )}
+
       {agent.status === "error" && (
         <div className="flex items-center gap-3 bg-red-50 border border-red-200 rounded-2xl px-5 py-3">
           <XCircle size={18} className="text-red-600 shrink-0" />

--- a/frontend-dashboard/components/agents/SettingsTab.tsx
+++ b/frontend-dashboard/components/agents/SettingsTab.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { Settings, Trash2, Loader2, Save, Copy, Share2, Download } from "lucide-react";
 import ConfirmDialog from "../ConfirmDialog";
+import BudgetSection from "./BudgetSection";
 import { useToast } from "../Toast";
 import {
   formatExecutionTargetLabel,
@@ -229,6 +230,8 @@ export default function SettingsTab({
           Resource limits are set by your subscription plan.
         </p>
       </section>
+
+      <BudgetSection agentId={agent.id} />
 
       {canDelete ? (
         <section className="bg-red-50 border border-red-200 rounded-2xl p-6 space-y-4">


### PR DESCRIPTION
## What

PR-3 of the 9-item pre-launch plan — the panel-confirmed "agents that can't run away with your bill" feature (the highest-threat competitor's single most-cited capability), implemented as only a provisioning control plane can: **when an agent crosses 100% of its spend cap, Nora stops the runtime.**

- **`agentBudgets.ts`** mirrors `workspaceBudgets.ts` semantics (per-period caps, soft-threshold alerts, `last_alerted_pct` dedup) and adds `checkAndEnforce()`: hard crossing on a running agent → write `paused_reason='budget_exceeded'` **first** (intent survives a failed stop) → `containerManager.stop()` → `status='stopped'` → `agent.budget_paused` event. Soft crossings emit `agent.budget_soft_exceeded` for the existing alert-rules delivery.
- **Two enforcement directions:** fire-and-forget after both `recordTokenUsage` callsites in `gatewayProxy.ts`, plus a 60s `sweepAgentBudgets` interval. Enforcement is deliberately **not** deduped — the status reconciler promotes `stopped→running` whenever a container reports live, so failed stops and manual restarts while over cap get re-paused on the next cycle. That race is the riskiest part of this feature and has a dedicated test.
- **Routes:** `GET/PUT /agents/:id/budget`, `DELETE /agents/:id/budget/:budgetId` (existing `agents:read`/`agents:write` scopes). Manual `POST /:id/start` clears `paused_reason` as an explicit operator override.
- **Schema:** `agent_budgets` table + `agents.paused_reason` column (in `db_schema.sql` and `migrateDB()` — additive, brownfield-safe).
- **UI:** budget editor with cap-vs-spend progress bars in the agent Settings tab; amber "Paused — budget cap reached" banner with Resume action on the Overview tab.
- **Docs:** endpoints documented in `docs/api/agents.mdx`.

## Design decision

No new status literal — `stopped` + `paused_reason` keeps the blast radius out of every status enum, reconciler branch, and badge style (per the implementation plan).

## Verification

- New `__tests__/agentBudgets.test.ts` (10 tests): validation, soft-alert dedup, pause ordering (reason → stop → status), **stop() throwing keeps intent without flipping status**, **re-enforcement with deduped alerts** (reconciler un-pause defense), no stop for non-running agents, sweep error isolation, clearPausedReason.
- Full backend suite green: **122 suites / 946 tests**. `backend-api` + `frontend-dashboard` typechecks clean; eslint/prettier clean.

## Follow-ups (deferred per plan)

Budget capture for usage sources that never call `recordTokenUsage` (Hermes cost path verification); `get/set_agent_budget` MCP tools as a small #177 follow-up once this merges.

Note: rebase on master after #179 (grpc advisory fix) merges to clear the unrelated `npm audit` failure.