### PR TITLE
feat(ports): allocate the published gateway port per host on deploy (BYOC Phase B)

### DIFF
--- a/backend-api/__tests__/provisioning.test.ts
+++ b/backend-api/__tests__/provisioning.test.ts
@@ -992,3 +992,50 @@ describe("Hermes dashboard provisioning", () => {
     );
   });
 });
+
+describe("docker gateway port allocation (BYOC Phase B)", () => {
+  function mockDockerBackend() {
+    const DockerBackend = require("../../workers/provisioner/backends/docker");
+    const backend = new DockerBackend();
+    backend._findComposeNetwork = jest.fn().mockResolvedValue(null);
+    const createdContainer = {
+      id: "oclaw-port-1",
+      start: jest.fn().mockResolvedValue({}),
+      putArchive: jest.fn().mockResolvedValue({}),
+      remove: jest.fn().mockResolvedValue({}),
+      inspect: jest.fn().mockResolvedValue({
+        NetworkSettings: {
+          IPAddress: "10.0.0.7",
+          Networks: {},
+          Ports: { "18789/tcp": [{ HostPort: "19500" }] },
+        },
+      }),
+    };
+    backend.docker = {
+      getImage: jest.fn().mockReturnValue({ inspect: jest.fn().mockResolvedValue({}) }),
+      getContainer: jest
+        .fn()
+        .mockReturnValue({ inspect: jest.fn().mockRejectedValue(new Error("not found")) }),
+      createVolume: jest.fn().mockResolvedValue({}),
+      createContainer: jest.fn().mockResolvedValue(createdContainer),
+      getNetwork: jest.fn().mockReturnValue({ connect: jest.fn().mockResolvedValue({}) }),
+      getVolume: jest.fn().mockReturnValue({ remove: jest.fn().mockResolvedValue({}) }),
+    };
+    return backend;
+  }
+
+  it("publishes the worker-allocated host port", async () => {
+    const backend = mockDockerBackend();
+    await backend.create({ id: "999", name: "Port QA", gatewayHostPort: 19500, env: {} });
+    const config = backend.docker.createContainer.mock.calls[0][0];
+    expect(config.HostConfig.PortBindings["18789/tcp"]).toEqual([{ HostPort: "19500" }]);
+  });
+
+  it("falls back to the deterministic hash when no port is allocated", async () => {
+    const backend = mockDockerBackend();
+    // id "999" -> 19000 + (999 % 1000) = 19999
+    await backend.create({ id: "999", name: "Port QA", env: {} });
+    const config = backend.docker.createContainer.mock.calls[0][0];
+    expect(config.HostConfig.PortBindings["18789/tcp"]).toEqual([{ HostPort: "19999" }]);
+  });
+});

--- a/backend-api/routes/agents.ts
+++ b/backend-api/routes/agents.ts
@@ -75,6 +75,7 @@ const { scopeByMethod } = require("../middleware/auth");
 const agentVersions = require("../agentVersions");
 const { assertKubernetesExecutionTargetAvailable } = require("../kubernetesClusters");
 const { assertRemoteHostExecutionTargetAvailable } = require("../remoteHosts");
+const { releaseGatewayPort } = require("../portAllocations");
 
 const router = express.Router();
 router.use(createMutationFailureAuditMiddleware("agent"));
@@ -1773,6 +1774,10 @@ async function destroyAgent(agentId, userId, req, res) {
     }
   }
 
