### PR TITLE
fix(gateway): SSRF allowlist on the OpenClaw embed + asset proxies (BYOC B2c)

### DIFF
--- a/backend-api/__tests__/controlPlane.test.ts
+++ b/backend-api/__tests__/controlPlane.test.ts
@@ -705,10 +705,17 @@ describe("gateway control-plane embed", () => {
       .set("Accept", "text/html");
 
     expect(res.status).toBe(200);
+    // The embed proxy now routes through the SSRF allowlist: it connects to the
+    // validated host and sets the upstream Host header (10.0.0.10 is RFC1918, so
+    // the resolved address is the IP itself). Root path normalizes to a trailing /.
     expect(global.fetch).toHaveBeenCalledWith(
-      "http://10.0.0.10:18789",
+      "http://10.0.0.10:18789/",
       expect.objectContaining({
-        headers: expect.objectContaining({ Accept: "text/html", "Accept-Encoding": "identity" }),
+        headers: expect.objectContaining({
+          Accept: "text/html",
+          "Accept-Encoding": "identity",
+          Host: "10.0.0.10:18789",
+        }),
       }),
     );
     expect(res.text).toContain('<base href="/api/agents/agent-1/gateway/embed/">');
@@ -760,42 +767,15 @@ describe("gateway control-plane embed", () => {
   });
 
   it("uses the published gateway host port when one is recorded", async () => {
-    process.env.GATEWAY_HOST = "gateway.internal";
+    // GATEWAY_HOST is the operator-configured published host; it must be on the
+    // allowlist (RFC1918 here) for the embed proxy to reach it.
+    process.env.GATEWAY_HOST = "10.10.0.5";
     mockDb.query.mockResolvedValueOnce({
       rows: [
         {
           host: "10.0.0.10",
           gateway_token: "gateway-password",
           gateway_host_port: 19123,
-          status: "running",
-        },
-      ],
-    });
-    global.fetch.mockResolvedValue({
-      ok: true,
-      status: 200,
-      headers: new Headers({ "content-type": "text/html; charset=utf-8" }),
-      text: async () => "<html><head></head><body>ok</body></html>",
-    });
-
-    const res = await request(app)
-      .get(`/agents/agent-1/gateway/embed?token=${encodeURIComponent(token)}`)
-      .set("Host", "nora.test")
-      .set("Accept", "text/html");
-
-    expect(res.status).toBe(200);
-    expect(global.fetch).toHaveBeenCalledWith("http://gateway.internal:19123", expect.any(Object));
-  });
-
-  it("prefers explicit gateway host and port when the backend provides them", async () => {
-    mockDb.query.mockResolvedValueOnce({
-      rows: [
-        {
-          host: "10.0.0.10",
-          gateway_token: "gateway-password",
-          gateway_host_port: 19123,
-          gateway_host: "gateway.service.internal",
-          gateway_port: 28789,
           status: "running",
         },
       ],
@@ -814,8 +794,45 @@ describe("gateway control-plane embed", () => {
 
     expect(res.status).toBe(200);
     expect(global.fetch).toHaveBeenCalledWith(
-      "http://gateway.service.internal:28789",
-      expect.any(Object),
+      "http://10.10.0.5:19123/",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Host: "10.10.0.5:19123" }),
+      }),
+    );
+  });
+
+  it("prefers explicit gateway host and port when the backend provides them", async () => {
+    mockDb.query.mockResolvedValueOnce({
+      rows: [
+        {
+          host: "10.0.0.10",
+          gateway_token: "gateway-password",
+          gateway_host_port: 19123,
+          gateway_host: "10.0.0.20",
+          gateway_port: 19500,
+          status: "running",
+        },
+      ],
+    });
+    global.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: new Headers({ "content-type": "text/html; charset=utf-8" }),
+      text: async () => "<html><head></head><body>ok</body></html>",
+    });
+
+    const res = await request(app)
+      .get(`/agents/agent-1/gateway/embed?token=${encodeURIComponent(token)}`)
+      .set("Host", "nora.test")
+      .set("Accept", "text/html");
+
+    expect(res.status).toBe(200);
+    // Explicit gateway_host + gateway_port win over host/published port.
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://10.0.0.20:19500/",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Host: "10.0.0.20:19500" }),
+      }),
     );
   });
 
@@ -826,7 +843,7 @@ describe("gateway control-plane embed", () => {
           host: "10.0.0.10",
           gateway_token: "gateway-password",
           gateway_host_port: 19123,
-          gateway_host: "nora-kind-control-plane",
+          gateway_host: "10.0.0.30",
           status: "running",
         },
       ],
