### PR TITLE
feat(monitoring): fleet "needs attention" roll-up

### DIFF
--- a/backend-api/__tests__/fleetStatus.test.ts
+++ b/backend-api/__tests__/fleetStatus.test.ts
@@ -1,0 +1,145 @@
+// @ts-nocheck
+const fleetStatus = require("../fleetStatus");
+
+const NOW = Date.UTC(2026, 5, 12, 12, 0, 0); // fixed clock for deterministic ages
+const minutesAgo = (m) => NOW - m * 60 * 1000;
+
+describe("deriveAttention (pure)", () => {
+  it("flags an errored agent", () => {
+    const v = fleetStatus.deriveAttention({ id: "a", name: "A", status: "error" }, { now: NOW });
+    expect(v.needsAttention).toBe(true);
+    expect(v.severity).toBe("error");
+    expect(v.reasons.map((r) => r.code)).toEqual(["error"]);
+  });
+
+  it("flags a budget-paused agent (stopped + paused_reason) but not a plain stop", () => {
+    const paused = fleetStatus.deriveAttention(
+      { id: "a", status: "stopped", paused_reason: "budget_exceeded" },
+      { now: NOW },
+    );
+    expect(paused.needsAttention).toBe(true);
+    expect(paused.reasons[0].code).toBe("budget_paused");
+
+    const plain = fleetStatus.deriveAttention(
+      { id: "b", status: "stopped", paused_reason: null },
+      { now: NOW },
+    );
+    expect(plain.needsAttention).toBe(false);
+    expect(plain.reasons).toEqual([]);
+  });
+
+  it("flags queued/deploying only after the stuck threshold", () => {
+    const fresh = fleetStatus.deriveAttention(
+      { id: "a", status: "deploying" },
+      { now: NOW, enteredDeployAt: minutesAgo(3) },
+    );
+    expect(fresh.needsAttention).toBe(false);
+
+    const stuck = fleetStatus.deriveAttention(
+      { id: "a", status: "deploying" },
+      { now: NOW, enteredDeployAt: minutesAgo(15) },
+    );
+    expect(stuck.needsAttention).toBe(true);
+    expect(stuck.reasons[0].code).toBe("stuck_deploying");
+    expect(stuck.reasons[0].label).toMatch(/15m/);
+  });
+
+  it("does not flag stuck when there is no deployment timestamp", () => {
+    const v = fleetStatus.deriveAttention(
+      { id: "a", status: "queued" },
+      { now: NOW, enteredDeployAt: null },
+    );
+    expect(v.needsAttention).toBe(false);
+  });
+
+  it("flags a soft budget crossing on a running agent", () => {
+    const v = fleetStatus.deriveAttention(
+      { id: "a", status: "running" },
+      { now: NOW, budgetSoftCrossed: true },
+    );
+    expect(v.reasons.map((r) => r.code)).toContain("budget_warning");
+  });
+
+  it("flags stalled telemetry only when stats exist and are old", () => {
+    const stalled = fleetStatus.deriveAttention(
+      { id: "a", status: "running" },
+      { now: NOW, lastStatAt: minutesAgo(20) },
+    );
+    expect(stalled.reasons.map((r) => r.code)).toContain("telemetry_stalled");
+
+    const fresh = fleetStatus.deriveAttention(
+      { id: "a", status: "running" },
+      { now: NOW, lastStatAt: minutesAgo(1) },
+    );
+    expect(fresh.needsAttention).toBe(false);
+
+    const neverReported = fleetStatus.deriveAttention(
+      { id: "a", status: "running" },
+      { now: NOW, lastStatAt: null },
+    );
+    expect(neverReported.needsAttention).toBe(false);
+  });
+
+  it("does not flag stuck/telemetry signals against a healthy running agent", () => {
+    const v = fleetStatus.deriveAttention(
+      { id: "a", status: "running" },
+      { now: NOW, enteredDeployAt: minutesAgo(120), lastStatAt: minutesAgo(1) },
+    );
+    expect(v.needsAttention).toBe(false);
+  });
+
+  it("orders error reasons before warning reasons", () => {
+    // A degraded (warning) agent that is also approaching its budget.
+    const v = fleetStatus.deriveAttention(
+      { id: "a", status: "warning" },
+      { now: NOW, budgetSoftCrossed: true },
+    );
+    expect(v.severity).toBe("warning");
+    expect(v.reasons[0].code).toBe("warning");
+  });
+});
+
+describe("getFleetAttention (gather)", () => {
+  function fakeDb(rows) {
+    return { query: jest.fn(async () => ({ rows })) };
+  }
+
+  it("returns an empty result without a user id", async () => {
+    const dbClient = fakeDb([]);
+    const res = await fleetStatus.getFleetAttention({ userId: null, dbClient, now: NOW });
+    expect(res).toEqual({
+      generatedAt: new Date(NOW).toISOString(),
+      total: 0,
+      attentionCount: 0,
+      agents: [],
+    });
+    expect(dbClient.query).not.toHaveBeenCalled();
+  });
+
+  it("returns only attention agents, errors first, with summary counts", async () => {
+    const dbClient = fakeDb([
+      { id: "ok", name: "Healthy", status: "running", last_stat_at: new Date(minutesAgo(1)) },
+      { id: "err", name: "Broken", status: "error" },
+      {
+        id: "stuck",
+        name: "Slow",
+        status: "deploying",
+        entered_deploy_at: new Date(minutesAgo(30)),
+      },
+    ]);
+    const res = await fleetStatus.getFleetAttention({ userId: "u1", dbClient, now: NOW });
+    expect(res.total).toBe(3);
+    expect(res.attentionCount).toBe(2);
+    expect(res.agents.map((a) => a.agentId)).toEqual(["err", "stuck"]); // error before warning
+    // The healthy agent is excluded.
+    expect(res.agents.find((a) => a.agentId === "ok")).toBeUndefined();
+    // Scoped query was parameterized by the user id.
+    expect(dbClient.query.mock.calls[0][1]).toEqual(["u1"]);
+  });
+
+  it("maps a soft-crossed budget flag from SQL into a budget_warning reason", async () => {
+    const dbClient = fakeDb([{ id: "a", name: "A", status: "running", budget_soft_crossed: true }]);
+    const res = await fleetStatus.getFleetAttention({ userId: "u1", dbClient, now: NOW });
+    expect(res.agents[0].reasons.map((r) => r.code)).toContain("budget_warning");
+  });
+});