+  // Free the agent's reserved gateway port. The FK is ON DELETE CASCADE so the
+  // hard delete below already releases it, but release explicitly so the
+  // allocation can't leak if agent deletion ever becomes a soft-delete.
+  await releaseGatewayPort(agent.id).catch(() => {});
   await db.query("DELETE FROM agents WHERE id = $1", [agent.id]);
   await monitoring.logEvent(
     "agent_deleted",

--- a/workers/provisioner/backends/docker.ts
+++ b/workers/provisioner/backends/docker.ts
@@ -334,6 +334,7 @@ class DockerBackend extends ProvisionerBackend {
       templatePayload,
       mcpServers: mcpServerEntries,
       abortSignal,
+      gatewayHostPort: allocatedGatewayPort,
     } = config;
     const containerName = container_name || safeContainerName("nora-oclaw", name, id);
     let container = null;
@@ -562,8 +563,14 @@ class DockerBackend extends ProvisionerBackend {
     const safeDefaultModel =
       defaultModel && /^[a-zA-Z0-9_\-/.]+$/.test(defaultModel) ? defaultModel : null;
 
-    // Derive the deterministic host port for this agent to include in allowedOrigins
-    const hostPort = 19000 + ((parseInt(id.replace(/\D/g, "").slice(0, 4)) || 0) % 1000);
+    // Use the port the worker reserved for this agent's host (collision-safe,
+    // BYOC Phase B). Fall back to the legacy deterministic hash only if no
+    // allocation was passed (older callers / safety net).
+    const allocatedPort = Number(allocatedGatewayPort);
+    const hostPort =
+      Number.isInteger(allocatedPort) && allocatedPort >= 1 && allocatedPort <= 65535
+        ? allocatedPort
+        : 19000 + ((parseInt(id.replace(/\D/g, "").slice(0, 4)) || 0) % 1000);
 
     const allowedOrigins = new Set([
       "http://localhost:8080",

--- a/workers/provisioner/worker.ts
+++ b/workers/provisioner/worker.ts
@@ -25,6 +25,7 @@ const {
 } = require("../../backend-api/hermesUi");
 const { getKubernetesClusterProfile } = require("../../backend-api/kubernetesClusters");
 const { getRemoteHostProfile } = require("../../backend-api/remoteHosts");
+const { allocateGatewayPort, LOCAL_HOST_KEY } = require("../../backend-api/portAllocations");
 const {
   buildIntegrationSyncEntry,
   decryptSensitiveConfig,
@@ -1741,6 +1742,27 @@ const worker = new Worker(
         if (resolvedBackend === "k8s" && container_name) {
           containerId = container_name;
         }
+        // Reserve a collision-safe published gateway port for docker / remote-docker
+        // agents (k8s/proxmox manage their own ports). Idempotent per agent+host,
+        // so redeploys keep the same port; released via ON DELETE CASCADE.
+        let allocatedGatewayPort;
+        {
+          const deployTarget = resolvedRuntimeFields.deploy_target;
+          const allocationHostKey =
+            deployTarget === "remote-docker"
+              ? String(resolvedRuntimeFields.execution_target_id || "")
+                  .trim()
+                  .toLowerCase() || null
+              : deployTarget === "docker"
+                ? LOCAL_HOST_KEY
+                : null;
+          if (allocationHostKey) {
+            allocatedGatewayPort = await allocateGatewayPort({
+              hostKey: allocationHostKey,
+              agentId: id,
+            });
+          }
+        }
         const createPromise = provisioner.create({
           id,
           name,
@@ -1749,6 +1771,7 @@ const worker = new Worker(
           ram_mb,
           disk_gb,
           container_name,
+          gatewayHostPort: allocatedGatewayPort,
           gatewayToken: agentRow.gateway_token || undefined,
           templatePayload,
           mcpServers: mcpServerEntries,


### PR DESCRIPTION
## What

Wires the port-allocation registry (#204) into provisioning, replacing the collision-prone hash and **fixing the pre-existing local-docker port-collision bug** (two agents whose ids hashed to the same `19000 + id%1000` slot fought over the published port).

## How

- **`worker.ts`**: before `provisioner.create()`, reserve a collision-safe published port via `allocateGatewayPort` for **docker** (`host_key "local"`) and **remote-docker** (`host_key "remote:<id>"`) agents — k8s/proxmox manage their own ports. The reserved port is passed into the create config as `gatewayHostPort`. Idempotent per agent+host (redeploys keep the same port); released automatically via the `gateway_port_allocations.agent_id` `ON DELETE CASCADE`.
- **`docker.ts create()`**: use the passed `gatewayHostPort` for the `18789` `PortBindings` (and `allowedOrigins`), falling back to the legacy hash only when no allocation was supplied (older callers / safety net).

Two agents on the same host can no longer collide on a published port; capacity exhaustion surfaces as a clear **503** instead of a Docker bind failure.

## Validation

Tests: docker `create()` publishes the allocated port (`PortBindings`) + falls back to the hash when none is supplied. Full backend suite **1082/1082**; backend + worker typecheck + lint clean. Going through an adversarial review (shared `docker.ts` + worker deploy path).

This completes **Phase B's port-allocation half (B1)**. Remaining Phase B: **B2** (Hermes on remote hosts). Then Phase C (RBAC + adopt-existing-runtime).