### PR TITLE
feat(api): OpenAPI 3.1 spec with drift-tested coverage + interactive /api-docs

### DIFF
--- a/backend-api/__tests__/openapi.test.ts
+++ b/backend-api/__tests__/openapi.test.ts
@@ -1,0 +1,104 @@
+// @ts-nocheck
+// OpenAPI anti-rot: the spec must cover every route the tier-1 routers
+// actually serve, and must not document routes that no longer exist. Requiring
+// the routers pulls in db/queue modules — reuse the same mocks the route tests
+// use so introspection works without infrastructure.
+
+process.env.JWT_SECRET = process.env.JWT_SECRET || "x".repeat(40);
+
+jest.mock("../db", () => ({ query: jest.fn(), connect: jest.fn() }));
+jest.mock("../redisQueue", () => ({
+  deployQueue: { getJobCounts: jest.fn() },
+  addDeploymentJob: jest.fn(),
+  getDLQJobs: jest.fn(),
+  retryDLQJob: jest.fn(),
+}));
+jest.mock("../scheduler", () => ({ selectNode: jest.fn() }));
+jest.mock("../containerManager", () => ({
+  start: jest.fn(),
+  stop: jest.fn(),
+  restart: jest.fn(),
+  destroy: jest.fn(),
+  canDestroy: jest.fn(),
+  isKubernetesAgent: jest.fn(),
+  status: jest.fn(),
+}));
+jest.mock("../authSync", () => ({
+  runContainerCommand: jest.fn(),
+  syncAuthToUserAgents: jest.fn(),
+}));
+jest.mock("../gatewayProxy", () => ({ rpcCall: jest.fn() }));
+
+const { listRouterPaths } = require("../openapi/routerPaths");
+const { buildOpenApiDocument } = require("../openapi");
+
+// Tier-1 routers and their mount prefixes (must match server.ts).
+const TIER1 = [
+  { name: "agents", router: () => require("../routes/agents"), mount: "/agents" },
+  { name: "monitoring", router: () => require("../routes/monitoring"), mount: "" },
+  {
+    name: "llmProviders",
+    router: () => require("../routes/llmProviders"),
+    mount: "/llm-providers",
+  },
+  { name: "auth", router: () => require("../routes/auth"), mount: "/auth" },
+];
+
+function specOperationKeys(doc) {
+  const keys = new Set();
+  for (const [path, ops] of Object.entries(doc.paths || {})) {
+    for (const method of Object.keys(ops || {})) {
+      keys.add(`${method.toUpperCase()} ${path}`);
+    }
+  }
+  return keys;
+}
+
+describe("OpenAPI document", () => {
+  const doc = buildOpenApiDocument();
+
+  it("is a structurally sane 3.1 document", () => {
+    expect(doc.openapi).toBe("3.1.0");
+    expect(doc.info.title).toMatch(/Nora/);
+    expect(doc.servers[0].url).toBe("/api");
+    expect(Object.keys(doc.paths).length).toBeGreaterThan(20);
+    expect(doc.components.securitySchemes.bearerAuth.scheme).toBe("bearer");
+  });
+
+  it("gives every operation a tag and a summary", () => {
+    const knownTags = new Set(doc.tags.map((t) => t.name));
+    for (const [path, ops] of Object.entries(doc.paths)) {
+      for (const [method, op] of Object.entries(ops)) {
+        expect(`${method.toUpperCase()} ${path}: ${op.summary || "MISSING SUMMARY"}`).not.toMatch(
+          /MISSING SUMMARY/,
+        );
+        expect(Array.isArray(op.tags) && op.tags.length > 0).toBe(true);
+        for (const tag of op.tags) {
+          expect(knownTags.has(tag) ? tag : `unknown tag "${tag}" on ${path}`).toBe(tag);
+        }
+      }
+    }
+  });
+
+  describe("drift against tier-1 routers", () => {
+    const specKeys = specOperationKeys(doc);
+
+    for (const tier of TIER1) {
+      it(`covers every route in routes/${tier.name}`, () => {
+        const served = listRouterPaths(tier.router(), tier.mount);
+        const missing = served.filter((key) => !specKeys.has(key));
+        expect(missing).toEqual([]);
+      });
+    }
+
+    it("documents no stale routes for tier-1 prefixes", () => {
+      const served = new Set(TIER1.flatMap((t) => listRouterPaths(t.router(), t.mount)));
+      const tierPrefixes = ["/agents", "/monitoring", "/llm-providers", "/auth"];
+      const stale = [...specKeys].filter((key) => {
+        const path = key.split(" ")[1];
+        return tierPrefixes.some((p) => path.startsWith(p)) && !served.has(key);
+      });
+      expect(stale).toEqual([]);
+    });
+  });
+});