--- a/backend-api/fleetStatus.ts
+++ b/backend-api/fleetStatus.ts
@@ -1,0 +1,168 @@
+// @ts-nocheck
+// Fleet "needs attention" roll-up. Derives, at read time, which agents an
+// operator should look at right now and why — without adding any state: the
+// signals come from columns/tables that already exist (agents.status +
+// paused_reason, the latest deployments row for "entered the deploy pipeline
+// at", the latest container_stats row for telemetry staleness, and
+// agent_budgets.last_alerted_pct for a soft budget crossing).
+//
+// deriveAttention is a pure function (plain values in, plain object out) so the
+// thresholds and reason logic are unit-testable without a database.
+
+const db = require("./db");
+
+// Thresholds (minutes). Deliberately conservative to avoid false alarms.
+const STUCK_DEPLOY_MINUTES = 10; // queued/deploying longer than this = stuck
+const STALE_TELEMETRY_MINUTES = 5; // running but no container_stats this recent
+
+const MINUTE_MS = 60 * 1000;
+
+// Reason severity ordering, highest first — drives sort + chip colour.
+const SEVERITY_RANK = { error: 0, warning: 1 };
+
+function minutesSince(fromMs, nowMs) {
+  if (fromMs == null) return null;
+  return (nowMs - fromMs) / MINUTE_MS;
+}
+
+// Pure: given an agent and the derived context numbers, return its attention
+// verdict. ctx timestamps are epoch ms (or null); now defaults to "now".
+function deriveAttention(agent, ctx = {}) {
+  const {
+    now = Date.now(),
+    enteredDeployAt = null,
+    lastStatAt = null,
+    budgetSoftCrossed = false,
+    stuckDeployMinutes = STUCK_DEPLOY_MINUTES,
+    staleTelemetryMinutes = STALE_TELEMETRY_MINUTES,
+  } = ctx;
+
+  const status = agent?.status;
+  const reasons = [];
+
+  if (status === "error") {
+    reasons.push({ code: "error", severity: "error", label: "Errored" });
+  }
+
+  if (status === "warning") {
+    reasons.push({ code: "warning", severity: "warning", label: "Degraded" });
+  }
+
+  if (status === "stopped" && agent?.paused_reason === "budget_exceeded") {
+    reasons.push({
+      code: "budget_paused",
+      severity: "error",
+      label: "Paused — budget cap reached",
+    });
+  }
+
+  if (status === "queued" || status === "deploying") {
+    const ageMin = minutesSince(enteredDeployAt, now);
+    if (ageMin != null && ageMin >= stuckDeployMinutes) {
+      reasons.push({
+        code: "stuck_deploying",
+        severity: "warning",
+        label: `Stuck ${status} for ${Math.floor(ageMin)}m`,
+      });
+    }
+  }
+
+  if (status === "running" || status === "warning") {
+    if (budgetSoftCrossed) {
+      reasons.push({
+        code: "budget_warning",
+        severity: "warning",
+        label: "Approaching budget cap",
+      });
+    }
+    // Only flag stalled telemetry when stats exist but are old — a never-yet-
+    // reported brand-new agent (lastStatAt null) is not "stalled".
+    const staleMin = minutesSince(lastStatAt, now);
+    if (staleMin != null && staleMin >= staleTelemetryMinutes) {
+      reasons.push({
+        code: "telemetry_stalled",
+        severity: "warning",
+        label: `No telemetry for ${Math.floor(staleMin)}m`,
+      });
+    }
+  }
+
+  reasons.sort((a, b) => SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity]);
+
+  return {
+    agentId: agent?.id,
+    name: agent?.name || null,
+    status: status || null,
+    runtimeFamily: agent?.runtime_family || null,
+    deployTarget: agent?.deploy_target || null,
+    needsAttention: reasons.length > 0,
+    severity: reasons[0]?.severity || null,
+    reasons,
+  };
+}
+
+// Gather the per-agent signals for every agent the user can access (direct
+// ownership or workspace membership), then derive attention for each. Returns
+// only the agents that need attention, plus summary counts. Deps are injectable
+// for testing.
+async function getFleetAttention({ userId, dbClient = db, now = Date.now() } = {}) {
+  if (!userId) {
+    return { generatedAt: new Date(now).toISOString(), total: 0, attentionCount: 0, agents: [] };
+  }
+
+  const result = await dbClient.query(
+    `SELECT a.id, a.name, a.status, a.paused_reason, a.runtime_family, a.deploy_target,
+            dep.created_at AS entered_deploy_at,
+            st.recorded_at AS last_stat_at,
+            COALESCE(bud.soft_crossed, false) AS budget_soft_crossed
+       FROM agents a
+       LEFT JOIN LATERAL (
+         SELECT created_at FROM deployments d
+          WHERE d.agent_id = a.id ORDER BY d.created_at DESC LIMIT 1
+       ) dep ON true
+       LEFT JOIN LATERAL (
+         SELECT recorded_at FROM container_stats s
+          WHERE s.agent_id = a.id ORDER BY s.recorded_at DESC LIMIT 1
+       ) st ON true
+       LEFT JOIN LATERAL (
+         SELECT bool_or(b.last_alerted_pct >= b.soft_threshold_pct AND b.last_alerted_pct < 100)
+                  AS soft_crossed
+           FROM agent_budgets b WHERE b.agent_id = a.id
+       ) bud ON true
+      WHERE a.user_id = $1
+         OR a.id IN (
+              SELECT wa.agent_id FROM workspace_agents wa
+                JOIN workspace_members wm ON wm.workspace_id = wa.workspace_id
+               WHERE wm.user_id = $1
+            )`,
+    [userId],
+  );
+
+  const toMs = (value) => (value == null ? null : new Date(value).getTime());
+  const items = result.rows.map((row) =>
+    deriveAttention(row, {
+      now,
+      enteredDeployAt: toMs(row.entered_deploy_at),
+      lastStatAt: toMs(row.last_stat_at),
+      budgetSoftCrossed: row.budget_soft_crossed === true,
+    }),
+  );
+
+  const attention = items.filter((item) => item.needsAttention);
+  // Errors before warnings; otherwise stable.
+  attention.sort((a, b) => SEVERITY_RANK[a.severity] - SEVERITY_RANK[b.severity]);
+
+  return {
+    generatedAt: new Date(now).toISOString(),
+    total: items.length,
+    attentionCount: attention.length,
+    agents: attention,
+  };
+}
+
+module.exports = {
+  STUCK_DEPLOY_MINUTES,
+  STALE_TELEMETRY_MINUTES,
+  deriveAttention,
+  getFleetAttention,
+};

