### PR TITLE
feat(ports): gateway host-port allocation registry (BYOC Phase B foundation)

### DIFF
--- a/backend-api/__tests__/portAllocations.test.ts
+++ b/backend-api/__tests__/portAllocations.test.ts
@@ -1,0 +1,106 @@
+// @ts-nocheck
+const mockDb = { query: jest.fn() };
+jest.mock("../db", () => mockDb);
+
+const {
+  allocateGatewayPort,
+  releaseGatewayPort,
+  getGatewayPortAllocation,
+  LOCAL_HOST_KEY,
+} = require("../portAllocations");
+
+// Route db.query on SQL shape. `insert` is an array of responses consumed in
+// order (so we can simulate a unique-violation race then success).
+function fakeDb({ existing = [], insertResponses = [] } = {}) {
+  const calls = [];
+  let insertIdx = 0;
+  mockDb.query.mockImplementation(async (sql, params) => {
+    calls.push({ sql, params });
+    if (sql.includes("SELECT host_key, port FROM gateway_port_allocations")) {
+      return { rows: existing };
+    }
+    if (sql.includes("SELECT port FROM gateway_port_allocations WHERE agent_id")) {
+      return { rows: existing };
+    }
+    if (sql.includes("INSERT INTO gateway_port_allocations")) {
+      const next = insertResponses[insertIdx++] ?? { rows: [] };
+      if (next instanceof Error) throw next;
+      return next;
+    }
+    if (sql.includes("DELETE FROM gateway_port_allocations")) {
+      return { rows: [] };
+    }
+    return { rows: [] };
+  });
+  return { calls };
+}
+
+beforeEach(() => mockDb.query.mockReset());
+
+describe("allocateGatewayPort", () => {
+  it("reuses the agent's existing allocation (idempotent across redeploys)", async () => {
+    const { calls } = fakeDb({ existing: [{ port: 19042 }] });
+    const port = await allocateGatewayPort({ hostKey: "local", agentId: "a1" });
+    expect(port).toBe(19042);
+    // no INSERT attempted
+    expect(calls.some((c) => c.sql.includes("INSERT INTO gateway_port_allocations"))).toBe(false);
+  });
+
+  it("claims the lowest free port for a fresh agent", async () => {
+    fakeDb({ existing: [], insertResponses: [{ rows: [{ port: 19000 }] }] });
+    const port = await allocateGatewayPort({ hostKey: "remote:my-vps", agentId: "a2" });
+    expect(port).toBe(19000);
+  });
+
+  it("retries on a UNIQUE-violation race and succeeds", async () => {
+    const raceError = new Error("duplicate key");
+    raceError.code = "23505";
+    fakeDb({ existing: [], insertResponses: [raceError, { rows: [{ port: 19001 }] }] });
+    const port = await allocateGatewayPort({ hostKey: "local", agentId: "a3" });
+    expect(port).toBe(19001);
+  });
+
+  it("throws 503 when the host's port range is exhausted", async () => {
+    fakeDb({ existing: [], insertResponses: [{ rows: [] }] });
+    await expect(
+      allocateGatewayPort({ hostKey: "local", agentId: "a4", rangeMin: 19000, rangeMax: 19000 }),
+    ).rejects.toMatchObject({ statusCode: 503 });
+  });
+
+  it("defaults a blank host key to the local host", async () => {
+    const { calls } = fakeDb({ existing: [], insertResponses: [{ rows: [{ port: 19000 }] }] });
+    await allocateGatewayPort({ agentId: "a5" });
+    const insert = calls.find((c) => c.sql.includes("INSERT INTO gateway_port_allocations"));
+    expect(insert.params[0]).toBe(LOCAL_HOST_KEY);
+  });
+
+  it("requires an agentId", async () => {
+    fakeDb();
+    await expect(allocateGatewayPort({ hostKey: "local" })).rejects.toThrow(/agentId/i);
+  });
+});
+
+describe("releaseGatewayPort", () => {
+  it("deletes every allocation the agent holds", async () => {
+    const { calls } = fakeDb();
+    await releaseGatewayPort("a1");
+    const del = calls.find((c) => c.sql.includes("DELETE FROM gateway_port_allocations"));
+    expect(del.params).toEqual(["a1"]);
+  });
+
+  it("no-ops without an agentId", async () => {
+    const { calls } = fakeDb();
+    await releaseGatewayPort();
+    expect(calls.length).toBe(0);
+  });
+});
+
+describe("getGatewayPortAllocation", () => {
+  it("returns null when the table has not been migrated yet", async () => {
+    mockDb.query.mockReset();
+    const undefinedTable = new Error('relation "gateway_port_allocations" does not exist');
+    undefinedTable.code = "42P01";
+    mockDb.query.mockRejectedValueOnce(undefinedTable);
+    expect(await getGatewayPortAllocation("a1")).toBeNull();
+  });
+});

