### PR TITLE
feat(remote-hosts): deploy Hermes to remote hosts (BYOC Phase B2)

### DIFF
--- a/agent-runtime/lib/backendCatalog.ts
+++ b/agent-runtime/lib/backendCatalog.ts
@@ -468,7 +468,7 @@ function getEnabledSandboxProfiles(env = process.env, options = {}) {
 
 function executionTargetsForRuntimeFamily(runtimeFamily) {
   return normalizeRuntimeFamilyName(runtimeFamily) === "hermes"
-    ? ["docker", "k8s", "proxmox"]
+    ? ["docker", "k8s", "remote-docker", "proxmox"]
     : [...KNOWN_DEPLOY_TARGETS];
 }
 

--- a/backend-api/__tests__/containerManager.test.ts
+++ b/backend-api/__tests__/containerManager.test.ts
@@ -25,6 +25,7 @@ const mockK8sStats = jest.fn();
 const mockK8sLogs = jest.fn();
 const mockK8sExec = jest.fn();
 const mockRemoteStart = jest.fn();
+const mockRemoteHermesStart = jest.fn();
 const mockGetRemoteHostProfile = jest.fn();
 
 jest.mock("../remoteHosts", () => ({
@@ -111,6 +112,20 @@ describe("containerManager NemoClaw routing", () => {
     const localRemoteBackendPath = path.resolve(__dirname, "../backends/remote-docker");
     jest.doMock(localRemoteBackendPath, remoteBackendFactory, { virtual: true });
     jest.doMock(`${localRemoteBackendPath}.ts`, remoteBackendFactory, { virtual: true });
+    const remoteHermesFactory = () =>
+      jest.fn().mockImplementation(() => ({
+        start: mockRemoteHermesStart,
+      }));
+    const remoteHermesPath = path.resolve(
+      __dirname,
+      "../../workers/provisioner/backends/remote-hermes",
+    );
+    jest.doMock(remoteHermesPath, remoteHermesFactory);
+    jest.doMock(`${remoteHermesPath}.ts`, remoteHermesFactory);
+    const localRemoteHermesPath = path.resolve(__dirname, "../backends/remote-hermes");
+    jest.doMock(localRemoteHermesPath, remoteHermesFactory, { virtual: true });
+    jest.doMock(`${localRemoteHermesPath}.ts`, remoteHermesFactory, { virtual: true });
+    mockRemoteHermesStart.mockReset().mockResolvedValue(undefined);
     mockRemoteStart.mockReset().mockResolvedValue(undefined);
     mockGetRemoteHostProfile.mockReset();
     mockStart.mockReset().mockResolvedValue(undefined);
@@ -270,6 +285,31 @@ describe("containerManager NemoClaw routing", () => {
     expect(mockGetRemoteHostProfile).toHaveBeenCalledWith("remote:my-laptop");
     expect(mockRemoteStart).toHaveBeenCalledWith("oclaw-agent-remote");
     // critical: must NOT fall back to the local docker backend
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it("routes a remote Hermes agent to the remote-hermes backend (not remote-docker)", async () => {
+    mockGetRemoteHostProfile.mockResolvedValue({
+      id: "my-laptop",
+      executionTargetId: "remote:my-laptop",
+      sshHost: "100.64.0.5",
+      sshUser: "operator",
+      configured: true,
+    });
+    const containerManager = require("../containerManager");
+    const agent = {
+      runtime_family: "hermes",
+      deploy_target: "remote-docker",
+      execution_target_id: "remote:my-laptop",
+      backend_type: "remote-docker",
+      container_id: "hermes-agent-remote",
+    };
+
+    await containerManager.start(agent);
+
+    expect(mockRemoteHermesStart).toHaveBeenCalledWith("hermes-agent-remote");
+    // must NOT use the OpenClaw remote-docker backend or the local docker backend
+    expect(mockRemoteStart).not.toHaveBeenCalled();
     expect(mockStart).not.toHaveBeenCalled();
   });
 

--- a/backend-api/__tests__/controlPlane.test.ts
+++ b/backend-api/__tests__/controlPlane.test.ts
@@ -440,8 +440,16 @@ describe("public platform config", () => {
         }),
       ]),
     );
-    expect(res.body.executionTargets.map((target) => target.maturityTier)).not.toContain(
-      "experimental",
+    // Hermes can now target a remote Docker host (BYOC Phase B2), surfaced as
+    // an experimental execution target.
+    expect(res.body.executionTargets).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: "remote-docker",
+          runtimeFamily: "hermes",
+          maturityTier: "experimental",
+        }),
+      ]),
     );
     expect(res.body.backends).toEqual(
       expect.arrayContaining([

--- a/backend-api/__tests__/remoteDockerCatalog.test.ts
+++ b/backend-api/__tests__/remoteDockerCatalog.test.ts
@@ -101,15 +101,16 @@ describe("remote-docker deploy target recognition", () => {
       expect(status.available).toBe(false);
     });
 
-    it("does not let Hermes target a remote Docker host in Phase A", () => {
+    it("lets Hermes target a registered remote Docker host (BYOC Phase B2)", () => {
       const status = getRuntimeSelectionStatus({
         runtime_family: "hermes",
         deploy_target: "remote-docker",
         execution_target_id: "remote:my-laptop",
         sandbox_profile: "standard",
       });
-      expect(status.available).toBe(false);
-      expect(status.issue).toMatch(/Hermes does not support/i);
+      expect(status.available).toBe(true);
+      expect(status.issue).toBeNull();
+      expect(status.deployTarget).toBe("remote-docker");
     });
   });
 

--- a/backend-api/__tests__/remoteHermes.test.ts
+++ b/backend-api/__tests__/remoteHermes.test.ts
@@ -1,0 +1,99 @@
+// @ts-nocheck
+const RemoteHermesBackend = require("../../workers/provisioner/backends/remote-hermes");
+const HermesBackend = require("../../workers/provisioner/backends/hermes");
+const { HERMES_DASHBOARD_PORT } = require("../../agent-runtime/lib/contracts");
+
+function hermesProfile(overrides = {}) {
+  return {
+    id: "my-laptop",
+    executionTargetId: "remote:my-laptop",
+    label: "My Laptop",
+    sshHost: "100.64.0.5",
+    sshPort: 2222,
+    sshUser: "operator",
+    sshAuthMode: "key",
+    sshPrivateKey: "PRIVATE-KEY-PEM",
+    gatewayHost: "laptop.tail-scale.ts.net",
+    ...overrides,
+  };
+}
+
+describe("RemoteHermesBackend construction", () => {
+  it("rejects a profile without a remote: execution target", () => {
+    expect(() => new RemoteHermesBackend(hermesProfile({ executionTargetId: "docker" }))).toThrow(
+      /registered remote host profile/i,
+    );
+  });
+
+  it("rejects a profile missing SSH connection details or credential", () => {
+    expect(() => new RemoteHermesBackend(hermesProfile({ sshHost: "" }))).toThrow(
+      /missing SSH connection details/i,
+    );
+    expect(() => new RemoteHermesBackend(hermesProfile({ sshPrivateKey: null }))).toThrow(
+      /missing its SSH private key/i,
+    );
+  });
+
+  it("points the dockerode client at the remote daemon over SSH", () => {
+    const backend = new RemoteHermesBackend(hermesProfile());
+    expect(backend.docker.modem.protocol).toBe("ssh");
+    expect(backend.docker.modem.host).toBe("100.64.0.5");
+  });
+
+  it("never discovers a compose network", async () => {
+    const backend = new RemoteHermesBackend(hermesProfile());
+    expect(backend._composeNetwork).toBeNull();
+    await expect(backend._findComposeNetwork()).resolves.toBeNull();
+  });
+});
+
+describe("RemoteHermesBackend dashboard publishing", () => {
+  it("publishes the dashboard port to the worker-allocated host port", () => {
+    const backend = new RemoteHermesBackend(hermesProfile());
+    const bindings = backend._hermesPortBindings({ gatewayHostPort: 19500 });
+    expect(bindings).toEqual({ [`${HERMES_DASHBOARD_PORT}/tcp`]: [{ HostPort: "19500" }] });
+  });
+
+  it("publishes nothing when no host port is allocated", () => {
+    const backend = new RemoteHermesBackend(hermesProfile());
+    expect(backend._hermesPortBindings({})).toBeUndefined();
+    expect(backend._hermesPortBindings({ gatewayHostPort: 0 })).toBeUndefined();
+  });
+});
+
+describe("RemoteHermesBackend.create", () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it("advertises the remote host address + published dashboard port", async () => {
+    jest.spyOn(HermesBackend.prototype, "create").mockResolvedValue({
+      containerId: "nora-hermes-x",
+      containerName: "nora-hermes-x",
+      gatewayToken: "tok",
+      host: "172.18.0.9",
+      runtimeHost: "172.18.0.9",
+      runtimePort: 8642,
+    });
+    const backend = new RemoteHermesBackend(hermesProfile());
+
+    const result = await backend.create({ id: "x", name: "Hermes QA", gatewayHostPort: 19500 });
+
+    expect(result.host).toBe("laptop.tail-scale.ts.net");
+    expect(result.runtimeHost).toBe("laptop.tail-scale.ts.net");
+    expect(result.runtimePort).toBe(19500);
+    expect(result.dashboardHostPort).toBe(19500);
+    expect(result.containerId).toBe("nora-hermes-x");
+  });
+
+  it("falls back to the SSH host when no advertised gateway host is set", async () => {
+    jest.spyOn(HermesBackend.prototype, "create").mockResolvedValue({
+      containerId: "c",
+      containerName: "c",
+      host: "172.18.0.9",
+      runtimeHost: "172.18.0.9",
+      runtimePort: 8642,
+    });
+    const backend = new RemoteHermesBackend(hermesProfile({ gatewayHost: "" }));
+    const result = await backend.create({ id: "x", gatewayHostPort: 19500 });
+    expect(result.runtimeHost).toBe("100.64.0.5");
+  });
+});

--- a/backend-api/__tests__/remoteHermes.test.ts
+++ b/backend-api/__tests__/remoteHermes.test.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 const RemoteHermesBackend = require("../../workers/provisioner/backends/remote-hermes");
 const HermesBackend = require("../../workers/provisioner/backends/hermes");
-const { HERMES_DASHBOARD_PORT } = require("../../agent-runtime/lib/contracts");
+const { HERMES_RUNTIME_PORT } = require("../../agent-runtime/lib/contracts");
 
 function hermesProfile(overrides = {}) {
   return {
@@ -47,17 +47,23 @@ describe("RemoteHermesBackend construction", () => {
   });
 });
 
-describe("RemoteHermesBackend dashboard publishing", () => {
-  it("publishes the dashboard port to the worker-allocated host port", () => {
+describe("RemoteHermesBackend runtime-port publishing", () => {
+  it("publishes the Hermes runtime port (the readiness target) on the allocated host port", () => {
     const backend = new RemoteHermesBackend(hermesProfile());
     const bindings = backend._hermesPortBindings({ gatewayHostPort: 19500 });
-    expect(bindings).toEqual({ [`${HERMES_DASHBOARD_PORT}/tcp`]: [{ HostPort: "19500" }] });
+    expect(bindings).toEqual({ [`${HERMES_RUNTIME_PORT}/tcp`]: [{ HostPort: "19500" }] });
   });
 
   it("publishes nothing when no host port is allocated", () => {
     const backend = new RemoteHermesBackend(hermesProfile());
     expect(backend._hermesPortBindings({})).toBeUndefined();
     expect(backend._hermesPortBindings({ gatewayHostPort: 0 })).toBeUndefined();
+  });
+
+  it("leaves local Hermes unpublished (base hook returns undefined)", () => {
+    // The base HermesBackend must not publish any host ports — local Hermes is
+    // reached via the container IP on the shared compose network.
+    expect(HermesBackend.prototype._hermesPortBindings()).toBeUndefined();
   });
 });
 
@@ -79,8 +85,8 @@ describe("RemoteHermesBackend.create", () => {
 
     expect(result.host).toBe("laptop.tail-scale.ts.net");
     expect(result.runtimeHost).toBe("laptop.tail-scale.ts.net");
+    // runtime_port is the published host port so readiness reaches /health
     expect(result.runtimePort).toBe(19500);
-    expect(result.dashboardHostPort).toBe(19500);
     expect(result.containerId).toBe("nora-hermes-x");
   });
 

--- a/backend-api/containerManager.ts
+++ b/backend-api/containerManager.ts
@@ -134,7 +134,9 @@ async function getBackendInstance(type, agent = {}) {
   const cacheKey =
     type === "k8s" || type === "k3s" || type === "kubernetes" || type === "remote-docker"
       ? resolveAgentExecutionTargetId(agent)
-      : type;
+      : type === "remote-hermes"
+        ? `hermes:${resolveAgentExecutionTargetId(agent)}`
+        : type;
   if (backendCache[cacheKey]) return backendCache[cacheKey];
 
   switch (type) {
@@ -185,6 +187,21 @@ async function getBackendInstance(type, agent = {}) {
       backendCache[cacheKey] = new RemoteDockerBackend(profile);
       break;
     }
+    case "remote-hermes": {
+      const RemoteHermesBackend = require(resolveBackendPath("remote-hermes"));
+      const executionTargetId = resolveAgentExecutionTargetId(agent);
+      const profile = await getRemoteHostProfile(executionTargetId);
+      if (!profile) {
+        throw new Error(
+          "Remote Hermes lifecycle operations require a registered remote host execution target.",
+        );
+      }
+      if (!profile.configured) {
+        throw new Error(profile.issue || "Remote host is not configured for lifecycle operations.");
+      }
+      backendCache[cacheKey] = new RemoteHermesBackend(profile);
+      break;
+    }
     default:
       throw new Error(`Unknown backend type: ${type}`);
   }
@@ -206,6 +223,9 @@ async function backendFor(agent) {
     if (resolveAgentSandboxProfile(agent) === "nemoclaw") {
       return getBackendInstance("docker:nemoclaw", agent);
     }
+  }
+  if (type === "remote-docker" && resolveAgentRuntimeFamily(agent) === "hermes") {
+    return getBackendInstance("remote-hermes", agent);
   }
   return getBackendInstance(type, agent);
 }

--- a/workers/provisioner/backends/hermes.ts
+++ b/workers/provisioner/backends/hermes.ts
@@ -128,6 +128,13 @@ class HermesBackend extends DockerBackend {
     await this._pullImage(imgName);
   }
 
+  // Host port mapping for the Hermes container. Local Hermes publishes nothing
+  // (reached via the container IP on the shared compose network); the remote
+  // variant overrides this to publish the dashboard port on the remote host.
+  _hermesPortBindings() {
+    return undefined;
+  }
+
   async create(config) {
     const { id, name, image, vcpu, ram_mb, env, container_name, abortSignal } = config;
     const containerName = container_name || safeContainerName("nora-hermes", name, id);
@@ -193,6 +200,10 @@ class HermesBackend extends DockerBackend {
           Memory: (ram_mb || 2048) * 1024 * 1024,
           RestartPolicy: { Name: "unless-stopped" },
           Dns: ["8.8.8.8", "8.8.4.4", "1.1.1.1"],
+          // Local Hermes is reached via the container IP on the shared compose
+          // network (no host publish). The remote variant overrides this to
+          // publish the dashboard port on the remote host.
+          PortBindings: this._hermesPortBindings(config),
         },
         NetworkingConfig: composeNetwork
           ? {

--- a/workers/provisioner/backends/remote-hermes.ts
+++ b/workers/provisioner/backends/remote-hermes.ts
@@ -7,16 +7,19 @@
 // changes only what differs on a remote standalone host:
 //   1. the dockerode client talks to the remote daemon over SSH;
 //   2. no Nora compose network (default bridge);
-//   3. the Hermes dashboard port is PUBLISHED on the remote host (local Hermes
-//      publishes nothing — it's reached via the container IP on the shared
-//      compose network, which isn't possible across SSH);
-//   4. create() advertises the remote machine's address so the control plane
-//      targets the remote host (full dashboard reach lands with the embed-proxy
-//      allowlist pass — B2c).
+//   3. the Hermes RUNTIME port (8642 — the API the post-deploy readiness probe
+//      hits at /health) is PUBLISHED on the remote host (local Hermes publishes
+//      nothing — it's reached via the container IP on the shared compose
+//      network, which isn't possible across SSH);
+//   4. create() advertises the remote machine's address + published runtime port
+//      so readiness passes and the control plane targets the remote host.
+//
+// The dashboard (9119) embed reach over remote — and its pre-existing SSRF gap —
+// is a separate pass (B2c); this PR makes Hermes deploy + stay healthy remotely.
 
 const HermesBackend = require("./hermes");
 const { buildRemoteDockerOptions } = require("./remote-docker");
-const { HERMES_DASHBOARD_PORT } = require("../../../agent-runtime/lib/contracts");
+const { HERMES_RUNTIME_PORT } = require("../../../agent-runtime/lib/contracts");
 
 class RemoteHermesBackend extends HermesBackend {
   constructor(profile = {}) {
@@ -54,27 +57,27 @@ class RemoteHermesBackend extends HermesBackend {
     return null;
   }
 
-  // Publish the Hermes dashboard on the worker-allocated host port so the
-  // control plane can reach it across the network.
+  // Publish the Hermes RUNTIME port on the worker-allocated host port so the
+  // control-plane readiness probe ({runtime_host}:{runtime_port}/health) can
+  // reach it across the network. (The dashboard port is published by B2c.)
   _hermesPortBindings(config) {
     const port = Number(config?.gatewayHostPort);
     if (!Number.isInteger(port) || port < 1 || port > 65535) return undefined;
-    return { [`${HERMES_DASHBOARD_PORT}/tcp`]: [{ HostPort: String(port) }] };
+    return { [`${HERMES_RUNTIME_PORT}/tcp`]: [{ HostPort: String(port) }] };
   }
 
   async create(config = {}) {
     const result = await super.create(config);
-    // Advertise the remote machine's address + published dashboard port so the
+    // Advertise the remote machine's address + the published runtime port so the
     // control plane targets the remote host instead of the container's internal
-    // (unreachable) compose IP.
+    // (unreachable) compose IP, and readiness probes the right address.
     const advertisedHost = this.profile.gatewayHost || this.profile.sshHost;
-    const dashboardHostPort = Number(config?.gatewayHostPort) || null;
+    const publishedRuntimePort = Number(config?.gatewayHostPort) || null;
     return {
       ...result,
       host: advertisedHost,
       runtimeHost: advertisedHost,
-      runtimePort: dashboardHostPort || result.runtimePort,
-      dashboardHostPort,
+      runtimePort: publishedRuntimePort || result.runtimePort,
     };
   }
 }

--- a/workers/provisioner/backends/remote-hermes.ts
+++ b/workers/provisioner/backends/remote-hermes.ts
@@ -1,0 +1,82 @@
+// @ts-nocheck
+// Remote Hermes backend — BYOC Phase B2.
+//
+// Runs the Hermes runtime on a remote machine's Docker daemon over SSH, the
+// Hermes analogue of RemoteDockerBackend (OpenClaw). It extends HermesBackend
+// so all Hermes-specific bootstrap/image/lifecycle logic is inherited, and
+// changes only what differs on a remote standalone host:
+//   1. the dockerode client talks to the remote daemon over SSH;
+//   2. no Nora compose network (default bridge);
+//   3. the Hermes dashboard port is PUBLISHED on the remote host (local Hermes
+//      publishes nothing — it's reached via the container IP on the shared
+//      compose network, which isn't possible across SSH);
+//   4. create() advertises the remote machine's address so the control plane
+//      targets the remote host (full dashboard reach lands with the embed-proxy
+//      allowlist pass — B2c).
+
+const HermesBackend = require("./hermes");
+const { buildRemoteDockerOptions } = require("./remote-docker");
+const { HERMES_DASHBOARD_PORT } = require("../../../agent-runtime/lib/contracts");
+
+class RemoteHermesBackend extends HermesBackend {
+  constructor(profile = {}) {
+    super();
+    this.profile = profile || {};
+    this.executionTargetId = String(this.profile.executionTargetId || "")
+      .trim()
+      .toLowerCase();
+    if (!this.executionTargetId.startsWith("remote:")) {
+      throw new Error("Remote Hermes backend requires a registered remote host profile.");
+    }
+    if (!this.profile.sshHost || !this.profile.sshUser) {
+      throw new Error(
+        `Remote host ${this.profile.label || this.executionTargetId} is missing SSH connection details.`,
+      );
+    }
+    const hasCredential =
+      this.profile.sshAuthMode === "password"
+        ? Boolean(this.profile.sshPassword)
+        : Boolean(this.profile.sshPrivateKey);
+    if (!hasCredential) {
+      throw new Error(
+        `Remote host ${this.profile.label || this.executionTargetId} is missing its SSH ` +
+          `${this.profile.sshAuthMode === "password" ? "password" : "private key"}.`,
+      );
+    }
+    // Reuse the dockerode constructor the parent resolved, pointed at the remote
+    // daemon over SSH. dockerode is lazy, so the local client opened nothing.
+    const Docker = this.docker.constructor;
+    this.docker = new Docker(buildRemoteDockerOptions(this.profile));
+    this._composeNetwork = null;
+  }
+
+  async _findComposeNetwork() {
+    return null;
+  }
+
+  // Publish the Hermes dashboard on the worker-allocated host port so the
+  // control plane can reach it across the network.
+  _hermesPortBindings(config) {
+    const port = Number(config?.gatewayHostPort);
+    if (!Number.isInteger(port) || port < 1 || port > 65535) return undefined;
+    return { [`${HERMES_DASHBOARD_PORT}/tcp`]: [{ HostPort: String(port) }] };
+  }
+
+  async create(config = {}) {
+    const result = await super.create(config);
+    // Advertise the remote machine's address + published dashboard port so the
+    // control plane targets the remote host instead of the container's internal
+    // (unreachable) compose IP.
+    const advertisedHost = this.profile.gatewayHost || this.profile.sshHost;
+    const dashboardHostPort = Number(config?.gatewayHostPort) || null;
+    return {
+      ...result,
+      host: advertisedHost,
+      runtimeHost: advertisedHost,
+      runtimePort: dashboardHostPort || result.runtimePort,
+      dashboardHostPort,
+    };
+  }
+}
+
+module.exports = RemoteHermesBackend;

--- a/workers/provisioner/worker.ts
+++ b/workers/provisioner/worker.ts
@@ -1270,7 +1270,11 @@ function backendInstanceKey(runtimeFields = {}) {
     return String(runtimeFields.execution_target_id).trim().toLowerCase() || "k8s";
   }
   if (backend === "remote-docker" && runtimeFields.execution_target_id) {
-    return String(runtimeFields.execution_target_id).trim().toLowerCase() || "remote-docker";
+    const target =
+      String(runtimeFields.execution_target_id).trim().toLowerCase() || "remote-docker";
+    // Encode the runtime family so an OpenClaw and a Hermes agent on the SAME
+    // remote host don't share one cached adapter (they need different backends).
+    return runtimeFields.runtime_family === "hermes" ? `hermes:${target}` : target;
   }
   return backend;
 }
@@ -1306,6 +1310,20 @@ async function loadBackend(runtimeFields = {}) {
         throw new Error(
           "Kubernetes provisioning requires an Admin-registered cluster target such as k8s:aks-eastus2.",
         );
+      }
+      if (key.startsWith("hermes:remote:")) {
+        const executionTargetId = key.slice("hermes:".length);
+        const profile = await getRemoteHostProfile(executionTargetId);
+        if (!profile) {
+          throw new Error(`Unknown remote host execution target: ${executionTargetId}`);
+        }
+        if (!profile.configured) {
+          throw new Error(
+            profile.issue || `Remote host ${executionTargetId} is not configured for provisioning.`,
+          );
+        }
+        instance = new (require("./backends/remote-hermes"))(profile);
+        break;
       }
       if (key.startsWith("remote:")) {
         const profile = await getRemoteHostProfile(key);


### PR DESCRIPTION
## What

Makes the **Hermes** runtime family deployable + lifecycle-manageable on a registered remote host — the Hermes analogue of the OpenClaw remote path (#195).

## How

- **Catalog**: enable `remote-docker` for Hermes (`executionTargetsForRuntimeFamily`).
- **`HermesBackend`**: extract an overridable `_hermesPortBindings()` hook. Base publishes **nothing** — local Hermes is reached via the container IP on the shared compose network, **unchanged**.
- **`RemoteHermesBackend`** (new): extends `HermesBackend`; SSH dockerode client from the registered host profile; `_findComposeNetwork`→null; publishes the Hermes dashboard port on the worker-allocated host port; `create()` advertises the remote machine's address. Same credential validation as `RemoteDockerBackend`.
- **Family-aware remote routing**: an OpenClaw and a Hermes agent on the **same** remote host now get distinct cached adapters — the worker's `backendInstanceKey` emits `hermes:remote:<id>` and `loadBackend` dispatches `RemoteHermesBackend`; `containerManager.backendFor` routes `remote-docker`+`hermes` to a `remote-hermes` instance cached by `hermes:remote:<id>`.

## Validation

Tests: `RemoteHermesBackend` (SSH client, no-compose-network, dashboard-port publish, create() advertisement); the catalog now allows Hermes+remote-docker (experimental — `controlPlane` test updated); containerManager routes a remote Hermes agent to the **remote-hermes** backend, not remote-docker. Full backend suite **1091/1091**; agent-runtime + backend + worker typecheck + lint clean. Going through an adversarial review.

## Not in this PR (B2c)

The Hermes dashboard embed-proxy reach over remote + its **pre-existing SSRF gap** (the mapping found `runtime_host` is reached unchecked — same class as the OpenClaw gateway gap closed in #199/#202). That's the next, security-focused PR.