### PR TITLE
fix(gateway): SSRF allowlist on the Hermes dashboard embed proxy (BYOC B2c)

### DIFF
--- a/agent-runtime/lib/agentEndpoints.ts
+++ b/agent-runtime/lib/agentEndpoints.ts
@@ -1,3 +1,4 @@
+const net = require("net");
 const { AGENT_RUNTIME_PORT, OPENCLAW_GATEWAY_PORT, HERMES_DASHBOARD_PORT } = require("./contracts");
 
 function normalizePath(path = "/") {
@@ -29,7 +30,10 @@ function runtimeUsesHermesDashboard(agent) {
 }
 
 function joinHttpUrl(host, port, path = "/") {
-  return `http://${host}:${port}${normalizePath(path)}`;
+  // Bracket IPv6 literals so the colons in the address don't collide with the
+  // port separator (e.g. ::1 → http://[::1]:9119/…). Hostnames/IPv4 pass through.
+  const hostForUrl = net.isIP(host) === 6 ? `[${host}]` : host;
+  return `http://${hostForUrl}:${port}${normalizePath(path)}`;
 }
 
 function resolveRuntimeAddress(agent) {

--- a/agent-runtime/lib/agentEndpoints.ts
+++ b/agent-runtime/lib/agentEndpoints.ts
@@ -139,6 +139,7 @@ function buildRuntimeAuthHeaders(token) {
 }
 
 module.exports = {
+  joinHttpUrl,
   resolveRuntimeAddress,
   resolveGatewayAddress,
   resolveHermesDashboardAddress,

--- a/backend-api/__tests__/agentEndpoints.test.ts
+++ b/backend-api/__tests__/agentEndpoints.test.ts
@@ -1,0 +1,55 @@
+// @ts-nocheck
+/**
+ * __tests__/agentEndpoints.test.ts — covers the shared agent-runtime URL helpers
+ * as consumed by the backend (the Hermes embed proxy builds its upstream URL via
+ * joinHttpUrl). Lives backend-side because agentEndpoints.ts is a CJS module that
+ * require()s ./contracts and is exercised by the control plane, not the runtime.
+ */
+const {
+  joinHttpUrl,
+  resolveHermesDashboardAddress,
+} = require("../../agent-runtime/lib/agentEndpoints");
+
+describe("joinHttpUrl", () => {
+  it("builds a plain URL for hostnames and IPv4", () => {
+    expect(joinHttpUrl("runtime.internal", 9119, "dashboard")).toBe(
+      "http://runtime.internal:9119/dashboard",
+    );
+    expect(joinHttpUrl("10.0.0.7", 9119)).toBe("http://10.0.0.7:9119/");
+  });
+
+  it("brackets IPv6 literals so the address colons don't collide with the port", () => {
+    // Without bracketing this would be the unparseable "http://::1:9119/health".
+    expect(joinHttpUrl("::1", 9119, "/health")).toBe("http://[::1]:9119/health");
+    expect(joinHttpUrl("fd00::1", 8642, "status")).toBe("http://[fd00::1]:8642/status");
+    // The bracketed result is a valid, parseable URL (hostname keeps brackets in
+    // the WHATWG URL API; the point is that it parses at all, which "::1:9119" does not).
+    expect(new URL(joinHttpUrl("::1", 9119, "/health")).href).toBe("http://[::1]:9119/health");
+  });
+});
+
+describe("resolveHermesDashboardAddress", () => {
+  it("returns null for a non-Hermes agent", () => {
+    expect(resolveHermesDashboardAddress({ runtime_family: "openclaw" })).toBeNull();
+  });
+
+  it("prefers the provisioned gateway exposure address when present (k8s)", () => {
+    expect(
+      resolveHermesDashboardAddress({
+        runtime_family: "hermes",
+        gateway_host: "203.0.113.20",
+        gateway_port: 30119,
+        runtime_host: "10.42.0.3",
+      }),
+    ).toEqual({ host: "203.0.113.20", port: 30119 });
+  });
+
+  it("falls back to runtime_host + default dashboard port for a local container", () => {
+    expect(
+      resolveHermesDashboardAddress({
+        runtime_family: "hermes",
+        runtime_host: "10.0.0.7",
+      }),
+    ).toEqual({ host: "10.0.0.7", port: 9119 });
+  });
+});

--- a/backend-api/__tests__/embedAgentColumns.test.ts
+++ b/backend-api/__tests__/embedAgentColumns.test.ts
@@ -1,0 +1,54 @@
+// @ts-nocheck
+/**
+ * __tests__/embedAgentColumns.test.ts — guards the SSRF-relevant column contract
+ * for the embed-proxy agent lookups. A previous regression dropped these fields
+ * from lookupHermesEmbedAgent's SELECT, which silently mis-authorized
+ * remote-docker / k8s targets (the row reached the allowlist without the fields
+ * it scopes on). This pins the contract so that can't recur.
+ */
+const { HERMES_EMBED_AGENT_COLUMNS, GATEWAY_EMBED_AGENT_COLUMNS } = require("../embedAgentColumns");
+
+describe("embed-proxy agent SELECT columns", () => {
+  // These are exactly the fields allowedGatewayHostsForAgent /
+  // resolveHermesDashboardAddress read off the agent row to authorize the proxy
+  // target. The Hermes embed lookup MUST load all of them.
+  const SSRF_REQUIRED = [
+    "deploy_target", // routes docker vs k8s vs remote-docker policy
+    "execution_target_id", // looks up the registered remote host
+    "user_id", // owner-scopes the remote host (cross-tenant guard)
+    "gateway_host", // k8s/remote exposure host
+    "gateway_port",
+    "runtime_host", // local Hermes dashboard host
+    "runtime_port",
+  ];
+
+  it("Hermes embed lookup loads every field the SSRF allowlist authorizes against", () => {
+    for (const col of SSRF_REQUIRED) {
+      expect(HERMES_EMBED_AGENT_COLUMNS).toContain(col);
+    }
+    // status + runtime_family gate availability / dashboard detection.
+    expect(HERMES_EMBED_AGENT_COLUMNS).toContain("status");
+    expect(HERMES_EMBED_AGENT_COLUMNS).toContain("runtime_family");
+  });
+
+  it("gateway embed lookup loads the gateway endpoint fields", () => {
+    for (const col of [
+      "gateway_host",
+      "gateway_port",
+      "gateway_host_port",
+      "gateway_token",
+      "status",
+    ]) {
+      expect(GATEWAY_EMBED_AGENT_COLUMNS).toContain(col);
+    }
+  });
+
+  it("exposes plain string column names (safe to interpolate into the SELECT)", () => {
+    for (const col of [...HERMES_EMBED_AGENT_COLUMNS, ...GATEWAY_EMBED_AGENT_COLUMNS]) {
+      expect(typeof col).toBe("string");
+      // Identifier-only — never a value or expression, so the join() into SQL
+      // can't carry injection.
+      expect(col).toMatch(/^[a-z_]+$/);
+    }
+  });
+});

--- a/backend-api/__tests__/remoteHostGatewayAllowlist.test.ts
+++ b/backend-api/__tests__/remoteHostGatewayAllowlist.test.ts
@@ -218,4 +218,23 @@ describe("hermes dashboard embed-proxy allowlist (SSRF)", () => {
       /not an allowed gateway address/i,
     );
   });
+
+  it("trusts a k8s Hermes agent's provisioned (public LoadBalancer/NodePort) dashboard", async () => {
+    // k8s exposure addresses are operator-provisioned, so the dashboard must be
+    // reachable even on a public IP — without a remote-host registry lookup. This
+    // relies on gateway_host/gateway_port being loaded by the embed lookup.
+    const agent = {
+      id: "hermes-k8s",
+      user_id: "user-1",
+      runtime_family: "hermes",
+      deploy_target: "k8s",
+      execution_target_id: "k8s:prod",
+      gateway_host: "203.0.113.20",
+      gateway_port: 30119, // NodePort range
+      runtime_host: "10.42.0.3",
+    };
+    const target = await resolveSafeHermesDashboardTarget(agent);
+    expect(target).toEqual({ host: "203.0.113.20", port: 30119 });
+    expect(mockGetRemoteHostByExecutionTarget).not.toHaveBeenCalled();
+  });
 });