--- a/backend-api/openapi/index.js
+++ b/backend-api/openapi/index.js
@@ -1,0 +1,63 @@
+// @ts-nocheck
+// Assembles Nora's OpenAPI 3.1 document from hand-authored path fragments.
+// Served at GET /api.json with an interactive reference at /api-docs (publicly
+// /api/api.json and /api/api-docs — nginx strips the /api prefix).
+//
+// Coverage policy: the tier-1 routers (agents, monitoring, llm-providers,
+// auth) are FULLY covered and enforced by the jest drift test
+// (__tests__/openapi.test.ts) — adding a route to one of those routers without
+// documenting it fails CI. Other routers (integrations, workspaces, channels,
+// billing, admin) are documented in the Mintlify docs and will join the spec
+// incrementally.
+
+const agentsPaths = require("./paths/agents");
+const monitoringPaths = require("./paths/monitoring");
+const llmProvidersPaths = require("./paths/llmProviders");
+const authPaths = require("./paths/auth");
+
+function buildOpenApiDocument() {
+  return {
+    openapi: "3.1.0",
+    info: {
+      title: "Nora Control Plane API",
+      version: process.env.NORA_VERSION || "1.10",
+      description:
+        "Operator API for the Nora self-hosted agent ops platform: deploy and manage agent runtimes, budgets, monitoring, and LLM provider keys. Authenticate with a session JWT or a scoped workspace API key (`nora_…`).",
+      license: { name: "Apache-2.0", url: "https://www.apache.org/licenses/LICENSE-2.0" },
+    },
+    servers: [
+      {
+        url: "/api",
+        description:
+          "Same-origin via nginx (the /api prefix is stripped before reaching the backend).",
+      },
+    ],
+    security: [{ bearerAuth: [] }],
+    tags: [
+      { name: "Agents", description: "Agent lifecycle: deploy, start/stop, versions." },
+      { name: "Budgets", description: "Per-agent LLM spend caps with auto-pause." },
+      { name: "Monitoring", description: "Metrics, events, cost, and the fleet roll-up." },
+      { name: "LLM Providers", description: "Encrypted provider key management." },
+      { name: "Auth", description: "Session endpoints (JWT + HttpOnly cookie)." },
+      { name: "Hermes", description: "Hermes-runtime specific operations." },
+    ],
+    components: {
+      securitySchemes: {
+        bearerAuth: {
+          type: "http",
+          scheme: "bearer",
+          description:
+            "A session JWT from POST /auth/login, or a workspace API key (`nora_…`). API keys carry scopes — each operation lists its requirement under `x-required-scopes`. Session users skip scope checks (role-based guards apply instead).",
+        },
+      },
+    },
+    paths: {
+      ...agentsPaths,
+      ...monitoringPaths,
+      ...llmProvidersPaths,
+      ...authPaths,
+    },
+  };
+}
+
+module.exports = { buildOpenApiDocument };

