### PR TITLE
feat(doctor): nora doctor control-plane self-check + admin Health panel

### DIFF
--- a/.github/workflows/ci-quality.yml
+++ b/.github/workflows/ci-quality.yml
@@ -22,6 +22,7 @@ on:
       - "workers/provisioner/**"
       - "e2e/**"
       - "mcp-server/**"
+      - "cli/**"
   push:
     branches:
       - master
@@ -44,6 +45,7 @@ jobs:
           - backend-api
           - workers/provisioner
           - mcp-server
+          - cli
         check:
           - eslint
           - prettier

--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -41,6 +41,7 @@ jobs:
           - workers/provisioner
           - e2e
           - mcp-server
+          - cli
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -70,6 +71,7 @@ jobs:
           - workers/provisioner
           - e2e
           - mcp-server
+          - cli
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/admin-dashboard/components/AdminLayout.tsx
+++ b/admin-dashboard/components/AdminLayout.tsx
@@ -3,6 +3,7 @@ import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import {
   ArrowUpRight,
+  Activity,
   FileText,
   Archive,
   Boxes,
@@ -22,6 +23,7 @@ import { useI18n } from "../lib/i18n";
 
 const NAV_ITEMS = [
   { name: "Overview", icon: LayoutDashboard, href: "/" },
+  { name: "Health", icon: Activity, href: "/health" },
   { name: "Fleet", icon: Server, href: "/fleet" },
   { name: "Queue", icon: TriangleAlert, href: "/queue" },
   { name: "Users", icon: Users, href: "/users" },

--- a/admin-dashboard/pages/health.tsx
+++ b/admin-dashboard/pages/health.tsx
@@ -1,0 +1,170 @@
+import { useCallback, useEffect, useState } from "react";
+import { Activity, CheckCircle2, AlertTriangle, XCircle, Loader2, RefreshCw } from "lucide-react";
+import { clsx } from "clsx";
+import AdminLayout from "../components/AdminLayout";
+import { useToast } from "../components/Toast";
+import { fetchWithAuth } from "../lib/api";
+import { formatDateTime } from "../lib/format";
+
+type CheckStatus = "ok" | "warn" | "fail";
+type Check = { id: string; label: string; status: CheckStatus; detail?: string };
+type Report = { generatedAt: string; overall: CheckStatus; checks: Check[] };
+
+const STATUS_META: Record<
+  CheckStatus,
+  { label: string; icon: typeof CheckCircle2; badge: string; icon_color: string }
+> = {
+  ok: {
+    label: "Healthy",
+    icon: CheckCircle2,
+    badge: "bg-emerald-50 text-emerald-700 ring-emerald-200",
+    icon_color: "text-emerald-500",
+  },
+  warn: {
+    label: "Warning",
+    icon: AlertTriangle,
+    badge: "bg-orange-50 text-orange-700 ring-orange-200",
+    icon_color: "text-orange-500",
+  },
+  fail: {
+    label: "Failing",
+    icon: XCircle,
+    badge: "bg-red-50 text-red-700 ring-red-200",
+    icon_color: "text-red-500",
+  },
+};
+
+function HealthBadge({ status }: { status: CheckStatus }) {
+  const meta = STATUS_META[status] || STATUS_META.fail;
+  return (
+    <span
+      className={clsx(
+        "inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-xs font-bold ring-1 ring-inset",
+        meta.badge,
+      )}
+    >
+      {meta.label}
+    </span>
+  );
+}
+
+export default function HealthPage() {
+  const [report, setReport] = useState<Report | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const toast = useToast();
+
+  const load = useCallback(
+    async (fresh = false) => {
+      try {
+        const res = await fetchWithAuth(`/api/admin/doctor${fresh ? "?fresh=1" : ""}`);
+        if (res.ok) {
+          setReport(await res.json());
+        } else {
+          toast.error("Failed to load health report");
+        }
+      } catch (error: any) {
+        toast.error(error?.message || "Failed to load health report");
+      } finally {
+        setLoading(false);
+        setRefreshing(false);
+      }
+    },
+    [toast],
+  );
+
+  useEffect(() => {
+    load();
+    const intervalId = setInterval(() => load(), 30000);
+    return () => clearInterval(intervalId);
+  }, [load]);
+
+  const overall = report?.overall;
+  const overallMeta = overall ? STATUS_META[overall] : null;
+  const OverallIcon = overallMeta?.icon || Activity;
+
+  return (
+    <AdminLayout>
+      <div className="flex flex-col gap-8">
+        <header className="flex flex-wrap items-center justify-between gap-4">
+          <div className="flex flex-col gap-1">
+            <h1 className="text-2xl font-black tracking-tight text-slate-900">
+              Control-plane health
+            </h1>
+            <p className="text-sm text-slate-500">
+              Self-check of the Nora control plane. Also available from the CLI as{" "}
+              <code className="rounded bg-slate-100 px-1.5 py-0.5 text-xs">nora doctor</code>.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              setRefreshing(true);
+              load(true);
+            }}
+            disabled={refreshing}
+            className="inline-flex items-center gap-2 rounded-xl bg-slate-900 px-4 py-2.5 text-xs font-bold text-white transition-colors hover:bg-slate-700 disabled:opacity-50"
+          >
+            {refreshing ? <Loader2 size={14} className="animate-spin" /> : <RefreshCw size={14} />}
+            Re-run
+          </button>
+        </header>
+
+        {loading ? (
+          <div className="flex justify-center p-20">
+            <Loader2 className="animate-spin text-slate-400" />
+          </div>
+        ) : !report ? (
+          <p className="text-sm text-slate-500">No report available.</p>
+        ) : (
+          <>
+            <section
+              className={clsx(
+                "flex items-center gap-4 rounded-2xl border p-5",
+                overall === "ok"
+                  ? "border-emerald-200 bg-emerald-50"
+                  : overall === "warn"
+                    ? "border-orange-200 bg-orange-50"
+                    : "border-red-200 bg-red-50",
+              )}
+            >
+              <OverallIcon size={28} className={overallMeta?.icon_color} />
+              <div className="flex flex-col">
+                <span className="text-lg font-black text-slate-900">
+                  {overall === "ok"
+                    ? "All systems healthy"
+                    : overall === "warn"
+                      ? "Attention recommended"
+                      : "Action required"}
+                </span>
+                <span className="text-xs text-slate-500">
+                  Generated {formatDateTime(report.generatedAt)}
+                </span>
+              </div>
+            </section>
+
+            <ul className="flex flex-col gap-3">
+              {report.checks.map((check) => {
+                const meta = STATUS_META[check.status] || STATUS_META.fail;
+                const Icon = meta.icon;
+                return (
+                  <li
+                    key={check.id}
+                    className="flex items-start gap-4 rounded-2xl border border-slate-200 bg-white p-5 shadow-sm"
+                  >
+                    <Icon size={20} className={clsx("mt-0.5 shrink-0", meta.icon_color)} />
+                    <div className="flex min-w-0 flex-1 flex-col gap-1">
+                      <span className="text-sm font-bold text-slate-900">{check.label}</span>
+                      <span className="text-sm text-slate-500">{check.detail}</span>
+                    </div>
+                    <HealthBadge status={check.status} />
+                  </li>
+                );
+              })}
+            </ul>
+          </>
+        )}
+      </div>
+    </AdminLayout>
+  );
+}

