### PR TITLE
fix(gateway): validate the gateway host on RPC-pool + WS-relay paths (BYOC A3b)

### DIFF
--- a/backend-api/__tests__/remoteHostGatewayAllowlist.test.ts
+++ b/backend-api/__tests__/remoteHostGatewayAllowlist.test.ts
@@ -91,6 +91,22 @@ describe("remote-host gateway allowlist (HTTP proxy)", () => {
     );
   });
 
+  it("trusts a k8s agent's operator-provisioned (public LoadBalancer) address", async () => {
+    // k8s exposure addresses (LB/NodePort) are operator-provisioned, so RPC/WS/HTTP
+    // must reach them even when public — without a registry lookup.
+    const k8sAgent = {
+      id: "agent-k8s",
+      user_id: "user-1",
+      deploy_target: "k8s",
+      execution_target_id: "k8s:prod",
+      gateway_host: "203.0.113.20",
+      gateway_port: 18789,
+    };
+    const target = await resolveSafeGatewayHttpTarget(k8sAgent, "status");
+    expect(target.url).toBe("http://203.0.113.20:18789/status");
+    expect(mockGetRemoteHostByExecutionTarget).not.toHaveBeenCalled();
+  });
+
   it("still allows an ordinary RFC1918 docker host (no regression)", async () => {
     const dockerAgent = remoteAgent({
       deploy_target: "docker",

--- a/backend-api/__tests__/remoteHostGatewayAllowlist.test.ts
+++ b/backend-api/__tests__/remoteHostGatewayAllowlist.test.ts
@@ -107,6 +107,29 @@ describe("remote-host gateway allowlist (HTTP proxy)", () => {
     expect(mockGetRemoteHostByExecutionTarget).not.toHaveBeenCalled();
   });
 
+  it("allows a docker agent to reach a custom (non-RFC1918) GATEWAY_HOST published host", async () => {
+    // Regression guard: a docker agent reaches its gateway via the operator's
+    // GATEWAY_HOST (publishedHost), which may not be RFC1918. Trusting it keeps
+    // docker chat working regardless of what the operator configured.
+    const prev = process.env.GATEWAY_HOST;
+    process.env.GATEWAY_HOST = "198.51.100.7"; // public test IP, not RFC1918
+    try {
+      const dockerAgent = {
+        id: "agent-docker",
+        user_id: "user-1",
+        deploy_target: "docker",
+        execution_target_id: "docker",
+        gateway_host: null,
+        gateway_host_port: 19042,
+      };
+      const target = await resolveSafeGatewayHttpTarget(dockerAgent, "status");
+      expect(target.url).toBe("http://198.51.100.7:19042/status");
+    } finally {
+      if (prev === undefined) delete process.env.GATEWAY_HOST;
+      else process.env.GATEWAY_HOST = prev;
+    }
+  });
+
   it("still allows an ordinary RFC1918 docker host (no regression)", async () => {
     const dockerAgent = remoteAgent({
       deploy_target: "docker",

--- a/backend-api/gatewayProxy.ts
+++ b/backend-api/gatewayProxy.ts
@@ -160,7 +160,13 @@ async function allowedGatewayHostsForAgent(agent) {
     if (agent?.runtime_host) allowed.add(String(agent.runtime_host).toLowerCase());
     return allowed.size ? allowed : EMPTY_ALLOWED_HOSTS;
   }
-  return EMPTY_ALLOWED_HOSTS;
+  // docker / other: trust the operator-configured published host — the address
+  // the control plane uses to reach the docker host's published port (GATEWAY_HOST
+  // or host.docker.internal). It is GLOBAL config, not a per-agent value, so this
+  // is not a per-agent SSRF vector; a docker agent's own gateway_host is NOT
+  // trusted here, so a public docker gateway_host still hits the RFC1918 floor.
+  const publishedHost = String(process.env.GATEWAY_HOST || "host.docker.internal").toLowerCase();
+  return new Set([publishedHost]);
 }
 
 function isAllowedGatewayIP(address, hostname, extraAllowedHosts) {

--- a/backend-api/gatewayProxy.ts
+++ b/backend-api/gatewayProxy.ts
@@ -143,6 +143,26 @@ async function allowedRemoteHostsForAgent(agent) {
   }
 }
 
+// The host allowance for an agent's gateway, used identically by the HTTP,
+// RPC-pool, and WS-relay paths so all three enforce the same SSRF policy:
+//  - remote-docker: the agent's OWN registered host address (owner-scoped).
+//  - k8s: the operator-provisioned cluster exposure address (LoadBalancer /
+//    NodePort / ClusterIP host the k8s adapter recorded). Trusting it matches
+//    the prior RPC/WS behavior (they did no host check), so k8s chat — incl.
+//    public LoadBalancer IPs — does not regress.
+//  - docker / other: none — falls through to the RFC1918/loopback floor.
+async function allowedGatewayHostsForAgent(agent) {
+  const target = normalizeDeployTargetName(agent?.deploy_target);
+  if (target === "remote-docker") return allowedRemoteHostsForAgent(agent);
+  if (target === "k8s") {
+    const allowed = new Set();
+    if (agent?.gateway_host) allowed.add(String(agent.gateway_host).toLowerCase());
+    if (agent?.runtime_host) allowed.add(String(agent.runtime_host).toLowerCase());
+    return allowed.size ? allowed : EMPTY_ALLOWED_HOSTS;
+  }
+  return EMPTY_ALLOWED_HOSTS;
+}
+
 function isAllowedGatewayIP(address, hostname, extraAllowedHosts) {
   if (isBlockedGatewayIP(address)) return false;
   const normalizedHostname = String(hostname || "").toLowerCase();
@@ -214,7 +234,7 @@ async function resolveSafeGatewayHttpTarget(agent, gatewayPath = "", search = ""
   if (!isAllowedGatewayPort(addr.port)) {
     throw new Error("agent gateway port is not allowed for proxying");
   }
-  const extraAllowedHosts = await allowedRemoteHostsForAgent(agent);
+  const extraAllowedHosts = await allowedGatewayHostsForAgent(agent);
   const resolvedHost = await resolveGatewayHostForProxy(
     addr.host,
     "agent gateway",
@@ -562,7 +582,16 @@ async function getConnection(agent) {
     pool.delete(key);
   }
 
-  conn = new GatewayConnection(addr.host, agent.gateway_token, addr.port);
+  // Validate + resolve the gateway host before opening a NEW connection (the
+  // alive-cache hit above already passed this when it was created). Closes the
+  // gap where the RPC pool checked only the port, not the host.
+  const extraAllowedHosts = await allowedGatewayHostsForAgent(agent);
+  const connectHost = await resolveGatewayHostForProxy(
+    addr.host,
+    "agent gateway",
+    extraAllowedHosts,
+  );
+  conn = new GatewayConnection(connectHost, agent.gateway_token, addr.port);
   pool.set(key, conn);
   try {
     await conn.connect();
@@ -1269,7 +1298,15 @@ function attachGatewayWS(server) {
       if (!isAllowedGatewayPort(addr.port)) {
         throw new Error("Agent gateway port is not allowed");
       }
-      const gwWs = new WebSocket(`ws://${addr.host}:${addr.port}`);
+      // Validate + resolve the gateway host (the WS relay previously checked
+      // only the port). Throws here are caught below → client gets an error.
+      const relayExtraAllowedHosts = await allowedGatewayHostsForAgent(agent);
+      const relayHost = await resolveGatewayHostForProxy(
+        addr.host,
+        "agent gateway",
+        relayExtraAllowedHosts,
+      );
+      const gwWs = new WebSocket(`ws://${relayHost}:${addr.port}`);
       const role = "operator";
       const scopes = [
         "operator.admin",


### PR DESCRIPTION
## What

Closes a pre-existing SSRF gap: only the **HTTP** proxy ran the gateway host allowlist. The **WS-RPC connection pool** (`getConnection`) and the **WS relay** (`attachGatewayWS`) checked the *port* but not the *host* — so a forged/bad agent `gateway_host` could make the control plane open a socket to an arbitrary internal address. Both now resolve + validate the host with the same allowlist HTTP uses.

## Regression-safe by design

The per-agent allowance is generalized (`allowedGatewayHostsForAgent`) so all three paths share one policy:
- **remote-docker** → the agent's OWN registered host (owner-scoped; unchanged from #199).
- **k8s** → the operator-provisioned exposure address (`gateway_host`/`runtime_host` the adapter recorded). Trusting it **matches the prior RPC/WS behavior**, so k8s chat — including public LoadBalancer IPs — does not regress; HTTP gains parity (fixes the gateway-UI tab for LB agents).
- **docker / other** → none → the RFC1918/loopback floor, now enforced on RPC/WS too.

`isBlockedGatewayIP` still hard-denies `0.0.0.0`/link-local/multicast on every path.

Mechanics: the RPC pool resolves only when creating a **new** connection (alive cache hits already passed it) and keeps the pool key on the **raw** host so `evictConnection` still matches. The WS-relay resolve sits inside the existing try/catch → a disallowed host cleanly errors the client socket.

## Validation

Tests: k8s provisioned-address trusted; docker public host blocked; remote owner-scoping retained; RFC1918 docker host unaffected. Full backend suite **1070/1070**; typecheck + lint clean. Going through a security + regression adversarial review.

This completes the gateway-allowlist hardening (A3). Remaining in Phase A: **A4-2** (rollback/in-place-restore deep-check gaps, which also affect k8s).