### PR TITLE
feat(demo): zero-key first-run demo agent on a built-in stub provider

### DIFF
--- a/agent-runtime/lib/runtimeBootstrap.ts
+++ b/agent-runtime/lib/runtimeBootstrap.ts
@@ -25,6 +25,10 @@ const RUNTIME_FILES = [
   "containerCommand.ts",
   "contracts.ts",
   "runtimeBootstrap.ts",
+  // Required by runtimeBootstrap's require("./mcpServersConfig") — every module
+  // runtimeBootstrap imports relatively must ship into the container with it,
+  // or the in-container runtime server fails at load.
+  "mcpServersConfig.ts",
   "execEndpoint.ts",
   "integrationTools.ts",
   "integrationToolCli.ts",
@@ -451,14 +455,44 @@ function buildOpenClawCustomProviders(env = {}) {
       models: buildFoundryModelEntries(env),
     };
   }
+  // Nora's zero-key demo provider: an OpenAI-compatible stub served by the
+  // control plane itself. The worker injects the derived token plus the
+  // in-network base URL (sister env var, same mechanism as Foundry's).
+  const demoToken = env.NORA_DEMO_LLM_TOKEN;
+  const demoBaseUrl = env.NORA_DEMO_LLM_BASE_URL;
+  if (demoToken && demoBaseUrl) {
+    providers[DEMO_OPENCLAW_PROVIDER_ID] = {
+      api: "openai-completions",
+      baseUrl: String(demoBaseUrl).replace(/\/+$/, ""),
+      apiKey: demoToken,
+      models: [
+        {
+          id: DEMO_OPENCLAW_MODEL_ID,
+          name: "Nora Demo (deterministic stub)",
+          api: "openai-completions",
+          reasoning: false,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow: 32768,
+          maxTokens: 4096,
+        },
+      ],
+    };
+  }
   return providers;
 }
 
+// OpenClaw-side ids for the zero-key demo provider. Distinct from Nora's
+// internal "demo" id so a future builtin OpenClaw provider can't collide.
+const DEMO_OPENCLAW_PROVIDER_ID = "nora-demo";
+const DEMO_OPENCLAW_MODEL_ID = "nora-demo-1";
+
 // Maps Nora's internal LLM provider id to the OpenClaw provider id that
 // must appear in model strings (e.g. `<provider>/<deployment>`). Only Foundry