--- a/backend-api/__tests__/doctor.test.ts
+++ b/backend-api/__tests__/doctor.test.ts
@@ -1,0 +1,144 @@
+// @ts-nocheck
+const doctor = require("../doctor");
+
+const NOW = Date.UTC(2026, 5, 12, 12, 0, 0);
+
+function okDb(overrides = {}) {
+  // Routes by SQL shape: SELECT 1, the fleet query, the gateway-exposure count.
+  return {
+    query: jest.fn(async (sql) => {
+      if (/SELECT 1/.test(sql)) return { rows: [{ "?column?": 1 }] };
+      if (/FROM agents a/.test(sql)) return { rows: overrides.fleetRows || [] };
+      if (/gateway_host_port IS NOT NULL/.test(sql))
+        return { rows: [{ exposed: overrides.exposed ?? 0 }] };
+      return { rows: [] };
+    }),
+  };
+}
+
+const okQueue = { getJobCounts: async () => ({ waiting: 0, active: 0, completed: 5, failed: 0 }) };
+const noDlq = async () => [];
+const noClusters = async () => [];
+
+const healthyDeps = (over = {}) => ({
+  dbClient: okDb(over.db || {}),
+  queue: over.queue || okQueue,
+  dlqJobs: over.dlqJobs || noDlq,
+  listKubernetesTargets: over.listKubernetesTargets || noClusters,
+  env: over.env || {
+    JWT_SECRET: "a-properly-long-jwt-secret-value",
+    NORA_API_KEY_HASH_SECRET: "a-properly-long-hash-secret-value",
+    ENCRYPTION_KEY: "a-properly-long-encryption-key-v",
+  },
+  now: NOW,
+});
+
+beforeEach(() => doctor._resetCacheForTests());
+
+describe("checkSecrets", () => {
+  it("passes with strong, present secrets", () => {
+    const r = doctor.checkSecrets({
+      JWT_SECRET: "a-properly-long-jwt-secret-value",
+      NORA_API_KEY_HASH_SECRET: "a-properly-long-hash-secret-value",
+      ENCRYPTION_KEY: "a-properly-long-encryption-key-v",
+    });
+    expect(r.status).toBe("ok");
+    expect(r.problems).toEqual([]);
+  });
+
+  it("fails on a missing required secret and warns on a missing encryption key", () => {
+    const r = doctor.checkSecrets({ ENCRYPTION_KEY: "" });
+    // JWT + hash secret missing => fail dominates
+    expect(r.status).toBe("fail");
+    const byEnv = Object.fromEntries(r.problems.map((p) => [p.env, p]));
+    expect(byEnv.JWT_SECRET.severity).toBe("fail");
+    expect(byEnv.ENCRYPTION_KEY.severity).toBe("warn");
+  });
+
+  it("flags placeholder values", () => {
+    const r = doctor.checkSecrets({
+      JWT_SECRET: "changeme-please",
+      NORA_API_KEY_HASH_SECRET: "your_secret_here",
+      ENCRYPTION_KEY: "a-properly-long-encryption-key-v",
+    });
+    expect(r.status).toBe("fail");
+    expect(r.problems.map((p) => p.issue)).toEqual(
+      expect.arrayContaining([expect.stringContaining("placeholder")]),
+    );
+  });
+});
+
+describe("runDoctor", () => {
+  it("reports overall ok when every check is healthy", async () => {
+    const report = await doctor.runDoctor(healthyDeps());
+    expect(report.overall).toBe("ok");
+    expect(report.checks.map((c) => c.id).sort()).toEqual([
+      "database",
+      "fleet",
+      "gateway_exposure",
+      "kubernetes",
+      "queue",
+      "secrets",
+    ]);
+    expect(report.generatedAt).toBe(new Date(NOW).toISOString());
+  });
+
+  it("degrades a thrown check to fail without taking down the report", async () => {
+    const queue = {
+      getJobCounts: async () => {
+        throw new Error("redis down");
+      },
+    };
+    const report = await doctor.runDoctor(healthyDeps({ queue }));
+    const queueCheck = report.checks.find((c) => c.id === "queue");
+    expect(queueCheck.status).toBe("fail");
+    expect(queueCheck.detail).toMatch(/redis down/);
+    expect(report.overall).toBe("fail");
+    // Other checks still ran.
+    expect(report.checks.find((c) => c.id === "database").status).toBe("ok");
+  });
+
+  it("warns when a Kubernetes target has not passed a connection test", async () => {
+    const listKubernetesTargets = async () => [
+      { id: "k1", label: "prod", lastTestStatus: "ok" },
+      { id: "k2", label: "staging", lastTestStatus: "failed", lastTestMessage: "timeout" },
+    ];
+    const report = await doctor.runDoctor(healthyDeps({ listKubernetesTargets }));
+    const k = report.checks.find((c) => c.id === "kubernetes");
+    expect(k.status).toBe("warn");
+    expect(k.targets).toHaveLength(1);
+    expect(k.targets[0].id).toBe("k2");
+    expect(report.overall).toBe("warn");
+  });
+
+  it("escalates fleet health to fail when an agent is errored", async () => {
+    const db = okDb({ fleetRows: [{ id: "a", name: "A", status: "error" }] });
+    const report = await doctor.runDoctor({ ...healthyDeps(), dbClient: db });
+    const fleet = report.checks.find((c) => c.id === "fleet");
+    expect(fleet.status).toBe("fail");
+    expect(fleet.attentionCount).toBe(1);
+    expect(fleet.reasons.error).toBe(1);
+  });
+
+  it("surfaces host-published gateways", async () => {
+    const report = await doctor.runDoctor(healthyDeps({ db: { exposed: 3 } }));
+    const gw = report.checks.find((c) => c.id === "gateway_exposure");
+    expect(gw.exposed).toBe(3);
+    expect(gw.detail).toMatch(/firewall/);
+  });
+});
+
+describe("getDoctorReport caching", () => {
+  it("serves a cached report within the TTL and recomputes on fresh", async () => {
+    const deps = healthyDeps();
+    const first = await doctor.getDoctorReport({}, deps);
+    const callsAfterFirst = deps.dbClient.query.mock.calls.length;
+    // Within TTL (same now) — cached, no new DB calls.
+    await doctor.getDoctorReport({}, deps);
+    expect(deps.dbClient.query.mock.calls.length).toBe(callsAfterFirst);
+    // fresh=true recomputes.
+    await doctor.getDoctorReport({ fresh: true }, deps);
+    expect(deps.dbClient.query.mock.calls.length).toBeGreaterThan(callsAfterFirst);
+    expect(first.overall).toBe("ok");
+  });
+});

