### PR TITLE
feat(integrations): per-agent MCP servers wired into the OpenClaw runtime

### DIFF
--- a/agent-runtime/__tests__/mcpServersConfig.test.ts
+++ b/agent-runtime/__tests__/mcpServersConfig.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import * as mcpServersConfig from "../lib/mcpServersConfig.ts";
+
+const { buildMcpServersConfig } = mcpServersConfig;
+
+describe("buildMcpServersConfig", () => {
+  it("emits a stdio npx entry keyed by server name with env", () => {
+    const config = buildMcpServersConfig([
+      {
+        name: "gitlab",
+        npmPackage: "@modelcontextprotocol/server-gitlab",
+        env: { GITLAB_PERSONAL_ACCESS_TOKEN: "glpat-xxx" },
+      },
+    ]);
+    expect(config).toEqual({
+      gitlab: {
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-gitlab"],
+        env: { GITLAB_PERSONAL_ACCESS_TOKEN: "glpat-xxx" },
+      },
+    });
+  });
+
+  it("appends extra args and drops empty/nullish env values", () => {
+    const config = buildMcpServersConfig([
+      {
+        name: "supabase",
+        npmPackage: "@supabase/mcp-server-supabase",
+        args: ["--read-only"],
+        env: { SUPABASE_ACCESS_TOKEN: "sbp", EMPTY: "", MISSING: null },
+      },
+    ]);
+    expect(config.supabase.args).toEqual(["-y", "@supabase/mcp-server-supabase", "--read-only"]);
+    expect(config.supabase.env).toEqual({ SUPABASE_ACCESS_TOKEN: "sbp" });
+  });
+
+  it("omits the env key entirely when there are no usable values", () => {
+    const config = buildMcpServersConfig([{ name: "x", npmPackage: "@x/y", env: { A: "" } }]);
+    expect(config.x).toEqual({ command: "npx", args: ["-y", "@x/y"] });
+    expect("env" in config.x).toBe(false);
+  });
+
+  it("skips malformed entries and tolerates non-array input", () => {
+    expect(buildMcpServersConfig([{ name: "no-pkg" }, { npmPackage: "no-name" }, null])).toEqual(
+      {},
+    );
+    expect(buildMcpServersConfig(undefined)).toEqual({});
+  });
+});

--- a/agent-runtime/lib/mcpServersConfig.ts
+++ b/agent-runtime/lib/mcpServersConfig.ts
@@ -1,0 +1,29 @@
+// @ts-nocheck
+// Pure builder for the openclaw.json `mcpServers` block. OpenClaw (>= 2026.4.x)
+// reads this map and launches each entry as a stdio MCP client (verified
+// against the runtime bundle: command/args/env stdio shape). `entries` is
+// already credential-resolved upstream, so this is a dependency-free shape
+// transform — kept in its own module so it can be unit-tested without loading
+// the rest of the runtime bootstrap. Keyed by server name:
+//   { "<name>": { command: "npx", args: ["-y", "<pkg>", ...], env: { ... } } }
+function buildMcpServersConfig(entries = []) {
+  const servers = {};
+  for (const entry of Array.isArray(entries) ? entries : []) {
+    if (!entry || !entry.name || !entry.npmPackage) continue;
+    const extraArgs = Array.isArray(entry.args) ? entry.args : [];
+    const env =
+      entry.env && typeof entry.env === "object"
+        ? Object.fromEntries(
+            Object.entries(entry.env).filter(([, value]) => value != null && value !== ""),
+          )
+        : {};
+    servers[entry.name] = {
+      command: "npx",
+      args: ["-y", entry.npmPackage, ...extraArgs],
+      ...(Object.keys(env).length > 0 ? { env } : {}),
+    };
+  }
+  return servers;
+}
+
+module.exports = { buildMcpServersConfig };

--- a/agent-runtime/lib/runtimeBootstrap.ts
+++ b/agent-runtime/lib/runtimeBootstrap.ts
@@ -43,10 +43,9 @@ const INTEGRATION_TOOL_WRAPPER_SOURCE = [
   'exec "$TSX_BIN" /opt/openclaw-runtime/lib/integrationToolCli.ts "$@"',
   "",
 ].join("\n");
-const INTEGRATION_TOOL_WRAPPER_B64 = Buffer.from(
-  INTEGRATION_TOOL_WRAPPER_SOURCE,
-  "utf8",
-).toString("base64");
+const INTEGRATION_TOOL_WRAPPER_B64 = Buffer.from(INTEGRATION_TOOL_WRAPPER_SOURCE, "utf8").toString(
+  "base64",
+);
 
 const OPENCLAW_WORKSPACE_ROOT = "/root/.openclaw/workspace";
 const OPENCLAW_LEGACY_AGENT_TEMPLATE_ROOT = "/root/.openclaw/agents/main/agent";
@@ -60,7 +59,10 @@ function stripGeneratedIntegrationPromptBlock(content) {
     `\\n?${NORA_INTEGRATIONS_PROMPT_BEGIN}[\\s\\S]*?${NORA_INTEGRATIONS_PROMPT_END}\\n?`,
     "g",
   );