-// needs translation today; everything else passes through unchanged.
+// and the demo stub need translation; everything else passes through unchanged.
 const NORA_TO_OPENCLAW_PROVIDER_ID = Object.freeze({
   "microsoft-foundry": FOUNDRY_OPENCLAW_PROVIDER_ID,
+  demo: DEMO_OPENCLAW_PROVIDER_ID,
 });
 
 function mapNoraProviderIdToOpenClaw(noraProviderId) {
@@ -636,6 +670,8 @@ module.exports = {
   buildOpenClawCustomProviders,
   mapNoraProviderIdToOpenClaw,
   FOUNDRY_OPENCLAW_PROVIDER_ID,
+  DEMO_OPENCLAW_PROVIDER_ID,
+  DEMO_OPENCLAW_MODEL_ID,
   resolveFoundryDeployment,
   foundryDefaultModel,
   buildTemplatePayloadBootstrapCommand,

--- a/backend-api/__tests__/demoLlm.test.ts
+++ b/backend-api/__tests__/demoLlm.test.ts
@@ -1,0 +1,136 @@
+// @ts-nocheck
+const express = require("express");
+const request = require("supertest");
+
+process.env.JWT_SECRET = process.env.JWT_SECRET || "secret";
+
+const {
+  DEMO_MODEL_ID,
+  deriveDemoToken,
+  demoLlmBaseUrl,
+  buildDemoReply,
+  chunkReply,
+} = require("../demoLlm");
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  app.use("/demo-llm", require("../routes/demoLlm"));
+  return app;
+}
+
+const TOKEN = deriveDemoToken();
+
+describe("demoLlm helpers", () => {
+  it("derives a stable token from JWT_SECRET", () => {
+    expect(deriveDemoToken()).toBe(deriveDemoToken());
+    expect(deriveDemoToken({ JWT_SECRET: "a" })).not.toBe(deriveDemoToken({ JWT_SECRET: "b" }));
+  });
+
+  it("builds the in-network stub URL from the backend env contract", () => {
+    expect(demoLlmBaseUrl({})).toBe("http://backend-api:4000/demo-llm/v1");
+    expect(demoLlmBaseUrl({ BACKEND_API_URL: "http://api.internal:9999/" })).toBe(
+      "http://api.internal:9999/demo-llm/v1",
+    );
+    expect(
+      demoLlmBaseUrl({
+        AGENT_RUNTIME_BACKEND_API_URL: "http://k8s-backend:4000",
+        BACKEND_API_URL: "http://other",
+      }),
+    ).toBe("http://k8s-backend:4000/demo-llm/v1");
+  });
+
+  it("produces a deterministic reply echoing the user message", () => {
+    const messages = [{ role: "user", content: "Hello demo" }];
+    expect(buildDemoReply(messages)).toBe(buildDemoReply(messages));
+    expect(buildDemoReply(messages)).toContain('You said: "Hello demo"');
+  });
+
+  it("chunks replies without losing characters", () => {
+    const reply = buildDemoReply([{ role: "user", content: "chunk me please" }]);
+    expect(chunkReply(reply).join("")).toBe(reply);
+  });
+});
+
+describe("POST /demo-llm/v1/chat/completions", () => {
+  it("rejects a missing or wrong bearer token", async () => {
+    const app = makeApp();
+    const noAuth = await request(app).post("/demo-llm/v1/chat/completions").send({ messages: [] });
+    expect(noAuth.status).toBe(401);
+    const badAuth = await request(app)
+      .post("/demo-llm/v1/chat/completions")
+      .set("Authorization", "Bearer wrong")
+      .send({ messages: [] });
+    expect(badAuth.status).toBe(401);
+  });
+
+  it("returns an OpenAI-shaped non-streaming completion", async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .post("/demo-llm/v1/chat/completions")
+      .set("Authorization", `Bearer ${TOKEN}`)
+      .send({ model: DEMO_MODEL_ID, messages: [{ role: "user", content: "ping" }] });
+    expect(res.status).toBe(200);
+    expect(res.body.object).toBe("chat.completion");
+    expect(res.body.model).toBe(DEMO_MODEL_ID);
+    expect(res.body.choices[0].message.role).toBe("assistant");
+    expect(res.body.choices[0].message.content).toContain('You said: "ping"');
+    expect(res.body.choices[0].finish_reason).toBe("stop");
+  });
+
+  it("streams SSE chunks with OpenAI delta framing and a [DONE] sentinel", async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .post("/demo-llm/v1/chat/completions")
+      .set("Authorization", `Bearer ${TOKEN}`)
+      .send({ stream: true, messages: [{ role: "user", content: "stream test" }] });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toMatch(/text\/event-stream/);
+
+    const events = res.text
+      .split("\n\n")
+      .filter((line) => line.startsWith("data: "))
+      .map((line) => line.slice(6));
+    expect(events[events.length - 1]).toBe("[DONE]");
+
+    const parsed = events.slice(0, -1).map((e) => JSON.parse(e));
+    expect(parsed[0].choices[0].delta.role).toBe("assistant");
+    expect(parsed[parsed.length - 1].choices[0].finish_reason).toBe("stop");
+    const text = parsed.map((p) => p.choices[0].delta.content || "").join("");
+    expect(text).toContain('You said: "stream test"');
+    // Reassembled stream matches the non-streaming reply exactly.
+    expect(text).toBe(buildDemoReply([{ role: "user", content: "stream test" }]));
+  });
+
+  it("lists the demo model", async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .get("/demo-llm/v1/models")
+      .set("Authorization", `Bearer ${TOKEN}`);
+    expect(res.status).toBe(200);
+    expect(res.body.data[0].id).toBe(DEMO_MODEL_ID);
+  });
+});
+
+describe("runtime wiring", () => {
+  it("registers the nora-demo custom provider when token+url env are present", () => {
+    const {
+      buildOpenClawCustomProviders,
+      mapNoraProviderIdToOpenClaw,
+    } = require("../../agent-runtime/lib/runtimeBootstrap");
+    const providers = buildOpenClawCustomProviders({
+      NORA_DEMO_LLM_TOKEN: "tok",
+      NORA_DEMO_LLM_BASE_URL: "http://backend-api:4000/demo-llm/v1/",
+    });
+    expect(providers["nora-demo"]).toMatchObject({
+      api: "openai-completions",
+      baseUrl: "http://backend-api:4000/demo-llm/v1",
+      apiKey: "tok",
+    });
+    expect(providers["nora-demo"].models[0].id).toBe("nora-demo-1");
+    expect(mapNoraProviderIdToOpenClaw("demo")).toBe("nora-demo");
+    // No env -> no provider.
+    expect(buildOpenClawCustomProviders({})).toEqual({});
+  });
+});

--- a/backend-api/__tests__/dockerBootstrap.test.ts
+++ b/backend-api/__tests__/dockerBootstrap.test.ts
@@ -444,3 +444,25 @@ describe("Provisioner backends", () => {
     expect(nemoclawSource).toContain('"$OPENCLAW_BIN" gateway');
   });
 });
