### PR TITLE
feat(remote-hosts): select a registered remote host as a deploy target (BYOC Phase A)

### DIFF
--- a/frontend-dashboard/lib/runtime.ts
+++ b/frontend-dashboard/lib/runtime.ts
@@ -280,6 +280,10 @@ function buildRemoteHostTarget(template: any = {}, host: any = {}) {
       availableForOnboarding: isStandard,
       isDefault: isStandard,
       issue: isStandard ? null : profile.issue || null,
+      // remote-docker is experimental in this phase regardless of which template
+      // was cloned (don't inherit a fallback docker template's "ga").
+      maturityTier: "experimental",
+      maturityLabel: "Experimental",
     };
   });
   return {
@@ -298,6 +302,10 @@ function buildRemoteHostTarget(template: any = {}, host: any = {}) {
     issue: null,
     defaultSandboxProfile: "standard",
     sandboxProfiles,
+    // remote-docker is experimental in this phase — set explicitly so a docker
+    // fallback template can't make a remote host report "ga".
+    maturityTier: "experimental",
+    maturityLabel: "Experimental",
     // k8s-only display fields must not leak onto a remote host card
     clusterName: undefined,
     namespace: undefined,

--- a/frontend-dashboard/lib/runtime.ts
+++ b/frontend-dashboard/lib/runtime.ts
@@ -258,6 +258,90 @@ export function pickSandboxProfileSelection(
   return nextProfile?.id || "";
 }
 
+function remoteHostTargetLabel(host: any = {}) {
+  const user = host.sshUser ? `${host.sshUser}@` : "";
+  const port = host.sshPort && host.sshPort !== 22 ? `:${host.sshPort}` : "";
+  return `${user}${host.sshHost || host.gatewayHost || "remote"}${port}`;
+}
+
+// Clone a generic execution-target template into a concrete per-host entry that
+// the deploy picker can render and select. remote-docker only supports the
+// standard sandbox profile in this phase.
+function buildRemoteHostTarget(template: any = {}, host: any = {}) {
+  const sandboxProfiles = (template.sandboxProfiles || []).map((profile: any) => {
+    const isStandard = profile.id === "standard";
+    return {
+      ...profile,
+      executionTargetId: host.executionTargetId,
+      deployTargetLabel: host.label,
+      enabled: isStandard,
+      configured: isStandard,
+      available: isStandard,
+      availableForOnboarding: isStandard,
+      isDefault: isStandard,
+      issue: isStandard ? null : profile.issue || null,
+    };
+  });
+  return {
+    ...template,
+    id: host.executionTargetId,
+    executionTargetId: host.executionTargetId,
+    deployTarget: "remote-docker",
+    label: host.label || host.executionTargetId,
+    shortLabel: host.label || host.executionTargetId,
+    summary: `Your remote Docker host · ${remoteHostTargetLabel(host)}`,
+    enabled: true,
+    configured: true,
+    available: true,
+    availableForOnboarding: true,
+    isDefault: false,
+    issue: null,
+    defaultSandboxProfile: "standard",
+    sandboxProfiles,
+    // k8s-only display fields must not leak onto a remote host card
+    clusterName: undefined,
+    namespace: undefined,
+    exposureMode: undefined,
+  };
+}
+
+// Merge the operator's own connected remote hosts into the (public, global)
+// backend catalog so they appear as selectable deploy targets — the per-user
+// equivalent of how registered Kubernetes clusters surface. Only connected
+// (available) hosts are injected, replacing the generic experimental
+// "remote-docker" placeholder. Pure + immutable; returns the original config
+// untouched when there are no usable hosts.
+export function mergeRemoteHostsIntoConfig(
+  backendConfig: BackendConfig = {},
+  remoteHosts: any[] = [],
+) {
+  const hosts = Array.isArray(remoteHosts)
+    ? remoteHosts.filter((host) => host && host.available)
+    : [];
+  if (!hosts.length) return backendConfig;
+  const runtimeFamilies = Array.isArray(backendConfig?.runtimeFamilies)
+    ? backendConfig.runtimeFamilies
+    : [];
+  if (!runtimeFamilies.length) return backendConfig;
+
+  const nextRuntimeFamilies = runtimeFamilies.map((family: any) => {
+    if (family.id !== "openclaw") return family;
+    const targets = Array.isArray(family.executionTargets) ? family.executionTargets : [];
+    const template =
+      targets.find((target: any) => target.id === "remote-docker") ||
+      targets.find((target: any) => target.deployTarget === "remote-docker") ||
+      targets.find((target: any) => target.id === "docker");
+    if (!template) return family;
+    const hostTargets = hosts.map((host) => buildRemoteHostTarget(template, host));
+    const withoutPlaceholder = targets.filter(
+      (target: any) => target.deployTarget !== "remote-docker",
+    );
+    return { ...family, executionTargets: [...withoutPlaceholder, ...hostTargets] };
+  });
+
+  return { ...backendConfig, runtimeFamilies: nextRuntimeFamilies };
+}
+
 export function resolveAgentRuntimeFamily(agent: AgentRuntimeMeta = {}) {
   const explicitRuntimeFamily = normalizeRuntimeFamily(agent.runtime_family);
   if (explicitRuntimeFamily) return explicitRuntimeFamily;

--- a/frontend-dashboard/pages/deploy/index.tsx
+++ b/frontend-dashboard/pages/deploy/index.tsx
@@ -30,6 +30,7 @@ import {
   activeExecutionTargetFromConfig,
   containerNamePrefixForSelection,
   formatRuntimeFamilyLabel,
+  mergeRemoteHostsIntoConfig,
   pickExecutionTargetSelection,
   pickRuntimeFamilySelection,
   runtimeFamilyFromConfig,
@@ -230,9 +231,19 @@ export default function Deploy() {
       .then((r) => (r.ok ? r.json() : null))
       .then((profile) => setViewerRole(profile?.role || "user"))
       .catch(() => {});
-    fetch("/api/config/backends")
-      .then((r) => r.json())
-      .then(setBackendConfig)
+    // Fetch the global catalog and the operator's own connected remote hosts,
+    // then merge the hosts in as selectable targets before storing the config.
+    Promise.all([
+      fetch("/api/config/backends")
+        .then((r) => r.json())
+        .catch(() => null),
+      fetchWithAuth("/api/remote-hosts")
+        .then((r) => (r.ok ? r.json() : []))
+        .catch(() => []),
+    ])
+      .then(([config, hosts]) => {
+        if (config) setBackendConfig(mergeRemoteHostsIntoConfig(config, hosts));
+      })
       .catch(() => {});
     fetch("/api/config/platform")
       .then((r) => r.json())


### PR DESCRIPTION
## What

Makes BYOC **end-to-end usable from the dashboard**: a connected remote host now appears as a selectable execution target in the deploy flow (#197 added host management; this closes the loop).

## How

The deploy picker is driven by the global `/config/backends` catalog, which is **public/pre-auth** and can't carry per-user hosts. So the deploy page now also fetches the operator's `/api/remote-hosts` and merges the connected ones into the catalog **client-side** before storing it:

- `lib/runtime.ts` → `mergeRemoteHostsIntoConfig(backendConfig, hosts)`: pure, immutable. Clones the generic `remote-docker` target template into a concrete per-host entry (`id = remote:<id>`, `available`, standard sandbox only) and replaces the experimental placeholder in the OpenClaw family's `executionTargets`. Only **connected** hosts are injected; with none, the config is returned untouched (placeholder stays, hinting "register a host").
- `deploy/index.tsx`: fetches catalog + hosts together, feeds the merged config to `setBackendConfig`.

Everything downstream — `visibleExecutionTargets`, `activeExecutionTarget`, sandbox/resource derivation, and the deploy body — is **unchanged**, because the host is now a first-class catalog entry. The deploy body already sends the selected target id as `deploy_target` + `execution_target_id`, which the backend normalizes (`remote:<id>` → `remote-docker`), identical to the k8s flow.

## Safety

- `docker` stays the default (host entries are `isDefault:false`, opt-in).
- If `/remote-hosts` fails or returns nothing, behavior is exactly as before.
- frontend typecheck + eslint + prettier clean. (No frontend unit-test runner; this is the critical deploy flow, so it's also going through a multi-agent adversarial review.)

## After this

BYOC is usable: register a host → test → deploy an agent to it. Remaining: admin fleet view (A5c), the gateway-allowlist extension so chat reaches remote gateways (A3), and deploy-path validation (A4).