--- a/backend-api/routes/monitoring.ts
+++ b/backend-api/routes/monitoring.ts
@@ -2,6 +2,7 @@
 const express = require("express");
 const db = require("../db");
 const monitoring = require("../monitoring");
+const fleetStatus = require("../fleetStatus");
 const metricsModule = require("../metrics");
 const { asyncHandler } = require("../middleware/errorHandler");
 const { findAccessibleAgent, requireAccessibleAgent } = require("../middleware/ownership");
@@ -86,6 +87,13 @@ router.get(
   "/monitoring/metrics",
   asyncHandler(async (req, res) => {
     res.json(await monitoring.getMetrics({ userId: req.user.id }));
+  }),
+);
+
+router.get(
+  "/monitoring/fleet-status",
+  asyncHandler(async (req, res) => {
+    res.json(await fleetStatus.getFleetAttention({ userId: req.user.id }));
   }),
 );
 

--- a/docs/api/monitoring.mdx
+++ b/docs/api/monitoring.mdx
@@ -41,6 +41,56 @@ GET /monitoring/metrics
 
 ***
 
+## Fleet needs-attention roll-up
+
+Return only the agents that need an operator's attention right now, with the reasons why. Derived at read time from existing state — no extra configuration. Use it to drive a triage view instead of scanning every agent. Requires the `monitoring:read` scope.
+
+Detected reasons: `error` and `budget_paused` (severity error); `warning`, `stuck_deploying` (queued/deploying over 10 minutes), `budget_warning` (a running agent crossed a budget soft threshold), and `telemetry_stalled` (a running agent reported no container telemetry for over 5 minutes).
+
+```
+GET /monitoring/fleet-status
+```
+
+### Response
+
+<ResponseField name="generatedAt" type="string">ISO timestamp the roll-up was computed.</ResponseField>
+<ResponseField name="total" type="number">Total number of accessible agents evaluated.</ResponseField>
+<ResponseField name="attentionCount" type="number">Number of agents needing attention.</ResponseField>
+<ResponseField name="agents" type="array">Agents needing attention, errors first. Each has `agentId`, `name`, `status`, `severity`, and a `reasons` array of `{ code, severity, label }`.</ResponseField>
+
+<CodeGroup>
+  ```bash curl theme={null}
+  curl http://localhost:8080/api/monitoring/fleet-status \
+    -H "Authorization: Bearer $TOKEN"
+  ```
+</CodeGroup>
+
+```json theme={null}
+{
+  "generatedAt": "2026-06-12T12:00:00.000Z",
+  "total": 4,
+  "attentionCount": 2,
+  "agents": [
+    {
+      "agentId": "a1b2c3d4-e5f6-7890-abcd-ef1234567890",
+      "name": "Billing bot",
+      "status": "stopped",
+      "severity": "error",
+      "reasons": [{ "code": "budget_paused", "severity": "error", "label": "Paused — budget cap reached" }]
+    },
+    {
+      "agentId": "b2c3d4e5-f6a7-8901-bcde-f23456789012",
+      "name": "Scraper",
+      "status": "deploying",
+      "severity": "warning",
+      "reasons": [{ "code": "stuck_deploying", "severity": "warning", "label": "Stuck deploying for 18m" }]
+    }
+  ]
+}
+```
+
+***
+
 ## Activity event log
 
 Return a chronological log of activity events. When you supply `agentId` the results are filtered to that agent; otherwise all events across your agents are returned.