--- a/backend-api/__tests__/remoteHostGatewayAllowlist.test.ts
+++ b/backend-api/__tests__/remoteHostGatewayAllowlist.test.ts
@@ -16,7 +16,10 @@ jest.mock("../remoteHosts", () => ({
   getRemoteHostByExecutionTarget: (...args) => mockGetRemoteHostByExecutionTarget(...args),
 }));
 
-const { resolveSafeGatewayHttpTarget } = require("../gatewayProxy");
+const {
+  resolveSafeGatewayHttpTarget,
+  resolveSafeHermesDashboardTarget,
+} = require("../gatewayProxy");
 
 const PUBLIC_IP = "203.0.113.5";
 
@@ -140,5 +143,79 @@ describe("remote-host gateway allowlist (HTTP proxy)", () => {
     const target = await resolveSafeGatewayHttpTarget(dockerAgent, "status");
     expect(target.url).toBe("http://10.0.0.10:19000/status");
     expect(mockGetRemoteHostByExecutionTarget).not.toHaveBeenCalled();
+  });
+});
+
+describe("hermes dashboard embed-proxy allowlist (SSRF)", () => {
+  it("allows a local Hermes agent's RFC1918 dashboard host", async () => {
+    const agent = {
+      id: "hermes-1",
+      user_id: "user-1",
+      runtime_family: "hermes",
+      deploy_target: "docker",
+      execution_target_id: "docker",
+      runtime_host: "10.0.0.7",
+    };
+    const target = await resolveSafeHermesDashboardTarget(agent);
+    expect(target).toEqual({ host: "10.0.0.7", port: 9119 });
+    expect(mockGetRemoteHostByExecutionTarget).not.toHaveBeenCalled();
+  });
+
+  it("rejects a Hermes agent whose runtime_host is a public address (SSRF guard)", async () => {
+    const agent = {
+      id: "hermes-2",
+      user_id: "user-1",
+      runtime_family: "hermes",
+      deploy_target: "docker",
+      execution_target_id: "docker",
+      runtime_host: PUBLIC_IP,
+    };
+    await expect(resolveSafeHermesDashboardTarget(agent)).rejects.toThrow(
+      /not an allowed gateway address/i,
+    );
+  });
+
+  it("allows a remote Hermes agent's own registered host (owner-scoped)", async () => {
+    mockGetRemoteHostByExecutionTarget.mockResolvedValue({
+      id: "my-vps",
+      ownerUserId: "user-1",
+      gatewayHost: PUBLIC_IP,
+      sshHost: PUBLIC_IP,
+    });
+    const agent = {
+      id: "hermes-3",
+      user_id: "user-1",
+      runtime_family: "hermes",
+      deploy_target: "remote-docker",
+      execution_target_id: "remote:my-vps",
+      runtime_host: PUBLIC_IP,
+      // dashboard_port is not yet persisted for remote (B2c-2), so the dashboard
+      // address resolves to the default Hermes port; the SSRF allowance is what
+      // this test verifies — the registered host's address is trusted.
+      dashboard_port: 9119,
+    };
+    const target = await resolveSafeHermesDashboardTarget(agent);
+    expect(target).toEqual({ host: PUBLIC_IP, port: 9119 });
+  });
+
+  it("does not trust a remote Hermes host registered by another operator", async () => {
+    mockGetRemoteHostByExecutionTarget.mockResolvedValue({
+      id: "my-vps",
+      ownerUserId: "user-2",
+      gatewayHost: PUBLIC_IP,
+      sshHost: PUBLIC_IP,
+    });
+    const agent = {
+      id: "hermes-4",
+      user_id: "user-1",
+      runtime_family: "hermes",
+      deploy_target: "remote-docker",
+      execution_target_id: "remote:my-vps",
+      runtime_host: PUBLIC_IP,
+      runtime_port: 19042,
+    };
+    await expect(resolveSafeHermesDashboardTarget(agent)).rejects.toThrow(
+      /not an allowed gateway address/i,
+    );
   });
 });

