### PR TITLE
feat(deploy): validate execution target on rollback + in-place restore (BYOC A4-2)

### DIFF
--- a/backend-api/backups.ts
+++ b/backend-api/backups.ts
@@ -28,6 +28,8 @@ const {
 } = require("./agentPayloads");
 const { getDefaultAgentImage } = require("../agent-runtime/lib/agentImages");
 const { getRuntimeSelectionStatus } = require("../agent-runtime/lib/backendCatalog");
+const { assertKubernetesExecutionTargetAvailable } = require("./kubernetesClusters");
+const { assertRemoteHostExecutionTargetAvailable } = require("./remoteHosts");
 const { buildAgentRuntimeFields, resolveRequestedRuntimeFields } = require("./agentRuntimeFields");
 
 const gzipAsync = promisify(gzip);
@@ -1487,6 +1489,12 @@ async function restoreBackupInPlace({ backupId, targetAgentId, confirmAgentName,
     fallback: targetRuntime,
   });
   assertRuntimeSelectionAvailable(runtimeFields);
+  // Deep execution-target checks (parity with the deploy route): the cluster /
+  // remote host must still exist + be connected. Owner-scoped to the target
+  // agent's owner so an admin cross-tenant restore still validates against the
+  // owner's registered host, not the admin actor.
+  await assertKubernetesExecutionTargetAvailable(runtimeFields);
+  await assertRemoteHostExecutionTargetAvailable(runtimeFields, { ownerUserId: target.user_id });
   const containerName = resolveContainerName({
     currentName: target.container_name,
     agentName: target.name,

--- a/backend-api/routes/agents.ts
+++ b/backend-api/routes/agents.ts
@@ -2075,6 +2075,15 @@ router.post(
       console.warn(`[agents.rollback] wiring materialize failed: ${err.message}`);
     }
     if (agent.container_id) {
+      // Validate the agent's execution target is still deployable before
+      // queuing the redeploy — a remote host / k8s cluster may have been
+      // removed or disconnected since the original deploy. Owner-scoped to the
+      // agent's owner (an editor may trigger the rollback). Fail before we
+      // clear container_id so a rejected rollback leaves the agent intact.
+      await assertRuntimeTargetAvailable(
+        buildAgentRuntimeFields(agent),
+        agent.user_id || req.user.id,
+      );
       await db.query(
         `UPDATE agents
             SET status = 'queued',


### PR DESCRIPTION
## What

The two redeploy paths that skipped the deep execution-target check now run it — closing the last A4 gap (pre-existing; it affected **k8s too**, not just remote):

- **Version rollback** (`routes/agents.ts`): before queuing the redeploy of a container-backed agent, run `assertRuntimeTargetAvailable(buildAgentRuntimeFields(agent), agent.user_id)`. Rolling back an agent whose remote host / k8s cluster was removed or disconnected now fails with a clear 400 instead of queuing a doomed job. Owner-scoped to the agent's owner (an editor may trigger rollback), and run **before** `container_id` is cleared so a rejected rollback leaves the agent intact.
- **In-place backup restore** (`backups.ts`): upgrade from the shallow `assertRuntimeSelectionAvailable` to also run `assertKubernetesExecutionTargetAvailable` + `assertRemoteHostExecutionTargetAvailable`, owner-scoped to the **target agent's** owner (so an admin cross-tenant restore validates the owner's host, not the admin actor).

## Validation

Both wire already-tested asserts (`remoteHosts.test.ts` owner-scoping + catalog tests). Full backend suite **1071/1071**; typecheck + lint clean.

## This completes Phase A

Remote BYOC is now fully built and hardened end-to-end (registry → adapter → routes → operator + admin UIs → deploy-picker → gateway allowlist → deploy/rollback/restore validation). Epic next: **Phase B** (port-range allocation + Hermes on remote) and **Phase C** (RBAC / shared hosts).