--- a/backend-api/doctor.ts
+++ b/backend-api/doctor.ts
@@ -1,0 +1,300 @@
+// @ts-nocheck
+// `nora doctor` — a control-plane self-check the operator can run from the CLI
+// (GET /admin/doctor) or read in the admin Health panel. Each check is
+// independent and best-effort: a thrown check degrades to a "fail" entry rather
+// than taking the whole report down, and the overall status is the worst of the
+// individual checks.
+//
+// Scope note: these checks read only state the control plane already owns (DB,
+// queue, registered Kubernetes targets, process secrets, and the agents table).
+// Per-agent OpenClaw runtime posture probes are intentionally NOT here yet —
+// they need live gateway probing that must be designed against a real runtime
+// first (tracked as a follow-up), and shipping speculative checks would
+// over-promise.
+
+const db = require("./db");
+const { deployQueue, getDLQJobs } = require("./redisQueue");
+const kubernetesClusters = require("./kubernetesClusters");
+const fleetStatus = require("./fleetStatus");
+
+// Mirror of agentHubSafety's placeholder detector. Duplicated (not imported) so
+// doctor stays a standalone read-only aggregator; PR-7 will centralize secret
+// validation and this stub will defer to it.
+const PLACEHOLDER_RE = /^(your_|example|sample|placeholder|changeme|replace-me|test-|demo-)/i;
+
+// Required process secrets and how strict each one is. ENCRYPTION_KEY is a
+// "warn" today (the app still boots without it, falling back to plaintext);
+// PR-7 makes it fatal in production.
+const SECRET_CHECKS = [
+  { env: "JWT_SECRET", label: "JWT signing secret", minLength: 16, severity: "fail" },
+  {
+    env: "NORA_API_KEY_HASH_SECRET",
+    label: "API-key hash secret",
+    minLength: 16,
+    severity: "fail",
+  },
+  { env: "ENCRYPTION_KEY", label: "API-key encryption key", minLength: 16, severity: "warn" },
+];
+
+const STATUS_RANK = { ok: 0, warn: 1, fail: 2 };
+const CACHE_TTL_MS = 30 * 1000;
+
+function worst(statuses) {
+  return statuses.reduce((acc, s) => (STATUS_RANK[s] > STATUS_RANK[acc] ? s : acc), "ok");
+}
+
+function looksLikePlaceholder(value) {
+  return PLACEHOLDER_RE.test(value) || value.includes("<") || value.includes("{{");
+}
+
+async function checkDatabase(dbClient) {
+  try {
+    await dbClient.query("SELECT 1");
+    return { id: "database", label: "Database", status: "ok", detail: "Reachable" };
+  } catch (err) {
+    return { id: "database", label: "Database", status: "fail", detail: err.message };
+  }
+}
+
+async function checkQueue(queue, dlqJobs) {
+  try {
+    const counts = await queue.getJobCounts("waiting", "active", "completed", "failed");
+    let failedCount = 0;
+    try {
+      failedCount = (await dlqJobs()).length;
+    } catch {
+      // DLQ read is best-effort; getJobCounts already proved the queue is up.
+    }
+    const status = failedCount > 0 ? "warn" : "ok";
+    return {
+      id: "queue",
+      label: "Provisioning queue",
+      status,
+      detail:
+        failedCount > 0
+          ? `${failedCount} job(s) in the dead-letter queue`
+          : `waiting ${counts.waiting || 0}, active ${counts.active || 0}`,
+      counts,
+      deadLettered: failedCount,
+    };
+  } catch (err) {
+    return {
+      id: "queue",
+      label: "Provisioning queue",
+      status: "fail",
+      detail: `Redis/queue unreachable: ${err.message}`,
+    };
+  }
+}
+
+async function checkKubernetesTargets(listTargets) {
+  try {
+    const clusters = await listTargets();
+    if (!clusters || clusters.length === 0) {
+      return {
+        id: "kubernetes",
+        label: "Kubernetes targets",
+        status: "ok",
+        detail: "No Kubernetes execution targets registered",
+      };
+    }
+    const untested = clusters.filter((c) => c.lastTestStatus !== "ok");
+    if (untested.length > 0) {
+      return {
+        id: "kubernetes",
+        label: "Kubernetes targets",
+        status: "warn",
+        detail: `${untested.length} of ${clusters.length} target(s) have not passed a connection test`,
+        targets: untested.map((c) => ({
+          id: c.id,
+          label: c.label,
+          lastTestStatus: c.lastTestStatus || null,
+          lastTestMessage: c.lastTestMessage || null,
+        })),
+      };
+    }
+    return {
+      id: "kubernetes",
+      label: "Kubernetes targets",
+      status: "ok",
+      detail: `${clusters.length} target(s), all connection-tested`,
+    };
+  } catch (err) {
+    return {
+      id: "kubernetes",
+      label: "Kubernetes targets",
+      status: "fail",
+      detail: err.message,
+    };
+  }
+}
+
+function checkSecrets(env) {
+  const problems = [];
+  for (const secret of SECRET_CHECKS) {
+    const value = env[secret.env];
+    if (!value) {
+      problems.push({ env: secret.env, severity: secret.severity, issue: "not set" });
+    } else if (looksLikePlaceholder(value)) {
+      problems.push({
+        env: secret.env,
+        severity: secret.severity,
+        issue: "looks like a placeholder",
+      });
+    } else if (value.length < secret.minLength) {
+      problems.push({
+        env: secret.env,
+        severity: secret.severity,
+        issue: `shorter than ${secret.minLength} characters`,
+      });
+    }
+  }
+  const status = worst(["ok", ...problems.map((p) => p.severity)]);
+  return {
+    id: "secrets",
+    label: "Secret posture",
+    status,
+    detail:
+      problems.length === 0
+        ? "All required secrets present and non-placeholder"
+        : problems.map((p) => `${p.env} ${p.issue}`).join("; "),
+    problems,
+  };
+}
+
+// Fleet-wide attention roll-up (admin view — every agent, not user-scoped),
+// reusing the pure deriveAttention from fleetStatus so doctor and the dashboard
+// strip agree on what "needs attention" means.
+async function checkFleet(dbClient, now) {
+  try {
+    const result = await dbClient.query(
+      `SELECT a.id, a.name, a.status, a.paused_reason,
+              dep.created_at AS entered_deploy_at,
+              st.recorded_at AS last_stat_at,
+              COALESCE(bud.soft_crossed, false) AS budget_soft_crossed
+         FROM agents a
+         LEFT JOIN LATERAL (
+           SELECT created_at FROM deployments d
+            WHERE d.agent_id = a.id ORDER BY d.created_at DESC LIMIT 1
+         ) dep ON true
+         LEFT JOIN LATERAL (
+           SELECT recorded_at FROM container_stats s
+            WHERE s.agent_id = a.id ORDER BY s.recorded_at DESC LIMIT 1
+         ) st ON true
+         LEFT JOIN LATERAL (
+           SELECT bool_or(b.last_alerted_pct >= b.soft_threshold_pct AND b.last_alerted_pct < 100)
+                    AS soft_crossed
+             FROM agent_budgets b WHERE b.agent_id = a.id
+         ) bud ON true`,
+    );
+    const toMs = (value) => (value == null ? null : new Date(value).getTime());
+    const items = result.rows.map((row) =>
+      fleetStatus.deriveAttention(row, {
+        now,
+        enteredDeployAt: toMs(row.entered_deploy_at),
+        lastStatAt: toMs(row.last_stat_at),
+        budgetSoftCrossed: row.budget_soft_crossed === true,
+      }),
+    );
+    const attention = items.filter((i) => i.needsAttention);
+    const byCode = {};
+    for (const item of attention) {
+      for (const reason of item.reasons) byCode[reason.code] = (byCode[reason.code] || 0) + 1;
+    }
+    const status = attention.some((i) => i.severity === "error")
+      ? "fail"
+      : attention.length > 0
+        ? "warn"
+        : "ok";
+    return {
+      id: "fleet",
+      label: "Fleet health",
+      status,
+      detail:
+        attention.length === 0
+          ? `${items.length} agent(s), none need attention`
+          : `${attention.length} of ${items.length} agent(s) need attention`,
+      total: items.length,
+      attentionCount: attention.length,
+      reasons: byCode,
+    };
+  } catch (err) {
+    return { id: "fleet", label: "Fleet health", status: "fail", detail: err.message };
+  }
+}
+
+// Count agents whose runtime gateway is published to a host port — a posture
+// signal (host-exposed gateways) worth surfacing, not necessarily a problem.
+async function checkGatewayExposure(dbClient) {
+  try {
+    const result = await dbClient.query(
+      "SELECT count(*)::int AS exposed FROM agents WHERE gateway_host_port IS NOT NULL",
+    );
+    const exposed = result.rows[0]?.exposed || 0;
+    return {
+      id: "gateway_exposure",
+      label: "Gateway exposure",
+      status: "ok",
+      detail:
+        exposed === 0
+          ? "No agent gateways are published to a host port"
+          : `${exposed} agent gateway(s) published to a host port — ensure they are firewalled`,
+      exposed,
+    };
+  } catch (err) {
+    return {
+      id: "gateway_exposure",
+      label: "Gateway exposure",
+      status: "fail",
+      detail: err.message,
+    };
+  }
+}
+
+async function runDoctor(deps = {}) {
+  const {
+    dbClient = db,
+    queue = deployQueue,
+    dlqJobs = getDLQJobs,
+    listKubernetesTargets = kubernetesClusters.listKubernetesExecutionTargets,
+    env = process.env,
+    now = Date.now(),
+  } = deps;
+
+  const checks = await Promise.all([
+    checkDatabase(dbClient),
+    checkQueue(queue, dlqJobs),
+    checkKubernetesTargets(listKubernetesTargets),
+    Promise.resolve(checkSecrets(env)),
+    checkFleet(dbClient, now),
+    checkGatewayExposure(dbClient),
+  ]);
+
+  return {
+    generatedAt: new Date(now).toISOString(),
+    overall: worst(checks.map((c) => c.status)),
+    checks,
+  };
+}
+
+// Small TTL cache so a CLI loop / panel refresh doesn't hammer the queue + DB.
+let cached = null;
+async function getDoctorReport({ fresh = false } = {}, deps = {}) {
+  const at = deps.now || Date.now();
+  if (!fresh && cached && at - cached.at < CACHE_TTL_MS) return cached.report;
+  const report = await runDoctor(deps);
+  cached = { at, report };
+  return report;
+}
+
+function _resetCacheForTests() {
+  cached = null;
+}
+
+module.exports = {
+  SECRET_CHECKS,
+  runDoctor,
+  getDoctorReport,
+  checkSecrets,
+  _resetCacheForTests,
+};

