### PR TITLE
feat(remote-hosts): operator + admin remote-host registry routes (BYOC Phase A)

### DIFF
--- a/backend-api/__tests__/remoteHostsRoutes.test.ts
+++ b/backend-api/__tests__/remoteHostsRoutes.test.ts
@@ -1,0 +1,160 @@
+// @ts-nocheck
+/**
+ * __tests__/remoteHostsRoutes.test.ts — operator + admin remote-host routes.
+ * Mocks the remoteHosts registry so we assert routing, per-owner scoping, and
+ * ownership enforcement without standing up Postgres.
+ */
+const request = require("supertest");
+const jwt = require("jsonwebtoken");
+
+const JWT_SECRET = process.env.JWT_SECRET || "secret";
+process.env.JWT_SECRET = JWT_SECRET;
+
+const mockDb = { query: jest.fn().mockResolvedValue({ rows: [] }), connect: jest.fn() };
+jest.mock("../db", () => mockDb);
+jest.mock("../redisQueue", () => ({
+  addDeploymentJob: jest.fn(),
+  getDLQJobs: jest.fn(),
+  retryDLQJob: jest.fn(),
+}));
+jest.mock("../scheduler", () => ({ selectNode: jest.fn() }));
+jest.mock("../containerManager", () => ({
+  start: jest.fn(),
+  stop: jest.fn(),
+  restart: jest.fn(),
+  destroy: jest.fn(),
+  status: jest.fn().mockResolvedValue({ running: true }),
+}));
+jest.mock("../monitoring", () => ({
+  logEvent: jest.fn().mockResolvedValue(undefined),
+  getMetrics: jest.fn().mockResolvedValue({}),
+  getRecentEvents: jest.fn().mockResolvedValue([]),
+}));
+jest.mock("../billing", () => ({
+  BILLING_ENABLED: false,
+  PLATFORM_MODE: "selfhosted",
+  enforceLimits: jest.fn().mockResolvedValue({ allowed: true }),
+  getSubscription: jest.fn().mockResolvedValue({ plan: "selfhosted" }),
+}));
+
+const mockRemoteHosts = {
+  listRemoteHosts: jest.fn(),
+  createRemoteHost: jest.fn(),
+  updateRemoteHost: jest.fn(),
+  deleteRemoteHost: jest.fn(),
+  testRemoteHost: jest.fn(),
+  getRemoteHost: jest.fn(),
+  // imported elsewhere (worker/containerManager); stubbed so server boot is happy
+  getRemoteHostProfile: jest.fn(),
+  isRemoteDockerTarget: jest.fn(),
+  listRemoteHostExecutionTargets: jest.fn().mockResolvedValue([]),
+};
+jest.mock("../remoteHosts", () => mockRemoteHosts);
+
+const app = require("../server");
+const userToken = jwt.sign({ id: "user-1", role: "user" }, JWT_SECRET, { expiresIn: "1h" });
+const otherToken = jwt.sign({ id: "user-2", role: "user" }, JWT_SECRET, { expiresIn: "1h" });
+const adminToken = jwt.sign({ id: "admin-1", role: "admin" }, JWT_SECRET, { expiresIn: "1h" });
+const auth = (req, token) => req.set("Authorization", `Bearer ${token}`);
+
+beforeEach(() => {
+  for (const fn of Object.values(mockRemoteHosts)) {
+    if (typeof fn?.mockReset === "function") fn.mockReset();
+  }
+  mockRemoteHosts.listRemoteHostExecutionTargets.mockResolvedValue([]);
+});
+
+describe("operator remote-host routes", () => {
+  it("requires authentication", async () => {
+    const res = await request(app).get("/remote-hosts");
+    expect(res.status).toBe(401);
+  });
+
+  it("lists only the caller's own hosts", async () => {
+    mockRemoteHosts.listRemoteHosts.mockResolvedValue([{ id: "my-laptop", ownerUserId: "user-1" }]);
+    const res = await auth(request(app).get("/remote-hosts"), userToken);
+    expect(res.status).toBe(200);
+    expect(mockRemoteHosts.listRemoteHosts).toHaveBeenCalledWith(
+      expect.objectContaining({ ownerUserId: "user-1", includeDisabled: true }),
+    );
+  });
+
+  it("creates a host owned by the caller", async () => {
+    mockRemoteHosts.createRemoteHost.mockResolvedValue({
+      id: "vps-1",
+      label: "VPS",
+      ownerUserId: "user-1",
+    });
+    const res = await auth(request(app).post("/remote-hosts"), userToken).send({
+      id: "vps-1",
+      sshHost: "1.2.3.4",
+      sshUser: "root",
+      sshPrivateKey: "KEY",
+    });
+    expect(res.status).toBe(201);
+    expect(mockRemoteHosts.createRemoteHost).toHaveBeenCalledWith(
+      expect.objectContaining({ ownerUserId: "user-1", sshHost: "1.2.3.4" }),
+    );
+  });
+
+  it("updates a host the caller owns", async () => {
+    mockRemoteHosts.getRemoteHost.mockResolvedValue({ id: "vps-1", ownerUserId: "user-1" });
+    mockRemoteHosts.updateRemoteHost.mockResolvedValue({ id: "vps-1", label: "Renamed" });
+    const res = await auth(request(app).put("/remote-hosts/vps-1"), userToken).send({
+      label: "Renamed",
+    });
+    expect(res.status).toBe(200);
+    expect(mockRemoteHosts.updateRemoteHost).toHaveBeenCalledWith(
+      "vps-1",
+      expect.objectContaining({ ownerUserId: "user-1", label: "Renamed" }),
+    );
+  });
+
+  it("returns 404 (not 403) when mutating another operator's host", async () => {
+    mockRemoteHosts.getRemoteHost.mockResolvedValue({ id: "vps-1", ownerUserId: "user-2" });
+    const res = await auth(request(app).delete("/remote-hosts/vps-1"), userToken);
+    expect(res.status).toBe(404);
+    expect(mockRemoteHosts.deleteRemoteHost).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when testing a host that does not exist", async () => {
+    mockRemoteHosts.getRemoteHost.mockResolvedValue(null);
+    const res = await auth(request(app).post("/remote-hosts/ghost/test"), userToken);
+    expect(res.status).toBe(404);
+    expect(mockRemoteHosts.testRemoteHost).not.toHaveBeenCalled();
+  });
+
+  it("tests a host the caller owns", async () => {
+    mockRemoteHosts.getRemoteHost.mockResolvedValue({
+      id: "vps-1",
+      ownerUserId: "user-1",
+      label: "VPS",
+    });
+    mockRemoteHosts.testRemoteHost.mockResolvedValue({ id: "vps-1", lastTestStatus: "ok" });
+    const res = await auth(request(app).post("/remote-hosts/vps-1/test"), userToken);
+    expect(res.status).toBe(200);
+    expect(res.body.lastTestStatus).toBe("ok");
+  });
+});
+
+describe("admin remote-host fleet view", () => {
+  it("lists every operator's hosts for an admin", async () => {
+    mockRemoteHosts.listRemoteHosts.mockResolvedValue([
+      { id: "a", ownerUserId: "user-1" },
+      { id: "b", ownerUserId: "user-2" },
+    ]);
+    const res = await auth(request(app).get("/admin/remote-hosts"), adminToken);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(2);
+    // fleet view is NOT owner-scoped
+    expect(mockRemoteHosts.listRemoteHosts).toHaveBeenCalledWith(
+      expect.objectContaining({ includeDisabled: true }),
+    );
+    expect(mockRemoteHosts.listRemoteHosts.mock.calls[0][0].ownerUserId).toBeUndefined();
+  });
+
+  it("forbids a non-admin from the fleet view", async () => {
+    const res = await auth(request(app).get("/admin/remote-hosts"), otherToken);
+    expect(res.status).toBe(403);
+  });
+});