+
+// Every module runtimeBootstrap.ts (and the other shipped runtime files)
+// require()s relatively must itself be in RUNTIME_FILES — otherwise the
+// in-container runtime server crashes at load with MODULE_NOT_FOUND (this
+// happened with mcpServersConfig). Walk the shipped sources and assert closure.
+describe("runtime bundle closure", () => {
+  it("ships every relatively-required module into the container", () => {
+    const runtimeBootstrap = require("../../agent-runtime/lib/runtimeBootstrap");
+    const shipped = runtimeBootstrap.buildRuntimeBootstrapFiles();
+    const shippedNames = new Set(shipped.map((f) => f.relPath));
+    const missing = [];
+    for (const file of shipped) {
+      const requires = [...file.source.matchAll(/require\(["']\.\/([A-Za-z0-9_-]+)["']\)/g)];
+      for (const [, mod] of requires) {
+        if (!shippedNames.has(`${mod}.ts`) && !shippedNames.has(`${mod}.js`)) {
+          missing.push(`${file.relPath} requires ./${mod}`);
+        }
+      }
+    }
+    expect(missing).toEqual([]);
+  });
+});

--- a/backend-api/demoLlm.ts
+++ b/backend-api/demoLlm.ts
@@ -1,0 +1,117 @@
+// @ts-nocheck
+// Zero-key demo LLM: a deterministic OpenAI-compatible stub served by the
+// backend itself, so a fresh install can deploy a working agent and see a chat
+// round-trip before adding any real provider key.
+//
+// The demo "provider" rides the existing LLM provider machinery end to end:
+// adding provider id "demo" stores a derived token as the api key and the stub
+// URL as config.baseUrl, the worker decrypts/injects them like any provider
+// (NORA_DEMO_LLM_TOKEN + NORA_DEMO_LLM_BASE_URL), and the runtime registers an
+// openai-completions custom provider pointing back at this stub.
+
+const crypto = require("crypto");
+
+const DEMO_PROVIDER_ID = "demo";
+const DEMO_MODEL_ID = "nora-demo-1";
+
+// Stable per-installation bearer token. Derived from JWT_SECRET so the worker
+// and backend agree without a new secret; not security-critical (the stub
+// returns canned text), the check just keeps the endpoint from being an open
+// relay for junk traffic.
+function deriveDemoToken(env = process.env) {
+  return crypto
+    .createHmac("sha256", String(env.JWT_SECRET || "nora-demo"))
+    .update("nora-demo-llm-v1")
+    .digest("hex");
+}
+
+// The stub URL as reachable FROM AGENT CONTAINERS (not the public origin) —
+// same resolution as buildRuntimeEnv's BACKEND_API_URL.
+function demoLlmBaseUrl(env = process.env) {
+  const backendUrl =
+    env.AGENT_RUNTIME_BACKEND_API_URL || env.BACKEND_API_URL || "http://backend-api:4000";
+  return `${String(backendUrl).replace(/\/+$/, "")}/demo-llm/v1`;
+}
+
+function lastUserMessage(messages = []) {
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const m = messages[i];
+    if (m?.role !== "user") continue;
+    if (typeof m.content === "string") return m.content;
+    if (Array.isArray(m.content)) {
+      const text = m.content.find((p) => p?.type === "text");
+      if (text?.text) return text.text;
+    }
+  }
+  return "";
+}
+
+// Deterministic reply: a short demo-agent persona answer keyed off the user's
+// message. No randomness — tests and the e2e journey assert on this text.
+function buildDemoReply(messages = []) {
+  const userText = lastUserMessage(messages).trim();
+  const intro =
+    "Hi! I'm Nora's demo agent, running on a built-in stub model — no API key required.";
+  if (!userText) {
+    return `${intro} Say anything and I'll echo a deterministic response. When you're ready for real intelligence, add an LLM provider key under Providers and redeploy.`;
+  }
+  return [
+    intro,
+    "",
+    `You said: "${userText}"`,
+    "",
+    "This response is generated locally by your Nora control plane (deterministic, zero cost). To chat with a real model, add a provider key under Providers and switch this agent off the demo provider.",
+  ].join("\n");
+}
+
+// OpenAI chat-completions response envelope. `created` is caller-supplied so
+// responses stay deterministic where tests need them to be.
+function buildCompletionPayload(reply, { model = DEMO_MODEL_ID, created, id } = {}) {
+  return {
+    id: id || `chatcmpl-nora-demo-${crypto.randomBytes(8).toString("hex")}`,
+    object: "chat.completion",
+    created: created ?? Math.floor(Date.now() / 1000),
+    model,
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content: reply },
+        finish_reason: "stop",
+      },
+    ],
+    usage: {
+      prompt_tokens: 0,
+      completion_tokens: 0,
+      total_tokens: 0,
+    },
+  };
+}
+
+// Split a reply into SSE-sized word chunks (OpenAI delta framing).
+function chunkReply(reply, chunkWords = 6) {
+  const words = String(reply).split(/(\s+)/); // keep whitespace tokens
+  const chunks = [];
+  let current = "";
+  let count = 0;
+  for (const token of words) {
+    current += token;
+    if (/\S/.test(token)) count += 1;
+    if (count >= chunkWords) {
+      chunks.push(current);
+      current = "";
+      count = 0;
+    }
+  }
+  if (current) chunks.push(current);
+  return chunks;
+}
+
+module.exports = {
+  DEMO_PROVIDER_ID,
+  DEMO_MODEL_ID,
+  deriveDemoToken,
+  demoLlmBaseUrl,
+  buildDemoReply,
+  buildCompletionPayload,
+  chunkReply,
+};