--- a/backend-api/openapi/paths/agents.js
+++ b/backend-api/openapi/paths/agents.js
@@ -1,0 +1,302 @@
+// @ts-nocheck
+// Agents router paths (mounted at /agents). Every route in routes/agents.ts
+// must appear here — the jest drift test fails otherwise. Headline endpoints
+// carry full request/response docs; the long tail is summarized.
+
+const agentParam = {
+  name: "id",
+  in: "path",
+  required: true,
+  schema: { type: "string", format: "uuid" },
+  description: "Agent UUID.",
+};
+
+const agentSummary = {
+  type: "object",
+  properties: {
+    id: { type: "string", format: "uuid" },
+    name: { type: "string" },
+    status: {
+      type: "string",
+      enum: ["queued", "deploying", "running", "warning", "error", "stopped"],
+    },
+    runtime_family: { type: "string", enum: ["openclaw", "hermes"] },
+    deploy_target: { type: "string" },
+    sandbox_profile: { type: "string" },
+    paused_reason: { type: "string", nullable: true },
+    vcpu: { type: "integer" },
+    ram_mb: { type: "integer" },
+    disk_gb: { type: "integer" },
+    created_at: { type: "string", format: "date-time" },
+  },
+};
+
+const ok = (description, schema) => ({
+  200: {
+    description,
+    ...(schema ? { content: { "application/json": { schema } } } : {}),
+  },
+});
+
+const summarize = (tag, summary, params = [agentParam], scopes = null) => ({
+  tags: [tag],
+  summary,
+  parameters: params,
+  ...(scopes ? { "x-required-scopes": scopes } : {}),
+  responses: ok("Success"),
+});
+
+module.exports = {
+  "/agents": {
+    get: {
+      tags: ["Agents"],
+      summary: "List agents accessible to the caller",
+      description:
+        "Direct ownership plus workspace-shared agents. API keys see the agents of their bound workspace.",
+      "x-required-scopes": ["agents:read"],
+      parameters: [
+        {
+          name: "scope",
+          in: "query",
+          schema: { type: "string", enum: ["accessible", "owned"] },
+          description: "'owned' restricts to agents created by the caller.",
+        },
+      ],
+      responses: ok("Array of agents", { type: "array", items: agentSummary }),
+    },
+  },
+  "/agents/deploy": {
+    post: {
+      tags: ["Agents"],
+      summary: "Provision and deploy a new agent",
+      description:
+        "Queues the deployment and returns the created agent; poll GET /agents/{id} until status is 'running'.",
+      "x-required-scopes": ["agents:write"],
+      requestBody: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              required: ["name"],
+              properties: {
+                name: { type: "string", maxLength: 100 },
+                runtime_family: { type: "string", enum: ["openclaw", "hermes"] },
+                deploy_target: { type: "string", description: "e.g. 'docker' or 'k8s'" },
+                execution_target_id: { type: "string" },
+                sandbox_profile: { type: "string", enum: ["standard", "nemoclaw"] },
+                vcpu: { type: "integer", minimum: 1 },
+                ram_mb: { type: "integer", minimum: 512 },
+                disk_gb: { type: "integer", minimum: 1 },
+              },
+            },
+          },
+        },
+      },
+      responses: ok("The created agent (status 'queued')", agentSummary),
+    },
+  },
+  "/agents/{id}": {
+    get: {
+      tags: ["Agents"],
+      summary: "Get one agent with live-reconciled status",
+      "x-required-scopes": ["agents:read"],
+      parameters: [agentParam],
+      responses: ok("Agent detail", agentSummary),
+    },
+    patch: summarize("Agents", "Rename / update agent fields", [agentParam], ["agents:write"]),
+    delete: {
+      tags: ["Agents"],
+      summary: "Permanently delete an agent and its runtime",
+      "x-required-scopes": ["agents:write"],
+      parameters: [agentParam],
+      responses: ok("Deletion result"),
+    },
+  },
+  "/agents/{id}/start": {
+    post: {
+      tags: ["Agents"],
+      summary: "Start a stopped agent",
+      description: "Also clears a budget pause marker (manual start is an explicit override).",
+      "x-required-scopes": ["agents:write"],
+      parameters: [agentParam],
+      responses: ok("Start result"),
+    },
+  },
+};
+
+// The terse tail — defined separately and merged so the headline block above
+// stays readable. Each entry still satisfies the drift test.
+const tail = {
+  "/agents/{id}/stop": {
+    post: summarize("Agents", "Stop a running agent", [agentParam], ["agents:write"]),
+  },
+  "/agents/{id}/restart": {
+    post: summarize("Agents", "Restart a running agent in place", [agentParam], ["agents:write"]),
+  },
+  "/agents/{id}/redeploy": {
+    post: summarize(
+      "Agents",
+      "Tear down and re-provision the runtime (agent must be stopped/warning/error)",
+      [agentParam],
+      ["agents:write"],
+    ),
+  },
+  "/agents/{id}/delete": {
+    post: summarize("Agents", "Delete an agent (legacy POST form)", [agentParam], ["agents:write"]),
+  },
+  "/agents/{id}/duplicate": {
+    post: summarize("Agents", "Duplicate an agent's configuration", [agentParam], ["agents:write"]),
+  },
+  "/agents/{id}/budget": {
+    get: {
+      tags: ["Budgets"],
+      summary: "List the agent's budgets with current spend",
+      "x-required-scopes": ["agents:read"],
+      parameters: [agentParam],
+      responses: ok("Budgets with spend", {
+        type: "object",
+        properties: {
+          budgets: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                id: { type: "string", format: "uuid" },
+                period: { type: "string", enum: ["daily", "weekly", "monthly"] },
+                limitUsd: { type: "number" },
+                softThresholdPct: { type: "integer" },
+                currentUsd: { type: "number" },
+                pct: { type: "integer" },
+                bucket: { type: "string", enum: ["none", "soft", "hard"] },
+              },
+            },
+          },
+          pausedReason: { type: "string", nullable: true },
+        },
+      }),
+    },
+    put: {
+      tags: ["Budgets"],
+      summary: "Create or update a budget for a period",
+      description:
+        "Crossing the soft threshold emits an alert event; crossing 100% pauses the runtime.",
+      "x-required-scopes": ["agents:write"],
+      parameters: [agentParam],
+      requestBody: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              required: ["limitUsd"],
+              properties: {
+                period: {
+                  type: "string",
+                  enum: ["daily", "weekly", "monthly"],
+                  default: "monthly",
+                },
+                limitUsd: { type: "number", exclusiveMinimum: 0 },
+                softThresholdPct: { type: "integer", minimum: 0, maximum: 100, default: 80 },
+              },
+            },
+          },
+        },
+      },
+      responses: ok("The saved budget"),
+    },
+  },
+  "/agents/{id}/budget/{budgetId}": {
+    delete: summarize(
+      "Budgets",
+      "Remove a budget",
+      [agentParam, { name: "budgetId", in: "path", required: true, schema: { type: "string" } }],
+      ["agents:write"],
+    ),
+  },
+  "/agents/{id}/versions": {
+    get: summarize("Agents", "List configuration version history", [agentParam], ["agents:read"]),
+  },
+  "/agents/{id}/versions/{versionId}": {
+    get: summarize(
+      "Agents",
+      "Get one configuration version",
+      [agentParam, { name: "versionId", in: "path", required: true, schema: { type: "string" } }],
+      ["agents:read"],
+    ),
+  },
+  "/agents/{id}/rollback/{versionId}": {
+    post: summarize(
+      "Agents",
+      "Roll back to a configuration version (queues a redeploy)",
+      [agentParam, { name: "versionId", in: "path", required: true, schema: { type: "string" } }],
+      ["agents:write"],
+    ),
+  },
+  "/agents/{id}/stats": {
+    get: summarize("Monitoring", "Live runtime stats snapshot", [agentParam], ["agents:read"]),
+  },
+  "/agents/{id}/stats/history": {
+    get: summarize("Monitoring", "Historical runtime stats", [agentParam], ["agents:read"]),
+  },
+  "/agents/{id}/gateway-url": {
+    get: summarize("Agents", "Gateway control UI URL for the agent", [agentParam], ["agents:read"]),
+  },
+  "/agents/{id}/hermes-ui": {
+    get: summarize("Hermes", "Hermes runtime snapshot", [agentParam], ["agents:read"]),
+  },
+  "/agents/{id}/hermes-ui/chat": {
+    post: summarize(
+      "Hermes",
+      "Send a chat message to a Hermes agent",
+      [agentParam],
+      ["agents:write"],
+    ),
+  },
+  "/agents/{id}/hermes-ui/cron": {
+    get: summarize("Hermes", "List Hermes cron jobs", [agentParam], ["agents:read"]),
+    post: summarize("Hermes", "Create a Hermes cron job", [agentParam], ["agents:write"]),
+  },
+  "/agents/{id}/hermes-ui/cron/{jobId}": {
+    put: summarize(
+      "Hermes",
+      "Update a Hermes cron job",
+      [agentParam, { name: "jobId", in: "path", required: true, schema: { type: "string" } }],
+      ["agents:write"],
+    ),
+    delete: summarize(
+      "Hermes",
+      "Delete a Hermes cron job",
+      [agentParam, { name: "jobId", in: "path", required: true, schema: { type: "string" } }],
+      ["agents:write"],
+    ),
+  },
+  "/agents/{id}/hermes-ui/channels": {
+    get: summarize("Hermes", "List Hermes channels", [agentParam], ["agents:read"]),
+    post: summarize("Hermes", "Create a Hermes channel", [agentParam], ["agents:write"]),
+  },
+  "/agents/{id}/hermes-ui/channels/{channelId}": {
+    patch: summarize(
+      "Hermes",
+      "Update a Hermes channel",
+      [agentParam, { name: "channelId", in: "path", required: true, schema: { type: "string" } }],
+      ["agents:write"],
+    ),
+    delete: summarize(
+      "Hermes",
+      "Delete a Hermes channel",
+      [agentParam, { name: "channelId", in: "path", required: true, schema: { type: "string" } }],
+      ["agents:write"],
+    ),
+  },
+  "/agents/{id}/hermes-ui/channels/{channelId}/test": {
+    post: summarize(
+      "Hermes",
+      "Test a Hermes channel",
+      [agentParam, { name: "channelId", in: "path", required: true, schema: { type: "string" } }],
+      ["agents:write"],
+    ),
+  },
+};
+
+module.exports = { ...module.exports, ...tail };

