### PR TITLE
fix(docs): repair malformed curl code blocks breaking the Mintlify build

### DIFF
--- a/docs/api/agents.mdx
+++ b/docs/api/agents.mdx
@@ -29,7 +29,9 @@ GET /agents
 
 <CodeGroup>
   ```bash curl theme={null}
-  curl http://localhost:8080/api/agents \ -H "Authorization: Bearer $TOKEN" ```
+  curl http://localhost:8080/api/agents \
+    -H "Authorization: Bearer $TOKEN"
+  ```
 </CodeGroup>
 
 ```json theme={null}
@@ -179,8 +181,9 @@ GET /agents/:id
 
 <CodeGroup>
   ```bash curl theme={null}
-  curl http://localhost:8080/api/agents/a1b2c3d4-e5f6-7890-abcd-ef1234567890 \ -H "Authorization:
-  Bearer $TOKEN" ```
+  curl http://localhost:8080/api/agents/a1b2c3d4-e5f6-7890-abcd-ef1234567890 \
+    -H "Authorization: Bearer $TOKEN"
+  ```
 </CodeGroup>
 
 ```json theme={null}
@@ -219,8 +222,9 @@ Returns the updated agent record with `status: "running"`.
 
 <CodeGroup>
   ```bash curl theme={null}
-  curl -X POST http://localhost:8080/api/agents/a1b2c3d4-e5f6-7890-abcd-ef1234567890/start \ -H
-  "Authorization: Bearer $TOKEN" ```
+  curl -X POST http://localhost:8080/api/agents/a1b2c3d4-e5f6-7890-abcd-ef1234567890/start \
+    -H "Authorization: Bearer $TOKEN"
+  ```
 </CodeGroup>
 
 | Status | Condition                               |
@@ -248,8 +252,9 @@ Returns the updated agent record with `status: "stopped"`.
 
 <CodeGroup>
   ```bash curl theme={null}
-  curl -X POST http://localhost:8080/api/agents/a1b2c3d4-e5f6-7890-abcd-ef1234567890/stop \ -H
-  "Authorization: Bearer $TOKEN" ```
+  curl -X POST http://localhost:8080/api/agents/a1b2c3d4-e5f6-7890-abcd-ef1234567890/stop \
+    -H "Authorization: Bearer $TOKEN"
+  ```
 </CodeGroup>
 
 ---
@@ -276,8 +281,9 @@ POST /agents/:id/restart
 
 <CodeGroup>
   ```bash curl theme={null}
-  curl -X POST http://localhost:8080/api/agents/a1b2c3d4-e5f6-7890-abcd-ef1234567890/restart \ -H
-  "Authorization: Bearer $TOKEN" ```
+  curl -X POST http://localhost:8080/api/agents/a1b2c3d4-e5f6-7890-abcd-ef1234567890/restart \
+    -H "Authorization: Bearer $TOKEN"
+  ```
 </CodeGroup>
 
 ```json theme={null}
@@ -315,8 +321,9 @@ POST /agents/:id/redeploy
 
 <CodeGroup>
   ```bash curl theme={null}
-  curl -X POST http://localhost:8080/api/agents/a1b2c3d4-e5f6-7890-abcd-ef1234567890/redeploy \ -H
-  "Authorization: Bearer $TOKEN" ```
+  curl -X POST http://localhost:8080/api/agents/a1b2c3d4-e5f6-7890-abcd-ef1234567890/redeploy \
+    -H "Authorization: Bearer $TOKEN"
+  ```
 </CodeGroup>
 
 ```json theme={null}
@@ -351,8 +358,9 @@ DELETE /agents/:id
 
 <CodeGroup>
   ```bash curl theme={null}
-  curl -X DELETE http://localhost:8080/api/agents/a1b2c3d4-e5f6-7890-abcd-ef1234567890 \ -H
-  "Authorization: Bearer $TOKEN" ```
+  curl -X DELETE http://localhost:8080/api/agents/a1b2c3d4-e5f6-7890-abcd-ef1234567890 \
+    -H "Authorization: Bearer $TOKEN"
+  ```
 </CodeGroup>
 
 ```json theme={null}
@@ -418,8 +426,9 @@ GET /agents/:id/stats
 
 <CodeGroup>
   ```bash curl theme={null}
-  curl http://localhost:8080/api/agents/a1b2c3d4-e5f6-7890-abcd-ef1234567890/stats \ -H
-  "Authorization: Bearer $TOKEN" ```
+  curl http://localhost:8080/api/agents/a1b2c3d4-e5f6-7890-abcd-ef1234567890/stats \
+    -H "Authorization: Bearer $TOKEN"
+  ```
 </CodeGroup>
 
 ```json theme={null}
@@ -564,8 +573,9 @@ GET /agents/:id/gateway-url
 
 <CodeGroup>
   ```bash curl theme={null}
-  curl http://localhost:8080/api/agents/a1b2c3d4-e5f6-7890-abcd-ef1234567890/gateway-url \ -H
-  "Authorization: Bearer $TOKEN" ```
+  curl http://localhost:8080/api/agents/a1b2c3d4-e5f6-7890-abcd-ef1234567890/gateway-url \
+    -H "Authorization: Bearer $TOKEN"
+  ```
 </CodeGroup>
 
 ```json theme={null}


### PR DESCRIPTION
## Problem

The **Mintlify Deployment** check went red ("Deployment Failed" after 14s). Root cause: `docs/api/agents.mdx` had 9 `<CodeGroup>` curl examples where the `\ -H ...` continuation and the closing ```` ``` ```` fence were collapsed onto a single line:

```
  ```bash curl theme={null}
  curl http://localhost:8080/api/agents \ -H "Authorization: Bearer $TOKEN" ```
</CodeGroup>
```

MDX never sees a fence closer, so it errors with `Expected a closing tag for <CodeGroup>` and the page fails to parse, failing the whole build.

## Fix

Split each block into a proper multi-line `curl` with the closing fence on its own line. Verified locally with the same strict check the deploy runs:

```
$ mint validate
success build validation passed   # exit 0
```

## Note

These malformed blocks predate this work — they were introduced with the OpenAPI docs page (`8e1a1e8`). The deploy surfaced them on the latest docs build. No content/behavior change; formatting only.