### PR TITLE
feat(remote-hosts): dockerode-over-SSH remote Docker adapter (BYOC Phase A)

### DIFF
--- a/backend-api/__tests__/containerManager.test.ts
+++ b/backend-api/__tests__/containerManager.test.ts
@@ -24,6 +24,12 @@ const mockK8sStatus = jest.fn();
 const mockK8sStats = jest.fn();
 const mockK8sLogs = jest.fn();
 const mockK8sExec = jest.fn();
+const mockRemoteStart = jest.fn();
+const mockGetRemoteHostProfile = jest.fn();
+
+jest.mock("../remoteHosts", () => ({
+  getRemoteHostProfile: (...args) => mockGetRemoteHostProfile(...args),
+}));
 
 jest.mock("../backends/hermes", () => {
   return jest.fn().mockImplementation(() => ({
@@ -92,6 +98,21 @@ describe("containerManager NemoClaw routing", () => {
     const localK8sBackendPath = path.resolve(__dirname, "../backends/k8s");
     jest.doMock(localK8sBackendPath, k8sBackendFactory, { virtual: true });
     jest.doMock(`${localK8sBackendPath}.ts`, k8sBackendFactory, { virtual: true });
+    const remoteBackendFactory = () =>
+      jest.fn().mockImplementation(() => ({
+        start: mockRemoteStart,
+      }));
+    const remoteBackendPath = path.resolve(
+      __dirname,
+      "../../workers/provisioner/backends/remote-docker",
+    );
+    jest.doMock(remoteBackendPath, remoteBackendFactory);
+    jest.doMock(`${remoteBackendPath}.ts`, remoteBackendFactory);
+    const localRemoteBackendPath = path.resolve(__dirname, "../backends/remote-docker");
+    jest.doMock(localRemoteBackendPath, remoteBackendFactory, { virtual: true });
+    jest.doMock(`${localRemoteBackendPath}.ts`, remoteBackendFactory, { virtual: true });
+    mockRemoteStart.mockReset().mockResolvedValue(undefined);
+    mockGetRemoteHostProfile.mockReset();
     mockStart.mockReset().mockResolvedValue(undefined);
     mockStop.mockReset().mockResolvedValue(undefined);
     mockRestart.mockReset().mockResolvedValue(undefined);
@@ -227,7 +248,13 @@ describe("containerManager NemoClaw routing", () => {
     expect(exec).toEqual({ exec: "k8s-exec", stream: "k8s-stream" });
   });
 
-  it("fails closed for remote-docker lifecycle ops and never touches the local docker host", async () => {
+  it("routes remote-docker lifecycle calls to the remote backend, not the local docker host", async () => {
+    mockGetRemoteHostProfile.mockResolvedValue({
+      id: "my-laptop",
+      executionTargetId: "remote:my-laptop",
+      sshHost: "100.64.0.5",
+      sshUser: "operator",
+    });
     const containerManager = require("../containerManager");
     const agent = {
       runtime_family: "openclaw",
@@ -237,9 +264,28 @@ describe("containerManager NemoClaw routing", () => {
       container_id: "oclaw-agent-remote",
     };
 
-    await expect(containerManager.start(agent)).rejects.toThrow(/not yet available/i);
-    // critical: must NOT silently fall back to the local docker backend
+    await containerManager.start(agent);
+
+    expect(mockGetRemoteHostProfile).toHaveBeenCalledWith("remote:my-laptop");
+    expect(mockRemoteStart).toHaveBeenCalledWith("oclaw-agent-remote");
+    // critical: must NOT fall back to the local docker backend
     expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it("fails closed for a remote-docker agent whose host is not registered", async () => {
+    mockGetRemoteHostProfile.mockResolvedValue(null);
+    const containerManager = require("../containerManager");
+    const agent = {
+      runtime_family: "openclaw",
+      deploy_target: "remote-docker",
+      execution_target_id: "remote:ghost",
+      backend_type: "remote-docker",
+      container_id: "oclaw-agent-ghost",
+    };
+
+    await expect(containerManager.start(agent)).rejects.toThrow(/registered remote host/i);
+    expect(mockStart).not.toHaveBeenCalled();
+    expect(mockRemoteStart).not.toHaveBeenCalled();
   });
 
   it("uses container_name as a Kubernetes destroy fallback when container_id was cleared", async () => {

--- a/backend-api/__tests__/containerManager.test.ts
+++ b/backend-api/__tests__/containerManager.test.ts
@@ -254,6 +254,7 @@ describe("containerManager NemoClaw routing", () => {
       executionTargetId: "remote:my-laptop",
       sshHost: "100.64.0.5",
       sshUser: "operator",
+      configured: true,
     });
     const containerManager = require("../containerManager");
     const agent = {
@@ -270,6 +271,29 @@ describe("containerManager NemoClaw routing", () => {
     expect(mockRemoteStart).toHaveBeenCalledWith("oclaw-agent-remote");
     // critical: must NOT fall back to the local docker backend
     expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it("fails closed for a remote-docker agent whose host is unconfigured (no credential)", async () => {
+    mockGetRemoteHostProfile.mockResolvedValue({
+      id: "half-set-up",
+      executionTargetId: "remote:half-set-up",
+      sshHost: "100.64.0.9",
+      sshUser: "operator",
+      configured: false,
+      issue: "Remote host requires an SSH private key.",
+    });
+    const containerManager = require("../containerManager");
+    const agent = {
+      runtime_family: "openclaw",
+      deploy_target: "remote-docker",
+      execution_target_id: "remote:half-set-up",
+      backend_type: "remote-docker",
+      container_id: "oclaw-agent-half",
+    };
+
+    await expect(containerManager.start(agent)).rejects.toThrow(/SSH private key/i);
+    expect(mockStart).not.toHaveBeenCalled();
+    expect(mockRemoteStart).not.toHaveBeenCalled();
   });
 
   it("fails closed for a remote-docker agent whose host is not registered", async () => {

--- a/backend-api/__tests__/remoteDocker.test.ts
+++ b/backend-api/__tests__/remoteDocker.test.ts
@@ -63,6 +63,20 @@ describe("RemoteDockerBackend construction", () => {
     );
   });
 
+  it("refuses to build with no credential (would let ssh2 use the worker's own identity)", () => {
+    // key mode, no private key
+    expect(() => new RemoteDockerBackend(keyProfile({ sshPrivateKey: null }))).toThrow(
+      /missing its SSH private key/i,
+    );
+    // password mode, no password
+    expect(
+      () =>
+        new RemoteDockerBackend(
+          keyProfile({ sshAuthMode: "password", sshPrivateKey: null, sshPassword: "" }),
+        ),
+    ).toThrow(/missing its SSH password/i);
+  });
+
   it("points the dockerode client at the remote daemon over SSH", () => {
     const backend = new RemoteDockerBackend(keyProfile());
     // dockerode exposes the docker-modem; the SSH protocol is what makes calls

--- a/backend-api/__tests__/remoteDocker.test.ts
+++ b/backend-api/__tests__/remoteDocker.test.ts
@@ -1,0 +1,116 @@
+// @ts-nocheck
+const path = require("path");
+
+const RemoteDockerBackend = require("../../workers/provisioner/backends/remote-docker");
+const DockerBackend = require("../../workers/provisioner/backends/docker");
+const { buildRemoteDockerOptions } = RemoteDockerBackend;
+
+function keyProfile(overrides = {}) {
+  return {
+    id: "my-laptop",
+    executionTargetId: "remote:my-laptop",
+    label: "My Laptop",
+    sshHost: "100.64.0.5",
+    sshPort: 2222,
+    sshUser: "operator",
+    sshAuthMode: "key",
+    sshPrivateKey: "PRIVATE-KEY-PEM",
+    sshPassphrase: "secret-phrase",
+    gatewayHost: "laptop.tail-scale.ts.net",
+    ...overrides,
+  };
+}
+
+describe("buildRemoteDockerOptions", () => {
+  it("builds key-based SSH options with a Buffer private key and passphrase", () => {
+    const opts = buildRemoteDockerOptions(keyProfile());
+    expect(opts.protocol).toBe("ssh");
+    expect(opts.host).toBe("100.64.0.5");
+    expect(opts.port).toBe(2222);
+    expect(opts.username).toBe("operator");
+    expect(Buffer.isBuffer(opts.sshOptions.privateKey)).toBe(true);
+    expect(opts.sshOptions.privateKey.toString()).toBe("PRIVATE-KEY-PEM");
+    expect(opts.sshOptions.passphrase).toBe("secret-phrase");
+    expect(opts.sshOptions.password).toBeUndefined();
+  });
+
+  it("builds password-based SSH options and omits key material", () => {
+    const opts = buildRemoteDockerOptions(
+      keyProfile({ sshAuthMode: "password", sshPassword: "hunter2", sshPrivateKey: null }),
+    );
+    expect(opts.sshOptions.password).toBe("hunter2");
+    expect(opts.sshOptions.privateKey).toBeUndefined();
+  });
+
+  it("defaults the SSH port to 22 when unset", () => {
+    expect(buildRemoteDockerOptions(keyProfile({ sshPort: null })).port).toBe(22);
+  });
+});
+
+describe("RemoteDockerBackend construction", () => {
+  it("rejects a profile without a remote: execution target", () => {
+    expect(() => new RemoteDockerBackend(keyProfile({ executionTargetId: "docker" }))).toThrow(
+      /registered remote host profile/i,
+    );
+  });
+
+  it("rejects a profile missing SSH connection details", () => {
+    expect(() => new RemoteDockerBackend(keyProfile({ sshHost: "" }))).toThrow(
+      /missing SSH connection details/i,
+    );
+    expect(() => new RemoteDockerBackend(keyProfile({ sshUser: "" }))).toThrow(
+      /missing SSH connection details/i,
+    );
+  });
+
+  it("points the dockerode client at the remote daemon over SSH", () => {
+    const backend = new RemoteDockerBackend(keyProfile());
+    // dockerode exposes the docker-modem; the SSH protocol is what makes calls
+    // route to the remote host instead of /var/run/docker.sock.
+    expect(backend.docker.modem.protocol).toBe("ssh");
+    expect(backend.docker.modem.host).toBe("100.64.0.5");
+  });
+
+  it("never discovers a compose network (remote hosts are standalone daemons)", async () => {
+    const backend = new RemoteDockerBackend(keyProfile());
+    expect(backend._composeNetwork).toBeNull();
+    await expect(backend._findComposeNetwork()).resolves.toBeNull();
+  });
+});
+
+describe("RemoteDockerBackend.create", () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it("advertises the remote host's gateway address and published port", async () => {
+    jest.spyOn(DockerBackend.prototype, "create").mockResolvedValue({
+      containerId: "oclaw-agent-x",
+      host: "172.18.0.4",
+      gatewayToken: "tok",
+      containerName: "oclaw-agent-x",
+      gatewayHostPort: 19042,
+    });
+    const backend = new RemoteDockerBackend(keyProfile());
+
+    const result = await backend.create({ id: "x", name: "X" });
+
+    expect(result.gatewayHost).toBe("laptop.tail-scale.ts.net");
+    expect(result.gatewayPort).toBe(19042);
+    // base fields preserved
+    expect(result.containerId).toBe("oclaw-agent-x");
+    expect(result.gatewayHostPort).toBe(19042);
+  });
+
+  it("falls back to the SSH host as the advertised gateway host", async () => {
+    jest.spyOn(DockerBackend.prototype, "create").mockResolvedValue({
+      containerId: "c",
+      host: "h",
+      gatewayToken: "t",
+      containerName: "c",
+      gatewayHostPort: 19000,
+    });
+    const backend = new RemoteDockerBackend(keyProfile({ gatewayHost: "" }));
+
+    const result = await backend.create({ id: "x" });
+    expect(result.gatewayHost).toBe("100.64.0.5");
+  });
+});

--- a/backend-api/containerManager.ts
+++ b/backend-api/containerManager.ts
@@ -179,6 +179,9 @@ async function getBackendInstance(type, agent = {}) {
           "Remote Docker lifecycle operations require a registered remote host execution target.",
         );
       }
+      if (!profile.configured) {
+        throw new Error(profile.issue || "Remote host is not configured for lifecycle operations.");
+      }
       backendCache[cacheKey] = new RemoteDockerBackend(profile);
       break;
     }

--- a/backend-api/containerManager.ts
+++ b/backend-api/containerManager.ts
@@ -23,6 +23,7 @@ const {
   resolveAgentSandboxProfile,
 } = require("./agentRuntimeFields");
 const { getKubernetesClusterProfile } = require("./kubernetesClusters");
+const { getRemoteHostProfile } = require("./remoteHosts");
 
 // Lazy-load backends so missing optional deps (e.g. @kubernetes/client-node)
 // don't crash the API server when only Docker is used.
@@ -131,7 +132,7 @@ function resolveBackendPath(name) {
 
 async function getBackendInstance(type, agent = {}) {
   const cacheKey =
-    type === "k8s" || type === "k3s" || type === "kubernetes"
+    type === "k8s" || type === "k3s" || type === "kubernetes" || type === "remote-docker"
       ? resolveAgentExecutionTargetId(agent)
       : type;
   if (backendCache[cacheKey]) return backendCache[cacheKey];
@@ -169,12 +170,18 @@ async function getBackendInstance(type, agent = {}) {
       backendCache[cacheKey] = new K8sBackend(profile);
       break;
     }
-    case "remote-docker":
-      // Registered in the catalog, but the remote adapter is not yet wired
-      // (BYOC Phase A). Fail closed rather than silently using the local host.
-      throw new Error(
-        "Remote Docker execution targets are not yet available for lifecycle operations in this release.",
-      );
+    case "remote-docker": {
+      const RemoteDockerBackend = require(resolveBackendPath("remote-docker"));
+      const executionTargetId = resolveAgentExecutionTargetId(agent);
+      const profile = await getRemoteHostProfile(executionTargetId);
+      if (!profile) {
+        throw new Error(
+          "Remote Docker lifecycle operations require a registered remote host execution target.",
+        );
+      }
+      backendCache[cacheKey] = new RemoteDockerBackend(profile);
+      break;
+    }
     default:
       throw new Error(`Unknown backend type: ${type}`);
   }

--- a/workers/provisioner/backends/remote-docker.ts
+++ b/workers/provisioner/backends/remote-docker.ts
@@ -1,0 +1,91 @@
+// @ts-nocheck
+// Remote Docker backend — BYOC Phase A (A2b).
+//
+// Runs the EXACT same OpenClaw orchestration as the local DockerBackend, but
+// against a remote machine's Docker daemon reached over SSH. dockerode 5 +
+// docker-modem 5 + ssh2 establish the connection programmatically (the modem
+// runs `docker system dial-stdio` over an ssh2 session — no shell ssh binary),
+// so every container/image/volume/exec/putArchive call transfers transparently.
+//
+// We therefore subclass DockerBackend and change only what differs on a remote
+// standalone host:
+//   1. the dockerode client points at the remote daemon over SSH;
+//   2. there is no Nora compose network to join (use the default bridge +
+//      published host port);
+//   3. create() advertises the remote machine's reachable gateway address so
+//      the control plane's resolveGatewayAddress targets the remote host, not
+//      host.docker.internal.
+//
+// The reusable bootstrap generators, tar injection, image build/pull, and
+// lifecycle methods are all inherited unchanged.
+
+const DockerBackend = require("./docker");
+
+const DEFAULT_SSH_PORT = 22;
+
+// Translate a remote_hosts profile into dockerode SSH connection options.
+function buildRemoteDockerOptions(profile = {}) {
+  const sshOptions = {};
+  if (profile.sshAuthMode === "password") {
+    if (profile.sshPassword) sshOptions.password = profile.sshPassword;
+  } else {
+    if (profile.sshPrivateKey) sshOptions.privateKey = Buffer.from(profile.sshPrivateKey);
+    if (profile.sshPassphrase) sshOptions.passphrase = profile.sshPassphrase;
+  }
+  return {
+    protocol: "ssh",
+    host: profile.sshHost,
+    port: profile.sshPort || DEFAULT_SSH_PORT,
+    username: profile.sshUser,
+    sshOptions,
+  };
+}
+
+class RemoteDockerBackend extends DockerBackend {
+  constructor(profile = {}) {
+    // The parent constructor wires this.docker to the LOCAL socket; we replace
+    // it below with an SSH-backed client before any operation runs.
+    super();
+    this.profile = profile || {};
+    this.executionTargetId = String(this.profile.executionTargetId || "")
+      .trim()
+      .toLowerCase();
+    if (!this.executionTargetId.startsWith("remote:")) {
+      throw new Error("Remote Docker backend requires a registered remote host profile.");
+    }
+    if (!this.profile.sshHost || !this.profile.sshUser) {
+      throw new Error(
+        `Remote host ${this.profile.label || this.executionTargetId} is missing SSH connection details.`,
+      );
+    }
+    // Reuse the exact dockerode constructor the parent resolved, but connect to
+    // the remote daemon over SSH instead of /var/run/docker.sock.
+    const Docker = this.docker.constructor;
+    this.docker = new Docker(buildRemoteDockerOptions(this.profile));
+    // A remote standalone host has no Nora compose network — never discover one.
+    this._composeNetwork = null;
+  }
+
+  // Remote daemons are standalone: skip compose-network discovery so create()
+  // falls back to the default bridge network and a published host port.
+  async _findComposeNetwork() {
+    return null;
+  }
+
+  async create(config = {}) {
+    const result = await super.create(config);
+    // The gateway port is published on the REMOTE host's interface, so point
+    // the control plane at the host's advertised address + that published port
+    // (resolveGatewayAddress prefers gateway_host + gateway_port). Without this
+    // it would fall back to host.docker.internal, which is the wrong machine.
+    const gatewayHost = this.profile.gatewayHost || this.profile.sshHost;
+    return {
+      ...result,
+      gatewayHost,
+      gatewayPort: result.gatewayHostPort || null,
+    };
+  }
+}
+
+module.exports = RemoteDockerBackend;
+module.exports.buildRemoteDockerOptions = buildRemoteDockerOptions;

--- a/workers/provisioner/backends/remote-docker.ts
+++ b/workers/provisioner/backends/remote-docker.ts
@@ -58,8 +58,24 @@ class RemoteDockerBackend extends DockerBackend {
         `Remote host ${this.profile.label || this.executionTargetId} is missing SSH connection details.`,
       );
     }
+    // Require the credential for the selected auth mode. Without this, an empty
+    // sshOptions would let docker-modem/ssh2 silently fall back to ambient
+    // credentials (the worker's own ~/.ssh key or SSH agent) and authenticate
+    // as the wrong identity — so fail loudly instead.
+    const hasCredential =
+      this.profile.sshAuthMode === "password"
+        ? Boolean(this.profile.sshPassword)
+        : Boolean(this.profile.sshPrivateKey);
+    if (!hasCredential) {
+      throw new Error(
+        `Remote host ${this.profile.label || this.executionTargetId} is missing its SSH ` +
+          `${this.profile.sshAuthMode === "password" ? "password" : "private key"}.`,
+      );
+    }
     // Reuse the exact dockerode constructor the parent resolved, but connect to
-    // the remote daemon over SSH instead of /var/run/docker.sock.
+    // the remote daemon over SSH instead of /var/run/docker.sock. dockerode is
+    // lazy — the local-socket client the parent just built opens no connection,
+    // so replacing it here leaks nothing.
     const Docker = this.docker.constructor;
     this.docker = new Docker(buildRemoteDockerOptions(this.profile));
     // A remote standalone host has no Nora compose network — never discover one.

--- a/workers/provisioner/worker.ts
+++ b/workers/provisioner/worker.ts
@@ -24,6 +24,7 @@ const {
   getPersistedHermesState,
 } = require("../../backend-api/hermesUi");
 const { getKubernetesClusterProfile } = require("../../backend-api/kubernetesClusters");
+const { getRemoteHostProfile } = require("../../backend-api/remoteHosts");
 const {
   buildIntegrationSyncEntry,
   decryptSensitiveConfig,
@@ -1305,11 +1306,17 @@ async function loadBackend(runtimeFields = {}) {
           "Kubernetes provisioning requires an Admin-registered cluster target such as k8s:aks-eastus2.",
         );
       }
-      // Fail closed for remote Docker hosts: the adapter is not yet available,
-      // so we must NOT silently provision on the LOCAL docker host. (BYOC Phase A.)
-      if (key === "remote-docker" || key.startsWith("remote:")) {
+      if (key.startsWith("remote:")) {
+        const profile = await getRemoteHostProfile(key);
+        if (!profile) {
+          throw new Error(`Unknown remote host execution target: ${key}`);
+        }
+        instance = new (require("./backends/remote-docker"))(profile);
+        break;
+      }
+      if (key === "remote-docker") {
         throw new Error(
-          "Remote Docker execution targets are registered but not yet provisionable in this release.",
+          "Remote Docker provisioning requires a registered host target such as remote:my-laptop.",
         );
       }
       console.warn(`Unknown backend "${key}", falling back to docker`);

--- a/workers/provisioner/worker.ts
+++ b/workers/provisioner/worker.ts
@@ -1311,6 +1311,11 @@ async function loadBackend(runtimeFields = {}) {
         if (!profile) {
           throw new Error(`Unknown remote host execution target: ${key}`);
         }
+        if (!profile.configured) {
+          throw new Error(
+            profile.issue || `Remote host ${key} is not configured for provisioning.`,
+          );
+        }
         instance = new (require("./backends/remote-docker"))(profile);
         break;
       }


### PR DESCRIPTION
## What

The `RemoteDockerBackend` — the BYOC Phase A core. Makes `remote-docker` a real, deployable target by running Nora's existing OpenClaw Docker orchestration against a **remote** machine's daemon over SSH. Builds on the registry (#193) and catalog recognition (#194).

## How

`workers/provisioner/backends/remote-docker.ts` **subclasses `DockerBackend`** and reuses all of its orchestration (bootstrap generators, tar injection, image build/pull, lifecycle). Only the remote-specific bits change:

- **SSH transport** — reconstructs the dockerode client with `{ protocol: "ssh", host, port, username, sshOptions }` from the encrypted host profile. dockerode 5 + docker-modem 5 + ssh2 establish this programmatically (`docker system dial-stdio` over ssh2 — no shell `ssh` binary), so every container/image/volume/exec/`putArchive` call transfers transparently.
- **No compose network** — overrides `_findComposeNetwork()`→`null` (a remote standalone host has no Nora compose network → default bridge + published host port).
- **Reachable gateway** — `create()` returns `gatewayHost` (the host's advertised address) + `gatewayPort` (the published host port), so the control plane's `resolveGatewayAddress` targets the remote machine instead of `host.docker.internal`.

**Wiring** (replaces #194's fail-closed throws with real construction):
- `worker.ts loadBackend`: a `remote:<id>` key fetches the profile via `getRemoteHostProfile` and constructs the adapter; a bare `remote-docker` or an unknown host still throws — **never** a silent local-docker fallback.
- `containerManager.ts`: same construction for lifecycle ops, cached per `execution_target_id` like k8s.

## Validation

- `remoteDocker.test.ts`: SSH-option building (Buffer key + passphrase vs password, port default), construction guards, `modem.protocol === "ssh"`, `_findComposeNetwork`→null, and `create()` gateway-address augmentation (+ sshHost fallback).
- Updated `containerManager` routing tests: routes to the remote backend; fails closed for an unregistered host; never touches the local docker backend.
- Full backend suite **1050/1050**; backend-api + workers/provisioner typecheck clean; prettier + eslint clean.

## Not in this PR

Host-registration routes/UI, the gateway-allowlist extension for remote/Tailscale/public addresses (today RFC1918/loopback only — so chat to a public/CGNAT gateway is still blocked), and deploy-path validation (`assertRemoteHostExecutionTargetAvailable` + the rollback/in-place-restore gaps). Real end-to-end against a live SSH host is a manual smoke test once the registration UI exists.