### PR TITLE
chore(npm): rename published packages to @noraai scope

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -1,12 +1,12 @@
 name: Release npm Packages
 
-# Publishes @nora/mcp-server and @nora/cli to the public npm registry when a
+# Publishes @noraai/mcp-server and @noraai/cli to the public npm registry when a
 # GitHub release is published (or on demand). Idempotent: a package version
 # that already exists on the registry is skipped, so re-running a release or
 # tagging without bumping a package version is safe.
 #
 # Requires the NPM_TOKEN repository secret (an npm automation token with
-# publish rights on the @nora scope). `id-token: write` enables npm provenance
+# publish rights on the @noraai scope). `id-token: write` enables npm provenance
 # attestations linking each published tarball to this workflow run.
 
 on:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The pre-launch feature release: nine capabilities identified by the 2026-06 comp
 
 ### Added
 
-- **Control-plane MCP server** (`@nora/mcp-server` + `nora mcp` CLI alias): operate Nora from Claude Code or any MCP client — 13 tools covering agent lifecycle, metrics, events, and cost, authenticated with existing scoped `nora_` API keys; `delete_agent` gated behind `NORA_MCP_ALLOW_DESTRUCTIVE=true`. (#177)
+- **Control-plane MCP server** (`@noraai/mcp-server` + `nora mcp` CLI alias): operate Nora from Claude Code or any MCP client — 13 tools covering agent lifecycle, metrics, events, and cost, authenticated with existing scoped `nora_` API keys; `delete_agent` gated behind `NORA_MCP_ALLOW_DESTRUCTIVE=true`. (#177)
 - **Official Helm chart** (`infra/helm/nora`): full control plane on Kubernetes with optional in-chart PostgreSQL/Redis (external toggles), fail-fast secrets, Ingress support, DB-readiness init containers, and a CI-drift-guarded vendored schema. (#178)
 - **Per-agent LLM budget hard caps with auto-pause**: soft thresholds emit alert events; crossing 100% stops the runtime (`status=stopped` + `paused_reason=budget_exceeded`) with sweep re-enforcement against the status reconciler; budget editor and paused-banner in the dashboard. (#180)
 - **Fleet needs-attention roll-up**: `GET /monitoring/fleet-status` returns only the agents needing operator action with reasons (errored, budget-paused, stuck deploying, approaching budget, stalled telemetry); triage strip on the dashboard. (#181)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ Each folder has its own `AGENTS.md` that narrows ownership, data-flow rules, and
 
 - `backend-api/` — primary integration hub: control-plane APIs, persistence, queue, auth, monitoring, Agent Hub, gateway proxy, runtime coordination
 - `cli/` — packaged command-line client for Nora's public REST APIs, workspace config, token auth, and operator automation commands
-- `mcp-server/` — `@nora/mcp-server`, standalone MCP (Model Context Protocol) stdio server exposing the public REST API as tools for Claude Code/Desktop/Cursor; pure API client authenticated by workspace API keys, no backend coupling
+- `mcp-server/` — `@noraai/mcp-server`, standalone MCP (Model Context Protocol) stdio server exposing the public REST API as tools for Claude Code/Desktop/Cursor; pure API client authenticated by workspace API keys, no backend coupling
 - `workers/provisioner/` — async provisioning worker; `workers/provisioner/backends/` holds adapter implementations (shared with backend-api via volume mount)
 - `agent-runtime/` — shared runtime contracts (mounted read-only into backend-api and worker)
 - `frontend-dashboard/` — operator UI at `/app`; coordinates with backend-api for API + WebSocket contracts

--- a/README.md
+++ b/README.md
@@ -128,15 +128,15 @@ export NORA_TOKEN="nora_..."
 curl -H "Authorization: Bearer $NORA_TOKEN" https://your-nora.example.com/api/agents
 ```
 
-A small CLI lives in [`cli/`](./cli) (`@nora/cli`): run `nora login` once to save your host and API token, then `nora workspaces`, `nora agents`, and `nora monitoring` wrap the same REST surface. `nora doctor` runs an admin-only control-plane health check, and `nora mcp` launches the MCP stdio server. See the [API reference](https://noradocs.solomontsao.com/api/overview) for the supported endpoints and scopes.
+A small CLI lives in [`cli/`](./cli) (`@noraai/cli`): run `nora login` once to save your host and API token, then `nora workspaces`, `nora agents`, and `nora monitoring` wrap the same REST surface. `nora doctor` runs an admin-only control-plane health check, and `nora mcp` launches the MCP stdio server. See the [API reference](https://noradocs.solomontsao.com/api/overview) for the supported endpoints and scopes.
 
-**Operate Nora from Claude Code, Claude Desktop, or Cursor:** the [`mcp-server/`](./mcp-server) package (`@nora/mcp-server`) exposes the same API as [Model Context Protocol](https://modelcontextprotocol.io) tools — deploy agents, control their lifecycle, and read fleet metrics, events, and per-agent cost from any MCP client. Destructive deletion stays disabled unless explicitly opted in.
+**Operate Nora from Claude Code, Claude Desktop, or Cursor:** the [`mcp-server/`](./mcp-server) package (`@noraai/mcp-server`) exposes the same API as [Model Context Protocol](https://modelcontextprotocol.io) tools — deploy agents, control their lifecycle, and read fleet metrics, events, and per-agent cost from any MCP client. Destructive deletion stays disabled unless explicitly opted in.
 
 ```bash
 claude mcp add nora \
   --env NORA_API_URL=https://your-nora.example.com \
   --env NORA_API_KEY=nora_... \
-  -- npx -y @nora/mcp-server
+  -- npx -y @noraai/mcp-server
 ```
 
 See the [MCP guide](https://noradocs.solomontsao.com/guides/mcp-server) for Claude Desktop/Cursor config, the tool list, and security notes.

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,13 +1,13 @@
-# `@nora/cli`
+# `@noraai/cli`
 
 Command-line interface for [Nora](https://github.com/solomon2773/nora). Talks to the public REST API exposed by every Nora installation.
 
 ## Install
 
 ```bash
-npm install -g @nora/cli
+npm install -g @noraai/cli
 # or run without installing
-npx @nora/cli --help
+npx @noraai/cli --help
 ```
 
 Requires Node.js 24 or newer.
@@ -67,7 +67,7 @@ The token must carry the matching scope for the operation:
 
 `nora doctor` needs an API key whose issuing user is a platform admin — it calls `GET /api/admin/doctor` behind `requireAdmin`, and on HTTP 403 it prints an admin-key error and exits 1.
 
-`nora mcp` forwards the host/token from `nora login` (`~/.nora/config.json`) to the `@nora/mcp-server` child as `NORA_API_URL` / `NORA_API_KEY`; `--allow-destructive` sets `NORA_MCP_ALLOW_DESTRUCTIVE=true`, so the MCP server's own scope/tool requirements apply.
+`nora mcp` forwards the host/token from `nora login` (`~/.nora/config.json`) to the `@noraai/mcp-server` child as `NORA_API_URL` / `NORA_API_KEY`; `--allow-destructive` sets `NORA_MCP_ALLOW_DESTRUCTIVE=true`, so the MCP server's own scope/tool requirements apply.
 
 Issuing API keys, mutating workspace membership, and other privileged flows require session authentication and are not available through the CLI.
 

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@nora/cli",
+  "name": "@noraai/cli",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@nora/cli",
+      "name": "@noraai/cli",
       "version": "0.1.0",
       "license": "Apache-2.0",
       "bin": {

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nora/cli",
+  "name": "@noraai/cli",
   "version": "0.1.0",
   "description": "Nora command-line interface for managing agents, workspaces, and runtimes via the public REST API.",
   "license": "Apache-2.0",

--- a/cli/src/commands/mcp.js
+++ b/cli/src/commands/mcp.js
@@ -1,6 +1,6 @@
 // `nora mcp` — run the Nora MCP server (stdio) so MCP clients like Claude
 // Code, Claude Desktop, or Cursor can operate this control plane. The server
-// itself lives in the separate @nora/mcp-server package; this command resolves
+// itself lives in the separate @noraai/mcp-server package; this command resolves
 // it (local checkout first, then npx) and hands over stdio. Host + token come
 // from the same config `nora login` writes, exported as env for the child.
 
@@ -25,7 +25,7 @@ async function run(args, flags) {
   const local = localServerEntrypoint();
   const [command, commandArgs] = local
     ? [process.execPath, [local]]
-    : ["npx", ["--yes", "@nora/mcp-server"]];
+    : ["npx", ["--yes", "@noraai/mcp-server"]];
 
   // stdio is the MCP transport — inherit all three streams untouched.
   const child = spawn(command, commandArgs, { env, stdio: "inherit" });

--- a/docs/guides/cli.mdx
+++ b/docs/guides/cli.mdx
@@ -1,20 +1,20 @@
 # Install and use the Nora CLI
 
-> Install `@nora/cli`, authenticate against your Nora instance with a workspace API key, and manage agents, monitoring, and control-plane health from the terminal.
+> Install `@noraai/cli`, authenticate against your Nora instance with a workspace API key, and manage agents, monitoring, and control-plane health from the terminal.
 
 The Nora CLI (`nora`) is a thin client for the [public REST API](/api/overview). It covers the day-to-day operator loop — list and manage agents, read monitoring events, run the control-plane health check — and doubles as the launcher for the [MCP server](/guides/mcp-server) via `nora mcp`.
 
 ## Install
 
 ```bash
-npm install -g @nora/cli
+npm install -g @noraai/cli
 nora --help
 ```
 
 Or run it without installing:
 
 ```bash
-npx @nora/cli --help
+npx @noraai/cli --help
 ```
 
 Requires Node 24+.

--- a/docs/guides/doctor.mdx
+++ b/docs/guides/doctor.mdx
@@ -6,7 +6,7 @@
 
 ## Run it from the CLI
 
-Install the CLI first if you have not (`npm install -g @nora/cli` — see [the CLI guide](/guides/cli)).
+Install the CLI first if you have not (`npm install -g @noraai/cli` — see [the CLI guide](/guides/cli)).
 
 ```bash
 nora doctor

--- a/docs/guides/mcp-server.mdx
+++ b/docs/guides/mcp-server.mdx
@@ -2,7 +2,7 @@
 
 > Run the Nora MCP server so Claude Code, Claude Desktop, Cursor, or any MCP client can deploy, inspect, and operate your agent fleet — "Claude, why is my agent stopped?" becomes a tool call against your own control plane.
 
-The `@nora/mcp-server` package exposes Nora's public REST API as [Model Context Protocol](https://modelcontextprotocol.io) tools over stdio. It authenticates with the same workspace API keys the REST API and CLI use, so workspace scoping and scope-based permissions apply unchanged.
+The `@noraai/mcp-server` package exposes Nora's public REST API as [Model Context Protocol](https://modelcontextprotocol.io) tools over stdio. It authenticates with the same workspace API keys the REST API and CLI use, so workspace scoping and scope-based permissions apply unchanged.
 
 ## Prerequisites
 
@@ -20,7 +20,7 @@ The `@nora/mcp-server` package exposes Nora's public REST API as [Model Context 
 claude mcp add nora \
   --env NORA_API_URL=https://nora.example.com \
   --env NORA_API_KEY=nora_xxxxxxxx \
-  -- npx -y @nora/mcp-server
+  -- npx -y @noraai/mcp-server
 ```
 
 ```json Claude Desktop / Cursor
@@ -28,7 +28,7 @@ claude mcp add nora \
   "mcpServers": {
     "nora": {
       "command": "npx",
-      "args": ["-y", "@nora/mcp-server"],
+      "args": ["-y", "@noraai/mcp-server"],
       "env": {
         "NORA_API_URL": "https://nora.example.com",
         "NORA_API_KEY": "nora_xxxxxxxx"
@@ -39,14 +39,14 @@ claude mcp add nora \
 ```
 
 ```bash Via the Nora CLI
-# Requires @nora/cli (see the CLI guide); reuses the host + token from `nora login`
+# Requires @noraai/cli (see the CLI guide); reuses the host + token from `nora login`
 nora login --host https://nora.example.com --token nora_xxxxxxxx
 nora mcp
 ```
 
 </CodeGroup>
 
-<Note>The `nora` command comes from [`@nora/cli`](/guides/cli) (`npm install -g @nora/cli`).</Note>
+<Note>The `nora` command comes from [`@noraai/cli`](/guides/cli) (`npm install -g @noraai/cli`).</Note>
 
 ## Configuration
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -1,4 +1,4 @@
-# @nora/mcp-server
+# @noraai/mcp-server
 
 MCP server for [Nora](https://github.com/solomon2773/nora), the self-hosted AI agent ops platform. Connect Claude Code, Claude Desktop, Cursor, or any [Model Context Protocol](https://modelcontextprotocol.io) client to your Nora control plane and operate your agent fleet in natural language: deploy runtimes, start/stop/restart them, tail fleet status, and pull metrics, events, and per-agent cost.
 
@@ -6,7 +6,7 @@ MCP server for [Nora](https://github.com/solomon2773/nora), the self-hosted AI a
 claude mcp add nora \
   --env NORA_API_URL=https://nora.example.com \
   --env NORA_API_KEY=nora_xxxxxxxx \
-  -- npx -y @nora/mcp-server
+  -- npx -y @noraai/mcp-server
 ```
 
 Or in any MCP client's JSON config:
@@ -16,7 +16,7 @@ Or in any MCP client's JSON config:
   "mcpServers": {
     "nora": {
       "command": "npx",
-      "args": ["-y", "@nora/mcp-server"],
+      "args": ["-y", "@noraai/mcp-server"],
       "env": {
         "NORA_API_URL": "https://nora.example.com",
         "NORA_API_KEY": "nora_xxxxxxxx"
@@ -33,7 +33,7 @@ Uses Nora workspace API keys (create one under Workspace → API Keys). Scopes a
 - `agents:read` + `monitoring:read` → read tools
 - `agents:write` → deploy/lifecycle tools
 
-Fallbacks: `NORA_HOST`/`NORA_TOKEN` env vars, then the Nora CLI's `~/.nora/config.json` — so after `nora login`, `nora mcp` (or plain `npx @nora/mcp-server`) just works.
+Fallbacks: `NORA_HOST`/`NORA_TOKEN` env vars, then the Nora CLI's `~/.nora/config.json` — so after `nora login`, `nora mcp` (or plain `npx @noraai/mcp-server`) just works.
 
 ## Tools
 

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@nora/mcp-server",
+  "name": "@noraai/mcp-server",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@nora/mcp-server",
+      "name": "@noraai/mcp-server",
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nora/mcp-server",
+  "name": "@noraai/mcp-server",
   "version": "0.1.0",
   "description": "MCP server for the Nora agent ops control plane — operate your agent fleet from Claude Code, Claude Desktop, Cursor, or any MCP client.",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Why

The npm org is **`noraai`**, not `nora`. The `@nora` scope is owned by an unrelated account, so any scoped publish there fails with `E403 Forbidden`. This renames both publishable packages to the scope we actually own so the first publish (and the `release-npm` workflow) can succeed.

## Changes

- `@nora/mcp-server` → `@noraai/mcp-server`
- `@nora/cli` → `@noraai/cli`

Updated everywhere they appear: package + lockfile `name` fields, the `release-npm.yml` workflow header comments, the CLI `nora mcp` alias hint, and all docs/README/CHANGELOG mentions.

## Validation

- Both packages `npm pack --dry-run` cleanly with `LICENSE` bundled and `publishConfig.access: public` set.
- `@noraai/mcp-server` and `@noraai/cli` are both unregistered/available on the public registry.
- Package tests pass (mcp-server 10, cli 4).
- Prettier + eslint clean on the changed in-package files.

After merge, both packages get their first `0.1.0` publish and `NPM_TOKEN` is set so `release-npm.yml` handles subsequent releases.