--- a/backend-api/openapi/paths/auth.js
+++ b/backend-api/openapi/paths/auth.js
@@ -1,0 +1,103 @@
+// @ts-nocheck
+// Auth routes (mounted at /auth). Drift-checked against routes/auth.ts.
+// These are session endpoints — API keys do not apply here.
+
+const ok = (description, schema) => ({
+  200: { description, ...(schema ? { content: { "application/json": { schema } } } : {}) },
+});
+
+const credentialsBody = {
+  required: true,
+  content: {
+    "application/json": {
+      schema: {
+        type: "object",
+        required: ["email", "password"],
+        properties: {
+          email: { type: "string", format: "email" },
+          password: { type: "string", minLength: 8 },
+        },
+      },
+    },
+  },
+};
+
+module.exports = {
+  "/auth/bootstrap-status": {
+    get: {
+      tags: ["Auth"],
+      summary: "First-run claim check",
+      description:
+        "True until the first user registers (who becomes the platform admin). Public; exposes only the boolean.",
+      security: [],
+      responses: ok("Status", {
+        type: "object",
+        properties: { needsFirstAdmin: { type: "boolean" } },
+      }),
+    },
+  },
+  "/auth/signup": {
+    post: {
+      tags: ["Auth"],
+      summary: "Create an operator account",
+      description:
+        "The first registered user becomes the platform admin. Rate-limited; optional bot-protection token when the operator configured Turnstile/reCAPTCHA.",
+      security: [],
+      requestBody: credentialsBody,
+      responses: ok("Created user"),
+    },
+  },
+  "/auth/login": {
+    post: {
+      tags: ["Auth"],
+      summary: "Log in and receive a JWT + HttpOnly session cookie",
+      security: [],
+      requestBody: credentialsBody,
+      responses: ok("Token + user"),
+    },
+  },
+  "/auth/oauth-login": {
+    post: {
+      tags: ["Auth"],
+      summary: "Exchange a verified OAuth identity for a Nora session",
+      security: [],
+      responses: ok("Token + user"),
+    },
+  },
+  "/auth/logout": {
+    post: {
+      tags: ["Auth"],
+      summary: "Clear the session cookie",
+      security: [],
+      responses: ok("Logout result"),
+    },
+  },
+  "/auth/me": {
+    get: {
+      tags: ["Auth"],
+      summary: "Current user profile",
+      responses: ok("Profile"),
+    },
+  },
+  "/auth/profile": {
+    patch: {
+      tags: ["Auth"],
+      summary: "Update profile fields (name, preferred locale)",
+      responses: ok("Updated profile"),
+    },
+  },
+  "/auth/password": {
+    patch: {
+      tags: ["Auth"],
+      summary: "Change password",
+      responses: ok("Result"),
+    },
+  },
+  "/auth/session-upgrade": {
+    post: {
+      tags: ["Auth"],
+      summary: "Mirror a bearer-token session into the HttpOnly cookie",
+      responses: ok("Result"),
+    },
+  },
+};