--- a/backend-api/llmProviders.ts
+++ b/backend-api/llmProviders.ts
@@ -9,15 +9,6 @@ const { DEMO_PROVIDER_ID, DEMO_MODEL_ID, deriveDemoToken, demoLlmBaseUrl } = req
 // Models updated per https://docs.openclaw.ai/providers (April 2026)
 const PROVIDERS = [
   {
-    // Zero-key demo: a deterministic stub served by this control plane. No
-    // user key — addProvider derives the token + in-network base URL itself.
-    id: DEMO_PROVIDER_ID,
-    name: "Demo (built-in, no key required)",
-    envVar: "NORA_DEMO_LLM_TOKEN",
-    requiresApiKey: false,
-    models: [DEMO_MODEL_ID],
-  },
-  {
     id: "anthropic",
     name: "Anthropic",
     envVar: "ANTHROPIC_API_KEY",
@@ -111,6 +102,16 @@ const PROVIDERS = [
       "AI21-Jamba-1.5-Large",
     ],
   },
+  {
+    // Zero-key demo: a deterministic stub served by this control plane. No
+    // user key — addProvider derives the token + in-network base URL itself.
+    // Deliberately LAST so key-based providers stay first in pickers.
+    id: DEMO_PROVIDER_ID,
+    name: "Demo (built-in, no key required)",
+    envVar: "NORA_DEMO_LLM_TOKEN",
+    requiresApiKey: false,
+    models: [DEMO_MODEL_ID],
+  },
 ];
 
 function getAvailableProviders() {
@@ -119,6 +120,7 @@ function getAvailableProviders() {
       id,
       name,
       models,
+      requiresApiKey,
       requiresBaseUrl,
       baseUrlPlaceholder,
       supportsApiVersion,
@@ -127,6 +129,7 @@ function getAvailableProviders() {
       id,
       name,
       models,
+      ...(requiresApiKey === false ? { requiresApiKey: false } : {}),
       ...(requiresBaseUrl ? { requiresBaseUrl: true } : {}),
       ...(baseUrlPlaceholder ? { baseUrlPlaceholder } : {}),
       ...(supportsApiVersion ? { supportsApiVersion: true } : {}),

--- a/backend-api/llmProviders.ts
+++ b/backend-api/llmProviders.ts
@@ -3,10 +3,20 @@
 
 const db = require("./db");
 const { encrypt, decrypt, ensureEncryptionConfigured } = require("./crypto");
+const { DEMO_PROVIDER_ID, DEMO_MODEL_ID, deriveDemoToken, demoLlmBaseUrl } = require("./demoLlm");
 
 // Approved LLM providers and their env var names
 // Models updated per https://docs.openclaw.ai/providers (April 2026)
 const PROVIDERS = [
+  {
+    // Zero-key demo: a deterministic stub served by this control plane. No
+    // user key — addProvider derives the token + in-network base URL itself.
+    id: DEMO_PROVIDER_ID,
+    name: "Demo (built-in, no key required)",
+    envVar: "NORA_DEMO_LLM_TOKEN",
+    requiresApiKey: false,
+    models: [DEMO_MODEL_ID],
+  },
   {
     id: "anthropic",
     name: "Anthropic",
@@ -165,9 +175,18 @@ async function addProvider(userId, provider, apiKey, model, config = {}) {
   if (!PROVIDERS.find((p) => p.id === provider)) {
     throw new Error(`Unknown LLM provider: ${provider}`);
   }
-  if (!apiKey) throw new Error("API key is required");
-
-  ensureEncryptionConfigured("LLM provider credential storage");
+  if (provider === DEMO_PROVIDER_ID) {
+    // Zero-key path: the token is derived (not user secret material) and the
+    // base URL points at this control plane's stub as reachable from agent
+    // containers. Deliberately no ensureEncryptionConfigured — the demo must
+    // work on a fresh install before any secrets are set up.
+    apiKey = deriveDemoToken();
+    model = model || DEMO_MODEL_ID;
+    config = { ...config, baseUrl: demoLlmBaseUrl() };
+  } else {
+    if (!apiKey) throw new Error("API key is required");
+    ensureEncryptionConfigured("LLM provider credential storage");
+  }
   const encryptedKey = encrypt(apiKey);
 
   // If no other providers exist for this user, make it default

--- a/backend-api/routes/demoLlm.ts
+++ b/backend-api/routes/demoLlm.ts
@@ -1,0 +1,74 @@
+// @ts-nocheck
+// OpenAI-compatible endpoints for the zero-key demo provider. Mounted PRE-auth
+// (agent runtimes call this directly over the container network with the
+// derived demo bearer token, not a JWT). Deterministic output, zero cost.
+
+const express = require("express");
+const {
+  DEMO_MODEL_ID,
+  deriveDemoToken,
+  buildDemoReply,
+  buildCompletionPayload,
+  chunkReply,
+} = require("../demoLlm");
+
+const router = express.Router();
+
+function checkDemoAuth(req, res) {
+  const header = String(req.headers.authorization || "");
+  const token = header.startsWith("Bearer ") ? header.slice(7).trim() : "";
+  if (!token || token !== deriveDemoToken()) {
+    res
+      .status(401)
+      .json({ error: { message: "Invalid demo token", type: "invalid_request_error" } });
+    return false;
+  }
+  return true;
+}
+
+// pi-ai/OpenAI clients may probe the model list.
+router.get("/v1/models", (req, res) => {
+  if (!checkDemoAuth(req, res)) return;
+  res.json({
+    object: "list",
+    data: [{ id: DEMO_MODEL_ID, object: "model", owned_by: "nora-demo" }],
+  });
+});
+
+router.post("/v1/chat/completions", (req, res) => {
+  if (!checkDemoAuth(req, res)) return;
+  const body = req.body || {};
+  const messages = Array.isArray(body.messages) ? body.messages : [];
+  const reply = buildDemoReply(messages);
+  const model = typeof body.model === "string" && body.model ? body.model : DEMO_MODEL_ID;
+
+  if (!body.stream) {
+    return res.json(buildCompletionPayload(reply, { model }));
+  }
+
+  // SSE streaming with OpenAI delta framing. Chunked transfer is what the
+  // gateway chat path expects; flush per event so deltas render live.
+  res.status(200);
+  res.setHeader("Content-Type", "text/event-stream; charset=utf-8");
+  res.setHeader("Cache-Control", "no-cache, no-transform");
+  res.setHeader("Connection", "keep-alive");
+  res.flushHeaders?.();
+
+  const id = `chatcmpl-nora-demo-${Date.now().toString(36)}`;
+  const created = Math.floor(Date.now() / 1000);
+  const base = { id, object: "chat.completion.chunk", created, model };
+
+  const send = (payload) => {
+    res.write(`data: ${JSON.stringify(payload)}\n\n`);
+  };
+
+  send({ ...base, choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] });
+  for (const chunk of chunkReply(reply)) {
+    send({ ...base, choices: [{ index: 0, delta: { content: chunk }, finish_reason: null }] });
+  }
+  send({ ...base, choices: [{ index: 0, delta: {}, finish_reason: "stop" }] });
+  res.write("data: [DONE]\n\n");
+  res.end();
+});
+
+module.exports = router;

--- a/backend-api/routes/llmProviders.ts
+++ b/backend-api/routes/llmProviders.ts
@@ -21,7 +21,9 @@ router.get("/", async (req, res, next) => {
 router.post("/", async (req, res) => {
   try {
     const { provider, apiKey, model, config } = req.body;
-    if (!provider || !apiKey)
+    // The built-in demo provider is the one zero-key path (its token is
+    // derived server-side); every real provider still requires a key.
+    if (!provider || (!apiKey && provider !== "demo"))
       return res.status(400).json({ error: "provider and apiKey required" });
     const result = await llmProviders.addProvider(req.user.id, provider, apiKey, model, config);
     syncAuthToUserAgents(req.user.id).catch(() => {});

--- a/backend-api/server.ts
+++ b/backend-api/server.ts
@@ -756,6 +756,10 @@ app.post("/webhooks/:channelId", async (req, res) => {
 
 app.use("/auth", require("./routes/auth"));
 
+// Zero-key demo LLM stub (OpenAI-compatible). Pre-auth: agent runtimes call it
+// over the container network with the derived demo bearer token, not a JWT.
+app.use("/demo-llm", require("./routes/demoLlm"));
+
 // ─── Gateway UI static assets (before auth wall — JS/CSS/icons contain no user data) ──
 // These are served pre-auth because iframes can't set Authorization headers on sub-resource loads.
 // Only opaque static files (JS bundles, CSS, favicons) are exempted — not HTML or

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -67,7 +67,7 @@ This guide takes you from a fresh machine to a running, validated agent runtime.
     Open **Settings** in the dashboard. Add an API key for a supported provider such as Anthropic, OpenAI, or Google. Nora encrypts provider keys at rest with AES-256-GCM and stores them centrally so you can sync them to any running agent at any time.
 
     <Tip>
-      Start with one key to validate the end-to-end flow. You can add more providers later from the same Settings page.
+      **No API key yet?** Click **Try the demo agent** on the Getting Started page instead. It enables Nora's built-in demo provider — a deterministic stub model served by your own control plane — and deploys a working agent you can chat with immediately, zero keys and zero cost. Swap in a real provider whenever you're ready.
     </Tip>
 
   </Step>

--- a/e2e/specs/navigation.spec.ts
+++ b/e2e/specs/navigation.spec.ts
@@ -43,7 +43,11 @@ test.describe("Public marketing pages", () => {
     ).toBeVisible();
 
     await page.goto("/signup");
-    await expect(page.getByRole("heading", { name: /create operator account/i })).toBeVisible();
+    // A zero-user instance renders first-run claim mode instead of the generic
+    // signup heading — both are legitimate states for this route.
+    await expect(
+      page.getByRole("heading", { name: /create operator account|claim this server/i }),
+    ).toBeVisible();
   });
 
   test("Spanish and French public routes render localized copy", async ({ page }) => {
@@ -71,7 +75,9 @@ test.describe("Public marketing pages", () => {
     ).toBeVisible();
 
     await page.goto("/fr/signup");
-    await expect(page.getByRole("heading", { name: /creer un compte operateur/i })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: /creer un compte operateur|claim this server/i }),
+    ).toBeVisible();
   });
 
   test("Simplified and Traditional Chinese routes render localized copy", async ({ page }) => {

--- a/e2e/specs/support/app.ts
+++ b/e2e/specs/support/app.ts
@@ -155,7 +155,13 @@ async function listAvailableProviders(request: APIRequestContext, token: string)
 
 async function getPreferredProvider(request: APIRequestContext, token: string) {
   const providers = await listAvailableProviders(request, token);
-  return providers.find((provider) => provider?.id && provider?.name) || null;
+  // Skip keyless providers (the built-in demo stub): this helper feeds the
+  // settings flow that types an API key into the provider form.
+  return (
+    providers.find(
+      (provider) => provider?.id && provider?.name && provider?.requiresApiKey !== false,
+    ) || null
+  );
 }
 
 async function waitForCondition<T>(

--- a/frontend-dashboard/pages/getting-started.tsx
+++ b/frontend-dashboard/pages/getting-started.tsx
@@ -1,6 +1,67 @@
+import { useState } from "react";
 import Layout from "../components/layout/Layout";
 import ActivationChecklist from "../components/onboarding/ActivationChecklist";
-import { ArrowRight, Bot, CheckCircle2, FolderKanban, KeyRound, Rocket, Shield } from "lucide-react";
+import { fetchWithAuth } from "../lib/api";
+import {
+  ArrowRight,
+  Bot,
+  CheckCircle2,
+  FolderKanban,
+  KeyRound,
+  Loader2,
+  Rocket,
+  Shield,
+  Sparkles,
+} from "lucide-react";
+
+// One-click zero-key demo: add the built-in demo provider (no key) and deploy
+// an agent against it, then land on the agent page for the first chat.
+function TryDemoButton() {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState("");
+
+  async function startDemo() {
+    setBusy(true);
+    setError("");
+    try {
+      const providerRes = await fetchWithAuth("/api/llm-providers", {
+        method: "POST",
+        body: JSON.stringify({ provider: "demo" }),
+      });
+      if (!providerRes.ok) {
+        const data = await providerRes.json().catch(() => ({}));
+        throw new Error(data.error || "Could not enable the demo provider");
+      }
+      const deployRes = await fetchWithAuth("/api/agents/deploy", {
+        method: "POST",
+        body: JSON.stringify({ name: "Demo Agent" }),
+      });
+      const agent = await deployRes.json().catch(() => ({}));
+      if (!deployRes.ok || !agent.id) {
+        throw new Error(agent.error || "Could not deploy the demo agent");
+      }
+      window.location.assign(`/app/agents/${agent.id}`);
+    } catch (err: any) {
+      setError(err?.message || "Demo setup failed");
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      <button
+        type="button"
+        onClick={startDemo}
+        disabled={busy}
+        className="inline-flex items-center gap-2 rounded-xl bg-emerald-600 text-white px-4 py-3 text-sm font-bold hover:bg-emerald-700 transition-all disabled:opacity-60"
+      >
+        {busy ? <Loader2 size={15} className="animate-spin" /> : <Sparkles size={15} />}
+        {busy ? "Deploying demo agent…" : "Try the demo agent — no API key"}
+      </button>
+      {error ? <p className="text-xs font-semibold text-red-600">{error}</p> : null}
+    </div>
+  );
+}
 
 const launchSignals = [
   "You can create or sign in to an operator account without friction.",
@@ -33,17 +94,24 @@ export default function GettingStartedPage() {
       <div className="max-w-6xl mx-auto flex flex-col gap-8 sm:gap-10 pb-12">
         <section className="grid xl:grid-cols-[1.2fr,0.8fr] gap-6 items-start">
           <div className="bg-slate-950 text-white rounded-[2rem] p-6 sm:p-8 border border-slate-800 shadow-2xl">
-            <p className="text-[10px] font-black uppercase tracking-[0.25em] text-blue-300 mb-3">Getting started</p>
+            <p className="text-[10px] font-black uppercase tracking-[0.25em] text-blue-300 mb-3">
+              Getting started
+            </p>
             <h1 className="text-3xl sm:text-4xl font-black tracking-tight leading-tight mb-4">
               Bring Nora online like a production operator platform
             </h1>
             <p className="text-slate-300 leading-relaxed max-w-2xl">
-              Nora is designed to move a team from setup to live operations quickly: connect one provider, deploy one OpenClaw agent, and run the operator workflow from inside the product.
+              Nora is designed to move a team from setup to live operations quickly: connect one
+              provider, deploy one OpenClaw agent, and run the operator workflow from inside the
+              product.
             </p>
 
             <div className="grid sm:grid-cols-2 gap-4 mt-8">
               {launchSignals.map((item) => (
-                <div key={item} className="rounded-3xl border border-white/10 bg-white/[0.03] p-5 flex items-start gap-3">
+                <div
+                  key={item}
+                  className="rounded-3xl border border-white/10 bg-white/[0.03] p-5 flex items-start gap-3"
+                >
                   <CheckCircle2 size={18} className="text-emerald-400 mt-0.5 shrink-0" />
                   <p className="text-sm text-slate-300 leading-relaxed">{item}</p>
                 </div>
@@ -52,7 +120,9 @@ export default function GettingStartedPage() {
           </div>
 
           <div className="bg-white border border-slate-200 rounded-[2rem] p-6 sm:p-8 shadow-sm">
-            <p className="text-[10px] font-black uppercase tracking-[0.25em] text-slate-500 mb-4">Fast self-hosted launch path</p>
+            <p className="text-[10px] font-black uppercase tracking-[0.25em] text-slate-500 mb-4">
+              Fast self-hosted launch path
+            </p>
             <div className="space-y-4">
               <div className="flex items-start gap-3">
                 <div className="w-11 h-11 rounded-2xl bg-blue-50 text-blue-600 flex items-center justify-center shrink-0">
@@ -60,7 +130,10 @@ export default function GettingStartedPage() {
                 </div>
                 <div>
                   <p className="text-sm font-black text-slate-900">1. Add one provider key</p>
-                  <p className="text-sm text-slate-500 mt-1">Start in Settings. A single working provider is enough to bring the deployment workflow online.</p>
+                  <p className="text-sm text-slate-500 mt-1">
+                    Start in Settings. A single working provider is enough to bring the deployment
+                    workflow online.
+                  </p>
                 </div>
               </div>
               <div className="flex items-start gap-3">
@@ -68,8 +141,12 @@ export default function GettingStartedPage() {
                   <Rocket size={18} />
                 </div>
                 <div>
-                  <p className="text-sm font-black text-slate-900">2. Deploy your first OpenClaw agent</p>
-                  <p className="text-sm text-slate-500 mt-1">Open Deploy and choose one enabled backend for your first live runtime.</p>
+                  <p className="text-sm font-black text-slate-900">
+                    2. Deploy your first OpenClaw agent
+                  </p>
+                  <p className="text-sm text-slate-500 mt-1">
+                    Open Deploy and choose one enabled backend for your first live runtime.
+                  </p>
                 </div>
               </div>
               <div className="flex items-start gap-3">
@@ -77,20 +154,36 @@ export default function GettingStartedPage() {
                   <Bot size={18} />
                 </div>
                 <div>
-                  <p className="text-sm font-black text-slate-900">3. Verify the runtime immediately</p>
-                  <p className="text-sm text-slate-500 mt-1">Open the agent page and confirm chat, logs, and terminal access before expanding the deployment.</p>
+                  <p className="text-sm font-black text-slate-900">
+                    3. Verify the runtime immediately
+                  </p>
+                  <p className="text-sm text-slate-500 mt-1">
+                    Open the agent page and confirm chat, logs, and terminal access before expanding
+                    the deployment.
+                  </p>
                 </div>
               </div>
             </div>
 
             <div className="flex flex-wrap gap-3 mt-8">
-              <a href="/app/settings" className="inline-flex items-center gap-2 rounded-xl bg-blue-600 text-white px-4 py-3 text-sm font-bold hover:bg-blue-700 transition-all">
+              <TryDemoButton />
+              <a
+                href="/app/settings"
+                className="inline-flex items-center gap-2 rounded-xl bg-blue-600 text-white px-4 py-3 text-sm font-bold hover:bg-blue-700 transition-all"
+              >
                 Start in Settings <ArrowRight size={15} />
               </a>
-              <a href="/app/deploy" className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm font-bold text-slate-700 hover:bg-slate-50 transition-all">
+              <a
+                href="/app/deploy"
+                className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-3 text-sm font-bold text-slate-700 hover:bg-slate-50 transition-all"
+              >
                 Deploy first agent <ArrowRight size={15} />
               </a>
             </div>
+            <p className="text-xs text-slate-400 mt-3">
+              The demo agent runs on a built-in deterministic model served by your control plane —
+              zero keys, zero cost. Swap in a real provider whenever you're ready.
+            </p>
           </div>
         </section>
 
@@ -101,7 +194,10 @@ export default function GettingStartedPage() {
 
         <section className="grid lg:grid-cols-3 gap-5">
           {bestFit.map((item) => (
-            <div key={item.title} className="bg-white border border-slate-200 rounded-3xl p-6 shadow-sm">
+            <div
+              key={item.title}
+              className="bg-white border border-slate-200 rounded-3xl p-6 shadow-sm"
+            >
               <div className="w-11 h-11 rounded-2xl bg-slate-950 text-white flex items-center justify-center mb-4">
                 <item.icon size={18} />
               </div>

--- a/workers/provisioner/backends/docker.ts
+++ b/workers/provisioner/backends/docker.ts
@@ -475,6 +475,9 @@ class DockerBackend extends ProvisionerBackend {
       CEREBRAS_API_KEY: "cerebras",
       NVIDIA_API_KEY: "nvidia",
       MICROSOFT_FOUNDRY_API_KEY: "microsoft-foundry",
+      // Zero-key demo stub (custom provider nora-demo). Deliberately LAST so a
+      // real provider key wins the first-configured default-model heuristic.
+      NORA_DEMO_LLM_TOKEN: "nora-demo",
     };
     // Build auth-profiles at CREATION TIME to determine the default model for setModelCmd.
     // This is only used for model selection — the actual auth-profiles.json on disk is
@@ -543,9 +546,15 @@ class DockerBackend extends ProvisionerBackend {
       // MICROSOFT_FOUNDRY_DEPLOYMENT (arbitrary per Azure resource), falling
       // back to "gpt-5.5".
       "microsoft-foundry": foundryDefaultModel(env || {}),
+      "nora-demo": "nora-demo/nora-demo-1",
     };
     const firstProvider = configuredProviders[0];
-    const defaultModel = firstProvider ? providerModelDefaults[firstProvider] : undefined;
+    // The worker computes NORA_DEFAULT_OPENCLAW_MODEL from the user's explicit
+    // default provider row; honor that before falling back to the
+    // first-configured-key heuristic (which only reflects env map order).
+    const defaultModel =
+      (env && env.NORA_DEFAULT_OPENCLAW_MODEL) ||
+      (firstProvider ? providerModelDefaults[firstProvider] : undefined);
 
     // Set default model in the config file BEFORE gateway starts (not via background CLI after).
     // Writing it into openclaw.json pre-launch avoids the config-change file watcher triggering

--- a/workers/provisioner/worker.ts
+++ b/workers/provisioner/worker.ts
@@ -139,6 +139,9 @@ const CLAWHUB_INSTALL_LOCK_RENEW_MS = Math.max(
 );
 
 const PROVIDER_ENV_MAP = Object.freeze({
+  // Zero-key demo stub; the sister NORA_DEMO_LLM_BASE_URL env var comes from
+  // the provider row's config.baseUrl through the standard mechanism below.
+  demo: "NORA_DEMO_LLM_TOKEN",
   anthropic: "ANTHROPIC_API_KEY",
   openai: "OPENAI_API_KEY",
   google: "GEMINI_API_KEY",
@@ -167,6 +170,9 @@ const PROVIDER_ENV_ENDPOINT_MAP = Object.freeze({
 });
 
 const PROVIDER_MODEL_DEFAULTS = Object.freeze({
+  // Bare model id — prefixed with the OpenClaw provider id (nora-demo) via
+  // mapNoraProviderIdToOpenClaw, same as microsoft-foundry below.
+  demo: "nora-demo-1",
   anthropic: "claude-sonnet-4-5",
   openai: "gpt-5.5",
   google: "gemini-3.1-pro-preview",


### PR DESCRIPTION
## What

A fresh Nora install can now deploy a **working, chattable agent before any LLM provider key exists** (PR-8 of the pre-launch plan). One click on Getting Started enables the built-in `demo` provider and deploys an agent against a deterministic OpenAI-compatible stub served by the control plane itself — zero keys, zero cost, swap in a real provider whenever.

## How

The demo provider **rides the existing provider machinery end to end**, no parallel pathway:

1. Adding provider `demo` stores a **derived token** (HMAC of `JWT_SECRET`) as the key and the control plane's **in-network stub URL** as `config.baseUrl`.
2. The worker decrypts/injects them like any provider — `NORA_DEMO_LLM_TOKEN` plus `NORA_DEMO_LLM_BASE_URL` via the standard sister-env mechanism.
3. The runtime registers an `openai-completions` custom provider (`nora-demo`) pointing back at the stub; default model composes to `nora-demo/nora-demo-1` through the existing id-mapping.

New pieces: `backend-api/demoLlm.ts` + `routes/demoLlm.ts` (deterministic `chat/completions` with JSON + SSE delta framing + `[DONE]`, `/v1/models`, bearer-checked, mounted pre-auth for container-network calls); `demo` entry in PROVIDERS with a keyless add path (also skips `ensureEncryptionConfigured` — the token is derived, and the demo must work before secrets exist); shared-runtime custom-provider registration; the one-click CTA on Getting Started; quickstart tip.

One behavior fix that fell out: the docker adapter now honors `NORA_DEFAULT_OPENCLAW_MODEL` (the user's **explicit default provider**) before its first-configured-key heuristic — previously env-map order, not the user's choice, decided the runtime default model.

## 🔧 Also fixes a PR-6 regression on master (found during live verification)

`runtimeBootstrap`'s `require("./mcpServersConfig")` was **not shipped into agent containers** via `RUNTIME_FILES` — every agent deployed since #183 has its in-container runtime sidecar (exec/files endpoints) crashing with `MODULE_NOT_FOUND`. Fixed by adding the module to `RUNTIME_FILES`, plus a new **runtime bundle closure** test that walks every shipped source's relative `require()`s so this class of bug can't recur.

## Verified live (the plan's gate)

On the local stack: zero-key provider add → became default → deploy → `running`; `openclaw.json` renders the `nora-demo` provider with the correct in-network baseUrl + default model; runtime sidecar boots clean; **a streamed gateway chat returns the deterministic stub reply through OpenClaw end to end** (the full pi-ai → stub SSE pipeline). Verification artifacts (agents, provider row, API key) cleaned up after.

## Tests

9 new jest tests (token/URL/reply determinism, 401s, OpenAI JSON shape, SSE framing with exact stream-reassembly equality, runtime wiring) + the bundle-closure regression test. Full backend suite **127 suites / 995 tests** green; typecheck green in backend-api, workers/provisioner, agent-runtime, frontend-dashboard.

## Deferred (follow-ups)

Agent Hub demo template seeding (the CTA deploys directly — simpler and equally effective), persistent demo-mode banner on demo-provider agents, `users.first_agent_deployed_at` instrumentation, Playwright zero-key journey.