--- a/backend-api/routes/admin.ts
+++ b/backend-api/routes/admin.ts
@@ -10,6 +10,7 @@ const snapshots = require("../snapshots");
 const containerManager = require("../containerManager");
 const releaseUpgrade = require("../releaseUpgrade");
 const kubernetesClusters = require("../kubernetesClusters");
+const doctor = require("../doctor");
 const { repairHermesAgentConfig } = require("../hermesUi");
 const { addBackupJob, addDeploymentJob, getDLQJobs, retryDLQJob } = require("../redisQueue");
 const backups = require("../backups");
@@ -68,6 +69,17 @@ const router = express.Router();
 
 router.use(requireAdmin);
 router.use(createMutationFailureAuditMiddleware("admin"));
+
+// Control-plane self-check (DB, queue, Kubernetes targets, secret posture,
+// fleet health, gateway exposure). Backs `nora doctor` and the admin Health
+// panel. Cached briefly; pass ?fresh=1 to force a recompute.
+router.get(
+  "/admin/doctor",
+  asyncHandler(async (req, res) => {
+    const fresh = req.query.fresh === "1" || req.query.fresh === "true";
+    res.json(await doctor.getDoctorReport({ fresh }));
+  }),
+);
 
 function parseInterval(pg) {
   const match = String(pg || "").match(/(\d+)\s*(day|minute|hour|second)/);

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,0 +1,19 @@
+{
+  "name": "@nora/cli",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@nora/cli",
+      "version": "0.1.0",
+      "license": "Apache-2.0",
+      "bin": {
+        "nora": "src/index.js"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    }
+  }
+}