--- a/backend-api/db_schema.sql
+++ b/backend-api/db_schema.sql
@@ -108,6 +108,18 @@ CREATE TABLE IF NOT EXISTS remote_hosts (
 CREATE INDEX IF NOT EXISTS idx_remote_hosts_owner
   ON remote_hosts(owner_user_id, enabled, is_default, label);
 
+CREATE TABLE IF NOT EXISTS gateway_port_allocations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  host_key TEXT NOT NULL,
+  agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  port INTEGER NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(host_key, port)
+);
+
+CREATE INDEX IF NOT EXISTS idx_gateway_port_allocations_agent
+  ON gateway_port_allocations(agent_id);
+
 CREATE TABLE IF NOT EXISTS deployments (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   agent_id UUID REFERENCES agents(id) ON DELETE CASCADE,

--- a/backend-api/portAllocations.ts
+++ b/backend-api/portAllocations.ts
@@ -1,0 +1,115 @@
+// @ts-nocheck
+// Gateway host-port allocation — BYOC Phase B (B1).
+//
+// Replaces the collision-prone deterministic hash (19000 + id % 1000) that
+// the docker adapter used to pick a published gateway port. That hash had no
+// reservation and no collision detection, so two agents whose ids hashed to the
+// same slot would fight over the port on a shared host. Here a port is reserved
+// in `gateway_port_allocations` with a UNIQUE(host_key, port) constraint, picked
+// atomically as the lowest free port in the range, scoped per host:
+//   - host_key "local"      → the local Docker host (all local docker agents).
+//   - host_key "remote:<id>" → a specific registered remote host.
+// Allocation is idempotent per (agent, host) so redeploys keep the same port.
+
+const db = require("./db");
+
+const DEFAULT_RANGE_MIN = 19000;
+const DEFAULT_RANGE_MAX = 19999;
+const LOCAL_HOST_KEY = "local";
+const MAX_RACE_RETRIES = 5;
+
+function normalizeHostKey(value) {
+  const key = String(value || "")
+    .trim()
+    .toLowerCase();
+  return key || LOCAL_HOST_KEY;
+}
+
+async function getGatewayPortAllocation(agentId) {
+  if (!agentId) return null;
+  try {
+    const result = await db.query(
+      "SELECT host_key, port FROM gateway_port_allocations WHERE agent_id = $1 LIMIT 1",
+      [agentId],
+    );
+    return result.rows[0] || null;
+  } catch (error) {
+    if (error?.code === "42P01") return null; // table not migrated yet
+    throw error;
+  }
+}
+
+// Reserve (or reuse) a published gateway port for an agent on a given host.
+// Returns the port number. Throws (statusCode 503) when the host's range is
+// exhausted.
+async function allocateGatewayPort({
+  hostKey,
+  agentId,
+  rangeMin = DEFAULT_RANGE_MIN,
+  rangeMax = DEFAULT_RANGE_MAX,
+} = {}) {
+  if (!agentId) throw new Error("agentId is required to allocate a gateway port");
+  const key = normalizeHostKey(hostKey);
+
+  // Idempotent: an agent keeps its port across redeploys on the same host.
+  const existing = await db.query(
+    "SELECT port FROM gateway_port_allocations WHERE agent_id = $1 AND host_key = $2",
+    [agentId, key],
+  );
+  if (existing.rows[0]) return existing.rows[0].port;
+
+  for (let attempt = 0; attempt < MAX_RACE_RETRIES; attempt++) {
+    try {
+      // Claim the lowest free port for this host in one statement. The
+      // UNIQUE(host_key, port) constraint makes concurrent claims race-safe:
+      // the loser hits a unique violation and retries against the new state.
+      const result = await db.query(
+        `INSERT INTO gateway_port_allocations (host_key, agent_id, port)
+         SELECT $1, $2, candidate.port
+           FROM generate_series($3, $4) AS candidate(port)
+          WHERE NOT EXISTS (
+            SELECT 1 FROM gateway_port_allocations existing
+             WHERE existing.host_key = $1 AND existing.port = candidate.port
+          )
+          ORDER BY candidate.port
+          LIMIT 1
+         RETURNING port`,
+        [key, agentId, rangeMin, rangeMax],
+      );
+      if (result.rows[0]) return result.rows[0].port;
+      // No row inserted → every port in the range is taken on this host.
+      const error = new Error(
+        `No free gateway port available on ${key} (range ${rangeMin}-${rangeMax}).`,
+      );
+      error.statusCode = 503;
+      throw error;
+    } catch (error) {
+      if (error?.code === "23505") continue; // unique_violation — lost the race, retry
+      throw error;
+    }
+  }
+
+  const error = new Error(`Could not allocate a gateway port on ${key} after retries.`);
+  error.statusCode = 503;
+  throw error;
+}
+
+// Release every allocation an agent holds (called on destroy). Idempotent.
+async function releaseGatewayPort(agentId) {
+  if (!agentId) return;
+  try {
+    await db.query("DELETE FROM gateway_port_allocations WHERE agent_id = $1", [agentId]);
+  } catch (error) {
+    if (error?.code === "42P01") return;
+    throw error;
+  }
+}
+
+module.exports = {
+  LOCAL_HOST_KEY,
+  DEFAULT_RANGE_MIN,
+  DEFAULT_RANGE_MAX,
+  allocateGatewayPort,
+  releaseGatewayPort,
+  getGatewayPortAllocation,
+};

--- a/backend-api/server.ts
+++ b/backend-api/server.ts
@@ -1323,6 +1323,16 @@ async function migrateDB() {
      )`,
     `CREATE INDEX IF NOT EXISTS idx_remote_hosts_owner
        ON remote_hosts(owner_user_id, enabled, is_default, label)`,
+    `CREATE TABLE IF NOT EXISTS gateway_port_allocations (
+       id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+       host_key TEXT NOT NULL,
+       agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+       port INTEGER NOT NULL,
+       created_at TIMESTAMPTZ DEFAULT NOW(),
+       UNIQUE(host_key, port)
+     )`,
+    `CREATE INDEX IF NOT EXISTS idx_gateway_port_allocations_agent
+       ON gateway_port_allocations(agent_id)`,
     `DO $$ BEGIN ALTER TABLE agents ADD COLUMN vcpu INTEGER DEFAULT 1; EXCEPTION WHEN duplicate_column THEN NULL; END $$`,
     `DO $$ BEGIN ALTER TABLE agents ADD COLUMN ram_mb INTEGER DEFAULT 1024; EXCEPTION WHEN duplicate_column THEN NULL; END $$`,
     `DO $$ BEGIN ALTER TABLE agents ADD COLUMN disk_gb INTEGER DEFAULT 10; EXCEPTION WHEN duplicate_column THEN NULL; END $$`,

--- a/infra/helm/nora/files/db_schema.sql
+++ b/infra/helm/nora/files/db_schema.sql
@@ -108,6 +108,18 @@ CREATE TABLE IF NOT EXISTS remote_hosts (
 CREATE INDEX IF NOT EXISTS idx_remote_hosts_owner
   ON remote_hosts(owner_user_id, enabled, is_default, label);
 
+CREATE TABLE IF NOT EXISTS gateway_port_allocations (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  host_key TEXT NOT NULL,
+  agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  port INTEGER NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE(host_key, port)
+);
+
+CREATE INDEX IF NOT EXISTS idx_gateway_port_allocations_agent
+  ON gateway_port_allocations(agent_id);
+
 CREATE TABLE IF NOT EXISTS deployments (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   agent_id UUID REFERENCES agents(id) ON DELETE CASCADE,


### PR DESCRIPTION
## What

First step of **Phase B**: a real per-host port reservation to replace the collision-prone hash the docker adapter used (`19000 + id % 1000` — no reservation, no collision detection, so two agents whose ids hashed to the same slot fought over the port on a shared host).

## How

- **`backend-api/portAllocations.ts`** — `allocateGatewayPort({ hostKey, agentId, range })` claims the **lowest free port** for a host in one `INSERT…SELECT generate_series` statement; `UNIQUE(host_key, port)` makes concurrent claims **race-safe** (the loser retries on the unique violation); **idempotent** per (agent, host) so redeploys keep the same port; throws **503** when the host's range is exhausted (capacity cap). `host_key` is `"local"` for the local Docker host or `"remote:<id>"` for a registered remote host. `releaseGatewayPort(agentId)` frees it on destroy.
- **`gateway_port_allocations` table** — server.ts migration + `db_schema.sql` + vendored Helm copy (kept in sync for `validate-infra`).
- **9 unit tests** — idempotent reuse, lowest-free-port claim, unique-race retry, capacity exhaustion (503), local-host default, agentId required, release, unmigrated-table fallback.

## Scope

Self-contained (db only); **not wired into the deploy path yet**. The follow-up PR will have the worker allocate on create + release on destroy and pass the port into the adapter (replacing the hash) — which also fixes the **local-docker** port-collision bug. Full backend suite **1080/1080**; typecheck + lint clean.