### PR TITLE
docs: reconcile documentation with the v1.11.0 codebase

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,7 +128,7 @@ Each folder has its own `AGENTS.md` that narrows ownership, data-flow rules, and
 - `admin-dashboard/` — platform admin UI at `/admin`
 - `frontend-marketing/` — public site + auth entrypoints at `/`
 - `e2e/` — Playwright smoke coverage and local stack bootstrapping
-- `infra/` — public-domain nginx template (`nginx_public.conf.template`), TLS setup (`setup-tls.sh`), Kind config, backup image, public/prod compose overlays
+- `infra/` — public-domain nginx template (`nginx_public.conf.template`), TLS setup (`setup-tls.sh`), Kind config, backup image, public/prod compose overlays, and the official Helm chart for installing Nora on Kubernetes (`helm/nora`, with `helm/scripts/kind-smoke.sh`)
 - `docs/` — Mintlify source for the public docs site at `noradocs.solomontsao.com`
 - `.github/` — CI and deploy workflows
 
@@ -147,7 +147,7 @@ When multiple agents work the repo at once:
 
 ## Environment
 
-Copy `.env.example` to `.env`. Required: `JWT_SECRET`, `ENCRYPTION_KEY`, `NEXTAUTH_URL`.
+Copy `.env.example` to `.env`. Required (boot fails closed in production): `JWT_SECRET`, `ENCRYPTION_KEY`. Also required for managed backups: `NORA_BACKUP_ENCRYPTION_KEY`. `NORA_AGENT_HUB_API_KEY_HASH_SECRET` is in the Required block but auto-generates on setup/update when missing. `NEXTAUTH_URL` has a working localhost default and is kept only for deploy-env compatibility (not validated).
 
 Commonly toggled: `PLATFORM_MODE` (`selfhosted` or `paas`), `ENABLED_RUNTIME_FAMILIES`, `ENABLED_BACKENDS`, `NGINX_CONFIG_FILE`, `NGINX_HTTP_PORT`, `BACKEND_API_PORT`, `NORA_KUBECONFIGS_DIR`, `NVIDIA_API_KEY` (required when `nemoclaw` is enabled), `CORS_ORIGINS`.
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Nginx
 ├── /admin/*    → admin-dashboard     (Next.js)
 └── /api/*      → backend-api         (Express.js)
                        ├── PostgreSQL
-                       ├── Redis + BullMQ  (deployments, clawhub-installs, backups, alert-deliveries)
+                       ├── Redis + BullMQ  (deployments, clawhub-jobs, backups, alert-deliveries)
                        ├── worker-provisioner
                        ├── worker-backup
                        └── runtime adapters/profiles  (Docker GA · k3s/k8s GA · NemoClaw experimental · Proxmox planned)
@@ -128,7 +128,7 @@ export NORA_TOKEN="nora_..."
 curl -H "Authorization: Bearer $NORA_TOKEN" https://your-nora.example.com/api/agents
 ```
 
-A small CLI lives in [`cli/`](./cli) (`@nora/cli`) and wraps the same surface for `nora workspaces`, `nora agents`, and `nora monitoring`. See the [API reference](https://noradocs.solomontsao.com/api/overview) for the supported endpoints and scopes.
+A small CLI lives in [`cli/`](./cli) (`@nora/cli`): run `nora login` once to save your host and API token, then `nora workspaces`, `nora agents`, and `nora monitoring` wrap the same REST surface. `nora doctor` runs an admin-only control-plane health check, and `nora mcp` launches the MCP stdio server. See the [API reference](https://noradocs.solomontsao.com/api/overview) for the supported endpoints and scopes.
 
 **Operate Nora from Claude Code, Claude Desktop, or Cursor:** the [`mcp-server/`](./mcp-server) package (`@nora/mcp-server`) exposes the same API as [Model Context Protocol](https://modelcontextprotocol.io) tools — deploy agents, control their lifecycle, and read fleet metrics, events, and per-agent cost from any MCP client. Destructive deletion stays disabled unless explicitly opted in.
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -7,7 +7,7 @@ Use this page to pick the fastest open-source route for your situation.
 Start here if you want to self-host Nora and bring it online on your own infrastructure.
 
 - [README Quick Start](README.md#quick-start)
-- [README Configuration](README.md#configuration)
+- [Configuration & environment variables](https://noradocs.solomontsao.com/configuration/platform-modes)
 - [`infra/setup-tls.sh`](infra/setup-tls.sh)
 
 Best fit:

--- a/admin-dashboard/README.md
+++ b/admin-dashboard/README.md
@@ -9,10 +9,15 @@ Runs on `/admin/*` behind nginx. Provides platform-wide visibility into users, a
 ## Features
 
 - **Ops Overview** — platform-wide metrics, queue health, recent audit activity, and DLQ awareness
+- **Control-plane Health** — admin view of the `nora doctor` self-check (database, queue, Kubernetes targets, secret posture, fleet health, gateway exposure) with auto-refresh and forced re-run
 - **Fleet Management** — global agent list, lifecycle actions, runtime metadata, telemetry samples, and live logs
 - **Queue Recovery** — dead-letter inspection and retry flows for failed deployment jobs
 - **User Management** — role changes, agent counts, and account deletion with agent cleanup
+- **Members & Workspaces** — workspace roster, member roles, and membership administration
+- **Kubernetes Registry** — register and manage Kubernetes clusters as deploy targets
 - **Agent Hub Moderation** — review and remove published Agent Hub listings
+- **Managed Backups** — backup storage, tier limits, schedule, inventory, and guarded restore/delete
+- **Platform Settings & Upgrades** — system banner, default language, deployment defaults, Agent Hub source-catalog key, SMTP notifications, and release status with one-click/manual upgrade guidance
 
 ## Development
 

--- a/backend-api/agent-hub-templates/communication-intelligence-claw/BOOTSTRAP.md
+++ b/backend-api/agent-hub-templates/communication-intelligence-claw/BOOTSTRAP.md
@@ -59,7 +59,7 @@ Direct them to the **Channels** tab for the option they chose. Say "connected" w
 
 This is different from how I reach you — these are the conversations I read. I can work two ways:
 
-- **Live monitoring** — connect a source in the **Integrations** tab so I can read it directly: **Slack**, **Microsoft Teams**, or **email**. Check `integrations/NORA_INTEGRATIONS.md` to see what's connected.
+- **Live monitoring** — connect a source in the **Integrations** tab so I can read it directly: **Slack** or **email**. Check `integrations/NORA_INTEGRATIONS.md` to see what's connected.
 - **Imported logs** — paste or import chat logs (WhatsApp/WeChat/group exports) and I'll triage those. No integration required.
 
 > Which conversations should I watch, and how — connect a live source, or send me logs? (Tell me the platforms and I'll point you to the Integrations tab for the connectable ones.)

--- a/backend-api/agent-hub-templates/communication-intelligence-claw/PROFILE.md
+++ b/backend-api/agent-hub-templates/communication-intelligence-claw/PROFILE.md
@@ -8,7 +8,7 @@
 ## Monitored Sources
 > What I watch — distinct from the channel I use to reach the operator.
 
-- **live_sources:** <Slack / Teams / email connected in the Integrations tab, if any>
+- **live_sources:** <Slack / email connected in the Integrations tab, if any>
 - **imported_logs:** <WhatsApp / WeChat / group-chat exports the operator pastes>
 
 ## Trigger Rules

--- a/backend-api/agent-hub-templates/communication-intelligence-claw/README.md
+++ b/backend-api/agent-hub-templates/communication-intelligence-claw/README.md
@@ -22,7 +22,7 @@ This is how Sentry reaches you — separate from the chats it monitors.
 ### 3. Point Sentry at what to watch
 Two ways, mix as needed:
 
-- **Live monitoring** — connect a source in the **Integrations** tab (**Slack**, **Microsoft Teams**, or **email**) so Sentry reads it directly.
+- **Live monitoring** — connect a source in the **Integrations** tab (**Slack** or **email**) so Sentry reads it directly.
 - **Imported logs** — paste or import chat exports (WhatsApp/WeChat/group logs); no integration required.
 
 ### 4. Say hi

--- a/backend-api/agent-hub-templates/communication-intelligence-claw/TOOLS.md
+++ b/backend-api/agent-hub-templates/communication-intelligence-claw/TOOLS.md
@@ -7,7 +7,7 @@
 
 ## Connected Integrations
 
-- Live monitoring sources are **optional** — you can also triage imported/pasted chat logs. If a source is connected (Slack, Teams, email), Nora lists it in `integrations/NORA_INTEGRATIONS.md` and appends a `<!-- NORA_INTEGRATIONS_BEGIN --> … _END -->` block to the bottom of this file. **Do not hand-write that block** — the runtime manages it.
+- Live monitoring sources are **optional** — you can also triage imported/pasted chat logs. If a source is connected (Slack, email), Nora lists it in `integrations/NORA_INTEGRATIONS.md` and appends a `<!-- NORA_INTEGRATIONS_BEGIN --> … _END -->` block to the bottom of this file. **Do not hand-write that block** — the runtime manages it.
 - Check `integrations/NORA_INTEGRATIONS.md` before claiming a source isn't available. Use `nora-integration-tool --list` and `nora-integration-tool <tool> '<json input>'`.
 - Keep two things distinct: the **monitored sources** (what you read) and the operator's **channel** (how you escalate to them).
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -45,6 +45,13 @@ nora agents rollback <id> <vid>  # restore a prior version
 nora monitoring metrics          # current metrics
 nora monitoring events --limit 50
 nora monitoring tail --interval 5000
+
+nora doctor                      # control-plane health check (needs an admin API key)
+nora doctor --json               # machine-readable report; exit 2 when overall=fail
+nora doctor --fresh              # force a recompute (bypass any cached report)
+
+nora mcp                         # run the Nora MCP server on stdio for Claude Code/Desktop/Cursor
+nora mcp --allow-destructive     # enable the MCP server's destructive tools
 ```
 
 ## Scopes
@@ -57,6 +64,10 @@ The token must carry the matching scope for the operation:
 | `agents start/stop/restart/redeploy/rollback` | `agents:write` |
 | `workspaces list/show/use` | `workspaces:read` |
 | `monitoring *` | `monitoring:read` |
+
+`nora doctor` needs an API key whose issuing user is a platform admin — it calls `GET /api/admin/doctor` behind `requireAdmin`, and on HTTP 403 it prints an admin-key error and exits 1.
+
+`nora mcp` forwards the host/token from `nora login` (`~/.nora/config.json`) to the `@nora/mcp-server` child as `NORA_API_URL` / `NORA_API_KEY`; `--allow-destructive` sets `NORA_MCP_ALLOW_DESTRUCTIVE=true`, so the MCP server's own scope/tool requirements apply.
 
 Issuing API keys, mutating workspace membership, and other privileged flows require session authentication and are not available through the CLI.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@ docs/
 ├── configuration/            # operator config (env vars, platform modes, …)
 ├── guides/                   # task-oriented walkthroughs
 ├── api/                      # REST API reference
-└── support/                  # FAQ, troubleshooting
+└── support/                  # FAQ, troubleshooting, contact
 ```
 
 ## Maintenance rule

--- a/docs/api/agents.mdx
+++ b/docs/api/agents.mdx
@@ -5,8 +5,8 @@
 The Agents API is the core of Nora. You use it to deploy new agent containers, control their lifecycle (start, stop, restart, redeploy, delete), poll live resource stats, and retrieve the gateway UI URL for direct browser access. Read endpoints include agents you own directly and agents shared with you through workspaces. Destructive deletion remains limited to the direct agent owner.
 
 <Note>
-  An agent moves through the following statuses: `queued` → `running`. From `running` it can
-  transition to `warning`, `error`, or `stopped`. Use `POST /agents/:id/redeploy` to recover an
+  An agent moves through the following statuses: `queued` → `deploying` → `running`. From `running`
+  it can transition to `warning`, `error`, or `stopped`. Use `POST /agents/:id/redeploy` to recover an
   agent that is in `warning`, `error`, or `stopped` state.
 </Note>
 

--- a/docs/api/authentication.mdx
+++ b/docs/api/authentication.mdx
@@ -2,7 +2,7 @@
 
 > Sign up, log in, and manage your Nora account via the Auth API. Includes JWT token usage, profile updates, and password management.
 
-Every protected Nora API endpoint verifies your identity with a JSON Web Token (JWT). You obtain the token by signing up and then logging in. The token is valid for **7 days** and must be included in the `Authorization` header of every subsequent request. This page covers all authentication endpoints and shows you exactly what each one returns.
+Every protected Nora API endpoint requires an authenticated identity — either a **session JWT** (covered on this page) or a **workspace API key** with scopes (see the [API overview](/api/overview#authentication) for the key-and-scope model). You obtain a JWT by signing up and then logging in; it is valid for **7 days**, sent as a Bearer token in the `Authorization` header of every subsequent request, and also accepted as an HttpOnly session cookie. This page covers all authentication endpoints and shows you exactly what each one returns.
 
 <Note>
   Login and OAuth auth endpoints are rate-limited to **20 requests per 15-minute window** per IP.
@@ -10,9 +10,42 @@ Every protected Nora API endpoint verifies your identity with a JSON Web Token (
   verification when configured.
 </Note>
 
+## Bootstrap status
+
+Check whether the server still needs its first admin. This drives the "claim
+this server" first-run flow: until the first user registers (that first account
+becomes the platform admin), `needsFirstAdmin` is `true`; afterward it is
+`false`. The endpoint deliberately exposes only the boolean — a user count or
+emails would aid account enumeration. See the
+[security overview](/concepts/security) for the broader claim flow.
+
+```
+GET /auth/bootstrap-status
+```
+
+Public — no authentication required.
+
+### Response
+
+<ResponseField name="needsFirstAdmin" type="boolean">
+  `true` until the first user registers, `false` afterward.
+</ResponseField>
+
+```bash
+curl http://localhost:8080/api/auth/bootstrap-status
+```
+
+```json theme={null}
+{ "needsFirstAdmin": true }
+```
+
+---
+
 ## Sign up
 
-Create a new user account.
+Create a new user account. The **first** registered user becomes the platform
+admin (the first-admin claim flow — see [bootstrap status](#bootstrap-status)
+and the [security overview](/concepts/security)).
 
 ```
 POST /auth/signup
@@ -286,3 +319,91 @@ PATCH /auth/password
 | `400`  | Missing fields, or account has no password (OAuth account) |
 | `401`  | Current password is incorrect                              |
 | `404`  | User record not found                                      |
+
+---
+
+## OAuth login
+
+Exchange a server-verified OAuth identity for a Nora session. On success this
+returns a `token` plus the `user` record and sets the HttpOnly session cookie.
+
+```
+POST /auth/oauth-login
+```
+
+<Note>
+  This endpoint is **disabled by default**. Unless `OAUTH_LOGIN_ENABLED=true`, it
+  returns `403` with `OAuth login is disabled until server-side provider
+  verification is implemented`. Like login, it is rate-limited to **20 requests
+  per 15-minute window** per IP.
+</Note>
+
+### Request body
+
+<ParamField body="provider" type="string" required>
+  OAuth provider identifier (for example `github` or `google`).
+</ParamField>
+
+<ParamField body="oauthAccessToken" type="string">
+  Provider access token. Either this or `oauthIdToken` is required.
+</ParamField>
+
+<ParamField body="oauthIdToken" type="string">
+  Provider ID token. Either this or `oauthAccessToken` is required.
+</ParamField>
+
+### Response
+
+<ResponseField name="token" type="string">
+  A signed JWT for the linked or newly created account.
+</ResponseField>
+
+<ResponseField name="user" type="object">
+  The authenticated user record.
+</ResponseField>
+
+---
+
+## Upgrade session
+
+Mirror an existing Bearer-token session into the browser's HttpOnly session
+cookie. The supplied token is re-verified, so a forged Bearer is rejected.
+
+```
+POST /auth/session-upgrade
+```
+
+**Requires authentication.** Send the token in the `Authorization: Bearer <token>` header.
+
+### Response
+
+<ResponseField name="success" type="boolean">
+  `true` when the cookie was set.
+</ResponseField>
+
+```json theme={null}
+{ "success": true }
+```
+
+---
+
+## Log out
+
+Clear the session cookie.
+
+```
+POST /auth/logout
+```
+
+This endpoint intentionally requires **no authentication**, so a page holding a
+stale or invalid cookie can still clean itself up.
+
+### Response
+
+<ResponseField name="success" type="boolean">
+  `true` when the cookie was cleared.
+</ResponseField>
+
+```json theme={null}
+{ "success": true }
+```

--- a/docs/api/llm-providers.mdx
+++ b/docs/api/llm-providers.mdx
@@ -27,6 +27,7 @@ Returns an array of provider descriptors.
 <ResponseField name="id" type="string">Provider identifier, e.g. `openai`, `anthropic`.</ResponseField>
 <ResponseField name="name" type="string">Human-readable provider name.</ResponseField>
 <ResponseField name="models" type="string[]">Supported model identifiers for this provider.</ResponseField>
+<ResponseField name="requiresApiKey" type="boolean">Present only for catalog entries that do not need a key — such as the built-in `demo` provider (`"Demo (built-in, no key required)"`), which carries `requiresApiKey: false`. Omitted for key-requiring providers.</ResponseField>
 
 <CodeGroup>
   ```bash curl theme={null}
@@ -112,8 +113,8 @@ POST /llm-providers
   Provider identifier, e.g. `openai`, `anthropic`. Must match a value from `GET /llm-providers/available`.
 </ParamField>
 
-<ParamField body="apiKey" type="string" required>
-  The API key issued by the provider.
+<ParamField body="apiKey" type="string">
+  The API key issued by the provider. Required for every provider except the built-in `demo` provider, whose token is derived server-side — omit `apiKey` when `provider` is `demo`. The `demo` entry is flagged `requiresApiKey: false` in `GET /llm-providers/available`.
 </ParamField>
 
 <ParamField body="model" type="string">
@@ -126,7 +127,7 @@ POST /llm-providers
 
 ### Response
 
-Returns the saved provider record with the API key masked.
+Returns the saved provider record (`id`, `provider`, `model`, `is_default`, `created_at`). The create response omits the masked key and config — use `GET /llm-providers` to retrieve the masked record.
 
 <CodeGroup>
   ```bash curl theme={null}
@@ -141,17 +142,15 @@ Returns the saved provider record with the API key masked.
 {
   "id": "f1e2d3c4-b5a6-7890-abcd-012345678901",
   "provider": "anthropic",
-  "api_key_masked": "sk-a••••••••ntc",
   "model": "claude-opus-4-6",
-  "config": {},
   "is_default": false,
   "created_at": "2025-03-10T09:00:00.000Z"
 }
 ```
 
-| Status | Condition                                                |
-| ------ | -------------------------------------------------------- |
-| `400`  | Missing `provider` or `apiKey`, or unrecognised provider |
+| Status | Condition                                                                                  |
+| ------ | ------------------------------------------------------------------------------------------ |
+| `400`  | Missing `provider`, missing `apiKey` for a key-requiring provider, or unrecognised provider |
 
 ***
 

--- a/docs/api/monitoring.mdx
+++ b/docs/api/monitoring.mdx
@@ -16,11 +16,25 @@ GET /monitoring/metrics
 
 ### Response
 
-<ResponseField name="agents_total" type="number">Total number of agents owned by the user.</ResponseField>
-<ResponseField name="agents_running" type="number">Agents currently in `running` state.</ResponseField>
-<ResponseField name="agents_stopped" type="number">Agents in `stopped` state.</ResponseField>
-<ResponseField name="agents_error" type="number">Agents in `error` or `warning` state.</ResponseField>
-<ResponseField name="events_today" type="number">Number of activity events recorded in the last 24 hours.</ResponseField>
+<ResponseField name="totalAgents" type="number">Total number of accessible agents.</ResponseField>
+<ResponseField name="activeAgents" type="number">Agents currently in `running` state.</ResponseField>
+<ResponseField name="deployingAgents" type="number">Agents currently in `deploying` state.</ResponseField>
+<ResponseField name="queuedAgents" type="number">Agents in `queued` state.</ResponseField>
+<ResponseField name="stoppedAgents" type="number">Agents in `stopped` state.</ResponseField>
+<ResponseField name="warningAgents" type="number">Agents in `warning` state.</ResponseField>
+<ResponseField name="errorAgents" type="number">Agents in `error` state.</ResponseField>
+<ResponseField name="totalDeployments" type="number">Total number of deployments.</ResponseField>
+
+<ResponseField name="queue" type="object">
+  Deployment queue job counts.
+
+  <Expandable title="properties">
+    <ResponseField name="waiting" type="number">Jobs waiting to run.</ResponseField>
+    <ResponseField name="active" type="number">Jobs currently running.</ResponseField>
+    <ResponseField name="completed" type="number">Jobs completed.</ResponseField>
+    <ResponseField name="failed" type="number">Jobs failed.</ResponseField>
+  </Expandable>
+</ResponseField>
 
 <CodeGroup>
   ```bash curl theme={null}
@@ -31,11 +45,15 @@ GET /monitoring/metrics
 
 ```json theme={null}
 {
-  "agents_total": 4,
-  "agents_running": 2,
-  "agents_stopped": 1,
-  "agents_error": 1,
-  "events_today": 37
+  "totalAgents": 4,
+  "activeAgents": 2,
+  "deployingAgents": 0,
+  "queuedAgents": 0,
+  "stoppedAgents": 1,
+  "warningAgents": 0,
+  "errorAgents": 1,
+  "totalDeployments": 7,
+  "queue": { "waiting": 0, "active": 0, "completed": 0, "failed": 0 }
 }
 ```
 
@@ -109,6 +127,30 @@ GET /monitoring/events
   Maximum number of events to return, ordered newest first.
 </ParamField>
 
+<ParamField query="type" type="string">
+  Filter events to a specific event type slug.
+</ParamField>
+
+<ParamField query="search" type="string">
+  Full-text filter across event messages.
+</ParamField>
+
+<ParamField query="from" type="string">
+  Inclusive start date (`YYYY-MM-DD`) for the event window.
+</ParamField>
+
+<ParamField query="to" type="string">
+  Inclusive end date (`YYYY-MM-DD`) for the event window.
+</ParamField>
+
+<ParamField query="page" type="number">
+  Page number for paginated results (1-based).
+</ParamField>
+
+<Note>
+  Supplying any of `page`, `search`, `type`, `from`, or `to` switches the response to a pagination envelope (with `limit` clamped to 10–100). Without those filters, a flat array is returned (`limit` 1–100, default 50).
+</Note>
+
 ### Response
 
 <ResponseField name="id" type="string">Event UUID.</ResponseField>
@@ -158,6 +200,10 @@ Return raw API performance metric records. Useful for building latency dashboard
 ```
 GET /monitoring/performance
 ```
+
+<Note>
+  Unlike the other `/monitoring/*` endpoints, this one requires the platform-admin role. Non-admin callers receive `403 {"error": "Admin access required"}`.
+</Note>
 
 ### Query parameters
 

--- a/docs/api/overview.mdx
+++ b/docs/api/overview.mdx
@@ -2,7 +2,7 @@
 
 > A complete reference for the Nora REST API: base URLs, authentication, rate limiting, content type, health check, and public config endpoints.
 
-The Nora REST API is a JSON-over-HTTP interface that lets you deploy agents, manage LLM providers, configure channels, and observe platform health programmatically. Every request must include a valid Bearer token in the `Authorization` header — except for the public health, config, and webhook endpoints listed below. All request and response bodies use `application/json`.
+The Nora REST API is a JSON-over-HTTP interface that lets you deploy agents, manage LLM providers, configure channels, and observe platform health programmatically. Every request must be authenticated — with either a session JWT or a workspace API key — except for the public health, config, and webhook endpoints listed below. All request and response bodies use `application/json`.
 
 <Tip>
   Every Nora instance also serves a machine-readable **OpenAPI 3.1 spec** at `GET /api/api.json` and an **interactive API reference** at `/api/api-docs`. The spec covers the tier-1 surface (agents, budgets, monitoring, LLM providers, auth) and is drift-tested in CI against the actual routers, so it cannot silently go stale.
@@ -28,13 +28,42 @@ https://app.example.com/api
 
 ## Authentication
 
-All protected endpoints require a JWT in the `Authorization` header:
+Protected endpoints accept **either** of two credentials.
+
+**1. A session JWT** — supplied as a Bearer token:
 
 ```
-Authorization: Bearer <token>
+Authorization: Bearer <jwt>
 ```
 
-Obtain a token via `POST /auth/login`. Tokens are valid for **7 days**. See the [Authentication](/api/authentication) page for the full login flow.
+Obtain one via `POST /auth/login`. Tokens are valid for **7 days** and are also accepted as an HttpOnly session cookie. See the [Authentication](/api/authentication) page for the full login flow.
+
+**2. A workspace API key** — supplied as a Bearer token (the key begins with `nora_`) or in the `X-Api-Key` header (alias `X-Nora-Api-Key`):
+
+```
+Authorization: Bearer nora_<key>
+```
+
+```
+X-Api-Key: nora_<key>
+```
+
+API keys carry **scopes** that are enforced per endpoint, drawn from the recognized v1 set:
+
+| Scope                 | Grants                                          |
+| --------------------- | ----------------------------------------------- |
+| `agents:read`         | Read agents in the workspace                    |
+| `agents:write`        | Create, update, and operate agents              |
+| `workspaces:read`     | Read workspace metadata and members             |
+| `monitoring:read`     | Read monitoring metrics and events              |
+| `integrations:read`   | Read integration configurations                 |
+| `integrations:write`  | Create and remove integrations                  |
+
+Session-authenticated requests skip scope checks (role-based guards apply instead). A request whose API key lacks the required scope is rejected with `403` and `{ "code": "missing_scope" }`.
+
+<Note>
+  Some mutating or destructive operations are **session-only** and reject API keys even with a valid scope — for example monitoring writes, workspace writes, and API-key issuance. These return `403` with `{ "code": "session_required" }`.
+</Note>
 
 ## Rate limiting
 

--- a/docs/concepts/agent-hub.mdx
+++ b/docs/concepts/agent-hub.mdx
@@ -26,7 +26,7 @@ Each workspace listing has a `shareTarget`:
 | `community`  | ❌                  | ✅                |
 | `both`       | ✅                  | ✅                |
 
-Switching to `community` or `both` triggers a sync to the upstream hub. The upstream review state is mirrored back into `centralShareStatus` (`not_shared`, `pending`, `approved`, `rejected`). Reviewers in the upstream hub can request changes, and the listing's `centralError` surfaces the reason.
+Switching to `community` or `both` triggers a sync to the upstream hub. The upstream review state is mirrored back into `centralShareStatus` (`not_shared`, `queued`, `submitted`, `failed`). Reviewers in the upstream hub can request changes, and the listing's `centralError` surfaces the reason.
 
 <Note>
   "Community" doesn't have to mean public. The upstream hub is whatever `NORA_AGENT_HUB_URL` points at — the default public catalog, or an Agent Hub you self-host for your own company. Point it at your own hub and `community`/`both` sharing becomes a private, org-internal catalog: every operator publishes to and installs from a shared company hub without anything leaving your infrastructure.

--- a/docs/concepts/architecture.mdx
+++ b/docs/concepts/architecture.mdx
@@ -88,7 +88,7 @@ WebSocket upgrades are handled at the nginx layer; the Express app attaches WS h
 | Service        | What it stores or carries                                                                                                                                                                                                            |
 | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | PostgreSQL     | Users, workspaces, workspace_members (RBAC), invitations, API keys (HMAC-hashed), agents, agent_versions, deployments, migration drafts, snapshots, Agent Hub listings/versions/reports, alert rules, backups, integrations, events. |
-| Redis + BullMQ | Four queues: `deployments`, `clawhub-installs`, `backups`, `alert-deliveries`. Each has its own retry, backoff, and DLQ retention configured in `backend-api/redisQueue.ts`.                                                         |
+| Redis + BullMQ | Four queues: `deployments`, `clawhub-jobs`, `backups`, `alert-deliveries`. Each has its own retry, backoff, and DLQ retention configured in `backend-api/redisQueue.ts`.                                                             |
 
 The API persists desired state first, then hands long-running work to a queue-backed worker. That keeps provisioning failures, retries, and delayed readiness out of the synchronous browser request path.
 
@@ -209,7 +209,7 @@ Compose mounts `./workers/provisioner/backends` into `backend-api` at `/app/back
 | Queue              | Job type          | Concurrency                             | Retry                                               | Worker                          | What it does                                                                            |
 | ------------------ | ----------------- | --------------------------------------- | --------------------------------------------------- | ------------------------------- | --------------------------------------------------------------------------------------- |
 | `deployments`      | `deploy-agent`    | `DEPLOYMENT_WORKER_CONCURRENCY` (6)     | 5 attempts, exponential 3 s base                    | `workers/provisioner/worker.ts` | Provisions or redeploys an agent runtime through the chosen backend adapter.            |
-| `clawhub-installs` | `install-skill`   | 1                                       | 1 attempt (operator drives retries)                 | `workers/provisioner/worker.ts` | Runs `clawhub install` inside an OpenClaw agent and persists the installed-skill state. |
+| `clawhub-jobs`     | `install-skill`   | 1                                       | 1 attempt (operator drives retries)                 | `workers/provisioner/worker.ts` | Runs `clawhub install` inside an OpenClaw agent and persists the installed-skill state. |
 | `backups`          | `run-backup`      | `BACKUP_WORKER_CONCURRENCY` (2)         | 2 attempts, exponential 5 s base                    | `workers/backup/worker.ts`      | Captures, encrypts, and uploads an agent backup archive, then prunes expired backups.   |
 | `alert-deliveries` | `deliver-webhook` | `ALERT_DELIVERY_WORKER_CONCURRENCY` (5) | `ALERT_DELIVERY_ATTEMPTS` (5), exponential 1 s base | `workers/provisioner/worker.ts` | Posts a webhook delivery for an alert rule. Each job is one (rule, channel) pair.       |
 

--- a/docs/concepts/llm-providers.mdx
+++ b/docs/concepts/llm-providers.mdx
@@ -31,6 +31,11 @@ Nora supports the following LLM providers. You can save a key for any of them fr
 | Cerebras          | `cerebras`          |
 | NVIDIA            | `nvidia`            |
 | Microsoft Foundry | `microsoft-foundry` |
+| Demo (built-in, no key required) | `demo` |
+
+<Note>
+  The **`demo`** provider is a zero-key, deterministic built-in stub served by your own control plane (model `nora-demo-1`, `requiresApiKey: false`). Unlike every other provider it needs no API key — Nora derives its token server-side — and it is listed last in the picker so key-based providers appear first. It exists so a fresh install can deploy a working agent and see a chat round-trip before adding a real provider key. Enable it via **Try the demo agent** on the Getting Started page (see the [quickstart](/quickstart)) rather than the Settings key-entry flow.
+</Note>
 
 <Note>
   **Microsoft Foundry** is a model gateway, not a single-vendor provider. One Foundry deployment gives you access to a multi-vendor catalog — OpenAI (`gpt-5.5`, `o3`), Microsoft (`Phi-4`), Meta (`Meta-Llama-3.1-405B-Instruct`), Mistral (`Mistral-Large-2411`, `Codestral-2501`), DeepSeek (`DeepSeek-V3`, `DeepSeek-R1`), Cohere, AI21, and more. The model id you save in Nora is your **Foundry deployment name** — operator-defined when you create the deployment, not a fixed vendor model id. For example, if the Azure deployment is named `gpt-5.5-1`, save `gpt-5.5-1`; Nora carries that exact deployment name into OpenClaw and Hermes runtime config.

--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -74,6 +74,7 @@ Redis backs BullMQ for deployment, ClawHub install, backup, and alert-delivery j
 | `ALERT_DELIVERY_WORKER_CONCURRENCY` | No       | `5`       | Concurrency of the alert-deliveries worker.                                                                                                        |
 | `WORKER_HEALTH_PORT`                | No       | `4001`    | Provisioner worker health-check port.                                                                                                              |
 | `BACKUP_WORKER_HEALTH_PORT`         | No       | `4002`    | Backup worker health-check port.                                                                                                                   |
+| `CLAWHUB_PRUNE_ORPHANED_SKILLS`     | No       | `false`   | When `true`, the provisioner reconciler uninstalls ClawHub skills present in a runtime container but not tracked in the agents table. Off by default — orphans are surfaced in the UI and removed explicitly. |
 
 ## Access and URL
 
@@ -85,6 +86,7 @@ These variables control which nginx configuration is mounted, the listening port
 | `NGINX_HTTP_PORT`   | No       | `8080`                  | Host port mapped to the nginx HTTP listener. Use `8080` locally and `80` when deploying on a public domain. Setup auto-picks another free local port when `8080` is busy. |
 | `NEXTAUTH_URL`      | No       | `http://localhost:8080` | Canonical browser-facing URL of your Nora deployment. Set to your `https://` origin when exposing on a domain.                                                            |
 | `NORA_PUBLIC_URL`   | No       | —                       | Optional explicit public origin used by emails, OAuth callbacks, and audit links when it differs from `NEXTAUTH_URL`.                                                     |
+| `NORA_FORCE_SECURE_COOKIES` | No | —              | When set to `1`, forces the `Secure` flag on session cookies regardless of inbound scheme. Set for always-on-TLS public deployments behind a proxy/CDN that may strip `X-Forwarded-Proto`; leave empty for local HTTP.                              |
 
 ## OAuth
 
@@ -367,6 +369,15 @@ Optional; only relevant when nginx terminates TLS directly inside the stack.
 | `TLS_CERT_PATH` | No       | —       | Path to the TLS certificate file on the host. Used when nginx is configured to terminate TLS. |
 | `TLS_KEY_PATH`  | No       | —       | Path to the TLS private key file on the host.                                                 |
 
+## Marketing analytics
+
+Optional privacy-light analytics for the public marketing site, powered by [Plausible](https://plausible.io). Off by default — self-hosted deployments ship zero tracking unless `NEXT_PUBLIC_ANALYTICS_DOMAIN` is set at build time.
+
+| Variable                       | Required | Default                              | Description                                                                                |
+| ------------------------------ | -------- | ------------------------------------ | ------------------------------------------------------------------------------------------ |
+| `NEXT_PUBLIC_ANALYTICS_DOMAIN` | No       | —                                    | Plausible domain for the public marketing site. Empty (default) ships zero tracking.       |
+| `NEXT_PUBLIC_ANALYTICS_SRC`    | No       | `https://plausible.io/js/script.js`  | Plausible script URL; point at a self-hosted Plausible instance if you run one.             |
+
 ## Cost reporting
 
 These optional rates drive the Cost dashboards. Nora estimates spend from token usage recorded by OpenClaw, Hermes, and future runtime chat paths.
@@ -393,3 +404,4 @@ These variables are read by older platform-settings code paths for backward comp
 | `AWS_S3_BUCKET`         | No       | —       | Legacy S3 bucket alias for backups. |
 | `AWS_ACCESS_KEY_ID`     | No       | —       | Legacy AWS access key ID.           |
 | `AWS_SECRET_ACCESS_KEY` | No       | —       | Legacy AWS secret access key.       |
+| `AWS_SESSION_TOKEN`     | No       | —       | Legacy optional AWS STS session token. |

--- a/docs/configuration/platform-modes.mdx
+++ b/docs/configuration/platform-modes.mdx
@@ -18,8 +18,8 @@ Nora operates in one of two platform modes, controlled by the `PLATFORM_MODE` en
 | **Resource limits**          | Set by operator via env vars            | Locked to Stripe subscription plan tier                      |
 | **Billing**                  | None                                    | Stripe (when `BILLING_ENABLED=true`)                         |
 | **Agent limit source**       | `MAX_AGENTS` env var                    | Subscription plan                                            |
-| **vCPU / RAM / disk source** | `MAX_VCPU`, `MAX_RAM_MB`, `MAX_DISK_GB` | Subscription plan tier                                       |
-| **Free tier**                | All users share operator limits         | Automatic free plan (3 agents, 2 vCPU, 2 GB RAM, 20 GB disk) |
+| **vCPU / RAM / disk source** | `MAX_VCPU`, `MAX_RAM_MB`, `MAX_DISK_GB` | Platform-wide deployment defaults (Admin Settings), shared across all plan tiers |
+| **Free tier**                | All users share operator limits         | Automatic free plan (3 agents; compute comes from the platform deployment defaults, not a per-plan value) |
 
 ## Self-hosted mode
 
@@ -70,11 +70,15 @@ BILLING_ENABLED=true
 
 Three tiers are defined in the billing module:
 
-| Plan         | Agents | vCPU | RAM   | Disk   |
-| ------------ | ------ | ---- | ----- | ------ |
-| `free`       | 3      | 2    | 2 GB  | 20 GB  |
-| `pro`        | 10     | 8    | 16 GB | 200 GB |
-| `enterprise` | 100    | 16   | 32 GB | 500 GB |
+| Plan         | Agents |
+| ------------ | ------ |
+| `free`       | 3      |
+| `pro`        | 10     |
+| `enterprise` | 100    |
+
+<Note>
+  vCPU, RAM, and disk are not differentiated by plan tier. Every PaaS subscription receives the platform-wide deployment defaults (`default_vcpu` / `default_ram_mb` / `default_disk_gb`) configured in Admin Settings — only the per-tier agent limit (and managed-backup limits) differ. The shipped fallback defaults are 1 vCPU / 1024 MB / 10 GB.
+</Note>
 
 New users are automatically placed on the `free` plan when they first deploy an agent.
 

--- a/docs/configuration/provisioner-backends/kubernetes-kind.mdx
+++ b/docs/configuration/provisioner-backends/kubernetes-kind.mdx
@@ -48,9 +48,16 @@ npm run smoke:k8s-kind
 
 Set `KEEP_ENV=true` to leave the cluster and Compose stack running after the script finishes.
 
-### 3. Inspect the deployed agent in the Nora UI
+### 3. Inspect the deployed agent
 
-With `KEEP_ENV=true`, open the dashboard at the API base URL the smoke script prints (defaults to `http://127.0.0.1:4110`) and pick a deployed agent from the fleet view to see its Kubernetes-flavored detail page.
+With `KEEP_ENV=true`, the smoke run leaves only `postgres`, `redis`, `backend-api`, and `worker-provisioner` running — no nginx and no frontend dashboard. The URL the script prints (default `http://127.0.0.1:4110`) is the backend REST API base (the host port maps to the backend-api container's API port 4000), **not** a UI. Inspect the agent via the API or `kubectl`:
+
+```bash theme={null}
+curl -fsS http://127.0.0.1:4110/health
+kubectl -n openclaw-agents get deploy,svc,pods
+```
+
+To view the agent in the operator dashboard fleet view, bring up the full stack with the command shown in [Manual stack (without the smoke script)](#manual-stack-without-the-smoke-script) below, then open the dashboard at `http://127.0.0.1:8080/app`.
 
 <Frame caption="Nora deploy wizard — Backend dropdown with Kubernetes available">
   ![Deploy wizard backend

--- a/docs/configuration/provisioner-backends/kubernetes.mdx
+++ b/docs/configuration/provisioner-backends/kubernetes.mdx
@@ -16,6 +16,14 @@ The agent Overview tab shows the live Kubernetes pod replica snapshot in the Det
 
 ## Configuration
 
+<Note>
+  Two Kubernetes install models are supported. (1) Nora runs in Docker Compose and provisions agents
+  into one or more registered clusters via mounted kubeconfigs (this page). (2) Run the Nora control
+  plane itself inside Kubernetes with the official Helm chart at `infra/helm/nora` — see the
+  Kubernetes (Helm) section of [Self-hosting](/self-hosting). Under Helm the chart sets
+  `ENABLED_BACKENDS=k8s` and mounts agent kubeconfigs via `kubeconfigs.existingSecret`.
+</Note>
+
 Register Kubernetes clusters in **Admin -> Kubernetes**. Nora does not create a Kubernetes execution target from `.env`; each enabled Admin row with a passing connection test becomes a concrete execution target such as `k8s:aks-eastus2`.
 
 For production, prefer a scoped identity or service account with the permissions below instead of a broad cluster-admin kubeconfig.

--- a/docs/guides/alert-rules.mdx
+++ b/docs/guides/alert-rules.mdx
@@ -12,11 +12,11 @@ A pattern matches an event type using one of three forms:
 
 | Pattern             | Example matches                                           | Notes                                                               |
 | ------------------- | --------------------------------------------------------- | ------------------------------------------------------------------- |
-| Literal             | `agent.error` matches only `agent.error`                  | Exact string match.                                                 |
-| Suffix glob         | `agent.*` matches `agent.error`, `agent.warning`, `agent` | The trailing `.*` matches one segment or none.                      |
+| Literal             | `agent.budget_paused` matches only `agent.budget_paused`                  | Exact string match.                                                 |
+| Suffix glob         | `agent.*` matches `agent.budget_paused`, `agent.budget_updated`, `agent` | The trailing `.*` matches one segment or none.                      |
 | Wildcard            | `*` matches every event type                              | Useful for catch-all monitoring rules.                              |
 
-Common event types include `agent.error`, `agent.warning`, `backup_agent_completed`, `backup_agent_failed`, `agent_hub_listing_published`, and `workspace.invitation_accepted`. The full list grows over time — point a `*` rule at a webhook in a staging workspace to discover what's emitted.
+Common event types include `agent_deployed`, `agent_stopped`, `backup_agent_queued`, `agent_hub_published`, `workspace_invitation_accepted`, and `agent.budget_paused`. Most event types use underscores (e.g. `agent_deployed`, `workspace_invitation_accepted`); the dot-delimited form is reserved for budget events (`agent.budget_*`). The full list grows over time — point a `*` rule at a webhook in a staging workspace to discover what's emitted.
 
 ## Channels
 
@@ -40,8 +40,8 @@ The body posted to your endpoint:
 
 ```json theme={null}
 {
-  "eventType": "agent.error",
-  "message": "Container exited unexpectedly",
+  "eventType": "agent_stopped",
+  "message": "Agent stopped unexpectedly",
   "metadata": { "agent": { "id": "..." }, "workspace": { "id": "..." } },
   "firedAt": "2026-05-07T00:00:00Z",
   "ruleId": "...",

--- a/docs/guides/backups.mdx
+++ b/docs/guides/backups.mdx
@@ -35,7 +35,7 @@ Credentials can be set via env at startup or managed at runtime from **Admin Set
   </Step>
 
   <Step title="Click New backup">
-    Optionally name the backup (defaults to a timestamped label). Confirm. Nora queues a backup job on the `backups` queue and the panel shows it as `pending`. The backup worker (`workers/backup`) picks it up, snapshots the agent state, encrypts the archive, and uploads it to the configured destination.
+    Optionally name the backup (defaults to a timestamped label). Confirm. Nora queues a backup job on the `backups` queue and the panel shows it as `queued`. The backup worker (`workers/backup`) picks it up, snapshots the agent state, encrypts the archive, and uploads it to the configured destination.
 
     <Note>
       Backup jobs have a hard `Promise.race` timeout of `NORA_BACKUP_JOB_TIMEOUT_MS` (default 30 minutes). Long-running snapshots are aborted at the timeout — agents holding open large datasets may need a higher value.
@@ -43,7 +43,7 @@ Credentials can be set via env at startup or managed at runtime from **Admin Set
   </Step>
 
   <Step title="Wait for completion">
-    The backup transitions through `pending` → `running` → `completed` (or `failed`). When complete, the **Download** action becomes available.
+    The backup transitions through `queued` → `running` → `ready` / `ready_with_warnings` (or `failed`). When complete, the **Download** action becomes available.
   </Step>
 </Steps>
 
@@ -56,7 +56,7 @@ Each agent has its own schedule. From the Backups panel, click **Schedule**:
 | Field            | Notes                                                                   |
 | ---------------- | ----------------------------------------------------------------------- |
 | **Enabled**      | Master toggle for the schedule.                                         |
-| **Frequency**    | One of `hourly`, `daily`, `weekly`, `monthly`.                          |
+| **Frequency**    | One of `hourly`, `daily`, `weekly`.                                     |
 | **Retain**       | How many scheduled backups to keep before pruning the oldest.           |
 | **Next run at**  | Computed from the frequency and the most recent successful backup.      |
 
@@ -68,7 +68,7 @@ The public API exposes **copy** restore only — it materializes the backup into
 
 <Steps>
   <Step title="Click Restore on a backup row">
-    From the agent's Backups panel, click the **Restore** action on any `completed` backup.
+    From the agent's Backups panel, click the **Restore** action on any `ready` (or `ready_with_warnings`) backup.
   </Step>
 
   <Step title="Confirm the destination">
@@ -106,8 +106,8 @@ PaaS deployments override these per subscription tier. See [Platform modes](/con
 ## Troubleshooting
 
 <AccordionGroup>
-  <Accordion title="Backup stays in 'pending' forever">
-    Check that the `nora-backup-worker` container is running. Its health endpoint is `http://backup-worker:4002/health`. If unhealthy, the BullMQ `backups` queue has nothing draining it.
+  <Accordion title="Backup stays in 'queued' forever">
+    Check that the `worker-backup` container is running. Its health endpoint is `http://worker-backup:4002/health`. If unhealthy, the BullMQ `backups` queue has nothing draining it.
   </Accordion>
 
   <Accordion title="Restore archive fails to decrypt">
@@ -119,6 +119,6 @@ PaaS deployments override these per subscription tier. See [Platform modes](/con
   </Accordion>
 
   <Accordion title="SSH upload hangs">
-    The SSH destination uses sftp under the hood. Check that the remote user can write to `NORA_BACKUP_SSH_REMOTE_PATH` and that the host is reachable from inside the backup-worker container.
+    The SSH destination uses sftp under the hood. Check that the remote user can write to `NORA_BACKUP_SSH_REMOTE_PATH` and that the host is reachable from inside the `worker-backup` container.
   </Accordion>
 </AccordionGroup>

--- a/docs/guides/channels.mdx
+++ b/docs/guides/channels.mdx
@@ -96,13 +96,13 @@ Deleting a channel removes the record and all associated message history.
 External services can send events to your agent through a public webhook endpoint. The URL format is:
 
 ```
-POST /webhooks/:channelId
+POST /api/webhooks/:channelId
 ```
 
 Where `:channelId` is the ID of the channel you want to receive events on. Nora accepts the payload, logs it as an inbound message, and forwards it to the agent runtime if the agent is currently running.
 
 ```http theme={null}
-POST /webhooks/ch_abc123
+POST /api/webhooks/3f9a2c10-7b1e-4d6a-9c44-2e8f1b0a7d55
 Content-Type: application/json
 
 {

--- a/docs/guides/doctor.mdx
+++ b/docs/guides/doctor.mdx
@@ -50,7 +50,7 @@ The admin **Health** panel renders the same report with a re-run button and auto
 | Database | A `SELECT 1` succeeds | PostgreSQL |
 | Provisioning queue | The queue responds and the dead-letter queue is empty | Redis / BullMQ |
 | Kubernetes targets | Every registered target has passed a connection test | Admin → Kubernetes |
-| Secret posture | `JWT_SECRET` and `NORA_API_KEY_HASH_SECRET` are set, non-placeholder, and long enough (`ENCRYPTION_KEY` is a warning) | Process environment |
+| Secret posture | `JWT_SECRET` and `ENCRYPTION_KEY` are set, non-placeholder, and long enough (`ENCRYPTION_KEY` must be a 64-char hex string); a missing/weak `NORA_API_KEY_HASH_SECRET` is a warning, not a failure | Process environment |
 | Fleet health | No agent needs attention (see the [needs-attention roll-up](/api/monitoring)) | Agents table |
 | Gateway exposure | Surfaces how many agent gateways are published to a host port so you can confirm they are firewalled | Agents table |
 

--- a/docs/guides/integrations/email.mdx
+++ b/docs/guides/integrations/email.mdx
@@ -53,10 +53,16 @@ No MCP server — SMTP isn't a query API.
 
 ## Environment variables Nora injects
 
-| Variable            | Source             |
-| ------------------- | ------------------ |
-| `SMTP_PASS`         | Password field     |
-| `SMTP_HOST`         | SMTP Host field    |
-| `SMTP_PORT`         | SMTP Port field    |
-| `SMTP_USER`         | Username field     |
-| `SMTP_FROM_ADDRESS` | From Address field |
+| Variable                | Source                     |
+| ----------------------- | -------------------------- |
+| `EMAIL_PASSWORD`        | Password field (primary secret) |
+| `EMAIL_USERNAME`        | Username field             |
+| `EMAIL_SMTP_HOST`       | SMTP Host field            |
+| `EMAIL_SMTP_PORT`       | SMTP Port field            |
+| `EMAIL_SMTP_SECURE`     | SMTP secure flag           |
+| `EMAIL_IMAP_HOST`       | IMAP Host field            |
+| `EMAIL_IMAP_PORT`       | IMAP Port field            |
+| `EMAIL_IMAP_SECURE`     | IMAP secure flag           |
+| `EMAIL_FROM_ADDRESS`    | From Address field         |
+| `EMAIL_FROM_NAME`       | From Name field            |
+| `EMAIL_PROVIDER_PRESET` | Provider preset            |

--- a/docs/guides/integrations/gitlab.mdx
+++ b/docs/guides/integrations/gitlab.mdx
@@ -66,7 +66,7 @@ GitLab has a reference Model Context Protocol server published by the MCP projec
 - **Docs:** [github.com/modelcontextprotocol/servers/tree/main/src/gitlab](https://github.com/modelcontextprotocol/servers/tree/main/src/gitlab)
 - **Env vars:** `GITLAB_PERSONAL_ACCESS_TOKEN`, optionally `GITLAB_API_URL` for self-hosted instances.
 
-Nora's runtime does not auto-launch this MCP server today — bring it up alongside your agent if you want MCP-style tool calls. The integration record itself injects `GITLAB_TOKEN` (and `GITLAB_BASE_URL` if set) into the agent container, so the MCP server picks them up automatically.
+Nora can run this MCP server for you: enable it from the **MCP Servers** panel on the agent's **Integrations** tab once the GitLab integration is connected, and Nora launches it over stdio on the next redeploy. Nora injects the integration's token; the server reads `GITLAB_PERSONAL_ACCESS_TOKEN` (and `GITLAB_API_URL` for self-hosted).
 
 ## Environment variables Nora injects
 

--- a/docs/guides/integrations/index.mdx
+++ b/docs/guides/integrations/index.mdx
@@ -13,9 +13,10 @@ The main [integrations guide](/guides/integrations) covers the connection workfl
 
 <Note>
   Many providers also publish a Model Context Protocol (MCP) server. Where one exists, the
-  per-provider page lists the npm/PyPI package and a link to its documentation. Nora's catalog
-  surfaces this as an "MCP" badge on the integration card, but the runtime does not auto-launch the
-  MCP server today — you bring it up alongside the integration if you want it.
+  per-provider page lists the npm/PyPI package and a link to its documentation. Nora can also
+  auto-launch a subset of these MCP servers for you (currently GitLab, Notion, Stripe, and Supabase)
+  from the **MCP Servers** panel on the agent's **Integrations** tab — see the main integrations
+  guide. For other providers, bring the MCP server up alongside the integration yourself.
 </Note>
 
 ## Catalog

--- a/docs/guides/integrations/slack.mdx
+++ b/docs/guides/integrations/slack.mdx
@@ -40,11 +40,11 @@ A Slack MCP server is available:
 
 - **Package:** `@modelcontextprotocol/server-slack`
 - **Docs:** [github.com/modelcontextprotocol/servers/tree/main/src/slack](https://github.com/modelcontextprotocol/servers/tree/main/src/slack)
-- **Env:** `SLACK_BOT_TOKEN` — Nora injects this automatically.
+- **Env:** `SLACK_BOT_TOKEN` — set this in the MCP server config to the value Nora injects as `SLACK_TOKEN`.
 
 ## Environment variables Nora injects
 
 | Variable                | Source                   |
 | ----------------------- | ------------------------ |
-| `SLACK_BOT_TOKEN`       | Bot Token field          |
+| `SLACK_TOKEN`           | Bot Token field          |
 | `SLACK_DEFAULT_CHANNEL` | Default Channel (if set) |

--- a/docs/guides/manage-providers.mdx
+++ b/docs/guides/manage-providers.mdx
@@ -39,6 +39,10 @@ Nora supports the following LLM providers:
   Microsoft Foundry requires more than an API key. Enter your Foundry resource base URL, for example `https://<resource>.services.ai.azure.com/openai/v1/`, and set the model field to the exact Azure deployment name, such as `gpt-5.5-1`. Deployment names are created in your Foundry resource, so do not trim `-1` or replace the value with the base model id.
 </Note>
 
+<Note>
+  Nora also ships a built-in **Demo** provider (`Demo (built-in, no key required)`) that needs no API key. It runs a deterministic stub served by the control plane itself (model `nora-demo-1`), so a fresh install can deploy a working agent and see a chat round-trip before any real provider key is added. Add it with `POST /api/llm-providers` and a body of `{"provider":"demo"}` (no key), or use the **Try the demo agent — no API key** button in the first-run flow. Replace it with a real provider key when you are ready to run production agents.
+</Note>
+
 ## Add a provider key
 
 ![Settings — saved provider keys with masked previews and default-provider star](/images/guides/providers/provider-keys.png)

--- a/docs/guides/monitoring.mdx
+++ b/docs/guides/monitoring.mdx
@@ -16,9 +16,25 @@ GET /api/monitoring/metrics
 
 Use this endpoint to get a high-level picture of your deployment before drilling into individual agents.
 
+## Fleet needs-attention
+
+The operator dashboard (`/app`) shows a **Needs attention** strip at the top that lists the agents you should look at right now and why. It is derived server-side at read time from existing state — no extra configuration — and stays hidden when the fleet is healthy, so it never adds noise to an all-clear deployment.
+
+It surfaces these reasons:
+
+| Reason             | Severity | Condition                                                              |
+| ------------------ | -------- | --------------------------------------------------------------------- |
+| Errored            | error    | Agent status is `error`                                               |
+| Budget cap reached | error    | Agent is paused at a budget cap (`paused_reason = budget_exceeded`)   |
+| Stuck deploying    | warning  | Agent has been queued or deploying for more than 10 minutes           |
+| Approaching budget | warning  | A running agent has crossed a budget soft threshold                   |
+| Stalled telemetry  | warning  | A running agent has reported no container stats for more than 5 minutes |
+
+Errors sort before warnings. The strip covers the agents you can access — directly owned plus workspace-shared. It is backed by the [fleet needs-attention roll-up](/api/monitoring) API (`GET /monitoring/fleet-status`, requires the `monitoring:read` scope), and the `nora doctor` [Fleet-health check](/guides/doctor) is built on the same roll-up.
+
 ## Agent-level metrics
 
-Each agent exposes a live stats snapshot and a historical stats series. Stats are collected every **10 seconds** and retained for **24 hours**.
+Each agent exposes a live stats snapshot and a historical stats series. Stats are collected every **5 seconds** and retained for **7 days**.
 
 ### Live stats
 
@@ -45,7 +61,7 @@ The response includes the following fields:
 | `running`         | boolean | Whether the container is currently running                          |
 
 <Note>
-  Live stats require a running container. If the agent is stopped or has no container, the endpoint returns a `409` error.
+  If the agent is stopped or has no container, the endpoint still returns `200` with `current.running: false` and an `error` field (e.g. "No container assigned") rather than live metrics.
 </Note>
 
 ### Historical stats
@@ -66,6 +82,8 @@ GET /api/agents/:id/stats/history?range=15m
 | `1h`      | Last 1 hour               |
 | `6h`      | Last 6 hours              |
 | `24h`     | Last 24 hours             |
+| `3d`      | Last 3 days               |
+| `7d`      | Last 7 days               |
 
 You can also query a custom window using ISO timestamps:
 
@@ -73,7 +91,7 @@ You can also query a custom window using ISO timestamps:
 GET /api/agents/:id/stats/history?from=2026-04-10T08:00:00Z&to=2026-04-10T09:00:00Z
 ```
 
-Each data point in the history response contains the same metric fields as the live stats endpoint, plus a `recorded_at` timestamp. Results are ordered by `recorded_at` ascending and capped at 2000 rows per query.
+Each data point in the history response contains the same metric fields as the live stats endpoint, plus a `recorded_at` timestamp. Results are ordered by `recorded_at` ascending and capped at 5000 rows for short windows (≤ 1 hour, returned un-aggregated) and 4000 rows for larger windows, which are time-bucketed/aggregated server-side.
 
 **Historical stat fields:**
 
@@ -159,6 +177,18 @@ To view one workspace's cost breakdown:
 ```http theme={null}
 GET /api/workspaces/:id/cost?period_days=30
 ```
+
+## Per-agent budget caps
+
+You can cap an agent's LLM spend so it pauses itself before it runs away. Open an agent's **Settings** tab and set one budget per period — `daily`, `weekly`, or `monthly` — each with a USD hard limit and a soft-threshold percent (default `80`).
+
+Nora enforces budgets automatically:
+
+- When spend crosses the soft threshold, Nora emits an `agent.budget_soft_exceeded` event as an early warning.
+- When spend reaches 100% of a period's limit, Nora pauses the runtime automatically, emits `agent.budget_exceeded`, and sets `paused_reason = budget_exceeded`.
+- Manually starting a still-over-cap agent clears `paused_reason`, but the budget sweep re-pauses it on its next cycle (within roughly a minute) while it remains over cap.
+
+Manage budgets through the API with `GET /api/agents/:id/budget`, `PUT /api/agents/:id/budget`, and `DELETE /api/agents/:id/budget/:budgetId` (see the [agents API reference](/api/agents)).
 
 ## Performance data
 

--- a/docs/guides/sentry-communication-intelligence.mdx
+++ b/docs/guides/sentry-communication-intelligence.mdx
@@ -45,12 +45,9 @@ Or use Telegram / Slack / Discord / email — see [Configure channels](/guides/c
 Two ways, mix as needed:
 
 - **Live monitoring** — connect a source in the **Integrations** tab so Sentry reads it directly:
-  <CardGroup cols={3}>
+  <CardGroup cols={2}>
     <Card title="Slack" href="/guides/integrations/slack" icon="slack" arrow>
       Monitor channels/DMs.
-    </Card>
-    <Card title="Microsoft Teams" href="/guides/integrations/teams" icon="microsoft" arrow>
-      Monitor chats.
     </Card>
     <Card title="Email" href="/guides/integrations/email" icon="envelope" arrow>
       Monitor threads.

--- a/docs/quickstart.mdx
+++ b/docs/quickstart.mdx
@@ -5,7 +5,7 @@
 This guide takes you from a fresh machine to a running, validated agent runtime. You will install Nora using the one-line installer or Docker Compose, create your operator account, connect an LLM provider, deploy your first agent, and confirm the end-to-end workflow is healthy — all in about 15 minutes.
 
 <Note>
-  The installer can install Docker, Docker Compose, and Git for you if they are not already present
+  The installer can install Docker, Docker Compose, Git, and OpenSSL for you if they are not already present
   on your machine. You need macOS 12+, Linux (Ubuntu 20.04+, Debian 11+, or Fedora 38+), or Windows
   10+ with WSL2, plus admin or sudo access.
 </Note>
@@ -58,9 +58,13 @@ This guide takes you from a fresh machine to a running, validated agent runtime.
   </Step>
 
 <Step title="Create an account or log in">
-  Go to the printed `/signup` URL and create your operator account. If you set `DEFAULT_ADMIN_EMAIL`
-  and `DEFAULT_ADMIN_PASSWORD` during setup, that account is already created — go to `/login` and
-  use those credentials instead.
+  Go to the printed `/signup` URL and create your operator account. On a brand-new instance with no
+  users yet, the signup page runs in first-run claim mode — it shows "Claim this Nora server" and the
+  first account you create becomes the platform admin. After you finish, you land on the Getting
+  Started page (`/app/getting-started`).
+
+  If you set `DEFAULT_ADMIN_EMAIL` and `DEFAULT_ADMIN_PASSWORD` during setup, that account is already
+  created — go to `/login` and use those credentials instead.
 </Step>
 
   <Step title="Add an LLM provider key">

--- a/docs/self-hosting.mdx
+++ b/docs/self-hosting.mdx
@@ -68,7 +68,7 @@ The installer script is the fastest path to a running Nora instance. It handles 
     http://localhost:8080
     ```
 
-    If setup selected a different port, use the printed URL instead. If you skipped the bootstrap admin account, go to `/signup` on that origin to create your operator account.
+    If setup selected a different port, use the printed URL instead. If you skipped the bootstrap admin account, go to `/signup` on that origin. On a fresh instance the signup page runs in "claim this server" mode and the first account you create becomes the platform admin (see [Security architecture](/concepts/security)).
 
   </Step>
 </Steps>
@@ -133,7 +133,7 @@ Use manual setup when you want full control over every configuration value befor
   </Step>
 
   <Step title="Open the dashboard">
-    Once the stack is up, open your browser to `http://localhost:8080`. Create your operator account at `/signup` if you did not pre-seed a bootstrap admin.
+    Once the stack is up, open your browser to `http://localhost:8080`. Open `/signup` to create your operator account if you did not pre-seed a bootstrap admin. On a fresh database this runs as first-run claim, and the first account created becomes the platform admin.
   </Step>
 </Steps>
 

--- a/docs/support/faq.mdx
+++ b/docs/support/faq.mdx
@@ -40,6 +40,7 @@ If you are evaluating Nora or have just started self-hosting it, the questions b
     * Hugging Face
     * Cerebras
     * NVIDIA
+    * Microsoft Foundry
 
     <Tip>
       After saving or updating a key in Settings, use the **Sync** button on the agent detail page to push the key to any running agents.

--- a/e2e/REAL_TESTS.md
+++ b/e2e/REAL_TESTS.md
@@ -16,6 +16,9 @@ security fixes shipped in integrations.ts / channels/adapters.ts.
   Bot API schema.
 - `specs/support/realConfig.ts` — `.env.real` loader and skip gates.
 - `specs/support/agents.ts` — API helpers.
+- `specs/support/app.ts` — session/auth + API request helpers
+  (`createUserSession`, `DEFAULT_PASSWORD`, `uniqueEmail`, `uniqueName`, plus
+  `apiJson`/`getCurrentUser`) imported by the real specs.
 - `.env.real.example` — fill in and copy to `.env.real`.
 
 ## Prerequisites
@@ -76,6 +79,7 @@ up.
 | OpenClaw + K8s      | `REAL_ENABLE_OPENCLAW_K8S=1`              | Control plane started with `docker-compose.kubernetes.yml`; add `docker-compose.kind.yml` only for local Kind networking |
 | OpenClaw + NemoClaw | `REAL_ENABLE_OPENCLAW_NEMOCLAW=1`         | `NVIDIA_API_KEY` set in `.env` for the stack                                                                                           |
 | Hermes + Docker     | `REAL_ENABLE_HERMES_DOCKER=1`             | First run pulls a large Hermes image — warm the cache or raise `REAL_PROVISION_TIMEOUT_MS`                                             |
+| Hermes + K8s        | `REAL_ENABLE_HERMES_K8S=1`                | Control plane started with `docker-compose.kubernetes.yml` (add `docker-compose.kind.yml` only for local Kind networking); first run pulls a large Hermes image — warm the cache or raise `REAL_PROVISION_TIMEOUT_MS` |
 
 Each cell runs in order: `[L1] deploy → [L2] reach running → [L3] gateway
 reachable → [L4] chat roundtrip → [L5] logs/events → [L7] metrics populate →

--- a/frontend-dashboard/README.md
+++ b/frontend-dashboard/README.md
@@ -8,41 +8,54 @@ Runs on `/app/*` behind nginx. Users manage their AI agents, configure LLM provi
 
 ## Pages
 
-| Route              | Description                                                                                              |
-| ------------------ | -------------------------------------------------------------------------------------------------------- |
-| `/app`             | Dashboard home — agent overview and quick stats                                                          |
-| `/app/agents`      | Agent fleet list with status indicators                                                                  |
-| `/app/agents/[id]` | Agent detail with 7-tab interface                                                                        |
-| `/app/deploy`      | Deploy a new agent (Docker or K8s/Kubernetes GA; Proxmox visible only as release-blocked roadmap target) |
-| `/app/agent-hub`   | Browse, share, and install agent templates                                                               |
-| `/app/workspaces`  | Manage isolated workspaces                                                                               |
-| `/app/monitoring`  | Real-time metrics via SSE                                                                                |
-| `/app/settings`    | User profile, LLM provider keys, connected accounts                                                      |
+| Route                       | Description                                                                                              |
+| --------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `/app`                      | Redirects to `/app/agents`                                                                               |
+| `/app/dashboard`            | Dashboard home: fleet roll-up, quick stats, and activation checklist                                     |
+| `/app/getting-started`      | First-run activation checklist / zero-key demo onboarding                                                |
+| `/app/agents`               | Agent fleet list with status indicators                                                                  |
+| `/app/agents/[id]`          | Agent detail with runtime-filtered tab interface (up to 10 tabs)                                         |
+| `/app/agents/[id]/versions` | Agent deploy-draft version history                                                                       |
+| `/app/deploy`               | Deploy a new agent (Docker or K8s/Kubernetes GA; Proxmox visible only as release-blocked roadmap target) |
+| `/app/agent-hub`            | Browse, share, and install agent templates                                                               |
+| `/app/workspaces`           | Manage isolated workspaces                                                                               |
+| `/app/monitoring`           | Real-time metrics via SSE                                                                                |
+| `/app/logs`                 | Standalone cross-agent log browser                                                                       |
+| `/app/cost`                 | All-workspaces cost dashboard (grouped by workspace)                                                     |
+| `/app/clawhub`              | ClawHub skill catalog browser used when building a deploy draft                                          |
+| `/app/settings`             | User profile, LLM provider keys, connected accounts                                                      |
 
 ## Agent Detail Tabs
 
-Each agent's `/app/agents/[id]` page has 7 tabs:
+Each agent's `/app/agents/[id]` page exposes a runtime-filtered tab set (up to 10 base tabs, filtered by runtime family and sandbox profile):
 
 - **Overview** — status, actions (start/stop/restart/redeploy), resource info
+- **Metrics** — agent resource and runtime metrics
 - **Terminal** — interactive xterm.js terminal via WebSocket
 - **Logs** — real-time log streaming
-- **OpenClaw** — 5 sub-panels: Chat, Files, Extensions, Gate (WS-RPC), Identity (Ed25519)
-- **Channels** — manage 9 channel types with dynamic config forms
-- **Integrations** — browse 60+ integrations with config modals
-- **Settings** — agent config, danger zone
+- **OpenClaw** (gateway runtimes only) — 7 sub-panels: Official Dashboard, Status, Chat, Integrations, ClawHub, Cron, Channels
+- **Hermes WebUI** (Hermes only) — embedded Hermes dashboard
+- **NemoClaw** (nemoclaw sandbox only) — sandbox profile controls
+- **Files** — agent workspace file browser
+- **Backups** — agent backup management
+- **Settings** — agent config, per-agent LLM budget hard caps (auto-pause when spend crosses 100%), danger zone
+
+Channels and Integrations are not top-level tabs — they are sub-panels inside the OpenClaw tab. The Integrations sub-panel browses 60+ integrations with config modals and adds per-agent MCP server management (expose a connected integration to the agent's OpenClaw runtime as an MCP server).
 
 ## Key Components
 
-| Component                                   | Purpose                                           |
-| ------------------------------------------- | ------------------------------------------------- |
-| `AgentTerminal.tsx`                         | xterm.js terminal with FitAddon, WebSocket        |
-| `TabBar.tsx`                                | 7-tab navigation bar                              |
-| `OpenClawTab.tsx`                           | 5-panel OpenClaw interface                        |
-| `ChannelsTab.tsx`                           | Channel CRUD with dynamic config forms            |
-| `IntegrationsTab.tsx`                       | Catalog browser with 17-category filter           |
-| `IntegrationCard.tsx`                       | Card with config modal for connecting             |
-| `LLMSetupWizard.tsx`                        | 3-step provider setup (select → configure → done) |
-| `Layout.tsx` / `Sidebar.tsx` / `Topbar.tsx` | App shell layout                                  |
+| Component                                   | Purpose                                             |
+| ------------------------------------------- | --------------------------------------------------- |
+| `AgentTerminal.tsx`                         | xterm.js terminal with FitAddon, WebSocket          |
+| `TabBar.tsx`                                | Runtime-filtered tab navigation bar (up to 10 tabs) |
+| `OpenClawTab.tsx`                           | 7-panel OpenClaw interface                          |
+| `ChannelsTab.tsx`                           | Channel CRUD with dynamic config forms              |
+| `IntegrationsTab.tsx`                       | Catalog browser with 17-category filter             |
+| `IntegrationCard.tsx`                       | Card with config modal for connecting               |
+| `BudgetSection.tsx`                         | Per-agent LLM budget hard caps (Settings tab)       |
+| `McpServersSection.tsx`                     | Per-agent MCP server management (Integrations panel)|
+| `LLMSetupWizard.tsx`                        | 3-step provider setup (select → configure → done)   |
+| `Layout.tsx` / `Sidebar.tsx` / `Topbar.tsx` | App shell layout                                    |
 
 ## Development
 
@@ -53,7 +66,7 @@ docker compose logs -f frontend-dashboard
 # Local development (outside Docker)
 cd frontend-dashboard
 npm install
-npm run dev   # Starts on port 3001
+npm run dev   # Starts on http://localhost:3000 (honors $PORT; default 3000)
 ```
 
 ## Configuration

--- a/frontend-marketing/README.md
+++ b/frontend-marketing/README.md
@@ -4,7 +4,7 @@ Public-facing marketing site for Nora. Built with Next.js 16, React 19, and Tail
 
 ## Overview
 
-Runs on `/` behind nginx. Serves the landing page, deployment/support-path page, login, and signup pages. Does not require authentication.
+Runs on `/` behind nginx. Serves the landing page, pricing/support-path page, login, signup, privacy, terms, and a custom 404 page. Does not require authentication.
 
 ## Pages
 
@@ -13,7 +13,9 @@ Runs on `/` behind nginx. Serves the landing page, deployment/support-path page,
 | `/` | Landing page — positioning, product facts, feature grid, CTA |
 | `/pricing` | Public deployment, support, and commercial-path page |
 | `/login` | Login form — email/password + Google/GitHub OAuth |
-| `/signup` | Registration form — name, email, password |
+| `/signup` | Registration form — email + password (first signup on a fresh instance claims the server and becomes platform admin; optional Turnstile/reCAPTCHA challenge) |
+| `/privacy` | Privacy policy |
+| `/terms` | Terms of service |
 
 ## Development
 


### PR DESCRIPTION
## What

A two-stage multi-agent audit of **every** documentation surface against the actual code, then 87 verified fixes + cross-file follow-ups. 92 raw findings → 87 confirmed, 5 correctly refuted (features that *were* already documented).

39 tracked files changed (+426/−117). (Per-subtree `AGENTS.md` files are git-ignored repo-wide, so their corrections are local-only and not in this diff.)

## Highlights

**Wrong facts corrected**
- BullMQ queue `clawhub-installs` → `clawhub-jobs` (README, CLAUDE.md, architecture)
- backup statuses `pending/completed` → `queued/ready/ready_with_warnings`; dropped non-existent `monthly` frequency; `worker-backup` container name
- agent lifecycle `queued→deploying→running`; inbound webhook `/api/webhooks/:id` with a real UUID; corrected Agent Hub `centralShareStatus` enum
- alert-rule event names → real emitted set; Slack/email injected env var names
- PaaS plan tiers: vCPU/RAM/disk are platform defaults, not per-tier
- API reference now documents the dual **JWT + API-key/scopes** auth model and the bootstrap/oauth-login/session-upgrade/logout endpoints

**Previously-undocumented behavior added**
- zero-key demo provider, per-agent budget caps + auto-pause, fleet needs-attention, per-agent MCP servers, `nora doctor` / `nora mcp` CLI, Helm install path, OpenAPI spec, and missing env vars (`NORA_FORCE_SECURE_COOKIES`, `CLAWHUB_PRUNE_ORPHANED_SKILLS`, Plausible, `AWS_SESSION_TOKEN`)
- removed **Microsoft Teams** as a "live monitoring" source everywhere (Teams is write-only in the catalog — it cannot read messages)

## Validation
- Every finding was adversarially re-verified against the cited code before edit
- All changed `.mdx` pass JSX-tag-balance, table-column-consistency, and internal link/anchor-resolution checks
- Live docs site nav already mirrors the repo 1:1, so fixes publish on the next build