--- a/backend-api/openapi/paths/llmProviders.js
+++ b/backend-api/openapi/paths/llmProviders.js
@@ -1,0 +1,71 @@
+// @ts-nocheck
+// LLM provider key management (mounted at /llm-providers). Drift-checked
+// against routes/llmProviders.ts.
+
+const ok = (description, schema) => ({
+  200: { description, ...(schema ? { content: { "application/json": { schema } } } : {}) },
+});
+
+module.exports = {
+  "/llm-providers/available": {
+    get: {
+      tags: ["LLM Providers"],
+      summary: "List supported providers",
+      description:
+        "Catalog of provider ids, display names, and known models. Entries with requiresApiKey=false (the built-in demo stub) can be added without a key.",
+      responses: ok("Provider catalog"),
+    },
+  },
+  "/llm-providers": {
+    get: {
+      tags: ["LLM Providers"],
+      summary: "List the caller's stored provider keys (masked)",
+      responses: ok("Stored providers"),
+    },
+    post: {
+      tags: ["LLM Providers"],
+      summary: "Store a provider API key",
+      description:
+        "Keys are AES-256-GCM encrypted at rest. The first provider becomes the default. For provider 'demo' the apiKey is omitted — the control plane derives a token for its built-in stub.",
+      requestBody: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              required: ["provider"],
+              properties: {
+                provider: { type: "string" },
+                apiKey: { type: "string", description: "Required except for provider 'demo'." },
+                model: { type: "string" },
+                config: { type: "object" },
+              },
+            },
+          },
+        },
+      },
+      responses: ok("The stored provider record"),
+    },
+  },
+  "/llm-providers/{id}": {
+    put: {
+      tags: ["LLM Providers"],
+      summary: "Update a stored provider (key, model, default flag)",
+      parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+      responses: ok("Updated record"),
+    },
+    delete: {
+      tags: ["LLM Providers"],
+      summary: "Delete a stored provider key",
+      parameters: [{ name: "id", in: "path", required: true, schema: { type: "string" } }],
+      responses: ok("Deletion result"),
+    },
+  },
+  "/llm-providers/sync": {
+    post: {
+      tags: ["LLM Providers"],
+      summary: "Push the caller's provider keys to their running agents",
+      responses: ok("Sync result"),
+    },
+  },
+};