--- a/cli/src/commands/doctor.js
+++ b/cli/src/commands/doctor.js
@@ -1,0 +1,40 @@
+const api = require("../client");
+
+const SYMBOL = { ok: "✔", warn: "!", fail: "✖" };
+
+async function run(args, flags) {
+  let report;
+  try {
+    report = await api.get("/api/admin/doctor", {
+      query: flags.fresh ? { fresh: "1" } : undefined,
+    });
+  } catch (err) {
+    if (err.status === 403) {
+      console.error(
+        "nora doctor requires an admin API key (the issuing user must be a platform admin).",
+      );
+      return 1;
+    }
+    throw err;
+  }
+
+  if (flags.json) {
+    console.log(JSON.stringify(report, null, 2));
+    return report.overall === "fail" ? 2 : 0;
+  }
+
+  console.log(`Nora doctor — overall: ${SYMBOL[report.overall] || "?"} ${report.overall}`);
+  console.log(`(${report.generatedAt})\n`);
+  for (const check of report.checks) {
+    const symbol = SYMBOL[check.status] || "?";
+    console.log(`  ${symbol} ${check.label.padEnd(20)} ${check.detail || ""}`);
+  }
+
+  // Non-zero exit on failure so the command is usable in scripts / CI.
+  return report.overall === "fail" ? 2 : 0;
+}
+
+module.exports = {
+  describe: "Run a control-plane health check (admin)",
+  run,
+};

