### PR TITLE
feat(remote-hosts): allow a registered remote host's gateway address in the HTTP proxy (BYOC A3a)

### DIFF
--- a/backend-api/__tests__/remoteHostGatewayAllowlist.test.ts
+++ b/backend-api/__tests__/remoteHostGatewayAllowlist.test.ts
@@ -23,6 +23,7 @@ const PUBLIC_IP = "203.0.113.5";
 function remoteAgent(overrides = {}) {
   return {
     id: "agent-1",
+    user_id: "user-1",
     deploy_target: "remote-docker",
     execution_target_id: "remote:my-vps",
     gateway_host: PUBLIC_IP,
@@ -39,12 +40,26 @@ describe("remote-host gateway allowlist (HTTP proxy)", () => {
   it("allows a remote-docker agent's own registered (non-RFC1918) host", async () => {
     mockGetRemoteHostByExecutionTarget.mockResolvedValue({
       id: "my-vps",
+      ownerUserId: "user-1",
       gatewayHost: PUBLIC_IP,
       sshHost: PUBLIC_IP,
     });
     const target = await resolveSafeGatewayHttpTarget(remoteAgent(), "status");
     expect(target.url).toBe(`http://${PUBLIC_IP}:19042/status`);
     expect(mockGetRemoteHostByExecutionTarget).toHaveBeenCalledWith("remote:my-vps");
+  });
+
+  it("does NOT trust a remote host registered by a different operator", async () => {
+    // Cross-tenant execution_target_id reference: the host belongs to user-2.
+    mockGetRemoteHostByExecutionTarget.mockResolvedValue({
+      id: "my-vps",
+      ownerUserId: "user-2",
+      gatewayHost: PUBLIC_IP,
+      sshHost: PUBLIC_IP,
+    });
+    await expect(resolveSafeGatewayHttpTarget(remoteAgent(), "status")).rejects.toThrow(
+      /not an allowed gateway address/i,
+    );
   });
 
   it("rejects a public host when no matching remote host is registered", async () => {

--- a/backend-api/__tests__/remoteHostGatewayAllowlist.test.ts
+++ b/backend-api/__tests__/remoteHostGatewayAllowlist.test.ts
@@ -1,0 +1,90 @@
+// @ts-nocheck
+/**
+ * __tests__/remoteHostGatewayAllowlist.test.ts — A3a: the HTTP gateway proxy
+ * allows a remote-docker agent's own registered host address (which is not
+ * RFC1918), while never widening the allowlist for other agents and still
+ * enforcing the hard blocked-IP floor.
+ */
+jest.mock("../db", () => ({ query: jest.fn() }));
+jest.mock("../integrations", () => ({}));
+jest.mock("../metrics", () => ({ recordMetric: jest.fn(), recordTokenUsage: jest.fn() }));
+jest.mock("../agentBudgets", () => ({ checkAndEnforce: jest.fn() }));
+jest.mock("ws", () => ({ WebSocket: class {}, WebSocketServer: class {} }));
+
+const mockGetRemoteHostByExecutionTarget = jest.fn();
+jest.mock("../remoteHosts", () => ({
+  getRemoteHostByExecutionTarget: (...args) => mockGetRemoteHostByExecutionTarget(...args),
+}));
+
+const { resolveSafeGatewayHttpTarget } = require("../gatewayProxy");
+
+const PUBLIC_IP = "203.0.113.5";
+
+function remoteAgent(overrides = {}) {
+  return {
+    id: "agent-1",
+    deploy_target: "remote-docker",
+    execution_target_id: "remote:my-vps",
+    gateway_host: PUBLIC_IP,
+    gateway_port: 19042,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockGetRemoteHostByExecutionTarget.mockReset();
+});
+
+describe("remote-host gateway allowlist (HTTP proxy)", () => {
+  it("allows a remote-docker agent's own registered (non-RFC1918) host", async () => {
+    mockGetRemoteHostByExecutionTarget.mockResolvedValue({
+      id: "my-vps",
+      gatewayHost: PUBLIC_IP,
+      sshHost: PUBLIC_IP,
+    });
+    const target = await resolveSafeGatewayHttpTarget(remoteAgent(), "status");
+    expect(target.url).toBe(`http://${PUBLIC_IP}:19042/status`);
+    expect(mockGetRemoteHostByExecutionTarget).toHaveBeenCalledWith("remote:my-vps");
+  });
+
+  it("rejects a public host when no matching remote host is registered", async () => {
+    mockGetRemoteHostByExecutionTarget.mockResolvedValue(null);
+    await expect(resolveSafeGatewayHttpTarget(remoteAgent(), "status")).rejects.toThrow(
+      /not an allowed gateway address/i,
+    );
+  });
+
+  it("does NOT widen the allowlist for a non-remote agent with a public host", async () => {
+    // A docker agent must never reach a public address — the registry lookup is
+    // skipped entirely (deploy_target !== remote-docker).
+    const dockerAgent = remoteAgent({ deploy_target: "docker", execution_target_id: "docker" });
+    await expect(resolveSafeGatewayHttpTarget(dockerAgent, "status")).rejects.toThrow(
+      /not an allowed gateway address/i,
+    );
+    expect(mockGetRemoteHostByExecutionTarget).not.toHaveBeenCalled();
+  });
+
+  it("still blocks dangerous addresses even for a registered remote host", async () => {
+    mockGetRemoteHostByExecutionTarget.mockResolvedValue({
+      id: "my-vps",
+      gatewayHost: "169.254.169.254",
+      sshHost: "169.254.169.254",
+    });
+    const linkLocal = remoteAgent({ gateway_host: "169.254.169.254" });
+    await expect(resolveSafeGatewayHttpTarget(linkLocal, "status")).rejects.toThrow(
+      /not an allowed gateway address/i,
+    );
+  });
+
+  it("still allows an ordinary RFC1918 docker host (no regression)", async () => {
+    const dockerAgent = remoteAgent({
+      deploy_target: "docker",
+      execution_target_id: "docker",
+      gateway_host: "10.0.0.10",
+      gateway_port: 19000,
+    });
+    const target = await resolveSafeGatewayHttpTarget(dockerAgent, "status");
+    expect(target.url).toBe("http://10.0.0.10:19000/status");
+    expect(mockGetRemoteHostByExecutionTarget).not.toHaveBeenCalled();
+  });
+});

--- a/backend-api/gatewayProxy.ts
+++ b/backend-api/gatewayProxy.ts
@@ -120,8 +120,9 @@ const EMPTY_ALLOWED_HOSTS = new Set();
 
 // A registered remote host's advertised address is operator-trusted, so allow
 // it even though it is not RFC1918/loopback. Scoped to the agent's OWN host
-// (looked up by execution target), so this can't widen the allowlist to
-// arbitrary addresses. Blocked addresses (0.0.0.0, link-local, …) still apply.
+// (looked up by execution target) AND to the agent's owner, so a cross-tenant
+// execution_target_id reference can't leak or reach another operator's host.
+// Blocked addresses (0.0.0.0, link-local, …) still apply.
 async function allowedRemoteHostsForAgent(agent) {
   if (normalizeDeployTargetName(agent?.deploy_target) !== "remote-docker") {
     return EMPTY_ALLOWED_HOSTS;
@@ -129,6 +130,10 @@ async function allowedRemoteHostsForAgent(agent) {
   try {
     const host = await remoteHosts.getRemoteHostByExecutionTarget(agent.execution_target_id);
     if (!host) return EMPTY_ALLOWED_HOSTS;
+    // Only trust a host the agent's owner actually registered.
+    if (agent.user_id && host.ownerUserId && host.ownerUserId !== agent.user_id) {
+      return EMPTY_ALLOWED_HOSTS;
+    }
     const allowed = new Set();
     if (host.gatewayHost) allowed.add(String(host.gatewayHost).toLowerCase());
     if (host.sshHost) allowed.add(String(host.sshHost).toLowerCase());

--- a/backend-api/gatewayProxy.ts
+++ b/backend-api/gatewayProxy.ts
@@ -11,6 +11,8 @@ const net = require("node:net");
 const db = require("./db");
 const integrations = require("./integrations");
 const { resolveAgentRuntimeFamily } = require("./agentRuntimeFields");
+const remoteHosts = require("./remoteHosts");
+const { normalizeDeployTargetName } = require("../agent-runtime/lib/backendCatalog");
 
 const metrics = require("./metrics");
 const agentBudgets = require("./agentBudgets");
@@ -114,20 +116,44 @@ function isBlockedGatewayIP(address) {
   );
 }
 
-function isAllowedGatewayIP(address, hostname) {
+const EMPTY_ALLOWED_HOSTS = new Set();
+
+// A registered remote host's advertised address is operator-trusted, so allow
+// it even though it is not RFC1918/loopback. Scoped to the agent's OWN host
+// (looked up by execution target), so this can't widen the allowlist to
+// arbitrary addresses. Blocked addresses (0.0.0.0, link-local, …) still apply.
+async function allowedRemoteHostsForAgent(agent) {
+  if (normalizeDeployTargetName(agent?.deploy_target) !== "remote-docker") {
+    return EMPTY_ALLOWED_HOSTS;
+  }
+  try {
+    const host = await remoteHosts.getRemoteHostByExecutionTarget(agent.execution_target_id);
+    if (!host) return EMPTY_ALLOWED_HOSTS;
+    const allowed = new Set();
+    if (host.gatewayHost) allowed.add(String(host.gatewayHost).toLowerCase());
+    if (host.sshHost) allowed.add(String(host.sshHost).toLowerCase());
+    return allowed;
+  } catch {
+    return EMPTY_ALLOWED_HOSTS;
+  }
+}
+
+function isAllowedGatewayIP(address, hostname, extraAllowedHosts) {
   if (isBlockedGatewayIP(address)) return false;
+  const normalizedHostname = String(hostname || "").toLowerCase();
   const allowedHosts = parseCsvSet(process.env.NORA_GATEWAY_PROXY_ALLOWED_HOSTS);
-  if (allowedHosts.has(String(hostname || "").toLowerCase())) return true;
+  if (allowedHosts.has(normalizedHostname)) return true;
+  if (extraAllowedHosts && extraAllowedHosts.has(normalizedHostname)) return true;
   const ipVersion = net.isIP(address);
   if (ipVersion === 4) return isAllowedGatewayIPv4(address);
   if (ipVersion === 6) return isAllowedGatewayIPv6(address);
   return false;
 }
 
-async function resolveGatewayHostForProxy(host, label = "agent gateway") {
+async function resolveGatewayHostForProxy(host, label = "agent gateway", extraAllowedHosts) {
   const normalizedHost = String(host || "").trim();
   if (net.isIP(normalizedHost)) {
-    if (!isAllowedGatewayIP(normalizedHost, normalizedHost)) {
+    if (!isAllowedGatewayIP(normalizedHost, normalizedHost, extraAllowedHosts)) {
       throw new Error(`${label} host is not an allowed gateway address`);
     }
     return normalizedHost;
@@ -140,7 +166,9 @@ async function resolveGatewayHostForProxy(host, label = "agent gateway") {
     throw new Error(`${label} host could not be resolved (${error.code || error.message})`);
   }
 
-  const firstAllowed = addresses.find((entry) => isAllowedGatewayIP(entry.address, normalizedHost));
+  const firstAllowed = addresses.find((entry) =>
+    isAllowedGatewayIP(entry.address, normalizedHost, extraAllowedHosts),
+  );
   if (!firstAllowed) {
     throw new Error(`${label} host does not resolve to an allowed gateway network`);
   }
@@ -181,7 +209,12 @@ async function resolveSafeGatewayHttpTarget(agent, gatewayPath = "", search = ""
   if (!isAllowedGatewayPort(addr.port)) {
     throw new Error("agent gateway port is not allowed for proxying");
   }
-  const resolvedHost = await resolveGatewayHostForProxy(addr.host);
+  const extraAllowedHosts = await allowedRemoteHostsForAgent(agent);
+  const resolvedHost = await resolveGatewayHostForProxy(
+    addr.host,
+    "agent gateway",
+    extraAllowedHosts,
+  );
   const targetUrl = new URL(`http://${hostForUrl(resolvedHost)}:${addr.port}/`);
   const cleanPath = normalizeProxyPath(gatewayPath);
   targetUrl.pathname = cleanPath ? `/${cleanPath}` : "/";

--- a/backend-api/remoteHosts.ts
+++ b/backend-api/remoteHosts.ts
@@ -310,6 +310,14 @@ async function getRemoteHost(hostId) {
   return row ? maskHost(row) : null;
 }
 
+// Masked lookup by execution target ("remote:<id>"), no secret decryption —
+// used by the gateway proxy to learn a remote host's advertised address.
+async function getRemoteHostByExecutionTarget(executionTargetId) {
+  const normalized = normalizeRemoteExecutionTargetId(executionTargetId);
+  if (!normalized) return null;
+  return getRemoteHost(normalized.slice("remote:".length));
+}
+
 async function clearOtherDefaults(hostId, ownerUserId) {
   await db.query(
     `UPDATE remote_hosts
@@ -587,6 +595,7 @@ module.exports = {
   createRemoteHost,
   deleteRemoteHost,
   getRemoteHost,
+  getRemoteHostByExecutionTarget,
   getRemoteHostProfile,
   isRemoteDockerTarget,
   listRemoteHosts,


### PR DESCRIPTION
## What

Unblocks the embedded **gateway-UI tab** for remote-docker agents. The UI iframe proxies over HTTP — the only gateway path that runs the RFC1918/loopback IP allowlist — so a remote host's advertised (public/Tailscale) address is rejected and the tab 502s. (Chat/sessions/cron go over WS-RPC, which already reaches remote hosts.)

## How

A **per-agent, operator-trusted** allowance:
- `allowedRemoteHostsForAgent(agent)` returns the agent's **own** registered host address (`gatewayHost`/`sshHost`) — only for `remote-docker` agents, looked up by execution target via the new masked `getRemoteHostByExecutionTarget`.
- `isAllowedGatewayIP` / `resolveGatewayHostForProxy` take an `extraAllowedHosts` set; `resolveSafeGatewayHttpTarget` threads it.

## Security

- **Scoped, no widening**: a non-remote agent never triggers the lookup; the allowance is the agent's own host only (not a global list).
- **Hard floor preserved**: `isBlockedGatewayIP` still rejects `0.0.0.0`/link-local/multicast even if it's the agent's advertised address.
- Tests cover: registered host allowed; unregistered public host rejected; non-remote agent with a public host rejected; link-local blocked even when registered; ordinary RFC1918 docker host still allowed (no regression).

1066 backend tests green; typecheck + lint clean. This change is going through a security-focused adversarial review.

## Deferred (A3b)

Close the **WS-relay + RPC-pool host-check gap** — those paths validate the port but not the host today (a pre-existing SSRF surface). Separate PR, since it *restricts* the critical chat path for every agent and needs its own review.