--- a/frontend-dashboard/components/FleetTriageStrip.tsx
+++ b/frontend-dashboard/components/FleetTriageStrip.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useState } from "react";
+import { AlertOctagon, AlertTriangle, ArrowUpRight } from "lucide-react";
+import { fetchWithAuth } from "../lib/api";
+
+type Reason = { code: string; severity: "error" | "warning"; label: string };
+type AttentionAgent = {
+  agentId: string;
+  name: string | null;
+  status: string | null;
+  severity: "error" | "warning" | null;
+  reasons: Reason[];
+};
+type FleetStatus = { attentionCount: number; agents: AttentionAgent[] };
+
+// Surfaces the agents an operator should look at right now, derived server-side
+// (errored, budget-paused, stuck deploying, approaching budget, stalled
+// telemetry). Renders nothing until loaded, and stays hidden when all clear so
+// it never adds noise to a healthy fleet.
+export default function FleetTriageStrip() {
+  const [data, setData] = useState<FleetStatus | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchWithAuth("/api/monitoring/fleet-status")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (!cancelled) setData(d);
+      })
+      .catch(() => {
+        if (!cancelled) setData(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!data || data.attentionCount === 0) return null;
+
+  return (
+    <section className="bg-white border border-amber-200 rounded-2xl sm:rounded-[2.5rem] p-5 sm:p-6 shadow-sm">
+      <div className="flex items-center gap-2 mb-4">
+        <AlertTriangle size={18} className="text-amber-600 shrink-0" />
+        <h2 className="text-sm font-black text-slate-900 tracking-tight">
+          Needs attention
+          <span className="ml-2 text-amber-700">({data.attentionCount})</span>
+        </h2>
+      </div>
+      <ul className="flex flex-col gap-2">
+        {data.agents.map((agent) => {
+          const isError = agent.severity === "error";
+          const Icon = isError ? AlertOctagon : AlertTriangle;
+          return (
+            <li key={agent.agentId}>
+              <a
+                href={`/app/agents/${agent.agentId}`}
+                className={`group flex items-center gap-3 rounded-xl border px-4 py-3 transition-colors ${
+                  isError
+                    ? "bg-red-50 border-red-200 hover:bg-red-100"
+                    : "bg-amber-50 border-amber-200 hover:bg-amber-100"
+                }`}
+              >
+                <Icon
+                  size={16}
+                  className={`shrink-0 ${isError ? "text-red-600" : "text-amber-600"}`}
+                />
+                <span className="text-sm font-bold text-slate-900 truncate min-w-0">
+                  {agent.name || agent.agentId}
+                </span>
+                <span className="flex flex-wrap gap-1.5 min-w-0">
+                  {agent.reasons.map((reason) => (
+                    <span
+                      key={reason.code}
+                      className={`text-[11px] font-semibold px-2 py-0.5 rounded-full ${
+                        reason.severity === "error"
+                          ? "bg-red-100 text-red-700"
+                          : "bg-amber-100 text-amber-700"
+                      }`}
+                    >
+                      {reason.label}
+                    </span>
+                  ))}
+                </span>
+                <ArrowUpRight
+                  size={15}
+                  className="ml-auto shrink-0 text-slate-400 group-hover:text-slate-600"
+                />
+              </a>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/frontend-dashboard/pages/dashboard.tsx
+++ b/frontend-dashboard/pages/dashboard.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import { clsx } from "clsx";
 import { fetchWithAuth } from "../lib/api";
 import ActivationChecklist from "../components/onboarding/ActivationChecklist";
+import FleetTriageStrip from "../components/FleetTriageStrip";
 
 export default function Dashboard() {
   const [agents, setAgents] = useState([]);
@@ -60,6 +61,8 @@ export default function Dashboard() {
             color="purple"
           />
         </div>
+
+        <FleetTriageStrip />
 
         <div className="flex flex-col gap-6">
           <div className="flex items-center justify-between">


### PR DESCRIPTION
## What

Adds a fleet **needs-attention** roll-up so an operator sees the agents that need action right now instead of scanning the whole fleet — the triage view buyers expect in the first 30 minutes (PR-4 of the pre-launch plan).

New `GET /monitoring/fleet-status` (scope `monitoring:read`) returns only the agents needing attention, with reasons, **derived at read time from state that already exists** — no schema change:

| Reason | Severity | Source |
|---|---|---|
| `error` | error | `agents.status = 'error'` |
| `budget_paused` | error | `stopped` + `paused_reason = 'budget_exceeded'` (from the budget-caps feature) |
| `warning` | warning | `agents.status = 'warning'` |
| `stuck_deploying` | warning | `queued`/`deploying` > 10m, measured from the latest `deployments` row |
| `budget_warning` | warning | a running agent crossed a budget soft threshold (`agent_budgets.last_alerted_pct`) |
| `telemetry_stalled` | warning | a running agent's latest `container_stats` is > 5m old |

## How

- **`backend-api/fleetStatus.ts`** — pure `deriveAttention(agent, ctx)` (thresholds/reasons unit-testable without a DB) + `getFleetAttention()` that gathers per-agent signals in a single `LATERAL`-join query scoped to the user's accessible agents (direct owner or workspace member).
- **`routes/monitoring.ts`** — the new route under the existing `monitoring:read` gate.
- **frontend-dashboard** — `FleetTriageStrip` on the dashboard between the stat grid and Recent Deployments; renders nothing when all clear, reason chips link to each agent, severity-coloured.
- **docs/api/monitoring.mdx** — endpoint reference.

## Design notes

- The "entered the deploy pipeline at" timestamp problem (`agents` has only `created_at`) is solved by reading the latest `deployments` row rather than adding a column or a trigger — so a redeploy of an old agent is measured from the redeploy, not its creation.
- Soft-budget detection reads the enforcement sweep's `last_alerted_pct` instead of recomputing cost live, keeping the endpoint cheap.

## Tests

11 new unit tests (pure derivation across every reason + the gather/scoping path). Full backend suite green (123 suites / 957 tests).