--- a/cli/src/index.js
+++ b/cli/src/index.js
@@ -10,6 +10,7 @@ const commands = {
   agents: require("./commands/agents"),
   monitoring: require("./commands/monitoring"),
   mcp: require("./commands/mcp"),
+  doctor: require("./commands/doctor"),
 };
 
 function printRootHelp() {
@@ -71,8 +72,9 @@ async function main(argv) {
     return 0;
   }
 
-  await cmd.run(rest, flags);
-  return 0;
+  // Commands may return a process exit code (e.g. doctor returns non-zero when
+  // the control plane is unhealthy); default to 0 when they return nothing.
+  return (await cmd.run(rest, flags)) || 0;
 }
 
 main(process.argv.slice(2))

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -147,6 +147,7 @@
           "guides/channels",
           "guides/mcp-server",
           "guides/monitoring",
+          "guides/doctor",
           "guides/alert-rules",
           "guides/backups",
           "guides/upgrades",

--- a/docs/guides/doctor.mdx
+++ b/docs/guides/doctor.mdx
@@ -1,0 +1,65 @@
+# Check control-plane health with `nora doctor`
+
+> Run a one-shot self-check of the Nora control plane — database, provisioning queue, Kubernetes targets, secret posture, fleet health, and gateway exposure — from the CLI or the admin Health panel.
+
+`nora doctor` aggregates the checks an operator runs by hand after an install or before a launch into a single report. It reads only state the control plane already owns, so it is safe to run any time. The same report backs the admin **Health** panel.
+
+## Run it from the CLI
+
+```bash
+nora doctor
+```
+
+```text
+Nora doctor — overall: ✔ ok
+(2026-06-12T12:00:00.000Z)
+
+  ✔ Database             Reachable
+  ✔ Provisioning queue   waiting 0, active 0
+  ✔ Kubernetes targets   No Kubernetes execution targets registered
+  ✔ Secret posture       All required secrets present and non-placeholder
+  ✔ Fleet health         4 agent(s), none need attention
+  ✔ Gateway exposure     No agent gateways are published to a host port
+```
+
+Flags:
+
+- `--json` — emit the raw report (for scripting or piping to `jq`).
+- `--fresh` — bypass the short server-side cache and recompute now.
+
+The command exits non-zero when the overall status is `fail`, so you can gate a deploy script on it:
+
+```bash
+nora doctor || echo "control plane is unhealthy — not deploying"
+```
+
+<Note>
+  `nora doctor` requires an API key whose issuing user is a platform admin. A non-admin key receives a clear 403 message.
+</Note>
+
+## Read it in the admin dashboard
+
+The admin **Health** panel renders the same report with a re-run button and auto-refreshes every 30 seconds.
+
+## What it checks
+
+| Check | Healthy when | Source |
+| --- | --- | --- |
+| Database | A `SELECT 1` succeeds | PostgreSQL |
+| Provisioning queue | The queue responds and the dead-letter queue is empty | Redis / BullMQ |
+| Kubernetes targets | Every registered target has passed a connection test | Admin → Kubernetes |
+| Secret posture | `JWT_SECRET` and `NORA_API_KEY_HASH_SECRET` are set, non-placeholder, and long enough (`ENCRYPTION_KEY` is a warning) | Process environment |
+| Fleet health | No agent needs attention (see the [needs-attention roll-up](/api/monitoring)) | Agents table |
+| Gateway exposure | Surfaces how many agent gateways are published to a host port so you can confirm they are firewalled | Agents table |
+
+The overall status is the worst of the individual checks: `ok`, `warn`, or `fail`. A single failing check (for example, an unreachable Redis) is reported on its own line and does not suppress the others.
+
+## API
+
+The report is also available directly:
+
+```
+GET /api/admin/doctor
+```
+
+Requires an admin session or an admin user's API key. Pass `?fresh=1` to bypass the cache. See the response shape in the report above (`--json`).


