### PR TITLE
feat(remote-hosts): recognize the remote-docker deploy target (BYOC Phase A)

### DIFF
--- a/agent-runtime/lib/backendCatalog.ts
+++ b/agent-runtime/lib/backendCatalog.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 const DEFAULT_RUNTIME_FAMILY = "openclaw";
 const KNOWN_RUNTIME_FAMILIES = Object.freeze(["openclaw", "hermes"]);
-const KNOWN_DEPLOY_TARGETS = Object.freeze(["docker", "k8s", "proxmox"]);
+const KNOWN_DEPLOY_TARGETS = Object.freeze(["docker", "k8s", "remote-docker", "proxmox"]);
 const KNOWN_BACKENDS = KNOWN_DEPLOY_TARGETS;
 const KNOWN_SANDBOX_PROFILES = Object.freeze(["standard", "nemoclaw"]);
 const PROXMOX_RELEASE_BLOCKER_ISSUE =
@@ -101,6 +101,16 @@ const EXECUTION_TARGET_METADATA = Object.freeze({
       "Use the Kubernetes adapter for K3s, AKS, GKE, EKS, or any conformant cluster reachable through the configured kubeconfig.",
     badges: ["Cluster workload", "Service-backed", "Kube API"],
   }),
+  "remote-docker": Object.freeze({
+    id: "remote-docker",
+    label: "Remote Docker host",
+    shortLabel: "Remote host",
+    summary:
+      "Run agents on your own remote machine — Mac, Windows, VPS, or cloud instance — reached over SSH instead of the local Docker host.",
+    detail:
+      "Nora connects to the remote machine's Docker daemon over SSH and runs the selected runtime there. Register a host in the operator console to make it selectable.",
+    badges: ["Bring your own compute", "SSH", "Remote daemon"],
+  }),
   proxmox: Object.freeze({
     id: "proxmox",
     label: "Proxmox",
@@ -153,6 +163,7 @@ function normalizeDeployTargetName(value) {
     .trim()
     .toLowerCase();
   if (normalized.startsWith("k8s:")) return "k8s";
+  if (normalized.startsWith("remote:")) return "remote-docker";
   return KNOWN_DEPLOY_TARGETS.includes(normalized) ? normalized : "docker";
 }
 
@@ -172,6 +183,14 @@ function normalizeExecutionTargetId(value) {
       .replace(/-+/g, "-")
       .replace(/^-|-$/g, "");
     return clusterId ? `k8s:${clusterId}` : "k8s";
+  }
+  if (normalized.startsWith("remote:")) {
+    const hostId = normalized
+      .slice(7)
+      .replace(/[^a-z0-9-]+/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-|-$/g, "");
+    return hostId ? `remote:${hostId}` : "remote-docker";
   }
   return KNOWN_DEPLOY_TARGETS.includes(normalized) ? normalized : null;
 }
@@ -198,7 +217,11 @@ function isKnownDeployTarget(value) {
   const normalized = String(value || "")
     .trim()
     .toLowerCase();
-  return normalized.startsWith("k8s:") || KNOWN_DEPLOY_TARGETS.includes(normalized);
+  return (
+    normalized.startsWith("k8s:") ||
+    normalized.startsWith("remote:") ||
+    KNOWN_DEPLOY_TARGETS.includes(normalized)
+  );
 }
 
 function isKnownBackend(value) {
@@ -381,6 +404,7 @@ function resolveMaturityTier({ deployTarget, sandboxProfile }) {
   const normalizedDeployTarget = normalizeDeployTargetName(deployTarget);
 
   if (normalizedDeployTarget === "proxmox") return "blocked";
+  if (normalizedDeployTarget === "remote-docker") return "experimental";
   if (normalizeSandboxProfileName(sandboxProfile) === "nemoclaw") return "experimental";
   return "ga";
 }
@@ -480,6 +504,15 @@ function baseDeployTargetIssue(deployTarget, env = process.env, selection = {}) 
         return null;
       }
       return "Kubernetes execution target requires an Admin-registered cluster such as k8s:aks-eastus2.";
+    case "remote-docker":
+      if (
+        normalizeExecutionTargetId(
+          selection.executionTargetId || selection.execution_target_id,
+        )?.startsWith("remote:")
+      ) {
+        return null;
+      }
+      return "Remote Docker execution target requires a registered host such as remote:my-laptop.";
     case "proxmox":
       return PROXMOX_RELEASE_BLOCKER_ISSUE;
     default:
@@ -567,8 +600,11 @@ function getRuntimeSelectionStatus(selection = {}, env = process.env) {
     ) || deployTarget;
   const hasRegisteredKubernetesTarget =
     deployTarget === "k8s" && String(executionTargetId || "").startsWith("k8s:");
+  const hasRegisteredRemoteTarget =
+    deployTarget === "remote-docker" && String(executionTargetId || "").startsWith("remote:");
   const deployTargetEnabled =
     hasRegisteredKubernetesTarget ||
+    hasRegisteredRemoteTarget ||
     getEnabledDeployTargets(env, { runtimeFamily }).includes(deployTarget);
   const enabled =
     getEnabledRuntimeFamilies(env).includes(runtimeFamily) &&

--- a/backend-api/__tests__/containerManager.test.ts
+++ b/backend-api/__tests__/containerManager.test.ts
@@ -227,6 +227,21 @@ describe("containerManager NemoClaw routing", () => {
     expect(exec).toEqual({ exec: "k8s-exec", stream: "k8s-stream" });
   });
 
+  it("fails closed for remote-docker lifecycle ops and never touches the local docker host", async () => {
+    const containerManager = require("../containerManager");
+    const agent = {
+      runtime_family: "openclaw",
+      deploy_target: "remote-docker",
+      execution_target_id: "remote:my-laptop",
+      backend_type: "remote-docker",
+      container_id: "oclaw-agent-remote",
+    };
+
+    await expect(containerManager.start(agent)).rejects.toThrow(/not yet available/i);
+    // critical: must NOT silently fall back to the local docker backend
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+
   it("uses container_name as a Kubernetes destroy fallback when container_id was cleared", async () => {
     const containerManager = require("../containerManager");
     const agent = {

--- a/backend-api/__tests__/remoteDockerCatalog.test.ts
+++ b/backend-api/__tests__/remoteDockerCatalog.test.ts
@@ -1,0 +1,143 @@
+// @ts-nocheck
+const {
+  getBackendCatalog,
+  getBackendStatus,
+  getDefaultBackend,
+  getRuntimeSelectionStatus,
+  isKnownDeployTarget,
+  normalizeDeployTargetName,
+  normalizeExecutionTargetId,
+} = require("../../agent-runtime/lib/backendCatalog");
+
+const ORIGINAL_ENV = { ...process.env };
+const ENV_KEYS = ["ENABLED_BACKENDS", "ENABLED_RUNTIME_FAMILIES", "ENABLED_SANDBOX_PROFILES"];
+
+function restoreEnv() {
+  for (const key of ENV_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(ORIGINAL_ENV, key)) {
+      process.env[key] = ORIGINAL_ENV[key];
+    } else {
+      delete process.env[key];
+    }
+  }
+}
+
+describe("remote-docker deploy target recognition", () => {
+  afterEach(() => restoreEnv());
+
+  describe("normalizers", () => {
+    it("maps the remote: execution-target prefix to the remote-docker deploy target", () => {
+      expect(normalizeDeployTargetName("remote-docker")).toBe("remote-docker");
+      expect(normalizeDeployTargetName("remote:my-laptop")).toBe("remote-docker");
+      expect(normalizeDeployTargetName("REMOTE:My-Laptop")).toBe("remote-docker");
+    });
+
+    it("does not let remote-docker change the docker fallback for unknown targets", () => {
+      expect(normalizeDeployTargetName("moon")).toBe("docker");
+      expect(normalizeDeployTargetName("")).toBe("docker");
+      expect(normalizeDeployTargetName("docker")).toBe("docker");
+    });
+
+    it("normalizes remote: execution-target ids and slugs the host id", () => {
+      expect(normalizeExecutionTargetId("remote:My_Laptop")).toBe("remote:my-laptop");
+      expect(normalizeExecutionTargetId("remote:  spaced  host ")).toBe("remote:spaced-host");
+      expect(normalizeExecutionTargetId("remote-docker")).toBe("remote-docker");
+      expect(normalizeExecutionTargetId("remote:")).toBe("remote-docker");
+    });
+
+    it("leaves the k8s prefix handling intact", () => {
+      expect(normalizeExecutionTargetId("k8s:aks-eastus2")).toBe("k8s:aks-eastus2");
+      expect(normalizeDeployTargetName("k8s:aks-eastus2")).toBe("k8s");
+    });
+
+    it("recognizes remote targets as known deploy targets", () => {
+      expect(isKnownDeployTarget("remote-docker")).toBe(true);
+      expect(isKnownDeployTarget("remote:my-laptop")).toBe(true);
+      expect(isKnownDeployTarget("nope")).toBe(false);
+    });
+  });
+
+  describe("runtime selection", () => {
+    beforeEach(() => {
+      process.env.ENABLED_BACKENDS = "docker";
+      process.env.ENABLED_RUNTIME_FAMILIES = "openclaw,hermes";
+      process.env.ENABLED_SANDBOX_PROFILES = "standard";
+    });
+
+    it("allows an OpenClaw deploy once a remote host target is selected", () => {
+      const status = getRuntimeSelectionStatus({
+        runtime_family: "openclaw",
+        deploy_target: "remote-docker",
+        execution_target_id: "remote:my-laptop",
+        sandbox_profile: "standard",
+      });
+      expect(status.enabled).toBe(true);
+      expect(status.configured).toBe(true);
+      expect(status.available).toBe(true);
+      expect(status.issue).toBeNull();
+      expect(status.deployTarget).toBe("remote-docker");
+      expect(status.executionTargetId).toBe("remote:my-laptop");
+    });
+
+    it("blocks a remote-docker deploy when no host target is registered", () => {
+      const status = getRuntimeSelectionStatus({
+        runtime_family: "openclaw",
+        deploy_target: "remote-docker",
+        sandbox_profile: "standard",
+      });
+      expect(status.available).toBe(false);
+      expect(status.issue).toMatch(/registered host such as remote:/i);
+    });
+
+    it("never enables remote-docker through ENABLED_BACKENDS alone (no registered host)", () => {
+      process.env.ENABLED_BACKENDS = "docker,remote-docker";
+      const status = getRuntimeSelectionStatus({
+        runtime_family: "openclaw",
+        deploy_target: "remote-docker",
+        sandbox_profile: "standard",
+      });
+      // remote-docker is filtered out of ENABLED_BACKENDS parsing; availability
+      // comes only from a registered remote:<id> target.
+      expect(status.available).toBe(false);
+    });
+
+    it("does not let Hermes target a remote Docker host in Phase A", () => {
+      const status = getRuntimeSelectionStatus({
+        runtime_family: "hermes",
+        deploy_target: "remote-docker",
+        execution_target_id: "remote:my-laptop",
+        sandbox_profile: "standard",
+      });
+      expect(status.available).toBe(false);
+      expect(status.issue).toMatch(/Hermes does not support/i);
+    });
+  });
+
+  describe("catalog surfacing", () => {
+    beforeEach(() => {
+      process.env.ENABLED_BACKENDS = "docker";
+      process.env.ENABLED_RUNTIME_FAMILIES = "openclaw";
+      process.env.ENABLED_SANDBOX_PROFILES = "standard";
+    });
+
+    it("surfaces remote-docker as an experimental, currently-unavailable target", () => {
+      const status = getBackendStatus("remote-docker");
+      expect(status.id).toBe("remote-docker");
+      expect(status.maturityTier).toBe("experimental");
+      expect(status.available).toBe(false);
+      expect(status.label).toMatch(/Remote/i);
+    });
+
+    it("keeps docker the default and leaves existing targets unchanged", () => {
+      expect(getDefaultBackend(process.env, { sandbox: "standard" })).toBe("docker");
+      const catalog = getBackendCatalog();
+      expect(catalog.find((b) => b.id === "docker")?.isDefault).toBe(true);
+      expect(catalog.find((b) => b.id === "remote-docker")?.isDefault).toBe(false);
+      expect(catalog.find((b) => b.id === "remote-docker")?.availableForOnboarding).toBe(false);
+      // existing non-cluster targets still present (k8s only surfaces per registered cluster)
+      expect(catalog.some((b) => b.id === "docker")).toBe(true);
+      expect(catalog.some((b) => b.id === "proxmox")).toBe(true);
+      expect(catalog.some((b) => b.id === "remote-docker")).toBe(true);
+    });
+  });
+});

--- a/backend-api/containerManager.ts
+++ b/backend-api/containerManager.ts
@@ -169,6 +169,12 @@ async function getBackendInstance(type, agent = {}) {
       backendCache[cacheKey] = new K8sBackend(profile);
       break;
     }
+    case "remote-docker":
+      // Registered in the catalog, but the remote adapter is not yet wired
+      // (BYOC Phase A). Fail closed rather than silently using the local host.
+      throw new Error(
+        "Remote Docker execution targets are not yet available for lifecycle operations in this release.",
+      );
     default:
       throw new Error(`Unknown backend type: ${type}`);
   }

--- a/frontend-dashboard/lib/runtime.ts
+++ b/frontend-dashboard/lib/runtime.ts
@@ -39,7 +39,8 @@ export function normalizeDeployTarget(value) {
     .toLowerCase();
   if (normalized.startsWith("k8s:") || normalized.startsWith("kubernetes:")) return "k8s";
   if (normalized === "kubernetes" || normalized === "k3s") return "k8s";
-  if (["docker", "k8s", "proxmox"].includes(normalized)) return normalized;
+  if (normalized.startsWith("remote:")) return "remote-docker";
+  if (["docker", "k8s", "remote-docker", "proxmox"].includes(normalized)) return normalized;
   return null;
 }
 
@@ -59,6 +60,14 @@ export function normalizeExecutionTargetId(value) {
       .replace(/-+/g, "-")
       .replace(/^-|-$/g, "");
     return clusterId ? `k8s:${clusterId}` : "k8s";
+  }
+  if (normalized.startsWith("remote:")) {
+    const hostId = normalized
+      .slice("remote:".length)
+      .replace(/[^a-z0-9-]+/g, "-")
+      .replace(/-+/g, "-")
+      .replace(/^-|-$/g, "");
+    return hostId ? `remote:${hostId}` : "remote-docker";
   }
   return normalizeDeployTarget(normalized);
 }
@@ -310,6 +319,8 @@ export function formatExecutionTargetLabel(
   switch (normalizeDeployTarget(value)) {
     case "k8s":
       return "Kubernetes";
+    case "remote-docker":
+      return "Remote Docker host";
     case "proxmox":
       return "Proxmox";
     default:

--- a/workers/provisioner/worker.ts
+++ b/workers/provisioner/worker.ts
@@ -1267,6 +1267,9 @@ function backendInstanceKey(runtimeFields = {}) {
   if (backend === "k8s" && runtimeFields.execution_target_id) {
     return String(runtimeFields.execution_target_id).trim().toLowerCase() || "k8s";
   }
+  if (backend === "remote-docker" && runtimeFields.execution_target_id) {
+    return String(runtimeFields.execution_target_id).trim().toLowerCase() || "remote-docker";
+  }
   return backend;
 }
 
@@ -1300,6 +1303,13 @@ async function loadBackend(runtimeFields = {}) {
       if (key === "k8s") {
         throw new Error(
           "Kubernetes provisioning requires an Admin-registered cluster target such as k8s:aks-eastus2.",
+        );
+      }
+      // Fail closed for remote Docker hosts: the adapter is not yet available,
+      // so we must NOT silently provision on the LOCAL docker host. (BYOC Phase A.)
+      if (key === "remote-docker" || key.startsWith("remote:")) {
+        throw new Error(
+          "Remote Docker execution targets are registered but not yet provisionable in this release.",
         );
       }
       console.warn(`Unknown backend "${key}", falling back to docker`);


### PR DESCRIPTION
## What

Makes **`remote-docker`** (execution targets of the form `remote:<id>`) a first-class deploy target in the shared backend catalog — the second BYOC Phase A step, on top of the remote-host registry (#193). Modeled on the Kubernetes-cluster pattern: availability comes **only** from a registered `remote:<id>` target, never from `ENABLED_BACKENDS`.

## Changes

**`agent-runtime/lib/backendCatalog.ts`** (shared — mounted into backend-api + worker):
- `KNOWN_DEPLOY_TARGETS`, `normalizeDeployTargetName`, `normalizeExecutionTargetId`, `isKnownDeployTarget` now understand `remote-docker` / `remote:<id>`.
- New `EXECUTION_TARGET_METADATA` entry; maturity tier `experimental`.
- `getRuntimeSelectionStatus` gains a `hasRegisteredRemoteTarget` bypass and `baseDeployTargetIssue` requires a `remote:` target — mirroring the k8s registered-cluster pattern. Hermes is intentionally excluded (Phase A is OpenClaw only).

**Fail closed until the adapter lands** (no silent local-host deploys — flagged by an adversarial review of the catalog change):
- `workers/provisioner/worker.ts` `loadBackend` now **throws** for `remote-docker`/`remote:` keys instead of falling back to the **local** docker backend (the dangerous mis-route).
- `backend-api/containerManager.ts` throws a clear "not yet available" error for remote-docker lifecycle ops.

**Frontend parity** (`frontend-dashboard/lib/runtime.ts`): `normalizeDeployTarget`, `normalizeExecutionTargetId`, `formatExecutionTargetLabel` recognize remote targets so agents render as **"Remote Docker host"** instead of mislabeled "Docker".

## Validation

- New: 11 catalog tests (normalizers, registered-target availability, Hermes exclusion, experimental surfacing, docker-default unchanged) + a containerManager fail-closed test asserting the local docker backend is never touched.
- Full backend suite **1040/1040** green (no regression to docker/k8s/proxmox).
- Typecheck clean across agent-runtime, backend-api, workers/provisioner, frontend-dashboard; prettier + eslint clean.
- This change was put through a multi-agent adversarial review; the safety/consistency findings it surfaced (worker mis-route, frontend mislabel) are fixed here.

## Not in this PR

No adapter yet — the dockerode-over-SSH `RemoteDockerBackend` + per-host routing is the next PR (the catalog deliberately fails closed until then). Routes/UI for host registration, the gateway-allowlist extension, and deploy-path validation follow after that.