-  return raw.replace(pattern, "\n").replace(/\n{3,}/g, "\n\n").trimEnd();
+  return raw
+    .replace(pattern, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trimEnd();
 }
 
 function buildIntegrationPromptPointerMarkdown() {
@@ -220,14 +222,20 @@ function withIntegrationBootstrapEntries(entries = []) {
   if (!hasWorkspaceTools) {
     nextEntries.push({
       targetPath: path.posix.join(OPENCLAW_WORKSPACE_ROOT, "TOOLS.md"),
-      contentBuffer: Buffer.from(upsertGeneratedIntegrationPromptBlock(defaultToolsContent), "utf8"),
+      contentBuffer: Buffer.from(
+        upsertGeneratedIntegrationPromptBlock(defaultToolsContent),
+        "utf8",
+      ),
       mode: 0o644,
     });
   }
   if (!hasLegacyTools) {
     nextEntries.push({
       targetPath: path.posix.join(OPENCLAW_LEGACY_AGENT_TEMPLATE_ROOT, "TOOLS.md"),
-      contentBuffer: Buffer.from(upsertGeneratedIntegrationPromptBlock(defaultToolsContent), "utf8"),
+      contentBuffer: Buffer.from(
+        upsertGeneratedIntegrationPromptBlock(defaultToolsContent),
+        "utf8",
+      ),
       mode: 0o644,
     });
   }
@@ -296,11 +304,41 @@ const FOUNDRY_OPENCLAW_PROVIDER_ID = "azure-openai-responses";
 // compat flag is `supportsStore: false` — Azure rejects `store: true`, which
 // is OpenClaw's default for Responses API.
 const FOUNDRY_DEFAULT_MODELS = [
-  { id: "gpt-5.5", name: "GPT-5.5 (Azure)", reasoning: true, contextWindow: 400000, maxTokens: 16384 },
-  { id: "gpt-5.5-mini", name: "GPT-5.5 Mini (Azure)", reasoning: true, contextWindow: 400000, maxTokens: 16384 },
-  { id: "gpt-5.5-pro", name: "GPT-5.5 Pro (Azure)", reasoning: true, contextWindow: 200000, maxTokens: 128000 },
-  { id: "gpt-5.5", name: "GPT-5.5 (Azure)", reasoning: true, contextWindow: 200000, maxTokens: 128000 },
-  { id: "gpt-5.2-codex", name: "GPT-5.2 Codex (Azure)", reasoning: true, contextWindow: 400000, maxTokens: 16384 },
+  {
+    id: "gpt-5.5",
+    name: "GPT-5.5 (Azure)",
+    reasoning: true,
+    contextWindow: 400000,
+    maxTokens: 16384,
+  },
+  {
+    id: "gpt-5.5-mini",
+    name: "GPT-5.5 Mini (Azure)",
+    reasoning: true,
+    contextWindow: 400000,
+    maxTokens: 16384,
+  },
+  {
+    id: "gpt-5.5-pro",
+    name: "GPT-5.5 Pro (Azure)",
+    reasoning: true,
+    contextWindow: 200000,
+    maxTokens: 128000,
+  },
+  {
+    id: "gpt-5.5",
+    name: "GPT-5.5 (Azure)",
+    reasoning: true,
+    contextWindow: 200000,
+    maxTokens: 128000,
+  },
+  {
+    id: "gpt-5.2-codex",
+    name: "GPT-5.2 Codex (Azure)",
+    reasoning: true,
+    contextWindow: 400000,
+    maxTokens: 16384,
+  },
   { id: "o3", name: "o3 (Azure)", reasoning: true, contextWindow: 200000, maxTokens: 100000 },
 ];
 
@@ -338,23 +376,21 @@ function buildFoundryModelEntries(env = {}) {
   // for the very deployment we set as default.
   const deployment = resolveFoundryDeployment(env);
   const seen = new Set();
-  const models = FOUNDRY_DEFAULT_MODELS
-    .filter((entry) => {
-      if (seen.has(entry.id)) return false;
-      seen.add(entry.id);
-      return true;
-    })
-    .map((entry) => ({
-      id: entry.id,
-      name: entry.name,
-      api: "azure-openai-responses",
-      reasoning: entry.reasoning,
-      input: ["text", "image"],
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: entry.contextWindow,
-      maxTokens: entry.maxTokens,
-      compat: { supportsStore: false, supportsReasoningEffort: true },
-    }));
+  const models = FOUNDRY_DEFAULT_MODELS.filter((entry) => {
+    if (seen.has(entry.id)) return false;
+    seen.add(entry.id);
+    return true;
+  }).map((entry) => ({
+    id: entry.id,
+    name: entry.name,
+    api: "azure-openai-responses",
+    reasoning: entry.reasoning,
+    input: ["text", "image"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: entry.contextWindow,
+    maxTokens: entry.maxTokens,
+    compat: { supportsStore: false, supportsReasoningEffort: true },
+  }));
   if (!deployment || models.some((model) => model.id === deployment)) return models;
 
   const baseModelId = deployment.replace(/-\d+$/, "");
@@ -477,6 +513,11 @@ function buildOpenClawConfigMergeCommand(configDelta) {
   return buildOpenClawConfigMergeScript(configDelta).join("\n");
 }
 
+// buildMcpServersConfig lives in its own dependency-free module so it can be
+// unit-tested without loading the rest of the bootstrap; re-exported here for
+// the worker/adapter consumers that already import from runtimeBootstrap.
+const { buildMcpServersConfig } = require("./mcpServersConfig");
+
 function buildRuntimeBootstrapCommand() {
   return [
     "mkdir -p /opt/openclaw-runtime/lib /var/log && ",
@@ -591,6 +632,7 @@ module.exports = {
   buildIntegrationToolWrapperScript,
   buildOpenClawConfigMergeScript,
   buildOpenClawConfigMergeCommand,
+  buildMcpServersConfig,
   buildOpenClawCustomProviders,
   mapNoraProviderIdToOpenClaw,
   FOUNDRY_OPENCLAW_PROVIDER_ID,

--- a/backend-api/__tests__/dockerBootstrap.test.ts
+++ b/backend-api/__tests__/dockerBootstrap.test.ts
@@ -4,6 +4,7 @@ const path = require("path");
 const {
   buildOpenClawConfigMergeScript,
   buildOpenClawConfigMergeCommand,
+  buildMcpServersConfig,
   buildOpenClawCustomProviders,
   buildOpenClawInstallCommand,
   buildRuntimeBootstrapCommand,
@@ -395,6 +396,29 @@ describe("Provisioner backends", () => {
     const startupScript = files.find((file) => file.name === "opt/openclaw-runtime/start.sh");
     expect(startupScript.content).toContain("azure-openai-responses");
     expect(startupScript.content).toContain('"apiKey": "ms-key"');
+  });
+
+  it("embeds a per-agent mcpServers block into the startup merge script", () => {
+    // buildMcpServersConfig produces the openclaw.json mcpServers shape; when it
+    // is placed on the gatewayConfig, _buildBootstrapFiles ships it verbatim
+    // into the deep-merge so OpenClaw spawns the stdio server with its creds.
+    const dockerBackend = new DockerBackend();
+    const mcpServers = buildMcpServersConfig([
+      {
+        name: "gitlab",
+        npmPackage: "@modelcontextprotocol/server-gitlab",
+        env: { GITLAB_PERSONAL_ACCESS_TOKEN: "glpat-secret" },
+      },
+    ]);
+    const files = dockerBackend._buildBootstrapFiles({
+      gatewayConfig: { gateway: { bind: "lan", mode: "local" }, mcpServers },
+      pairedJson: '{"device":"paired"}',
+      buildAuthScript: 'console.log("build auth");',
+    });
+    const startupScript = files.find((file) => file.name === "opt/openclaw-runtime/start.sh");
+    expect(startupScript.content).toContain('"mcpServers"');
+    expect(startupScript.content).toContain("@modelcontextprotocol/server-gitlab");
+    expect(startupScript.content).toContain('"GITLAB_PERSONAL_ACCESS_TOKEN": "glpat-secret"');
   });
 
   it("wires the executable guard into OpenClaw startup paths", () => {

--- a/backend-api/__tests__/mcpServers.test.ts
+++ b/backend-api/__tests__/mcpServers.test.ts
@@ -1,0 +1,127 @@
+// @ts-nocheck
+const mcpServers = require("../mcpServers");
+
+// A trimmed catalog covering supported + unsupported + not-yet-available cases.
+const CATALOG = [
+  {
+    id: "gitlab",
+    name: "GitLab",
+    mcp: {
+      available: true,
+      transport: "stdio",
+      npmPackage: "@modelcontextprotocol/server-gitlab",
+      docsUrl: "https://example.com/gitlab",
+    },
+  },
+  {
+    id: "notion",
+    name: "Notion",
+    mcp: { available: true, transport: "stdio", npmPackage: "@notionhq/notion-mcp-server" },
+  },
+  {
+    id: "stripe",
+    name: "Stripe",
+    mcp: { available: true, transport: "stdio", npmPackage: "@stripe/mcp" },
+  },
+  {
+    id: "supabase",
+    name: "Supabase",
+    mcp: { available: true, transport: "stdio", npmPackage: "@supabase/mcp-server-supabase" },
+  },
+  // Supported provider id, but the catalog has not declared it available.
+  { id: "github", name: "GitHub", mcp: { available: false } },
+  // Available, but not in the supported set (deferred — file/connection creds).
+  {
+    id: "kubernetes",
+    name: "Kubernetes",
+    mcp: { available: true, transport: "stdio", npmPackage: "@kubernetes/mcp-server" },
+  },
+];
+
+describe("loadMcpCatalog", () => {
+  it("returns only supported providers that declare a usable stdio server", () => {
+    const ids = mcpServers.loadMcpCatalog(CATALOG).map((e) => e.provider);
+    expect(ids.sort()).toEqual(["gitlab", "notion", "stripe", "supabase"]);
+  });
+});
+
+describe("normalizeEnabledIds", () => {
+  it("keeps supported ids, dedupes, and accepts {provider} objects", () => {
+    expect(
+      mcpServers.normalizeEnabledIds([
+        "gitlab",
+        "gitlab",
+        { provider: "stripe" },
+        "nope",
+        "kubernetes",
+      ]),
+    ).toEqual(["gitlab", "stripe"]);
+    expect(mcpServers.normalizeEnabledIds("not-an-array")).toEqual([]);
+  });
+});
+
+describe("resolveMcpEntries", () => {
+  it("injects each provider's credential under its server's expected env var", () => {
+    const entries = mcpServers.resolveMcpEntries({
+      enabledIds: ["gitlab", "notion"],
+      integrationsByProvider: {
+        gitlab: { token: "glpat-1", config: { api_url: "https://gl.example.com/api/v4" } },
+        notion: { token: "secret_n" },
+      },
+      catalog: CATALOG,
+    });
+    const byName = Object.fromEntries(entries.map((e) => [e.name, e]));
+    expect(byName.gitlab.npmPackage).toBe("@modelcontextprotocol/server-gitlab");
+    expect(byName.gitlab.env).toEqual({
+      GITLAB_PERSONAL_ACCESS_TOKEN: "glpat-1",
+      GITLAB_API_URL: "https://gl.example.com/api/v4",
+    });
+    expect(byName.notion.env).toEqual({ NOTION_TOKEN: "secret_n" });
+  });
+
+  it("skips an enabled provider whose integration is missing or has no token", () => {
+    const entries = mcpServers.resolveMcpEntries({
+      enabledIds: ["gitlab", "stripe"],
+      integrationsByProvider: { gitlab: { token: "" }, stripe: undefined },
+      catalog: CATALOG,
+    });
+    expect(entries).toEqual([]);
+  });
+});
+
+describe("getAvailableMcpServers", () => {
+  function fakeDb({ mcpRows = [], connectedProviders = [] } = {}) {
+    return {
+      query: jest.fn(async (sql) => {
+        if (/SELECT mcp_servers FROM agents/.test(sql)) return { rows: [{ mcp_servers: mcpRows }] };
+        if (/FROM integrations/.test(sql))
+          return { rows: connectedProviders.map((p) => ({ provider: p })) };
+        return { rows: [] };
+      }),
+    };
+  }
+
+  it("annotates each supported server with connected + enabled", async () => {
+    const dbClient = fakeDb({ mcpRows: ["gitlab"], connectedProviders: ["gitlab", "stripe"] });
+    const servers = await mcpServers.getAvailableMcpServers("a-1", { dbClient, catalog: CATALOG });
+    const byProvider = Object.fromEntries(servers.map((s) => [s.provider, s]));
+    expect(byProvider.gitlab).toMatchObject({ connected: true, enabled: true });
+    expect(byProvider.stripe).toMatchObject({ connected: true, enabled: false });
+    expect(byProvider.notion).toMatchObject({ connected: false, enabled: false });
+  });
+});
+
+describe("setAgentMcpServerIds", () => {
+  it("validates against the supported set and writes JSON", async () => {
+    const calls = [];
+    const dbClient = {
+      query: jest.fn(async (sql, params) => (calls.push({ sql, params }), { rows: [] })),
+    };
+    const result = await mcpServers.setAgentMcpServerIds("a-1", ["gitlab", "bogus", "gitlab"], {
+      dbClient,
+    });
+    expect(result).toEqual(["gitlab"]);
+    expect(calls[0].params[0]).toBe(JSON.stringify(["gitlab"]));
+    expect(calls[0].params[1]).toBe("a-1");
+  });
+});

--- a/backend-api/db_schema.sql
+++ b/backend-api/db_schema.sql
@@ -46,6 +46,7 @@ CREATE TABLE IF NOT EXISTS agents (
   ram_mb INTEGER DEFAULT 1024,
   disk_gb INTEGER DEFAULT 10,
   paused_reason TEXT,
+  mcp_servers JSONB DEFAULT '[]',
   created_at TIMESTAMP DEFAULT NOW()
 );
 

--- a/backend-api/mcpServers.ts
+++ b/backend-api/mcpServers.ts
@@ -1,0 +1,143 @@
+// @ts-nocheck
+// Per-agent MCP server management. Lets an operator turn a *connected*
+// integration into a Model Context Protocol server that the agent's OpenClaw
+// runtime spawns over stdio. The runtime support is verified: OpenClaw
+// (>= 2026.4.x) reads an `mcpServers` block from openclaw.json and launches
+// each entry with StdioClientTransport.
+//
+// The npm package + transport come from the integration catalog (the source of
+// truth, `mcp.available === true`). This module adds the one thing the catalog
+// can't: the mapping from a provider's stored credential to the specific env
+// var its MCP server reads — which is NOT the generic name the worker injects
+// for tools (e.g. the GitLab MCP server wants GITLAB_PERSONAL_ACCESS_TOKEN, not
+// the GITLAB_TOKEN the tool layer uses).
+//
+// Scope: the four single-token (api_key) providers whose credential maps
+// cleanly to one env var. postgresql (needs a POSTGRES_URL assembled from a
+// multi-field credential) and the file-credential providers (google-drive,
+// kubernetes) are deliberately deferred.
+
+const db = require("./db");
+const { loadCatalog } = require("./integrations/catalog/catalogLoader");
+
+// provider id -> how to turn its decrypted credential into MCP server env.
+//   primaryEnv: the env var the MCP server reads the access token from.
+//   configEnv:  optional map of decrypted-config key -> env var (e.g. self-hosted URL).
+const SUPPORTED_MCP_PROVIDERS = {
+  gitlab: {
+    primaryEnv: "GITLAB_PERSONAL_ACCESS_TOKEN",
+    configEnv: { api_url: "GITLAB_API_URL", base_url: "GITLAB_API_URL" },
+  },
+  notion: { primaryEnv: "NOTION_TOKEN" },
+  stripe: { primaryEnv: "STRIPE_SECRET_KEY" },
+  supabase: { primaryEnv: "SUPABASE_ACCESS_TOKEN" },
+};
+
+function isSupportedProvider(provider) {
+  return Object.prototype.hasOwnProperty.call(SUPPORTED_MCP_PROVIDERS, provider);
+}
+
+// Catalog entries for the supported providers that actually declare a usable
+// stdio MCP server. Returns [{ provider, name, npmPackage, docsUrl, notes }].
+function loadMcpCatalog(catalog = loadCatalog()) {
+  const items = Array.isArray(catalog) ? catalog : [];
+  const out = [];
+  for (const item of items) {
+    const provider = item?.id || item?.provider;
+    if (!provider || !isSupportedProvider(provider)) continue;
+    const mcp = item.mcp;
+    if (!mcp || mcp.available !== true || mcp.transport !== "stdio" || !mcp.npmPackage) continue;
+    out.push({
+      provider,
+      name: item.name || provider,
+      npmPackage: mcp.npmPackage,
+      docsUrl: mcp.docsUrl || null,
+      notes: mcp.notes || null,
+    });
+  }
+  return out;
+}
+
+function normalizeEnabledIds(value) {
+  if (!Array.isArray(value)) return [];
+  const seen = new Set();
+  const out = [];
+  for (const entry of value) {
+    const id = typeof entry === "string" ? entry : entry?.provider;
+    if (id && isSupportedProvider(id) && !seen.has(id)) {
+      seen.add(id);
+      out.push(id);
+    }
+  }
+  return out;
+}
+
+async function getAgentMcpServerIds(agentId, { dbClient = db } = {}) {
+  const result = await dbClient.query("SELECT mcp_servers FROM agents WHERE id = $1", [agentId]);
+  if (result.rows.length === 0) return null; // agent not found
+  return normalizeEnabledIds(result.rows[0].mcp_servers);
+}
+
+// Persist the enabled provider ids (validated against the supported set).
+async function setAgentMcpServerIds(agentId, providerIds, { dbClient = db } = {}) {
+  const ids = normalizeEnabledIds(providerIds);
+  await dbClient.query("UPDATE agents SET mcp_servers = $1::jsonb WHERE id = $2", [
+    JSON.stringify(ids),
+    agentId,
+  ]);
+  return ids;
+}
+
+// For the management UI: every supported MCP server, annotated with whether the
+// agent has the integration connected and whether the server is enabled.
+async function getAvailableMcpServers(agentId, { dbClient = db, catalog } = {}) {
+  const enabledIds = (await getAgentMcpServerIds(agentId, { dbClient })) || [];
+  const connectedResult = await dbClient.query(
+    "SELECT DISTINCT provider FROM integrations WHERE agent_id = $1 AND status = 'active'",
+    [agentId],
+  );
+  const connected = new Set(connectedResult.rows.map((r) => r.provider));
+  return loadMcpCatalog(catalog).map((entry) => ({
+    provider: entry.provider,
+    name: entry.name,
+    npmPackage: entry.npmPackage,
+    docsUrl: entry.docsUrl,
+    notes: entry.notes,
+    connected: connected.has(entry.provider),
+    enabled: enabledIds.includes(entry.provider),
+  }));
+}
+
+// PURE: turn the agent's enabled ids + already-decrypted integration creds into
+// the entries buildMcpServersConfig expects. The worker calls this at deploy
+// (it has decrypted tokens in hand) — no DB or crypto here, so it is unit
+// testable. integrationsByProvider: { gitlab: { token, config: {api_url} } }.
+// An enabled provider with no connected/credentialed integration is skipped.
+function resolveMcpEntries({ enabledIds = [], integrationsByProvider = {}, catalog } = {}) {
+  const byProvider = Object.fromEntries(loadMcpCatalog(catalog).map((e) => [e.provider, e]));
+  const entries = [];
+  for (const provider of normalizeEnabledIds(enabledIds)) {
+    const cat = byProvider[provider];
+    const mapping = SUPPORTED_MCP_PROVIDERS[provider];
+    const integration = integrationsByProvider[provider];
+    if (!cat || !mapping || !integration || !integration.token) continue;
+    const env = { [mapping.primaryEnv]: integration.token };
+    const config = integration.config || {};
+    for (const [cfgKey, envVar] of Object.entries(mapping.configEnv || {})) {
+      if (config[cfgKey]) env[envVar] = String(config[cfgKey]);
+    }
+    entries.push({ name: provider, npmPackage: cat.npmPackage, env });
+  }
+  return entries;
+}
+
+module.exports = {
+  SUPPORTED_MCP_PROVIDERS,
+  isSupportedProvider,
+  loadMcpCatalog,
+  normalizeEnabledIds,
+  getAgentMcpServerIds,
+  setAgentMcpServerIds,
+  getAvailableMcpServers,
+  resolveMcpEntries,
+};

--- a/backend-api/routes/integrations.ts
+++ b/backend-api/routes/integrations.ts
@@ -3,6 +3,7 @@ const express = require("express");
 const crypto = require("crypto");
 const db = require("../db");
 const integrations = require("../integrations");
+const mcpServers = require("../mcpServers");
 const { encrypt, decrypt } = require("../crypto");
 const { rpcCall } = require("../gatewayProxy");
 const { runContainerCommand, syncAuthToUserAgents } = require("../authSync");
@@ -36,6 +37,10 @@ const SINGLETON_INTEGRATION_PROVIDERS = new Set(["wecom"]);
 router.use("/agents/:id/integrations", requireAccessibleAgent("editor", "id"));
 // API keys must carry integrations:read or integrations:write to call these.
 router.use("/agents/:id/integrations", scopeByMethod("integrations:read", "integrations:write"));
+
+// Per-agent MCP server management reuses the same access + scope gates.
+router.use("/agents/:id/mcp-servers", requireAccessibleAgent("editor", "id"));
+router.use("/agents/:id/mcp-servers", scopeByMethod("integrations:read", "integrations:write"));
 
 function base64Url(buffer) {
   return Buffer.from(buffer)
@@ -436,6 +441,31 @@ async function invokeAgentIntegrationTool(agentId, payload = {}) {
 router.get("/agents/:id/integrations", async (req, res) => {
   try {
     res.json(await integrations.listIntegrations(req.params.id));
+  } catch (e) {
+    res.status(e.statusCode || 500).json({ error: e.message });
+  }
+});
+
+// List the MCP servers available to this agent (supported providers annotated
+// with connected/enabled), and let an operator set which are enabled. Changing
+// the set requires a redeploy to re-merge the runtime config.
+router.get("/agents/:id/mcp-servers", async (req, res) => {
+  try {
+    res.json({ servers: await mcpServers.getAvailableMcpServers(req.params.id) });
+  } catch (e) {
+    res.status(e.statusCode || 500).json({ error: e.message });
+  }
+});
+
+router.put("/agents/:id/mcp-servers", async (req, res) => {
+  try {
+    const providers = Array.isArray(req.body?.providers) ? req.body.providers : [];
+    const enabled = await mcpServers.setAgentMcpServerIds(req.params.id, providers);
+    res.json({
+      enabled,
+      redeployRequired: true,
+      servers: await mcpServers.getAvailableMcpServers(req.params.id),
+    });
   } catch (e) {
     res.status(e.statusCode || 500).json({ error: e.message });
   }

--- a/backend-api/server.ts
+++ b/backend-api/server.ts
@@ -1688,6 +1688,10 @@ async function migrateDB() {
        ALTER TABLE agents ADD COLUMN paused_reason TEXT;
      EXCEPTION WHEN duplicate_column THEN NULL;
      END $$`,
+    `DO $$ BEGIN
+       ALTER TABLE agents ADD COLUMN mcp_servers JSONB DEFAULT '[]';
+     EXCEPTION WHEN duplicate_column THEN NULL;
+     END $$`,
     // ─── Phase 3: agent configuration history ───────────────────────────
     `CREATE TABLE IF NOT EXISTS agent_versions (
        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/docs/api/integrations.mdx
+++ b/docs/api/integrations.mdx
@@ -133,6 +133,60 @@ GET /agents/:id/integrations
 
 ***
 
+## List per-agent MCP servers
+
+List the Model Context Protocol servers available to an agent. Each supported provider is annotated with whether the agent has the integration connected (`connected`) and whether the server is enabled (`enabled`). Requires the `integrations:read` scope.
+
+```
+GET /agents/:id/mcp-servers
+```
+
+### Response
+
+<ResponseField name="servers" type="array">
+  One entry per supported provider, each with `provider`, `name`, `npmPackage`, `docsUrl`, `notes`, `connected`, and `enabled`.
+</ResponseField>
+
+```json theme={null}
+{
+  "servers": [
+    {
+      "provider": "gitlab",
+      "name": "GitLab",
+      "npmPackage": "@modelcontextprotocol/server-gitlab",
+      "docsUrl": "https://github.com/modelcontextprotocol/servers/tree/main/src/gitlab",
+      "notes": "Reference MCP server.",
+      "connected": true,
+      "enabled": false
+    }
+  ]
+}
+```
+
+## Set enabled MCP servers
+
+Replace the set of enabled MCP servers for an agent. Only providers with a connected integration take effect; unknown providers are ignored. The change is applied to the runtime on the agent's next redeploy. Requires the `integrations:write` scope.
+
+```
+PUT /agents/:id/mcp-servers
+```
+
+### Body
+
+<ParamField body="providers" type="string[]" required>
+  Provider ids to enable, e.g. `["gitlab", "notion"]`.
+</ParamField>
+
+```json theme={null}
+{
+  "enabled": ["gitlab"],
+  "redeployRequired": true,
+  "servers": [{ "provider": "gitlab", "connected": true, "enabled": true }]
+}
+```
+
+***
+
 ## Connect an integration
 
 Attach a third-party integration to an agent. The credentials are encrypted and synced to the agent runtime immediately.

--- a/docs/guides/integrations.mdx
+++ b/docs/guides/integrations.mdx
@@ -134,6 +134,16 @@ Nora calls the provider's API using the stored credentials and reports success o
 
 Removing an integration deletes the stored credentials. It does not restart the agent — the environment variables will no longer be injected on the next deployment or sync.
 
+## Expose an integration as an MCP server
+
+Some connected integrations can also run as a [Model Context Protocol](https://modelcontextprotocol.io) (MCP) server inside the agent's OpenClaw runtime, giving the agent that provider's MCP tools directly. The **MCP Servers** panel on the agent's **Integrations** tab lists every supported provider; toggle one on once its integration is connected.
+
+Nora launches each enabled server over stdio with the integration's own credentials — you don't paste anything twice. Supported today: **GitLab, Notion, Stripe, and Supabase**. The set of enabled servers is applied to the runtime on the agent's next **redeploy**, so the panel shows a reminder after a change.
+
+<Note>
+  Providers whose MCP server needs file-based credentials (Google Drive, Kubernetes) or a connection string (PostgreSQL) are not yet available in the panel.
+</Note>
+
 ## Per-provider guides
 
 Every supported integration has a dedicated page that documents where to apply for the credential, which scopes/permissions to grant, and how to connect it to Nora. The same `credentialsUrl` and `setupGuide` content surfaces inline in the dashboard's integration modal, so docs and dashboard stay in sync.

--- a/frontend-dashboard/components/agents/IntegrationsTab.tsx
+++ b/frontend-dashboard/components/agents/IntegrationsTab.tsx
@@ -3,6 +3,7 @@ import { Puzzle, Search, Loader2 } from "lucide-react";
 import IntegrationCard from "./IntegrationCard";
 import ActiveIntegrationsPanel from "./ActiveIntegrationsPanel";
 import IntegrationDetailPanel from "./IntegrationDetailPanel";
+import McpServersSection from "./McpServersSection";
 import { fetchWithAuth } from "../../lib/api";
 import { useToast } from "../Toast";
 import { emitAgentDataChanged, subscribeToAgentDataChanged } from "./agentEvents";
@@ -284,6 +285,9 @@ export default function IntegrationsTab({ agentId }) {
           </div>
         </div>
       )}
+
+      {/* MCP Servers */}
+      <McpServersSection agentId={agentId} />
 
       {/* Catalog Browser */}
       <div className="space-y-4">

--- a/frontend-dashboard/components/agents/McpServersSection.tsx
+++ b/frontend-dashboard/components/agents/McpServersSection.tsx
@@ -1,0 +1,134 @@
+import { useEffect, useState } from "react";
+import { Loader2, Plug, ExternalLink, AlertTriangle } from "lucide-react";
+import { fetchWithAuth } from "../../lib/api";
+import { useToast } from "../Toast";
+
+type McpServer = {
+  provider: string;
+  name: string;
+  npmPackage: string;
+  docsUrl: string | null;
+  notes: string | null;
+  connected: boolean;
+  enabled: boolean;
+};
+
+// Turns a connected integration into a Model Context Protocol server the agent's
+// OpenClaw runtime spawns. Changing the set requires a redeploy to re-merge the
+// runtime config, so we surface that explicitly after a change.
+export default function McpServersSection({ agentId }: { agentId: string }) {
+  const [servers, setServers] = useState<McpServer[] | null>(null);
+  const [saving, setSaving] = useState<string | null>(null);
+  const [dirty, setDirty] = useState(false);
+  const toast = useToast();
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchWithAuth(`/api/agents/${agentId}/mcp-servers`)
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (!cancelled) setServers(d?.servers || []);
+      })
+      .catch(() => {
+        if (!cancelled) setServers([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [agentId]);
+
+  async function toggle(provider: string, next: boolean) {
+    if (!servers) return;
+    const enabledProviders = servers
+      .filter((s) => (s.provider === provider ? next : s.enabled))
+      .map((s) => s.provider);
+    setSaving(provider);
+    try {
+      const res = await fetchWithAuth(`/api/agents/${agentId}/mcp-servers`, {
+        method: "PUT",
+        body: JSON.stringify({ providers: enabledProviders }),
+      });
+      if (!res.ok) throw new Error((await res.json().catch(() => ({})))?.error || "Save failed");
+      const data = await res.json();
+      setServers(data.servers || []);
+      setDirty(true);
+    } catch (error: any) {
+      toast.error(error?.message || "Failed to update MCP servers");
+    } finally {
+      setSaving(null);
+    }
+  }
+
+  if (!servers) {
+    return (
+      <section className="bg-white border border-slate-200 rounded-2xl p-6 shadow-sm">
+        <div className="flex items-center gap-2 text-slate-400">
+          <Loader2 size={16} className="animate-spin" /> Loading MCP servers…
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="bg-white border border-slate-200 rounded-2xl p-6 shadow-sm space-y-4">
+      <div className="flex items-center gap-2">
+        <Plug size={16} className="text-blue-600" />
+        <h3 className="text-sm font-bold text-slate-700">MCP Servers</h3>
+      </div>
+      <p className="text-xs text-slate-500 leading-relaxed">
+        Expose a connected integration to this agent as a Model Context Protocol server. The runtime
+        spawns each enabled server with the integration&apos;s own credentials.
+      </p>
+
+      {dirty ? (
+        <div className="flex items-center gap-2 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2">
+          <AlertTriangle size={14} className="text-amber-600 shrink-0" />
+          <span className="text-xs font-semibold text-amber-800">
+            Redeploy the agent to apply MCP server changes.
+          </span>
+        </div>
+      ) : null}
+
+      <ul className="divide-y divide-slate-100">
+        {servers.map((server) => (
+          <li key={server.provider} className="flex items-center gap-4 py-3">
+            <div className="flex min-w-0 flex-1 flex-col">
+              <span className="text-sm font-semibold text-slate-900">{server.name}</span>
+              <span className="text-[11px] font-mono text-slate-400 truncate">
+                {server.npmPackage}
+              </span>
+              {!server.connected ? (
+                <span className="text-[11px] text-slate-400">
+                  Connect the {server.name} integration above to enable.
+                </span>
+              ) : server.docsUrl ? (
+                <a
+                  href={server.docsUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="inline-flex items-center gap-1 text-[11px] text-blue-600 hover:underline w-fit"
+                >
+                  Server docs <ExternalLink size={11} />
+                </a>
+              ) : null}
+            </div>
+            {saving === server.provider ? (
+              <Loader2 size={16} className="animate-spin text-slate-400" />
+            ) : (
+              <label className="relative inline-flex cursor-pointer items-center">
+                <input
+                  type="checkbox"
+                  className="peer sr-only"
+                  checked={server.enabled}
+                  disabled={!server.connected}
+                  onChange={(e) => toggle(server.provider, e.target.checked)}
+                />
+                <div className="h-5 w-9 rounded-full bg-slate-200 peer-checked:bg-blue-600 peer-disabled:opacity-40 transition-colors after:absolute after:left-0.5 after:top-0.5 after:h-4 after:w-4 after:rounded-full after:bg-white after:transition-all peer-checked:after:translate-x-4" />
+              </label>
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/infra/helm/nora/files/db_schema.sql
+++ b/infra/helm/nora/files/db_schema.sql
@@ -46,6 +46,7 @@ CREATE TABLE IF NOT EXISTS agents (
   ram_mb INTEGER DEFAULT 1024,
   disk_gb INTEGER DEFAULT 10,
   paused_reason TEXT,
+  mcp_servers JSONB DEFAULT '[]',
   created_at TIMESTAMP DEFAULT NOW()
 );
 

--- a/workers/provisioner/backends/docker.ts
+++ b/workers/provisioner/backends/docker.ts
@@ -5,6 +5,7 @@ const path = require("path");
 const {
   buildOpenClawInstallCommand,
   buildOpenClawConfigMergeScript,
+  buildMcpServersConfig,
   buildOpenClawCustomProviders,
   buildIntegrationToolWrapperScript,
   buildRuntimeBootstrapFiles,
@@ -331,6 +332,7 @@ class DockerBackend extends ProvisionerBackend {
       env,
       container_name,
       templatePayload,
+      mcpServers: mcpServerEntries,
       abortSignal,
     } = config;
     const containerName = container_name || safeContainerName("nora-oclaw", name, id);
@@ -608,6 +610,11 @@ class DockerBackend extends ProvisionerBackend {
     const customProviders = buildOpenClawCustomProviders(env || {});
     if (Object.keys(customProviders).length > 0) {
       gatewayConfig.models = { providers: customProviders };
+    }
+    // Per-agent MCP servers (credential-resolved by the worker). OpenClaw spawns
+    // each over stdio; merged into openclaw.json alongside the other config.
+    if (Array.isArray(mcpServerEntries) && mcpServerEntries.length > 0) {
+      gatewayConfig.mcpServers = buildMcpServersConfig(mcpServerEntries);
     }
 
     const bootstrapFiles = this._buildBootstrapFiles({

--- a/workers/provisioner/worker.ts
+++ b/workers/provisioner/worker.ts
@@ -25,6 +25,7 @@ const {
   buildIntegrationSyncEntry,
   decryptSensitiveConfig,
 } = require("../../backend-api/integrations");
+const mcpServers = require("../../backend-api/mcpServers");
 const {
   HERMES_INTEGRATIONS_CONFIG_FILE,
   HERMES_INTEGRATIONS_DIR,
@@ -1371,7 +1372,7 @@ const worker = new Worker(
     try {
       const agentRowResult = await db.query(
         `SELECT image, template_payload, sandbox_type, backend_type, runtime_family,
-            deploy_target, execution_target_id, sandbox_profile, gateway_token
+            deploy_target, execution_target_id, sandbox_profile, gateway_token, mcp_servers
        FROM agents
       WHERE id = $1`,
         [id],
@@ -1437,6 +1438,9 @@ const worker = new Worker(
 
       // Fetch integration credentials for this agent and inject as env vars into the container
       let integrationEnvVars = {};
+      // Decrypted creds for providers the operator enabled as MCP servers, keyed
+      // by provider — resolved into an openclaw.json mcpServers block below.
+      const mcpIntegrationsByProvider = {};
       try {
         const INTEGRATION_ENV_MAP = {
           huggingface: "HF_TOKEN",
@@ -1619,6 +1623,19 @@ const worker = new Worker(
               integrationEnvVars[cfgEnvName] = String(cfgValue);
             }
           }
+          // Stash the decrypted token+config for providers that can back an MCP
+          // server, so an enabled MCP server gets the credential its own server
+          // expects (which differs from the generic tool env var above).
+          if (mcpServers.isSupportedProvider(row.provider) && row.access_token) {
+            try {
+              mcpIntegrationsByProvider[row.provider] = {
+                token: decrypt(row.access_token),
+                config: cfg,
+              };
+            } catch {
+              // Already logged above when the tool token failed to decrypt.
+            }
+          }
         }
         if (Object.keys(integrationEnvVars).length > 0) {
           console.log(
@@ -1644,6 +1661,26 @@ const worker = new Worker(
           `[provisioner] Failed to fetch agent secret overrides for agent ${id}:`,
           e.message,
         );
+      }
+
+      // Resolve the agent's enabled MCP servers into openclaw.json entries
+      // (credential-injected). Empty unless the operator enabled one and the
+      // backing integration is connected. OpenClaw-only; ignored elsewhere.
+      let mcpServerEntries = [];
+      try {
+        mcpServerEntries = mcpServers.resolveMcpEntries({
+          enabledIds: agentRow.mcp_servers,
+          integrationsByProvider: mcpIntegrationsByProvider,
+        });
+        if (mcpServerEntries.length > 0) {
+          console.log(
+            `[provisioner] Wiring ${mcpServerEntries.length} MCP server(s) for agent ${id}: ${mcpServerEntries
+              .map((e) => e.name)
+              .join(", ")}`,
+          );
+        }
+      } catch (e) {
+        console.warn(`[provisioner] Failed to resolve MCP servers for agent ${id}:`, e.message);
       }
 
       const configuredProvisionTimeout = parseTimeoutMs(process.env.PROVISION_TIMEOUT_MS, 840000);
@@ -1678,6 +1715,7 @@ const worker = new Worker(
           container_name,
           gatewayToken: agentRow.gateway_token || undefined,
           templatePayload,
+          mcpServers: mcpServerEntries,
           runtimeFamily: resolvedRuntimeFields.runtime_family,
           deployTarget: resolvedRuntimeFields.deploy_target,
           executionTargetId: resolvedRuntimeFields.execution_target_id,


### PR DESCRIPTION
## What

Lets an operator expose a **connected integration** to an agent as a **Model Context Protocol server** that the agent's OpenClaw runtime spawns over stdio — with the integration's own credentials, nothing pasted twice (PR-6 of the pre-launch plan, the ⚠️ shared-zone item).

Supported now: **GitLab, Notion, Stripe, Supabase** — the four single-token providers whose stored credential maps cleanly to the env var their MCP server expects. Deferred: postgresql (needs `POSTGRES_URL` assembled from a multi-field credential) and the file-credential providers (google-drive, kubernetes).

## Verify-first gate (passed)

The plan gated this design on whether OpenClaw actually consumes an `mcpServers` config block. Verified against the shipped runtime bundle (OpenClaw 2026.4.15 inside a live `nora-openclaw-agent:local` container): 146 `mcpServers` references, a dedicated `mcp-config` module, and `StdioClientTransport` — it spawns `{command, args, env}` stdio entries from `openclaw.json`. The dockerBootstrap fixture test proves our block lands verbatim in the rendered start.sh deep-merge.

## How

- **backend-api/mcpServers.ts** — supported-provider map translating each stored credential to the env var *its MCP server* reads (e.g. `GITLAB_PERSONAL_ACCESS_TOKEN`, not the tool layer's generic `GITLAB_TOKEN`); catalog filter (`mcp.available && transport=stdio && npmPackage` — the catalog stays the source of truth); enabled-ids CRUD on a new additive `agents.mcp_servers JSONB` column; and a **pure** `resolveMcpEntries` the worker calls with decrypted creds.
- **routes/integrations.ts** — `GET/PUT /agents/:id/mcp-servers` behind `requireAccessibleAgent("editor")` (which also enforces API-key workspace binding) + `integrations:read/write` scopes.
- **agent-runtime (shared)** — new dependency-free `lib/mcpServersConfig.ts` builder for the `mcpServers` block, re-exported from `runtimeBootstrap` for adapter consumers.
- **workers/provisioner (shared)** — the deploy path resolves enabled ids + decrypted integration creds into entries and threads them into `create()`; the docker adapter merges the block into the `openclaw.json` deep-merge beside gateway/model config.
- **frontend-dashboard** — *MCP Servers* panel on the agent Integrations tab: per-provider toggle (disabled until the integration is connected), docs links, and a redeploy-required notice after changes.
- **Schema** — additive `agents.mcp_servers JSONB DEFAULT '[]'` (db_schema + idempotent migrateDB); Helm vendored schema re-synced (drift guard green, chart renders 21 valid resources).

## Shared-zone diligence

Per CLAUDE.md, both consumers verified: **typecheck green in backend-api, workers/provisioner, and agent-runtime** (plus frontend-dashboard). Full backend suite: **125 suites / 973 tests**. agent-runtime vitest: 10/10.

## Tests

6 backend unit tests (catalog filter, id normalization, credential resolution incl. the GitLab self-hosted URL config-env path, connected/enabled annotation, persistence validation), 4 agent-runtime vitest on the config shape, and 1 dockerBootstrap end-to-end fixture asserting the rendered startup script carries `mcpServers` + the credential env.

## Notes

- An enabled server whose integration is later disconnected simply resolves to no entry at the next deploy — fail-safe, no dangling creds.
- Changing the set requires a redeploy (config is merged at bootstrap); the UI says so explicitly.
- Live end-to-end (deploy an agent with a real GitLab token and watch the MCP tools appear) needs a real provider credential — the rendered-config fixture covers the wiring deterministically.