--- a/backend-api/openapi/paths/monitoring.js
+++ b/backend-api/openapi/paths/monitoring.js
@@ -1,0 +1,129 @@
+// @ts-nocheck
+// Monitoring router paths (mounted at "/"). Drift-checked against
+// routes/monitoring.ts.
+
+const agentParam = {
+  name: "id",
+  in: "path",
+  required: true,
+  schema: { type: "string", format: "uuid" },
+  description: "Agent UUID.",
+};
+
+const ok = (description, schema) => ({
+  200: { description, ...(schema ? { content: { "application/json": { schema } } } : {}) },
+});
+
+module.exports = {
+  "/monitoring/metrics": {
+    get: {
+      tags: ["Monitoring"],
+      summary: "Platform metrics summary scoped to the caller",
+      "x-required-scopes": ["monitoring:read"],
+      responses: ok("Aggregate agent counts, deployments, and queue depth"),
+    },
+  },
+  "/monitoring/fleet-status": {
+    get: {
+      tags: ["Monitoring"],
+      summary: "Fleet needs-attention roll-up",
+      description:
+        "Only the agents needing operator attention, with reasons (error, budget_paused, stuck_deploying, budget_warning, telemetry_stalled). Errors first.",
+      "x-required-scopes": ["monitoring:read"],
+      responses: ok("Roll-up", {
+        type: "object",
+        properties: {
+          generatedAt: { type: "string", format: "date-time" },
+          total: { type: "integer" },
+          attentionCount: { type: "integer" },
+          agents: {
+            type: "array",
+            items: {
+              type: "object",
+              properties: {
+                agentId: { type: "string", format: "uuid" },
+                name: { type: "string", nullable: true },
+                status: { type: "string", nullable: true },
+                severity: { type: "string", enum: ["error", "warning"] },
+                reasons: {
+                  type: "array",
+                  items: {
+                    type: "object",
+                    properties: {
+                      code: { type: "string" },
+                      severity: { type: "string", enum: ["error", "warning"] },
+                      label: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      }),
+    },
+  },
+  "/monitoring/events": {
+    get: {
+      tags: ["Monitoring"],
+      summary: "Activity event log",
+      description:
+        "Filters (type/search/from/to or page) switch the response to a pagination envelope with an effective minimum limit of 10; without filters a flat array is returned honoring limit >= 1.",
+      "x-required-scopes": ["monitoring:read"],
+      parameters: [
+        { name: "agentId", in: "query", schema: { type: "string", format: "uuid" } },
+        { name: "limit", in: "query", schema: { type: "integer" } },
+        { name: "type", in: "query", schema: { type: "string" } },
+        { name: "search", in: "query", schema: { type: "string" } },
+        { name: "from", in: "query", schema: { type: "string", format: "date" } },
+        { name: "to", in: "query", schema: { type: "string", format: "date" } },
+        { name: "page", in: "query", schema: { type: "integer" } },
+      ],
+      responses: ok("Events (array or pagination envelope, see description)"),
+    },
+  },
+  "/monitoring/performance": {
+    get: {
+      tags: ["Monitoring"],
+      summary: "Raw API performance metric records",
+      "x-required-scopes": ["monitoring:read"],
+      parameters: [{ name: "since", in: "query", schema: { type: "string", format: "date-time" } }],
+      responses: ok("Metric records"),
+    },
+  },
+  "/agents/{id}/metrics": {
+    get: {
+      tags: ["Monitoring"],
+      summary: "Time-series metrics for one agent",
+      "x-required-scopes": ["monitoring:read"],
+      parameters: [
+        agentParam,
+        { name: "type", in: "query", schema: { type: "string" } },
+        { name: "from", in: "query", schema: { type: "string", format: "date-time" } },
+        { name: "to", in: "query", schema: { type: "string", format: "date-time" } },
+      ],
+      responses: ok("Metric records"),
+    },
+  },
+  "/agents/{id}/metrics/summary": {
+    get: {
+      tags: ["Monitoring"],
+      summary: "Pre-aggregated metrics summary for one agent",
+      "x-required-scopes": ["monitoring:read"],
+      parameters: [agentParam],
+      responses: ok("Summary"),
+    },
+  },
+  "/agents/{id}/cost": {
+    get: {
+      tags: ["Monitoring"],
+      summary: "Accumulated LLM cost for one agent",
+      "x-required-scopes": ["monitoring:read"],
+      parameters: [
+        agentParam,
+        { name: "period_days", in: "query", schema: { type: "integer", default: 30 } },
+      ],
+      responses: ok("Cost summary"),
+    },
+  },
+};

--- a/backend-api/openapi/routerPaths.js
+++ b/backend-api/openapi/routerPaths.js
@@ -1,0 +1,29 @@
+// @ts-nocheck
+// Express router introspection for the OpenAPI drift test: extracts every
+// (method, path) a router serves so the spec can be checked against reality.
+// Express 4 keeps routes on router.stack as layers with a `route` property.
+
+// Convert an Express path (/agents/:id/budget/:budgetId) to the OpenAPI
+// template form (/agents/{id}/budget/{budgetId}).
+function toOpenApiPath(expressPath) {
+  return String(expressPath).replace(/:([A-Za-z0-9_]+)/g, "{$1}");
+}
+
+// List "<METHOD> <openapi path>" strings for a router, with an optional mount
+// prefix (e.g. "/agents"). Skips middleware layers; `_all` is Express
+// bookkeeping, not a method.
+function listRouterPaths(router, mountPrefix = "") {
+  const out = [];
+  for (const layer of router.stack || []) {
+    if (!layer.route) continue;
+    const methods = Object.keys(layer.route.methods || {}).filter((m) => m !== "_all");
+    const routePath = layer.route.path === "/" ? "" : layer.route.path;
+    const fullPath = toOpenApiPath(`${mountPrefix}${routePath}`) || "/";
+    for (const method of methods) {
+      out.push(`${method.toUpperCase()} ${fullPath}`);
+    }
+  }
+  return out;
+}
+
+module.exports = { toOpenApiPath, listRouterPaths };

--- a/backend-api/server.ts
+++ b/backend-api/server.ts
@@ -760,6 +760,30 @@ app.use("/auth", require("./routes/auth"));
 // over the container network with the derived demo bearer token, not a JWT.
 app.use("/demo-llm", require("./routes/demoLlm"));
 
+// ─── OpenAPI spec + interactive reference (pre-auth: the spec documents the
+// public surface and contains no secrets; publicly /api/api.json + /api/api-docs).
+app.get("/api.json", (req, res) => {
+  const { buildOpenApiDocument } = require("./openapi");
+  res.json(buildOpenApiDocument());
+});
+app.get("/api-docs", (req, res) => {
+  // Scalar's standalone bundle renders the reference client-side from the spec
+  // URL; loading it from the CDN keeps the backend dependency-free.
+  res
+    .type("html")
+    .send(
+      [
+        "<!doctype html>",
+        "<html><head><title>Nora API Reference</title>",
+        '<meta charset="utf-8"/><meta name="viewport" content="width=device-width, initial-scale=1"/>',
+        "</head><body>",
+        '<script id="api-reference" data-url="api.json"></script>',
+        '<script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference"></script>',
+        "</body></html>",
+      ].join("\n"),
+    );
+});
+
 // ─── Gateway UI static assets (before auth wall — JS/CSS/icons contain no user data) ──
 // These are served pre-auth because iframes can't set Authorization headers on sub-resource loads.
 // Only opaque static files (JS bundles, CSS, favicons) are exempted — not HTML or

--- a/docs/api/overview.mdx
+++ b/docs/api/overview.mdx
@@ -4,6 +4,10 @@
 
 The Nora REST API is a JSON-over-HTTP interface that lets you deploy agents, manage LLM providers, configure channels, and observe platform health programmatically. Every request must include a valid Bearer token in the `Authorization` header — except for the public health, config, and webhook endpoints listed below. All request and response bodies use `application/json`.
 
+<Tip>
+  Every Nora instance also serves a machine-readable **OpenAPI 3.1 spec** at `GET /api/api.json` and an **interactive API reference** at `/api/api-docs`. The spec covers the tier-1 surface (agents, budgets, monitoring, LLM providers, auth) and is drift-tested in CI against the actual routers, so it cannot silently go stale.
+</Tip>
+
 ## Base URL
 
 The Nora API is served under the `/api` path of your Nora origin. In local mode this is:


### PR DESCRIPTION
## What

The final item of the pre-launch plan (PR-9, sequenced last so the spec covers everything that landed before it): every Nora instance now serves a **machine-readable OpenAPI 3.1 spec** at `GET /api/api.json` and an **interactive API reference** at `/api/api-docs`. Both pre-auth — the spec documents the public surface and contains no secrets.

## How

- **`backend-api/openapi/`** — `index.js` assembles the 3.1 document (info, `/api` server matching the nginx contract, a bearer scheme covering both session JWTs and `nora_` API keys with `x-required-scopes` annotated per operation, tags) from hand-authored path fragments: `paths/agents.js` (31 operations incl. the new budgets endpoints, versions, hermes-ui), `paths/monitoring.js` (incl. the new fleet-status roll-up), `paths/llmProviders.js` (incl. the keyless demo provider), `paths/auth.js` (incl. bootstrap-status). **53 operations across 44 paths.**
- **Anti-rot (the verify-first item, prototype confirmed)** — `__tests__/openapi.test.ts` introspects `router.stack` of the four tier-1 routers via a small `routerPaths.js` helper and fails when a served route is undocumented **or** a documented tier-1 route no longer exists, plus structural sanity (3.1, valid tags, summaries everywhere). Adding a route to a tier-1 router without documenting it now fails CI in both directions.
- **`/api-docs`** renders with Scalar's standalone CDN bundle — **zero new backend dependencies** (no npm package, nothing for the audit/license matrices to chew on).
- `docs/api/overview.mdx` points readers at the spec + reference.

## Scope

Tier-1 (agents, budgets, monitoring, llm-providers, auth — the surface the CLI and MCP server drive) is fully covered and drift-enforced. integrations/workspaces/channels/billing join incrementally — the plan's explicit "OpenAPI beyond tier-1" deferral.

## Verified

Live on a local stack: `/api/api.json` serves the document through nginx and `/api/api-docs` renders the Scalar shell. 7 new jest tests; full backend suite **128 suites / 1002 tests** green; typecheck clean.