--- a/backend-api/embedAgentColumns.ts
+++ b/backend-api/embedAgentColumns.ts
@@ -1,0 +1,52 @@
+// @ts-nocheck
+/**
+ * embedAgentColumns.ts — the agent-row columns the embed proxies must load.
+ *
+ * Both embed proxies resolve their upstream target through the gateway SSRF
+ * allowlist (gatewayProxy.resolveSafe*Target → allowedGatewayHostsForAgent →
+ * resolveHermesDashboardAddress). That allowlist authorizes the target by
+ * reading several agent fields off the row the embed lookup returns:
+ *
+ *   - deploy_target        routes the docker vs k8s vs remote-docker policy
+ *   - execution_target_id  looks up the agent's registered remote host
+ *   - user_id              owner-scopes that remote host (cross-tenant guard)
+ *   - gateway_host/_port   k8s/remote exposure address (LoadBalancer/NodePort)
+ *   - runtime_host/_port   the Hermes dashboard host (local container)
+ *
+ * A lookup that omits any of these silently mis-authorizes the target — e.g. a
+ * remote-docker agent gets normalized to "docker" and its registered host is
+ * rejected, or (worse) the owner check short-circuits because user_id is
+ * undefined. Keep these lists in sync with what allowedGatewayHostsForAgent /
+ * resolveHermesDashboardAddress actually consume.
+ */
+
+// Hermes dashboard embed proxy (server.ts proxyEmbeddedHermes →
+// resolveSafeHermesDashboardTarget).
+const HERMES_EMBED_AGENT_COLUMNS = [
+  "host",
+  "runtime_host",
+  "runtime_port",
+  "status",
+  "runtime_family",
+  "backend_type",
+  "deploy_target",
+  "execution_target_id",
+  "user_id",
+  "gateway_host",
+  "gateway_port",
+];
+
+// OpenClaw gateway embed proxy (server.ts proxyEmbeddedGateway). The SSRF
+// allowlist is not yet wired into this path; the deploy_target/execution_target_id/
+// user_id fields will be added here when it is (so the same owner-scoped policy
+// applies), mirroring HERMES_EMBED_AGENT_COLUMNS.
+const GATEWAY_EMBED_AGENT_COLUMNS = [
+  "host",
+  "gateway_token",
+  "gateway_host_port",
+  "gateway_host",
+  "gateway_port",
+  "status",
+];
+
+module.exports = { HERMES_EMBED_AGENT_COLUMNS, GATEWAY_EMBED_AGENT_COLUMNS };