@@ -844,13 +861,17 @@ describe("gateway control-plane embed", () => {
       .set("Accept", "text/html");
 
     expect(res.status).toBe(200);
+    // Explicit gateway_host wins; it is paired with the published host port.
     expect(global.fetch).toHaveBeenCalledWith(
-      "http://nora-kind-control-plane:19123",
-      expect.any(Object),
+      "http://10.0.0.30:19123/",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Host: "10.0.0.30:19123" }),
+      }),
     );
   });
 
   it("allows embed for warning agents so degraded control-plane recovery still works", async () => {
+    process.env.GATEWAY_HOST = "10.10.0.5";
     mockDb.query.mockResolvedValueOnce({
       rows: [
         {
@@ -875,8 +896,10 @@ describe("gateway control-plane embed", () => {
 
     expect(res.status).toBe(200);
     expect(global.fetch).toHaveBeenCalledWith(
-      "http://host.docker.internal:19123",
-      expect.any(Object),
+      "http://10.10.0.5:19123/",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Host: "10.10.0.5:19123" }),
+      }),
     );
   });
 
@@ -920,7 +943,59 @@ describe("gateway control-plane embed", () => {
     expect(global.fetch).not.toHaveBeenCalled();
   });
 
+  it("rejects embed proxy access to a public (non-allowlisted) gateway host (SSRF guard)", async () => {
+    // A docker agent's own gateway host that is not RFC1918/loopback/publishedHost
+    // must not be reachable — the embed proxy enforces the same allowlist as the
+    // HTTP gateway proxy.
+    mockDb.query.mockResolvedValueOnce({
+      rows: [
+        {
+          host: "203.0.113.5",
+          gateway_token: "gateway-password",
+          gateway_host: "203.0.113.5",
+          gateway_port: 18789,
+          status: "running",
+          deploy_target: "docker",
+          execution_target_id: "docker",
+          user_id: "user-1",
+        },
+      ],
+    });
+
+    const res = await request(app)
+      .get(`/agents/agent-1/gateway/embed?token=${encodeURIComponent(token)}`)
+      .set("Host", "nora.test")
+      .set("Accept", "text/html");
+
+    expect(res.status).toBe(502);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("rejects asset proxy access to a public (non-allowlisted) gateway host (SSRF guard)", async () => {
+    mockDb.query.mockResolvedValueOnce({
+      rows: [
+        {
+          host: "203.0.113.5",
+          gateway_host: "203.0.113.5",
+          gateway_port: 18789,
+          status: "running",
+          deploy_target: "docker",
+          execution_target_id: "docker",
+          user_id: "user-1",
+        },
+      ],
+    });
+
+    const res = await request(app)
+      .get(`/agents/agent-1/gateway/assets/app.js?token=${encodeURIComponent(token)}`)
+      .set("Host", "nora.test");
+
+    expect(res.status).toBe(502);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
   it("allows asset proxy access for warning agents so degraded control-plane recovery still works", async () => {
+    process.env.GATEWAY_HOST = "10.10.0.5";
     mockDb.query.mockResolvedValueOnce({
       rows: [
         {
@@ -943,13 +1018,15 @@ describe("gateway control-plane embed", () => {
 
     expect(res.status).toBe(200);
     expect(global.fetch).toHaveBeenCalledWith(
-      "http://host.docker.internal:19123/assets/app.js",
-      expect.any(Object),
+      "http://10.10.0.5:19123/assets/app.js",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Host: "10.10.0.5:19123" }),
+      }),
     );
   });
 
   it("uses GATEWAY_HOST for asset proxy access when a published gateway port is recorded", async () => {
-    process.env.GATEWAY_HOST = "gateway.external";
+    process.env.GATEWAY_HOST = "10.10.0.5";
     mockDb.query.mockResolvedValueOnce({
       rows: [
         {
@@ -972,8 +1049,10 @@ describe("gateway control-plane embed", () => {
 
     expect(res.status).toBe(200);
     expect(global.fetch).toHaveBeenCalledWith(
-      "http://gateway.external:19123/assets/app.js",
-      expect.any(Object),
+      "http://10.10.0.5:19123/assets/app.js",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Host: "10.10.0.5:19123" }),
+      }),
     );
   });
 

--- a/backend-api/__tests__/embedAgentColumns.test.ts
+++ b/backend-api/__tests__/embedAgentColumns.test.ts
@@ -43,6 +43,15 @@ describe("embed-proxy agent SELECT columns", () => {
     }
   });
 
+  it("gateway embed lookup also loads the SSRF-authorizing fields (both embed proxies are guarded)", () => {
+    // proxyEmbeddedGateway + proxyGatewayAsset route through
+    // resolveSafeGatewayHttpTarget, so the gateway embed lookup needs the same
+    // owner-scoping / routing fields the Hermes path does.
+    for (const col of ["deploy_target", "execution_target_id", "user_id", "runtime_host"]) {
+      expect(GATEWAY_EMBED_AGENT_COLUMNS).toContain(col);
+    }
+  });
+
   it("exposes plain string column names (safe to interpolate into the SELECT)", () => {
     for (const col of [...HERMES_EMBED_AGENT_COLUMNS, ...GATEWAY_EMBED_AGENT_COLUMNS]) {
       expect(typeof col).toBe("string");

--- a/backend-api/embedAgentColumns.ts
+++ b/backend-api/embedAgentColumns.ts
@@ -36,10 +36,11 @@ const HERMES_EMBED_AGENT_COLUMNS = [
   "gateway_port",
 ];
 
-// OpenClaw gateway embed proxy (server.ts proxyEmbeddedGateway). The SSRF
-// allowlist is not yet wired into this path; the deploy_target/execution_target_id/
-// user_id fields will be added here when it is (so the same owner-scoped policy
-// applies), mirroring HERMES_EMBED_AGENT_COLUMNS.
+// OpenClaw gateway embed proxies (server.ts proxyEmbeddedGateway +
+// proxyGatewayAsset). These route through resolveSafeGatewayHttpTarget, so they
+// need the same SSRF-authorizing fields as the Hermes path (deploy_target /
+// execution_target_id / user_id for owner-scoped remote-docker, runtime_host for
+// the k8s exposure set), plus gateway_token for the embed bootstrap script.
 const GATEWAY_EMBED_AGENT_COLUMNS = [
   "host",
   "gateway_token",
@@ -47,6 +48,11 @@ const GATEWAY_EMBED_AGENT_COLUMNS = [
   "gateway_host",
   "gateway_port",
   "status",
+  "runtime_host",
+  "runtime_family",
+  "deploy_target",
+  "execution_target_id",
+  "user_id",
 ];
 
 module.exports = { HERMES_EMBED_AGENT_COLUMNS, GATEWAY_EMBED_AGENT_COLUMNS };

--- a/backend-api/gatewayProxy.ts
+++ b/backend-api/gatewayProxy.ts
@@ -247,6 +247,13 @@ async function resolveSafeGatewayHttpTarget(agent, gatewayPath = "", search = ""
     "agent gateway",
     extraAllowedHosts,
   );
+  // The connection is pinned to the validated, resolved IP (no re-resolution at
+  // fetch time, so no DNS-rebinding window). The Host header intentionally keeps
+  // the operator-configured hostname, not the resolved IP: a gateway reached
+  // through a vhost/ingress that routes by Host needs the hostname to land on the
+  // right backend. addr.host is already syntactically validated by
+  // assertSafeAgentAddress, and it cannot redirect the connection (the URL holds
+  // the IP), so this is not an SSRF vector.
   const targetUrl = new URL(`http://${hostForUrl(resolvedHost)}:${addr.port}/`);
   const cleanPath = normalizeProxyPath(gatewayPath);
   targetUrl.pathname = cleanPath ? `/${cleanPath}` : "/";

--- a/backend-api/server.ts
+++ b/backend-api/server.ts
@@ -32,6 +32,7 @@ const { correlationId, errorHandler } = require("./middleware/errorHandler");
 const {
   createGatewayRouter,
   attachGatewayWS,
+  resolveSafeGatewayHttpTarget,
   resolveSafeHermesDashboardTarget,
 } = require("./gatewayProxy");
 const { isGatewayAvailableStatus } = require("./agentStatus");
@@ -39,7 +40,6 @@ const { repairHermesAgentConfig } = require("./hermesUi");
 const { HERMES_EMBED_AGENT_COLUMNS, GATEWAY_EMBED_AGENT_COLUMNS } = require("./embedAgentColumns");
 const {
   joinHttpUrl,
-  gatewayUrlForAgent,
   hasGatewayEndpoint,
   hasHermesDashboardEndpoint,
 } = require("../agent-runtime/lib/agentEndpoints");
@@ -850,10 +850,19 @@ async function proxyEmbeddedGateway(req, res) {
     if (!access) return;
 
     const gatewayPath = getEmbeddedGatewayPath(req);
-    const targetUrl = `${gatewayUrlForAgent(access.agent, gatewayPath)}${buildForwardedSearch(req)}`;
+    // Validate + resolve the gateway host against the SSRF allowlist before
+    // connecting (mirrors the HTTP gateway proxy; closes the embed-proxy SSRF
+    // gap where gatewayUrlForAgent reached the agent host unchecked).
+    const safeTarget = await resolveSafeGatewayHttpTarget(
+      access.agent,
+      gatewayPath,
+      buildForwardedSearch(req),
+    );
+    const targetUrl = safeTarget.url;
     const headers = {
       Accept: req.headers.accept || "*/*",
       "Accept-Encoding": "identity",
+      Host: safeTarget.hostHeader,
     };
 
     const method = req.method.toUpperCase();
@@ -1050,10 +1059,20 @@ async function proxyGatewayAsset(req, res) {
     if (!access) return;
 
     const gatewayPath = req.path || "/";
-    const targetUrl = `${gatewayUrlForAgent(access.agent, gatewayPath)}${buildForwardedSearch(req)}`;
-    const resp = await fetch(targetUrl, {
+    // Same SSRF allowlist as the embed proxy — gateway asset/favicon fetches must
+    // not reach an unvalidated agent host either.
+    const safeTarget = await resolveSafeGatewayHttpTarget(
+      access.agent,
+      gatewayPath,
+      buildForwardedSearch(req),
+    );
+    const resp = await fetch(safeTarget.url, {
       method: req.method,
-      headers: { Accept: req.headers.accept || "*/*", "Accept-Encoding": "identity" },
+      headers: {
+        Accept: req.headers.accept || "*/*",
+        "Accept-Encoding": "identity",
+        Host: safeTarget.hostHeader,
+      },
       signal: AbortSignal.timeout(10000),
     });
     res.status(resp.status);


### PR DESCRIPTION
## What

Follow-up to #207. That PR closed the SSRF gap in the **Hermes** dashboard embed proxy. While verifying it, the adversarial review surfaced that the two **OpenClaw** embed paths still had the identical gap — and OpenClaw is the *default* family, so this is the primary chat-embed path:

- `proxyEmbeddedGateway` (the gateway UI embed) and
- `proxyGatewayAsset` (gateway asset/favicon proxy)

both built their upstream URL via the unchecked `gatewayUrlForAgent(agent, …)`, reaching the agent's recorded gateway host with **no allowlist check**. The HTTP gateway proxy (`createGatewayRouter`) already routes through `resolveSafeGatewayHttpTarget`; these embed paths bypassed it.

## How

- Route both embed paths through **`resolveSafeGatewayHttpTarget`** — the same resolver the HTTP gateway proxy uses: hard blocked-IP floor (`assertSafeAgentAddress`) → port allowlist (`isAllowedGatewayPort`) → owner-scoped host allowlist (`allowedGatewayHostsForAgent`: RFC1918/loopback, the agent's own registered remote host, k8s provisioned exposure, or the operator's published host), then connect to the **validated/resolved IP** with the original `Host` header.
- Expand `GATEWAY_EMBED_AGENT_COLUMNS` (`embedAgentColumns.ts`) so the embed lookup loads the SSRF-authorizing fields — `deploy_target`, `execution_target_id`, `user_id`, `runtime_host` — mirroring the Hermes fix in #207. (Same class of bug as #207's HIGH finding: a resolver that authorizes on fields the lookup didn't load.)
- Remove the now-unused `gatewayUrlForAgent` import from `server.ts`.

## Tests

- Updated the gateway embed/asset route tests in `controlPlane.test.ts` to the **validated** behavior: connect to the resolved host with a `Host: host:port` header, trailing-slash root URLs (WHATWG `URL` normalization), and allowlisted ports. The test intents (explicit host wins, published-port path, GATEWAY_HOST usage, warning-status allowed) are preserved with RFC1918 hosts — mirroring the HTTP-proxy suite's convention.
- Added two **SSRF-rejection** tests: a public gateway host on the embed proxy and on the asset proxy each return 502 with `fetch` never called.
- Extended the `embedAgentColumns` contract test to assert the gateway list now carries the SSRF fields.

Backend suite **1108 green**; backend-api + worker typecheck, eslint, prettier clean.

## Scope

This completes the embed-proxy SSRF hardening for both runtime families. Remaining tracked follow-ups: `fetchHermesDashboard`/`fetchHermesApi` in `routes/agents.ts` (pre-existing, lower-reach — auth+owner gated, no client-forwarded path/query), and **B2c-2** (persist/publish the remote Hermes dashboard port for end-to-end remote reach).