### PR DESCRIPTION
## What

Adds `nora doctor` — a one-shot control-plane self-check — surfaced three ways: `GET /admin/doctor` (admin), the `nora doctor` CLI command, and an admin **Health** panel (PR-5 of the pre-launch plan). It folds the checks an operator runs by hand after an install / before a launch into one report.

Each check is independent and best-effort: a thrown check degrades to a `fail` line rather than taking the whole report down, and overall status is the worst of the checks (`ok`/`warn`/`fail`).

| Check | Source |
|---|---|
| Database | `SELECT 1` |
| Provisioning queue + DLQ depth | Redis / BullMQ |
| Kubernetes targets | stored connection-test status |
| Secret posture | `JWT_SECRET`, `NORA_API_KEY_HASH_SECRET` (fail), `ENCRYPTION_KEY` (warn) — presence + placeholder + length |
| Fleet health | reuses `fleetStatus.deriveAttention`, fleet-wide |
| Gateway exposure | agents with a host-published gateway port |

## How

- **`backend-api/doctor.ts`** + `GET /admin/doctor` in `routes/admin.ts` (behind the router's `requireAdmin`), 30s cache, `?fresh=1` to bust. Deps injectable; 9 unit tests.
- **CLI** — `nora doctor` (`--json`, `--fresh`); exits non-zero on `fail` so it can gate a deploy script (the dispatcher now propagates a command's return code — safe; existing commands return `undefined`).
- **admin-dashboard** — Health page + nav entry, auto-refresh + manual re-run.
- **CI** — added `cli` to the quality (eslint/prettier) and security (audit/license) matrices; it was in **none** before. Generated `cli/package-lock.json` (zero deps) so the per-package `npm ci` works.
- **docs/guides/doctor.mdx** + nav.

## Design notes

- **Secret posture is a deliberate stub** — it shares PR-7's intent; PR-7 will centralize secret validation and this check will defer to it.
- **Per-agent OpenClaw runtime posture probes are deferred** — they need live gateway probing designed against a real runtime first. Shipping speculative checks I can't verify against a live OpenClaw agent would over-promise; tracked as a follow-up. Everything here reads control-plane-owned state only.

## Tests

9 new doctor unit tests (each check, the degrade-on-throw path, caching). Full backend suite green (124 suites / 966 tests). Backend + admin-dashboard typecheck clean.