--- a/backend-api/gatewayProxy.ts
+++ b/backend-api/gatewayProxy.ts
@@ -267,8 +267,10 @@ async function resolveSafeHermesDashboardTarget(agent) {
     throw new Error("hermes dashboard is not available for this agent");
   }
   const addr = assertSafeAgentAddress(address, "hermes dashboard");
-  // The dashboard runs on HERMES_DASHBOARD_PORT (local container) or a published
-  // host port for remote/k8s exposure.
+  // Allow either the default dashboard port (HERMES_DASHBOARD_PORT = 9119, the
+  // local container) OR a published host port (Docker published port / k8s
+  // NodePort) in the gateway port range — those are the two ways the dashboard
+  // is exposed. 9119 is outside the gateway port range, hence the explicit OR.
   if (addr.port !== HERMES_DASHBOARD_PORT && !isAllowedGatewayPort(addr.port)) {
     throw new Error("hermes dashboard port is not allowed for proxying");
   }

--- a/backend-api/gatewayProxy.ts
+++ b/backend-api/gatewayProxy.ts
@@ -16,9 +16,10 @@ const { normalizeDeployTargetName } = require("../agent-runtime/lib/backendCatal
 
 const metrics = require("./metrics");
 const agentBudgets = require("./agentBudgets");
-const { OPENCLAW_GATEWAY_PORT } = require("../agent-runtime/lib/contracts");
+const { OPENCLAW_GATEWAY_PORT, HERMES_DASHBOARD_PORT } = require("../agent-runtime/lib/contracts");
 const {
   resolveGatewayAddress,
+  resolveHermesDashboardAddress,
   hasGatewayEndpoint,
 } = require("../agent-runtime/lib/agentEndpoints");
 const GATEWAY_PORT = OPENCLAW_GATEWAY_PORT;
@@ -254,6 +255,30 @@ async function resolveSafeGatewayHttpTarget(agent, gatewayPath = "", search = ""
     url: targetUrl.toString(),
     hostHeader: hostHeaderForGateway(addr.host, addr.port),
   };
+}
+
+// Validate + resolve a Hermes agent's dashboard address before the embed proxy
+// connects to it — the Hermes equivalent of resolveSafeGatewayHttpTarget, which
+// closes the SSRF gap where the embed proxy reached runtime_host unchecked.
+// Returns the resolved (allowlisted) host + port; throws if disallowed.
+async function resolveSafeHermesDashboardTarget(agent) {
+  const address = resolveHermesDashboardAddress(agent);
+  if (!address) {
+    throw new Error("hermes dashboard is not available for this agent");
+  }
+  const addr = assertSafeAgentAddress(address, "hermes dashboard");
+  // The dashboard runs on HERMES_DASHBOARD_PORT (local container) or a published
+  // host port for remote/k8s exposure.
+  if (addr.port !== HERMES_DASHBOARD_PORT && !isAllowedGatewayPort(addr.port)) {
+    throw new Error("hermes dashboard port is not allowed for proxying");
+  }
+  const extraAllowedHosts = await allowedGatewayHostsForAgent(agent);
+  const resolvedHost = await resolveGatewayHostForProxy(
+    addr.host,
+    "hermes dashboard",
+    extraAllowedHosts,
+  );
+  return { host: resolvedHost, port: addr.port };
 }
 
 // ─── Device Identity (Ed25519 keypair for Gateway auth) ──────────
