### PR TITLE
fix(security): authenticate the agent runtime sidecar (:9090)

### DIFF
--- a/agent-runtime/lib/agentEndpoints.ts
+++ b/agent-runtime/lib/agentEndpoints.ts
@@ -1,8 +1,4 @@
-const {
-  AGENT_RUNTIME_PORT,
-  OPENCLAW_GATEWAY_PORT,
-  HERMES_DASHBOARD_PORT,
-} = require("./contracts");
+const { AGENT_RUNTIME_PORT, OPENCLAW_GATEWAY_PORT, HERMES_DASHBOARD_PORT } = require("./contracts");
 
 function normalizePath(path = "/") {
   if (!path) return "";
@@ -15,9 +11,7 @@ function normalizePort(value, fallback) {
 }
 
 function runtimeExposesGateway(agent) {
-  const runtimeFamily = String(
-    agent?.runtime_family ?? agent?.runtimeFamily ?? ""
-  )
+  const runtimeFamily = String(agent?.runtime_family ?? agent?.runtimeFamily ?? "")
     .trim()
     .toLowerCase();
   if (runtimeFamily) return runtimeFamily !== "hermes";
@@ -26,9 +20,7 @@ function runtimeExposesGateway(agent) {
 }
 
 function runtimeUsesHermesDashboard(agent) {
-  const runtimeFamily = String(
-    agent?.runtime_family ?? agent?.runtimeFamily ?? ""
-  )
+  const runtimeFamily = String(agent?.runtime_family ?? agent?.runtimeFamily ?? "")
     .trim()
     .toLowerCase();
   if (runtimeFamily) return runtimeFamily === "hermes";
@@ -54,7 +46,7 @@ function resolveRuntimeAddress(agent) {
 
 function resolveGatewayAddress(
   agent,
-  { publishedHost = process.env.GATEWAY_HOST || "host.docker.internal" } = {}
+  { publishedHost = process.env.GATEWAY_HOST || "host.docker.internal" } = {},
 ) {
   if (!agent) return null;
   if (!runtimeExposesGateway(agent)) return null;
@@ -138,6 +130,14 @@ function hasHermesDashboardEndpoint(agent) {
   return Boolean(resolveHermesDashboardAddress(agent));
 }
 
+// Bearer headers for calling the runtime sidecar (:9090). The sidecar
+// authenticates every route except /health with the per-agent gateway token
+// (injected as OPENCLAW_GATEWAY_TOKEN). Returns an empty object when no token
+// is known, so a caller against a tokenless/legacy runtime still works.
+function buildRuntimeAuthHeaders(token) {
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
 module.exports = {
   resolveRuntimeAddress,
   resolveGatewayAddress,
@@ -148,4 +148,5 @@ module.exports = {
   hasRuntimeEndpoint,
   hasGatewayEndpoint,
   hasHermesDashboardEndpoint,
+  buildRuntimeAuthHeaders,
 };

--- a/agent-runtime/lib/server.ts
+++ b/agent-runtime/lib/server.ts
@@ -65,9 +65,13 @@ const RUNTIME_PUBLIC_PATHS = new Set(["/health"]);
 function isRuntimeRequestAuthorized(req) {
   if (!RUNTIME_AUTH_TOKEN) return true; // unenforceable; warned at startup
   const header = req.headers["authorization"] || "";
-  const match = /^Bearer\s+(.+)$/i.exec(header);
-  if (!match) return false;
-  const presented = Buffer.from(match[1]);
+  // Parse "Bearer <token>" with plain string ops — a `\s+(.+)` regex here is a
+  // ReDoS footgun (the two quantifiers both match spaces, so a header of
+  // "Bearer " + many spaces backtracks catastrophically).
+  if (header.slice(0, 7).toLowerCase() !== "bearer ") return false;
+  const presentedToken = header.slice(7).trim();
+  if (!presentedToken) return false;
+  const presented = Buffer.from(presentedToken);
   const expected = Buffer.from(RUNTIME_AUTH_TOKEN);
   return presented.length === expected.length && crypto.timingSafeEqual(presented, expected);
 }

--- a/agent-runtime/lib/server.ts
+++ b/agent-runtime/lib/server.ts
@@ -9,6 +9,7 @@ const http = require("http");
 const os = require("os");
 const fs = require("fs");
 const path = require("path");
+const crypto = require("crypto");
 const { execSync, execFileSync, spawn } = require("child_process");
 const { AGENT_RUNTIME_PORT, OPENCLAW_GATEWAY_PORT } = require("./contracts");
 const {
@@ -51,6 +52,24 @@ function parseBody(req) {
 function json(res, status, data) {
   res.writeHead(status, { "Content-Type": "application/json" });
   res.end(JSON.stringify(data));
+}
+
+// Every route except /health requires `Authorization: Bearer <gateway token>`.
+// The token (OPENCLAW_GATEWAY_TOKEN) is the per-agent secret the control plane
+// already holds. Constant-time compared. If no token is provisioned we cannot
+// enforce, so we fail OPEN (and warn loudly at boot) rather than brick a
+// runtime that was never given one — the historical behavior was fully open.
+const RUNTIME_AUTH_TOKEN = process.env.OPENCLAW_GATEWAY_TOKEN || "";
+const RUNTIME_PUBLIC_PATHS = new Set(["/health"]);
+
+function isRuntimeRequestAuthorized(req) {
+  if (!RUNTIME_AUTH_TOKEN) return true; // unenforceable; warned at startup
+  const header = req.headers["authorization"] || "";
+  const match = /^Bearer\s+(.+)$/i.exec(header);
+  if (!match) return false;
+  const presented = Buffer.from(match[1]);
+  const expected = Buffer.from(RUNTIME_AUTH_TOKEN);
+  return presented.length === expected.length && crypto.timingSafeEqual(presented, expected);
 }
 
 const startTime = Date.now();
@@ -150,7 +169,10 @@ function stripGeneratedIntegrationPromptBlock(content) {
     `\\n?${NORA_INTEGRATIONS_PROMPT_BEGIN}[\\s\\S]*?${NORA_INTEGRATIONS_PROMPT_END}\\n?`,
     "g",
   );
-  return raw.replace(pattern, "\n").replace(/\n{3,}/g, "\n\n").trimEnd();
+  return raw
+    .replace(pattern, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trimEnd();
 }
 
 function buildIntegrationPromptPointerMarkdown() {
@@ -214,9 +236,7 @@ function buildIntegrationContextMarkdown(integrations = []) {
         ? integration.credentialEnv
         : {};
     const configEnv =
-      credentialEnv.config && typeof credentialEnv.config === "object"
-        ? credentialEnv.config
-        : {};
+      credentialEnv.config && typeof credentialEnv.config === "object" ? credentialEnv.config : {};
     const visibleConfigEntries = Object.entries(redactedConfig).filter(
       ([, value]) => value != null && value !== "" && value !== "[REDACTED]",
     );
@@ -474,6 +494,11 @@ async function forwardToGatewayAndReply(body) {
 const server = http.createServer(async (req, res) => {
   const url = new URL(req.url, `http://localhost:${PORT}`);
   const path = url.pathname;
+
+  // Auth gate: everything but /health requires the gateway bearer token.
+  if (!RUNTIME_PUBLIC_PATHS.has(path) && !isRuntimeRequestAuthorized(req)) {
+    return json(res, 401, { error: "unauthorized" });
+  }
 
   // ── GET /health ───────────────────────────────────────
   if (req.method === "GET" && path === "/health") {
@@ -801,6 +826,11 @@ const server = http.createServer(async (req, res) => {
 function startServer() {
   server.listen(PORT, "0.0.0.0", () => {
     console.log(`[openclaw-runtime] HTTP server listening on port ${PORT}`);
+    if (!RUNTIME_AUTH_TOKEN) {
+      console.warn(
+        "[openclaw-runtime] SECURITY WARNING: OPENCLAW_GATEWAY_TOKEN is not set — the runtime API (including /exec) is UNAUTHENTICATED. Ensure this port is never network-reachable.",
+      );
+    }
   });
 }
 

--- a/backend-api/__tests__/runtimeAuth.test.ts
+++ b/backend-api/__tests__/runtimeAuth.test.ts
@@ -1,0 +1,47 @@
+// @ts-nocheck
+const mockDb = { query: jest.fn() };
+jest.mock("../db", () => mockDb);
+
+const { runtimeAuthHeaders } = require("../runtimeAuth");
+const { buildRuntimeAuthHeaders } = require("../../agent-runtime/lib/agentEndpoints");
+
+beforeEach(() => mockDb.query.mockReset());
+
+describe("buildRuntimeAuthHeaders", () => {
+  it("formats a Bearer header, or nothing when tokenless", () => {
+    expect(buildRuntimeAuthHeaders("tok-123")).toEqual({ Authorization: "Bearer tok-123" });
+    expect(buildRuntimeAuthHeaders("")).toEqual({});
+    expect(buildRuntimeAuthHeaders(null)).toEqual({});
+  });
+});
+
+describe("runtimeAuthHeaders", () => {
+  it("uses the token already on the agent without touching the DB", async () => {
+    const headers = await runtimeAuthHeaders({ id: "a1", gateway_token: "from-row" });
+    expect(headers).toEqual({ Authorization: "Bearer from-row" });
+    expect(mockDb.query).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a DB lookup when the agent object omits the token", async () => {
+    mockDb.query.mockResolvedValueOnce({ rows: [{ gateway_token: "from-db" }] });
+    const headers = await runtimeAuthHeaders({ id: "a1" });
+    expect(headers).toEqual({ Authorization: "Bearer from-db" });
+    expect(mockDb.query.mock.calls[0][1]).toEqual(["a1"]);
+  });
+
+  it("returns no header when neither the row nor the DB has a token", async () => {
+    mockDb.query.mockResolvedValueOnce({ rows: [] });
+    expect(await runtimeAuthHeaders({ id: "a1" })).toEqual({});
+  });
+
+  it("degrades to no header (never throws) when the DB lookup fails", async () => {
+    mockDb.query.mockRejectedValueOnce(new Error("db down"));
+    expect(await runtimeAuthHeaders({ id: "a1" })).toEqual({});
+  });
+
+  it("returns no header for a null/idless agent", async () => {
+    expect(await runtimeAuthHeaders(null)).toEqual({});
+    expect(await runtimeAuthHeaders({})).toEqual({});
+    expect(mockDb.query).not.toHaveBeenCalled();
+  });
+});

--- a/backend-api/agentPayloads.ts
+++ b/backend-api/agentPayloads.ts
@@ -4,6 +4,7 @@ const db = require("./db");
 const integrations = require("./integrations");
 const channels = require("./channels");
 const { runtimeUrlForAgent } = require("../agent-runtime/lib/agentEndpoints");
+const { runtimeAuthHeaders } = require("./runtimeAuth");
 const { NORA_INTEGRATIONS_CONTEXT_FILE } = require("../agent-runtime/lib/runtimeBootstrap");
 const { NORA_INTEGRATIONS_SKILL_FILE } = require("../agent-runtime/lib/integrationTools");
 const {
@@ -454,7 +455,7 @@ async function fetchTemplateExportViaRuntime(agent, includeMemory) {
 
   const response = await fetch(runtimeUrl, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...(await runtimeAuthHeaders(agent)) },
     body: JSON.stringify({ includeMemory }),
   });
 
@@ -560,7 +561,7 @@ process.stdout.write(JSON.stringify(result));
   const command = `node -e ${JSON.stringify(exportScript)} ${includeMemory ? "1" : "0"}`;
   const response = await fetch(runtimeUrl, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...(await runtimeAuthHeaders(agent)) },
     body: JSON.stringify({
       command,
       timeout: 120000,

--- a/backend-api/agentTelemetry.ts
+++ b/backend-api/agentTelemetry.ts
@@ -3,6 +3,7 @@ const db = require("./db");
 const containerManager = require("./containerManager");
 const { buildAgentRuntimeFields, isNemoClawSandbox } = require("./agentRuntimeFields");
 const { runtimeUrlForAgent } = require("../agent-runtime/lib/agentEndpoints");
+const { runtimeAuthHeaders } = require("./runtimeAuth");
 const path = require("path");
 const telemetryModulePath = resolveTelemetryModulePath();
 const {
@@ -405,8 +406,8 @@ async function collectAgentTelemetrySample(agent) {
   return persistTelemetrySample(agent.id, telemetry);
 }
 
-async function fetchJson(url) {
-  const response = await fetch(url, { signal: AbortSignal.timeout(5000) });
+async function fetchJson(url, headers = {}) {
+  const response = await fetch(url, { headers, signal: AbortSignal.timeout(5000) });
   if (!response.ok) {
     throw new Error(`Runtime returned ${response.status}`);
   }
@@ -438,10 +439,11 @@ async function loadNemoSummary(agent) {
 
   const policyUrl = runtimeUrlForAgent(agent, "/nemoclaw/policy");
   const approvalsUrl = runtimeUrlForAgent(agent, "/nemoclaw/approvals");
+  const authHeaders = await runtimeAuthHeaders(agent);
   const [statusResult, policyResult, approvalsResult] = await Promise.allSettled([
-    fetchJson(statusUrl),
-    fetchJson(policyUrl),
-    fetchJson(approvalsUrl),
+    fetchJson(statusUrl, authHeaders),
+    fetchJson(policyUrl, authHeaders),
+    fetchJson(approvalsUrl, authHeaders),
   ]);
 
   if (statusResult.status === "fulfilled") {

--- a/backend-api/authSync.ts
+++ b/backend-api/authSync.ts
@@ -8,6 +8,7 @@ const db = require("./db");
 const containerManager = require("./containerManager");
 const llmProviders = require("./llmProviders");
 const { runtimeUrlForAgent } = require("../agent-runtime/lib/agentEndpoints");
+const { runtimeAuthHeaders } = require("./runtimeAuth");
 const { waitForAgentReadiness } = require("./healthChecks");
 const { resolveAgentRuntimeFamily } = require("./agentRuntimeFields");
 const { shellSingleQuote } = require("../agent-runtime/lib/containerCommand");
@@ -362,7 +363,7 @@ async function runRuntimeCommand(agent, command, { timeout = 30000 } = {}) {
 
   const response = await fetch(runtimeUrl, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...(await runtimeAuthHeaders(agent)) },
     body: JSON.stringify({
       command,
       timeout,

--- a/backend-api/channels/index.ts
+++ b/backend-api/channels/index.ts
@@ -6,13 +6,14 @@
 const db = require("../db");
 const { encrypt, decrypt, ensureEncryptionConfigured } = require("../crypto");
 const { runtimeUrlForAgent } = require("../../agent-runtime/lib/agentEndpoints");
+const { runtimeAuthHeaders } = require("../runtimeAuth");
 const { getAdapter, listAdapterTypes } = require("./adapters");
 
 const REDACTED_SECRET = "[REDACTED]";
 const SECRET_CONFIG_KEY_RE = /(token|secret|password|webhook_url|smtp_pass|auth_token)/i;
 
 function parseConfig(config) {
-  return typeof config === "string" ? JSON.parse(config) : (config || {});
+  return typeof config === "string" ? JSON.parse(config) : config || {};
 }
 
 function restoreRedactedConfigValue(nextValue, currentValue) {
@@ -22,9 +23,7 @@ function restoreRedactedConfigValue(nextValue, currentValue) {
 
   if (Array.isArray(nextValue)) {
     const currentItems = Array.isArray(currentValue) ? currentValue : [];
-    return nextValue.map((entry, index) =>
-      restoreRedactedConfigValue(entry, currentItems[index]),
-    );
+    return nextValue.map((entry, index) => restoreRedactedConfigValue(entry, currentItems[index]));
   }
 
   if (nextValue && typeof nextValue === "object") {
@@ -48,7 +47,7 @@ function getSensitiveChannelKeys(type) {
   return new Set(
     (adapter.configFields || [])
       .filter((field) => field?.type === "password" || SECRET_CONFIG_KEY_RE.test(field?.key || ""))
-      .map((field) => field.key)
+      .map((field) => field.key),
   );
 }
 
@@ -117,10 +116,7 @@ function stripChannelSecrets(type, config = {}) {
 }
 
 function buildCloneableChannel(channel = {}) {
-  const { config, removedSensitive } = stripChannelSecrets(
-    channel.type,
-    channel.config
-  );
+  const { config, removedSensitive } = stripChannelSecrets(channel.type, channel.config);
 
   return {
     type: channel.type,
@@ -151,7 +147,7 @@ function hydrateChannel(channel) {
 async function listChannels(agentId) {
   const result = await db.query(
     "SELECT * FROM channels WHERE agent_id = $1 ORDER BY created_at DESC",
-    [agentId]
+    [agentId],
   );
   return result.rows.map(sanitizeChannel);
 }
@@ -165,16 +161,16 @@ async function createChannel(agentId, type, name, config = {}) {
   }
   const result = await db.query(
     "INSERT INTO channels(agent_id, type, name, config) VALUES($1, $2, $3, $4) RETURNING *",
-    [agentId, type, name, JSON.stringify(secured)]
+    [agentId, type, name, JSON.stringify(secured)],
   );
   return sanitizeChannel(result.rows[0]);
 }
 
 async function updateChannel(channelId, agentId, updates) {
-  const existingResult = await db.query(
-    "SELECT * FROM channels WHERE id = $1 AND agent_id = $2",
-    [channelId, agentId]
-  );
+  const existingResult = await db.query("SELECT * FROM channels WHERE id = $1 AND agent_id = $2", [
+    channelId,
+    agentId,
+  ]);
   const existing = existingResult.rows[0];
   if (!existing) throw new Error("Channel not found");
 
@@ -208,7 +204,7 @@ async function updateChannel(channelId, agentId, updates) {
   params.push(channelId, agentId);
   const result = await db.query(
     `UPDATE channels SET ${sets.join(", ")} WHERE id = $${idx++} AND agent_id = $${idx} RETURNING *`,
-    params
+    params,
   );
   if (!result.rows[0]) throw new Error("Channel not found");
   return sanitizeChannel(result.rows[0]);
@@ -217,7 +213,7 @@ async function updateChannel(channelId, agentId, updates) {
 async function deleteChannel(channelId, agentId) {
   const result = await db.query(
     "DELETE FROM channels WHERE id = $1 AND agent_id = $2 RETURNING id",
-    [channelId, agentId]
+    [channelId, agentId],
   );
   if (!result.rows[0]) throw new Error("Channel not found");
 }
@@ -236,7 +232,7 @@ async function sendMessage(channelId, content, metadata = {}) {
   // Log the outbound message
   await db.query(
     "INSERT INTO channel_messages(channel_id, direction, content, metadata) VALUES($1, 'outbound', $2, $3)",
-    [channelId, content, JSON.stringify(metadata)]
+    [channelId, content, JSON.stringify(metadata)],
   );
 
   return result;
@@ -250,7 +246,7 @@ async function getMessages(channelId, agentId, limit = 50) {
      WHERE cm.channel_id = $1 AND c.agent_id = $2
      ORDER BY cm.created_at DESC
      LIMIT $3`,
-    [channelId, agentId, limit]
+    [channelId, agentId, limit],
   );
   return result.rows;
 }
@@ -258,10 +254,10 @@ async function getMessages(channelId, agentId, limit = 50) {
 // ── Testing ──────────────────────────────────────────────
 
 async function testChannel(channelId, agentId) {
-  const chResult = await db.query(
-    "SELECT * FROM channels WHERE id = $1 AND agent_id = $2",
-    [channelId, agentId]
-  );
+  const chResult = await db.query("SELECT * FROM channels WHERE id = $1 AND agent_id = $2", [
+    channelId,
+    agentId,
+  ]);
   const channel = hydrateChannel(chResult.rows[0]);
   if (!channel) throw new Error("Channel not found");
 
@@ -294,13 +290,17 @@ async function handleInboundWebhook(channelId, payload, headers) {
   // Log the inbound message
   await db.query(
     "INSERT INTO channel_messages(channel_id, direction, content, metadata) VALUES($1, 'inbound', $2, $3)",
-    [channelId, formatted.content, JSON.stringify({ sender: formatted.sender, ...formatted.metadata })]
+    [
+      channelId,
+      formatted.content,
+      JSON.stringify({ sender: formatted.sender, ...formatted.metadata }),
+    ],
   );
 
   // Forward to agent runtime if agent is running
   const agentResult = await db.query(
-    "SELECT host, runtime_host, runtime_port FROM agents WHERE id = $1",
-    [channel.agent_id]
+    "SELECT id, host, runtime_host, runtime_port, gateway_token FROM agents WHERE id = $1",
+    [channel.agent_id],
   );
   const agent = agentResult.rows[0];
   const runtimeUrl = runtimeUrlForAgent(agent, "/channels/receive");
@@ -308,7 +308,7 @@ async function handleInboundWebhook(channelId, payload, headers) {
     try {
       await fetch(runtimeUrl, {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: { "Content-Type": "application/json", ...(await runtimeAuthHeaders(agent)) },
         body: JSON.stringify({
           channelId,
           channelType: channel.type,

--- a/backend-api/routes/integrations.ts
+++ b/backend-api/routes/integrations.ts
@@ -4,6 +4,7 @@ const crypto = require("crypto");
 const db = require("../db");
 const integrations = require("../integrations");
 const mcpServers = require("../mcpServers");
+const { runtimeAuthHeaders } = require("../runtimeAuth");
 const { encrypt, decrypt } = require("../crypto");
 const { rpcCall } = require("../gatewayProxy");
 const { runContainerCommand, syncAuthToUserAgents } = require("../authSync");
@@ -324,7 +325,7 @@ async function syncIntegrationsToAgent(agentId, { strict = false, strictHermes =
     const syncData = await integrations.getIntegrationsForSync(agentId);
     const response = await fetch(runtimeUrl, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...(await runtimeAuthHeaders(agent)) },
       body: JSON.stringify({ integrations: syncData }),
     });
     if (!response.ok) {
@@ -422,7 +423,7 @@ async function invokeAgentIntegrationTool(agentId, payload = {}) {
 
   const response = await fetch(runtimeUrl, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: { "Content-Type": "application/json", ...(await runtimeAuthHeaders(agent)) },
     body: JSON.stringify(payload),
   });
   const data = await response.json().catch(() => ({}));

--- a/backend-api/routes/nemoclaw.ts
+++ b/backend-api/routes/nemoclaw.ts
@@ -3,6 +3,7 @@ const express = require("express");
 const db = require("../db");
 const { isNemoClawSandbox } = require("../agentRuntimeFields");
 const { runtimeUrlForAgent } = require("../../agent-runtime/lib/agentEndpoints");
+const { runtimeAuthHeaders } = require("../runtimeAuth");
 
 const router = express.Router();
 
@@ -20,7 +21,7 @@ router.get("/:id/nemoclaw/status", async (req, res, next) => {
     if (!runtimeUrl || agent.status !== "running")
       return res.json({ status: agent.status, sandbox: null });
 
-    const resp = await fetch(runtimeUrl);
+    const resp = await fetch(runtimeUrl, { headers: await runtimeAuthHeaders(agent) });
     if (!resp.ok) throw new Error(`Agent runtime returned ${resp.status}`);
     res.json(await resp.json());
   } catch (e) {
@@ -42,7 +43,7 @@ router.get("/:id/nemoclaw/policy", async (req, res, next) => {
     if (!runtimeUrl || agent.status !== "running")
       return res.status(400).json({ error: "Agent is not running" });
 
-    const resp = await fetch(runtimeUrl);
+    const resp = await fetch(runtimeUrl, { headers: await runtimeAuthHeaders(agent) });
     if (!resp.ok) throw new Error(`Agent runtime returned ${resp.status}`);
     res.json(await resp.json());
   } catch (e) {
@@ -66,7 +67,7 @@ router.post("/:id/nemoclaw/policy", async (req, res, next) => {
 
     const resp = await fetch(runtimeUrl, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...(await runtimeAuthHeaders(agent)) },
       body: JSON.stringify(req.body),
     });
     if (!resp.ok) throw new Error(`Agent runtime returned ${resp.status}`);
@@ -89,7 +90,7 @@ router.get("/:id/nemoclaw/approvals", async (req, res, next) => {
     const runtimeUrl = runtimeUrlForAgent(agent, "/nemoclaw/approvals");
     if (!runtimeUrl || agent.status !== "running") return res.json({ approvals: [] });
 
-    const resp = await fetch(runtimeUrl);
+    const resp = await fetch(runtimeUrl, { headers: await runtimeAuthHeaders(agent) });
     if (!resp.ok) throw new Error(`Agent runtime returned ${resp.status}`);
     res.json(await resp.json());
   } catch (e) {
@@ -113,7 +114,7 @@ router.post("/:id/nemoclaw/approvals/:rid", async (req, res, next) => {
 
     const resp = await fetch(runtimeUrl, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", ...(await runtimeAuthHeaders(agent)) },
       body: JSON.stringify(req.body),
     });
     if (!resp.ok) throw new Error(`Agent runtime returned ${resp.status}`);

--- a/backend-api/runtimeAuth.ts
+++ b/backend-api/runtimeAuth.ts
@@ -1,0 +1,25 @@
+// @ts-nocheck
+// Resolves the bearer headers for calling an agent's runtime sidecar (:9090),
+// which authenticates every route except /health with the per-agent gateway
+// token. Most agent objects passed around the backend already carry
+// gateway_token, but some loading queries omit it (e.g. the auth-sync query);
+// fall back to a cheap indexed lookup so no caller path can silently send an
+// empty token and get a 401.
+
+const db = require("./db");
+const { buildRuntimeAuthHeaders } = require("../agent-runtime/lib/agentEndpoints");
+
+async function runtimeAuthHeaders(agent) {
+  let token = agent && agent.gateway_token ? agent.gateway_token : null;
+  if (!token && agent && agent.id) {
+    try {
+      const result = await db.query("SELECT gateway_token FROM agents WHERE id = $1", [agent.id]);
+      token = result.rows[0]?.gateway_token || null;
+    } catch {
+      token = null;
+    }
+  }
+  return buildRuntimeAuthHeaders(token);
+}
+
+module.exports = { runtimeAuthHeaders };

--- a/workers/provisioner/worker.ts
+++ b/workers/provisioner/worker.ts
@@ -3,7 +3,10 @@ const { Worker } = require("bullmq");
 const IORedis = require("ioredis");
 const { Pool } = require("pg");
 const { getDefaultAgentImage } = require("../../agent-runtime/lib/agentImages");
-const { runtimeUrlForAgent } = require("../../agent-runtime/lib/agentEndpoints");
+const {
+  runtimeUrlForAgent,
+  buildRuntimeAuthHeaders,
+} = require("../../agent-runtime/lib/agentEndpoints");
 const {
   getDefaultBackend,
   getEnabledBackends,
@@ -652,7 +655,10 @@ async function runRuntimeCommand(agent, command, { timeout = 30000 } = {}) {
 
   const response = await fetch(runtimeUrl, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      ...buildRuntimeAuthHeaders(agent && agent.gateway_token),
+    },
     body: JSON.stringify({
       command,
       timeout,
@@ -835,6 +841,7 @@ async function reconcileRuntimeLlmAuth({
   gatewayHostPort,
   gatewayHost,
   gatewayPort,
+  gatewayToken,
 } = {}) {
   const llmEnvVars = await fetchUserLlmEnvVars(userId);
   const defaultProvider = await fetchDefaultProvider(userId);
@@ -851,6 +858,7 @@ async function reconcileRuntimeLlmAuth({
     gateway_host_port: gatewayHostPort,
     gateway_host: gatewayHost,
     gateway_port: gatewayPort,
+    gateway_token: gatewayToken,
   };
 
   if (runtimeFamily === "hermes") {
@@ -1991,6 +1999,7 @@ const worker = new Worker(
               gatewayHostPort,
               gatewayHost,
               gatewayPort,
+              gatewayToken,
             });
             if (authSyncResult.status === "synced") {
               console.log(`[provisioner] Post-deploy LLM auth sync completed for agent ${id}`);
@@ -2041,7 +2050,10 @@ const worker = new Worker(
             );
             await fetch(runtimeUrl, {
               method: "POST",
-              headers: { "Content-Type": "application/json" },
+              headers: {
+                "Content-Type": "application/json",
+                ...buildRuntimeAuthHeaders(gatewayToken),
+              },
               body: JSON.stringify({ integrations: syncData }),
             });
             console.log(`[provisioner] Synced ${syncData.length} integration(s) to agent ${id}`);


### PR DESCRIPTION
## Why (Phase 0 of the remote-host/connector epic, but a standalone security fix)

The agent runtime sidecar (`agent-runtime/lib/server.ts`, port 9090) served **every** route with **no authentication** — including `POST /exec`, which runs arbitrary `/bin/sh`. It was protected only by network isolation, but the **Kubernetes NodePort path already exposes it on the node's external interface** → an unauthenticated RCE surface. Closing this is also the prerequisite for ever reaching a runtime across the internet (the connector epic).

## What

**Sidecar gate** — every route except `/health` now requires `Authorization: Bearer <OPENCLAW_GATEWAY_TOKEN>` (the per-agent token the control plane already injects), constant-time compared. **Fails open with a loud boot warning** only when no token is provisioned, so a tokenless/legacy runtime is never bricked (historical behavior was fully open); every real OpenClaw/NemoClaw/K8s agent injects the token, so all are enforced.

**Callers** — every backend *and* worker path that hits the sidecar now sends the token:
- `agentEndpoints.buildRuntimeAuthHeaders(token)` (pure, shared) + `backend-api/runtimeAuth.runtimeAuthHeaders(agent)` (uses `agent.gateway_token`, DB-fallback on `agent.id` when a loading query omitted it).
- backend: authSync `/exec`, agentPayloads export + `/exec`, agentTelemetry NemoClaw probes, **routes/nemoclaw.ts (5 routes)**, **routes/integrations.ts (sync + tools/invoke)**, **channels `/channels/receive`** (SELECT widened to carry the token).
- worker: **its own duplicate `runRuntimeCommand`** (post-deploy auth-sync) + the deploy-time `/integrations/sync`, threading the post-create gateway token.

> An adversarial review of the first pass caught that it wired only 4 of ~8 callers and missed the worker's **separate** copy of `runRuntimeCommand` — the shared-but-duplicated trap CLAUDE.md warns about. All confirmed gaps are fixed here; the `routes/agents.ts` Hermes calls are out of scope (they hit Hermes's own API server, not this sidecar).

## Verified

- **Live, twice:** fresh agent — `/exec` no-token → **401**, wrong-token → **401**, correct-token → **200**, `/health` open. Deploy + post-deploy auth-sync completed with no `401`/reconcile-failure in the worker logs and `auth-profiles.json` written correctly (the `modelCommand` path has no fallback, so a worker-side 401 would have surfaced — it didn't).
- 6 unit tests (`runtimeAuth`); full backend suite **1008 green**; typecheck clean in backend-api, workers/provisioner, agent-runtime.
- Backward compatible: existing agents keep their open sidecar (extra header ignored); new agents get the enforcing sidecar **and** token-sending callers.

## Follow-up (tracked, low)

The sidecar bearer currently **reuses** the OpenClaw gateway password (`gateway_token`); a Phase-1 hardening should derive a distinct per-agent runtime secret to decouple the two services' blast radius.