### PR TITLE
feat(remote-hosts): owner-scoped deploy-path validation for remote targets (BYOC A4)

### DIFF
--- a/backend-api/__tests__/remoteHosts.test.ts
+++ b/backend-api/__tests__/remoteHosts.test.ts
@@ -286,6 +286,25 @@ describe("assertRemoteHostExecutionTargetAvailable", () => {
     expect(profile.id).toBe("my-laptop");
     expect(profile.available).toBe(true);
   });
+
+  it("rejects a host registered by a different operator (owner-scoped)", async () => {
+    mockDb.query.mockResolvedValueOnce({ rows: [remoteHostRow()] }); // owner = user-1
+    await expect(
+      remoteHosts.assertRemoteHostExecutionTargetAvailable(
+        { deploy_target: "remote-docker", execution_target_id: "remote:my-laptop" },
+        { ownerUserId: "user-2" },
+      ),
+    ).rejects.toThrow(/Unknown remote host/i);
+  });
+
+  it("allows a host owned by the requesting operator", async () => {
+    mockDb.query.mockResolvedValueOnce({ rows: [remoteHostRow()] });
+    const profile = await remoteHosts.assertRemoteHostExecutionTargetAvailable(
+      { deploy_target: "remote-docker", execution_target_id: "remote:my-laptop" },
+      { ownerUserId: "user-1" },
+    );
+    expect(profile.id).toBe("my-laptop");
+  });
 });
 
 describe("listRemoteHostExecutionTargets", () => {

--- a/backend-api/remoteHosts.ts
+++ b/backend-api/remoteHosts.ts
@@ -550,7 +550,7 @@ async function testRemoteHost(hostId, options = {}) {
 // Deploy-path gate, mirroring assertKubernetesExecutionTargetAvailable. Wiring
 // this into the deploy queue happens in a later Phase A PR; it lives here now so
 // the contract is defined alongside the registry.
-async function assertRemoteHostExecutionTargetAvailable(runtimeFields = {}) {
+async function assertRemoteHostExecutionTargetAvailable(runtimeFields = {}, options = {}) {
   if (!isRemoteDockerTarget(runtimeFields.deploy_target ?? runtimeFields.deployTarget)) {
     return null;
   }
@@ -565,7 +565,10 @@ async function assertRemoteHostExecutionTargetAvailable(runtimeFields = {}) {
     throw error;
   }
   const profile = await getRemoteHostProfile(executionTargetId);
-  if (!profile) {
+  const ownerUserId = options.ownerUserId || null;
+  // Owner-scoped: a host registered by another operator is treated as unknown
+  // (don't leak its existence, and never deploy onto it cross-tenant).
+  if (!profile || (ownerUserId && profile.ownerUserId && profile.ownerUserId !== ownerUserId)) {
     const error = new Error(`Unknown remote host execution target: ${executionTargetId}`);
     error.statusCode = 400;
     throw error;

--- a/backend-api/routes/admin.ts
+++ b/backend-api/routes/admin.ts
@@ -131,6 +131,9 @@ function assertRuntimeSelectionAvailable(runtimeFields) {
 async function assertRuntimeTargetAvailable(runtimeFields) {
   const status = assertRuntimeSelectionAvailable(runtimeFields);
   await kubernetesClusters.assertKubernetesExecutionTargetAvailable(runtimeFields);
+  // Admin re-deploys an existing agent, so this validates host availability
+  // (enabled/configured/connected) without owner-scoping the trusted admin.
+  await remoteHosts.assertRemoteHostExecutionTargetAvailable(runtimeFields);
   return status;
 }
 

--- a/backend-api/routes/agentHub.ts
+++ b/backend-api/routes/agentHub.ts
@@ -13,6 +13,7 @@ const snapshots = require("../snapshots");
 const scheduler = require("../scheduler");
 const monitoring = require("../monitoring");
 const { assertKubernetesExecutionTargetAvailable } = require("../kubernetesClusters");
+const { assertRemoteHostExecutionTargetAvailable } = require("../remoteHosts");
 const {
   buildTemplatePayloadFromAgent,
   extractTemplateDefaultsFromSnapshot,
@@ -177,9 +178,10 @@ function assertRuntimeSelectionAvailable(runtimeFields) {
   return status;
 }
 
-async function assertRuntimeTargetAvailable(runtimeFields) {
+async function assertRuntimeTargetAvailable(runtimeFields, ownerUserId) {
   const status = assertRuntimeSelectionAvailable(runtimeFields);
   await assertKubernetesExecutionTargetAvailable(runtimeFields);
+  await assertRemoteHostExecutionTargetAvailable(runtimeFields, { ownerUserId });
   return status;
 }
 
@@ -678,7 +680,7 @@ router.post(
       execution_target_id: defaults.executionTargetId || null,
       sandbox_type: defaults.sandbox || "standard",
     });
-    await assertRuntimeTargetAvailable(runtimeFields);
+    await assertRuntimeTargetAvailable(runtimeFields, req.user.id);
 
     const specs = resolveTemplateSpecs(defaults, limits.subscription || {});
     const image = resolveRequestedImage({

--- a/backend-api/routes/agents.ts
+++ b/backend-api/routes/agents.ts
@@ -74,6 +74,7 @@ const { findAccessibleAgent } = require("../middleware/ownership");
 const { scopeByMethod } = require("../middleware/auth");
 const agentVersions = require("../agentVersions");
 const { assertKubernetesExecutionTargetAvailable } = require("../kubernetesClusters");
+const { assertRemoteHostExecutionTargetAvailable } = require("../remoteHosts");
 
 const router = express.Router();
 router.use(createMutationFailureAuditMiddleware("agent"));
@@ -140,9 +141,10 @@ function isIgnorableStopError(error) {
   return message.includes("already stopped") || message.includes("not running");
 }
 
-async function assertRuntimeTargetAvailable(runtimeFields) {
+async function assertRuntimeTargetAvailable(runtimeFields, ownerUserId) {
   const status = assertRuntimeSelectionAvailable(runtimeFields);
   await assertKubernetesExecutionTargetAvailable(runtimeFields);
+  await assertRemoteHostExecutionTargetAvailable(runtimeFields, { ownerUserId });
   return status;
 }
 
@@ -1339,7 +1341,7 @@ router.post("/deploy", async (req, res) => {
       agentName: name,
       runtimeSelection: runtimeFields,
     });
-    const runtimeSelectionStatus = await assertRuntimeTargetAvailable(runtimeFields);
+    const runtimeSelectionStatus = await assertRuntimeTargetAvailable(runtimeFields, req.user.id);
     if (migrationDraft && runtimeFields.runtime_family !== migrationDraft.manifest.runtimeFamily) {
       return res.status(400).json({
         error: `Migration draft targets the ${migrationDraft.manifest.runtimeFamily} runtime family and cannot be deployed as ${runtimeFields.runtime_family}.`,
@@ -1564,7 +1566,7 @@ router.post(
       },
       fallback: sourceRuntime,
     });
-    await assertRuntimeTargetAvailable(runtimeFields);
+    await assertRuntimeTargetAvailable(runtimeFields, req.user.id);
     const node = await scheduler.selectNode({
       fallback: runtimeFields.deploy_target,
     });
@@ -1853,7 +1855,7 @@ router.post("/:id/redeploy", async (req, res) => {
       },
       fallback: currentRuntimeFields,
     });
-    await assertRuntimeTargetAvailable(runtimeFields);
+    await assertRuntimeTargetAvailable(runtimeFields, req.user.id);
     const containerName = resolveContainerName({
       requestedName: requestBody.container_name,
       currentName: agent.container_name,


### PR DESCRIPTION
## What

Wires `assertRemoteHostExecutionTargetAvailable` into the deploy paths so a remote-docker deployment is validated up front — mirroring the Kubernetes cluster gate — and **closes the cross-tenant gap the security review flagged**: a user could deploy an agent referencing **another operator's** `remote:<id>` (the gate was never called; provisioning failed on the foreign SSH creds, but the reference was accepted).

## The gate

- Requires a registered `remote:` target that is **enabled + configured + connection-tested** (same contract as the k8s gate).
- **Owner-scoped**: `assertRemoteHostExecutionTargetAvailable(runtimeFields, { ownerUserId })` treats a host registered by a different operator as "Unknown remote host" — no existence leak, no cross-tenant deploy.

Wired through each route file's `assertRuntimeTargetAvailable`:
- `routes/agents.ts`: deploy, clone, redeploy → owner-scoped to `req.user.id`.
- `routes/agentHub.ts`: hub install → owner-scoped to `req.user.id`.
- `routes/admin.ts`: admin retry → availability check only (trusted admin re-deploying an existing agent).

## Validation

Owner-scoping tests (foreign owner rejected, matching owner allowed) added to the registry suite. Full backend suite **1069/1069**; typecheck + lint clean.

## Deferred (A4-2)

The version-rollback and in-place backup-restore paths skip `assertRuntimeTargetAvailable` entirely (pre-existing, affects k8s too) — separate PR.