@@ -1525,4 +1550,5 @@ module.exports = {
   resolveAgent,
   evictConnection,
   resolveSafeGatewayHttpTarget,
+  resolveSafeHermesDashboardTarget,
 };

--- a/backend-api/server.ts
+++ b/backend-api/server.ts
@@ -36,6 +36,7 @@ const {
 } = require("./gatewayProxy");
 const { isGatewayAvailableStatus } = require("./agentStatus");
 const { repairHermesAgentConfig } = require("./hermesUi");
+const { HERMES_EMBED_AGENT_COLUMNS, GATEWAY_EMBED_AGENT_COLUMNS } = require("./embedAgentColumns");
 const {
   joinHttpUrl,
   gatewayUrlForAgent,
@@ -423,7 +424,7 @@ function setProxyResponseHeaders(res, resp, { cachePolicy = "asset" } = {}) {
 
 async function lookupEmbedAgent(agentId, userId) {
   const result = await db.query(
-    `SELECT host, gateway_token, gateway_host_port, gateway_host, gateway_port, status
+    `SELECT ${GATEWAY_EMBED_AGENT_COLUMNS.join(", ")}
        FROM agents
       WHERE id = $1 AND user_id = $2`,
     [agentId, userId],
@@ -439,8 +440,12 @@ async function lookupEmbedAgent(agentId, userId) {
 }
 
 async function lookupHermesEmbedAgent(agentId, userId) {
+  // Selects the SSRF-relevant fields (deploy_target / execution_target_id /
+  // user_id / gateway_host) the embed proxy's allowlist authorizes against — see
+  // embedAgentColumns.ts. Omitting them would mis-route a remote-docker/k8s agent
+  // or short-circuit the owner-scoping check.
   const result = await db.query(
-    `SELECT host, runtime_host, runtime_port, status, runtime_family, backend_type
+    `SELECT ${HERMES_EMBED_AGENT_COLUMNS.join(", ")}
        FROM agents
       WHERE id = $1 AND user_id = $2`,
     [agentId, userId],

--- a/backend-api/server.ts
+++ b/backend-api/server.ts
@@ -29,12 +29,16 @@ const { getBootstrapAdminSeedConfig } = require("./bootstrapAdmin");
 const { ensureFirstRegisteredUserIsAdmin } = require("./ensureAdminUser");
 const { authenticateToken } = require("./middleware/auth");
 const { correlationId, errorHandler } = require("./middleware/errorHandler");
-const { createGatewayRouter, attachGatewayWS } = require("./gatewayProxy");
+const {
+  createGatewayRouter,
+  attachGatewayWS,
+  resolveSafeHermesDashboardTarget,
+} = require("./gatewayProxy");
 const { isGatewayAvailableStatus } = require("./agentStatus");
 const { repairHermesAgentConfig } = require("./hermesUi");
 const {
+  joinHttpUrl,
   gatewayUrlForAgent,
-  dashboardUrlForAgent,
   hasGatewayEndpoint,
   hasHermesDashboardEndpoint,
 } = require("../agent-runtime/lib/agentEndpoints");
@@ -907,7 +911,10 @@ async function proxyEmbeddedHermes(req, res) {
     if (!access) return;
 
     const hermesPath = getEmbeddedHermesPath(req);
-    const targetUrl = `${dashboardUrlForAgent(access.agent, hermesPath)}${buildForwardedSearch(req)}`;
+    // Validate + resolve the dashboard host against the gateway allowlist before
+    // connecting (closes the SSRF gap where runtime_host was reached unchecked).
+    const safeTarget = await resolveSafeHermesDashboardTarget(access.agent);
+    const targetUrl = `${joinHttpUrl(safeTarget.host, safeTarget.port, hermesPath)}${buildForwardedSearch(req)}`;
     const cookies = parseCookieHeader(req.headers.cookie || "");
     const dashboardTokenCookieName = getEmbedSessionCookieName(
       access.agentId,


### PR DESCRIPTION
## What

Closes an SSRF gap in the **Hermes dashboard embed proxy**. Previously
`proxyEmbeddedHermes` built its upstream URL straight from `dashboardUrlForAgent(agent)`,
which reads `agent.runtime_host`/`gateway_host` and connects with **no allowlist
check** — the only proxy path in the gateway that wasn't gated. Every other proxy
path (the HTTP gateway proxy, the RPC/WS paths) already routes through the
`isBlockedGatewayIP → isAllowedGatewayIP → resolveGatewayHostForProxy` allowlist.

This was surfaced while mapping the Hermes-on-remote reach work (BYOC Phase B2):
a malicious or corrupted `runtime_host` on a Hermes agent row could make the
backend issue requests to arbitrary internal addresses.

## How

- New `resolveSafeHermesDashboardTarget(agent)` in `gatewayProxy.ts` — the Hermes
  analogue of `resolveSafeGatewayHttpTarget`. It:
  1. resolves the dashboard address via `resolveHermesDashboardAddress`,
  2. runs the hard blocked-IP floor (`assertSafeAgentAddress`),
  3. enforces the port is `HERMES_DASHBOARD_PORT` or an allowed published gateway port,
  4. resolves the host against the **owner-scoped** allowlist
     (`allowedGatewayHostsForAgent` → registered remote host for the agent's own user,
     k8s provisioned exposure, or docker published host).
- `server.ts proxyEmbeddedHermes` now awaits `resolveSafeHermesDashboardTarget`
  and builds the URL from the validated host/port via `joinHttpUrl` (exported from
  `agentEndpoints.ts`). Removed the now-unused `dashboardUrlForAgent` import.

## Tests

Adds a `hermes dashboard embed-proxy allowlist (SSRF)` suite to
`remoteHostGatewayAllowlist.test.ts` (4 cases):
- local RFC1918 dashboard host allowed,
- public `runtime_host` blocked (the SSRF guard),
- remote Hermes agent's own registered host allowed (owner-scoped),
- a remote host registered by a **different** operator rejected.

Full backend suite green (1096 tests); agent-runtime + backend-api typecheck,
eslint, and prettier all clean.

## Scope note

This is the security half of BYOC B2c. The follow-up (B2c-2) will **persist/publish
the remote Hermes dashboard port** so the remote dashboard UI loads end-to-end —
today a remote Hermes agent's dashboard address resolves to the default port. This
PR is standalone-valuable and safe to merge independently.