--- a/backend-api/remoteHosts.ts
+++ b/backend-api/remoteHosts.ts
@@ -303,6 +303,13 @@ async function getRemoteHostProfile(executionTargetId) {
   return rowToProfile(row, { includeSecret: true });
 }
 
+// Masked single-host lookup by id (no secrets) — used by the route layer to
+// enforce per-owner access before mutating.
+async function getRemoteHost(hostId) {
+  const row = await getHostRow(hostId);
+  return row ? maskHost(row) : null;
+}
+
 async function clearOtherDefaults(hostId, ownerUserId) {
   await db.query(
     `UPDATE remote_hosts
@@ -579,6 +586,7 @@ module.exports = {
   assertRemoteHostExecutionTargetAvailable,
   createRemoteHost,
   deleteRemoteHost,
+  getRemoteHost,
   getRemoteHostProfile,
   isRemoteDockerTarget,
   listRemoteHosts,

--- a/backend-api/routes/admin.ts
+++ b/backend-api/routes/admin.ts
@@ -10,6 +10,7 @@ const snapshots = require("../snapshots");
 const containerManager = require("../containerManager");
 const releaseUpgrade = require("../releaseUpgrade");
 const kubernetesClusters = require("../kubernetesClusters");
+const remoteHosts = require("../remoteHosts");
 const doctor = require("../doctor");
 const { repairHermesAgentConfig } = require("../hermesUi");
 const { addBackupJob, addDeploymentJob, getDLQJobs, retryDLQJob } = require("../redisQueue");
@@ -710,6 +711,16 @@ router.delete(
       }),
     );
     res.json({ success: true, cluster });
+  }),
+);
+
+// Fleet-wide read-only view of every operator's registered remote hosts (BYOC).
+// Hosts are owned per-user; this is the admin oversight surface. Secrets are
+// masked by the registry's list path.
+router.get(
+  "/remote-hosts",
+  asyncHandler(async (_req, res) => {
+    res.json(await remoteHosts.listRemoteHosts({ includeDisabled: true }));
   }),
 );
 

--- a/backend-api/routes/remoteHosts.ts
+++ b/backend-api/routes/remoteHosts.ts
@@ -1,0 +1,94 @@
+// @ts-nocheck
+// Operator-facing remote-host registry routes (BYOC Phase A, A5).
+//
+// Each operator manages their OWN remote hosts (owner_user_id = req.user.id).
+// Registering a host stores SSH credentials, so — like API-key minting — these
+// routes are session-only (requireSession): an API key cannot create or read
+// SSH credentials. Admin gets a separate read-only fleet view under /admin.
+
+const express = require("express");
+const remoteHosts = require("../remoteHosts");
+const monitoring = require("../monitoring");
+const { asyncHandler } = require("../middleware/errorHandler");
+const { requireSession } = require("../middleware/auth");
+
+const router = express.Router();
+router.use(requireSession);
+
+// Load a host and confirm it belongs to the caller. Returns 404 (not 403) when
+// it exists but is owned by someone else, so we never leak its existence.
+async function loadOwnedHost(req) {
+  const host = await remoteHosts.getRemoteHost(req.params.id);
+  if (!host || host.ownerUserId !== req.user.id) {
+    const error = new Error("Remote host not found");
+    error.statusCode = 404;
+    throw error;
+  }
+  return host;
+}
+
+router.get(
+  "/",
+  asyncHandler(async (req, res) => {
+    res.json(
+      await remoteHosts.listRemoteHosts({ ownerUserId: req.user.id, includeDisabled: true }),
+    );
+  }),
+);
+
+router.post(
+  "/",
+  asyncHandler(async (req, res) => {
+    const host = await remoteHosts.createRemoteHost({
+      ...(req.body || {}),
+      ownerUserId: req.user.id,
+    });
+    await monitoring.logEvent("remote_host_registered", `Registered remote host "${host.label}"`, {
+      userId: req.user.id,
+      remoteHost: { id: host.id, label: host.label },
+    });
+    res.status(201).json(host);
+  }),
+);
+
+router.put(
+  "/:id",
+  asyncHandler(async (req, res) => {
+    await loadOwnedHost(req);
+    // ownerUserId is pinned to the caller — a host cannot be reassigned.
+    const host = await remoteHosts.updateRemoteHost(req.params.id, {
+      ...(req.body || {}),
+      ownerUserId: req.user.id,
+    });
+    res.json(host);
+  }),
+);
+
+router.post(
+  "/:id/test",
+  asyncHandler(async (req, res) => {
+    const owned = await loadOwnedHost(req);
+    const host = await remoteHosts.testRemoteHost(req.params.id);
+    await monitoring.logEvent(
+      "remote_host_tested",
+      `Tested remote host "${owned.label}" (${host.lastTestStatus})`,
+      { userId: req.user.id, remoteHost: { id: host.id, status: host.lastTestStatus } },
+    );
+    res.json(host);
+  }),
+);
+
+router.delete(
+  "/:id",
+  asyncHandler(async (req, res) => {
+    await loadOwnedHost(req);
+    const host = await remoteHosts.deleteRemoteHost(req.params.id);
+    await monitoring.logEvent("remote_host_deleted", `Deleted remote host "${host.label}"`, {
+      userId: req.user.id,
+      remoteHost: { id: host.id, label: host.label },
+    });
+    res.json(host);
+  }),
+);
+
+module.exports = router;

--- a/backend-api/server.ts
+++ b/backend-api/server.ts
@@ -1076,6 +1076,7 @@ app.use("/llm-providers", require("./routes/llmProviders"));
 app.use("/clawhub", require("./routes/clawhub"));
 app.use("/agent-hub", require("./routes/agentHub"));
 app.use("/workspaces", require("./routes/workspaces"));
+app.use("/remote-hosts", require("./routes/remoteHosts"));
 app.use("/billing", require("./routes/billing"));
 // Fleet routes mount before /admin so the explicit prefix wins; both still go
 // through requireAdmin (the fleet router applies it itself, and /admin's own


### PR DESCRIPTION
## What

Exposes the remote-host registry (#193) over HTTP so the dashboards can manage hosts — the backend half of A5. Operator routes (per-user) + an admin fleet view, matching the chosen "both consoles" model.

## Operator routes — `routes/remoteHosts.ts`, mounted at `/remote-hosts`

- `GET / POST / PUT /:id / DELETE /:id` + `POST /:id/test`, all scoped to the caller (`owner_user_id = req.user.id`).
- **Session-only** (`requireSession`): registering a host stores SSH credentials, so — like API-key minting — an API key cannot create or read them.
- Mutations verify ownership first and return **404 (not 403)** for another operator's host, so existence isn't leaked. `ownerUserId` is pinned to the caller on create/update — a host can't be reassigned.

## Admin route — `routes/admin.ts`

- `GET /admin/remote-hosts` — read-only, fleet-wide view of every operator's hosts (secrets masked) for oversight.

`remoteHosts.ts` gains `getRemoteHost(id)` (masked single-host lookup) for the ownership check.

## Validation

`remoteHostsRoutes.test.ts`: auth required; per-owner list scoping; create/update/test/delete happy paths; cross-owner mutation → 404; missing host → 404; admin fleet view returns all owners and is admin-gated. Full backend suite **1061/1061**; typecheck + lint clean.

## Next

Operator-console UI + admin fleet view UI (A5b/A5c) and docs. Still pending after A5: the gateway-allowlist extension (so remote gateways are chattable) and deploy-path validation wiring.