### PR TITLE
feat(remote-hermes): publish + persist the dashboard port for remote reach (BYOC B2c-2)

### DIFF
--- a/backend-api/__tests__/agentEndpoints.test.ts
+++ b/backend-api/__tests__/agentEndpoints.test.ts
@@ -52,4 +52,17 @@ describe("resolveHermesDashboardAddress", () => {
       }),
     ).toEqual({ host: "10.0.0.7", port: 9119 });
   });
+
+  it("uses the persisted dashboard_port for a remote agent (published host port)", () => {
+    // Remote Hermes advertises runtime_host = the remote machine and persists the
+    // published dashboard host port in dashboard_port (B2c-2). No gateway_host is
+    // set, so the docker-family branch resolves {runtime_host, dashboard_port}.
+    expect(
+      resolveHermesDashboardAddress({
+        runtime_family: "hermes",
+        runtime_host: "laptop.tail-scale.ts.net",
+        dashboard_port: 19044,
+      }),
+    ).toEqual({ host: "laptop.tail-scale.ts.net", port: 19044 });
+  });
 });

--- a/backend-api/__tests__/embedAgentColumns.test.ts
+++ b/backend-api/__tests__/embedAgentColumns.test.ts
@@ -29,6 +29,9 @@ describe("embed-proxy agent SELECT columns", () => {
     // status + runtime_family gate availability / dashboard detection.
     expect(HERMES_EMBED_AGENT_COLUMNS).toContain("status");
     expect(HERMES_EMBED_AGENT_COLUMNS).toContain("runtime_family");
+    // dashboard_port carries the remote published dashboard host port; without it
+    // resolveHermesDashboardAddress targets the in-container 9119 on the remote host.
+    expect(HERMES_EMBED_AGENT_COLUMNS).toContain("dashboard_port");
   });
 
   it("gateway embed lookup loads the gateway endpoint fields", () => {

--- a/backend-api/__tests__/portAllocations.test.ts
+++ b/backend-api/__tests__/portAllocations.test.ts
@@ -7,6 +7,8 @@ const {
   releaseGatewayPort,
   getGatewayPortAllocation,
   LOCAL_HOST_KEY,
+  GATEWAY_PORT_PURPOSE,
+  DASHBOARD_PORT_PURPOSE,
 } = require("../portAllocations");
 
 // Route db.query on SQL shape. `insert` is an array of responses consumed in
@@ -77,6 +79,50 @@ describe("allocateGatewayPort", () => {
   it("requires an agentId", async () => {
     fakeDb();
     await expect(allocateGatewayPort({ hostKey: "local" })).rejects.toThrow(/agentId/i);
+  });
+
+  it("defaults the purpose to the gateway slot", async () => {
+    const { calls } = fakeDb({ existing: [], insertResponses: [{ rows: [{ port: 19000 }] }] });
+    await allocateGatewayPort({ hostKey: "remote:my-vps", agentId: "a6" });
+    const select = calls.find((c) =>
+      c.sql.includes("SELECT port FROM gateway_port_allocations WHERE agent_id"),
+    );
+    const insert = calls.find((c) => c.sql.includes("INSERT INTO gateway_port_allocations"));
+    expect(select.params[2]).toBe(GATEWAY_PORT_PURPOSE);
+    expect(insert.params[4]).toBe(GATEWAY_PORT_PURPOSE);
+  });
+
+  it("scopes the lookup + claim by purpose so a second slot gets its own port", async () => {
+    // 'gateway' is already taken at 19000; a 'dashboard' allocation for the SAME
+    // agent + host must look up its own purpose row (none yet) and claim a
+    // different free port — the NOT EXISTS spans all purposes on the host.
+    const { calls } = fakeDb({ existing: [], insertResponses: [{ rows: [{ port: 19001 }] }] });
+    const port = await allocateGatewayPort({
+      hostKey: "remote:my-vps",
+      agentId: "a7",
+      purpose: DASHBOARD_PORT_PURPOSE,
+    });
+    expect(port).toBe(19001);
+    const select = calls.find((c) =>
+      c.sql.includes("SELECT port FROM gateway_port_allocations WHERE agent_id"),
+    );
+    const insert = calls.find((c) => c.sql.includes("INSERT INTO gateway_port_allocations"));
+    expect(select.params).toEqual(["a7", "remote:my-vps", DASHBOARD_PORT_PURPOSE]);
+    expect(insert.params[4]).toBe(DASHBOARD_PORT_PURPOSE);
+    // The free-port scan spans the whole host (no purpose filter), so a second
+    // purpose can't land on a port another purpose already holds there.
+    expect(insert.sql).toContain("existing.host_key = $1 AND existing.port = candidate.port");
+  });
+
+  it("reuses an existing same-purpose allocation (idempotent per purpose)", async () => {
+    const { calls } = fakeDb({ existing: [{ port: 19500 }] });
+    const port = await allocateGatewayPort({
+      hostKey: "remote:my-vps",
+      agentId: "a8",
+      purpose: DASHBOARD_PORT_PURPOSE,
+    });
+    expect(port).toBe(19500);
+    expect(calls.some((c) => c.sql.includes("INSERT INTO gateway_port_allocations"))).toBe(false);
   });
 });
 

--- a/backend-api/__tests__/remoteHermes.test.ts
+++ b/backend-api/__tests__/remoteHermes.test.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 const RemoteHermesBackend = require("../../workers/provisioner/backends/remote-hermes");
 const HermesBackend = require("../../workers/provisioner/backends/hermes");
-const { HERMES_RUNTIME_PORT } = require("../../agent-runtime/lib/contracts");
+const { HERMES_RUNTIME_PORT, HERMES_DASHBOARD_PORT } = require("../../agent-runtime/lib/contracts");
 
 function hermesProfile(overrides = {}) {
   return {
@@ -47,11 +47,31 @@ describe("RemoteHermesBackend construction", () => {
   });
 });
 
-describe("RemoteHermesBackend runtime-port publishing", () => {
-  it("publishes the Hermes runtime port (the readiness target) on the allocated host port", () => {
+describe("RemoteHermesBackend port publishing", () => {
+  it("publishes BOTH the runtime port (readiness) and the dashboard port (UI) on their host ports", () => {
     const backend = new RemoteHermesBackend(hermesProfile());
-    const bindings = backend._hermesPortBindings({ gatewayHostPort: 19500 });
-    expect(bindings).toEqual({ [`${HERMES_RUNTIME_PORT}/tcp`]: [{ HostPort: "19500" }] });
+    const bindings = backend._hermesPortBindings({
+      gatewayHostPort: 19500,
+      dashboardHostPort: 19044,
+    });
+    expect(bindings).toEqual({
+      [`${HERMES_RUNTIME_PORT}/tcp`]: [{ HostPort: "19500" }],
+      [`${HERMES_DASHBOARD_PORT}/tcp`]: [{ HostPort: "19044" }],
+    });
+  });
+
+  it("publishes only the runtime port when no dashboard port is allocated", () => {
+    const backend = new RemoteHermesBackend(hermesProfile());
+    expect(backend._hermesPortBindings({ gatewayHostPort: 19500 })).toEqual({
+      [`${HERMES_RUNTIME_PORT}/tcp`]: [{ HostPort: "19500" }],
+    });
+  });
+
+  it("publishes only the dashboard port when no runtime port is allocated", () => {
+    const backend = new RemoteHermesBackend(hermesProfile());
+    expect(backend._hermesPortBindings({ dashboardHostPort: 19044 })).toEqual({
+      [`${HERMES_DASHBOARD_PORT}/tcp`]: [{ HostPort: "19044" }],
+    });
   });
 
   it("publishes nothing when no host port is allocated", () => {
@@ -70,7 +90,7 @@ describe("RemoteHermesBackend runtime-port publishing", () => {
 describe("RemoteHermesBackend.create", () => {
   afterEach(() => jest.restoreAllMocks());
 
-  it("advertises the remote host address + published dashboard port", async () => {
+  it("advertises the remote host address + published runtime and dashboard ports", async () => {
     jest.spyOn(HermesBackend.prototype, "create").mockResolvedValue({
       containerId: "nora-hermes-x",
       containerName: "nora-hermes-x",
@@ -81,13 +101,33 @@ describe("RemoteHermesBackend.create", () => {
     });
     const backend = new RemoteHermesBackend(hermesProfile());
 
-    const result = await backend.create({ id: "x", name: "Hermes QA", gatewayHostPort: 19500 });
+    const result = await backend.create({
+      id: "x",
+      name: "Hermes QA",
+      gatewayHostPort: 19500,
+      dashboardHostPort: 19044,
+    });
 
     expect(result.host).toBe("laptop.tail-scale.ts.net");
     expect(result.runtimeHost).toBe("laptop.tail-scale.ts.net");
     // runtime_port is the published host port so readiness reaches /health
     expect(result.runtimePort).toBe(19500);
+    // dashboard_port is the published host port so the embed proxy resolves the UI
+    expect(result.dashboardPort).toBe(19044);
     expect(result.containerId).toBe("nora-hermes-x");
+  });
+
+  it("reports a null dashboard port when none was allocated", async () => {
+    jest.spyOn(HermesBackend.prototype, "create").mockResolvedValue({
+      containerId: "c",
+      containerName: "c",
+      host: "172.18.0.9",
+      runtimeHost: "172.18.0.9",
+      runtimePort: 8642,
+    });
+    const backend = new RemoteHermesBackend(hermesProfile());
+    const result = await backend.create({ id: "x", gatewayHostPort: 19500 });
+    expect(result.dashboardPort).toBeNull();
   });
 
   it("falls back to the SSH host when no advertised gateway host is set", async () => {

--- a/backend-api/__tests__/remoteHostGatewayAllowlist.test.ts
+++ b/backend-api/__tests__/remoteHostGatewayAllowlist.test.ts
@@ -189,13 +189,14 @@ describe("hermes dashboard embed-proxy allowlist (SSRF)", () => {
       deploy_target: "remote-docker",
       execution_target_id: "remote:my-vps",
       runtime_host: PUBLIC_IP,
-      // dashboard_port is not yet persisted for remote (B2c-2), so the dashboard
-      // address resolves to the default Hermes port; the SSRF allowance is what
-      // this test verifies — the registered host's address is trusted.
-      dashboard_port: 9119,
+      // B2c-2: the remote dashboard is published on its own host port (in the
+      // gateway range) and persisted in dashboard_port. The embed proxy resolves
+      // {runtime_host, dashboard_port} and the owner-scoped registered host is
+      // trusted by the allowlist.
+      dashboard_port: 19044,
     };
     const target = await resolveSafeHermesDashboardTarget(agent);
-    expect(target).toEqual({ host: PUBLIC_IP, port: 9119 });
+    expect(target).toEqual({ host: PUBLIC_IP, port: 19044 });
   });
 
   it("does not trust a remote Hermes host registered by another operator", async () => {

--- a/backend-api/db_schema.sql
+++ b/backend-api/db_schema.sql
@@ -36,6 +36,7 @@ CREATE TABLE IF NOT EXISTS agents (
   gateway_host TEXT,
   gateway_port INTEGER,
   gateway_host_port INTEGER,
+  dashboard_port INTEGER,
   gateway_token TEXT,
   container_id TEXT,
   container_name TEXT,
@@ -113,6 +114,10 @@ CREATE TABLE IF NOT EXISTS gateway_port_allocations (
   host_key TEXT NOT NULL,
   agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
   port INTEGER NOT NULL,
+  -- Which published port this row holds for the agent on host_key. Lets one
+  -- agent reserve several collision-safe ports on the same physical host
+  -- (e.g. remote Hermes: 'gateway' = runtime API 8642, 'dashboard' = UI 9119).
+  purpose TEXT NOT NULL DEFAULT 'gateway',
   created_at TIMESTAMPTZ DEFAULT NOW(),
   UNIQUE(host_key, port)
 );

--- a/backend-api/embedAgentColumns.ts
+++ b/backend-api/embedAgentColumns.ts
@@ -34,6 +34,10 @@ const HERMES_EMBED_AGENT_COLUMNS = [
   "user_id",
   "gateway_host",
   "gateway_port",
+  // The remote Hermes dashboard is published on its own host port, persisted here;
+  // resolveHermesDashboardAddress reads it (falls back to 9119 for local). Without
+  // it the embed proxy would target the in-container 9119 on the remote address.
+  "dashboard_port",
 ];
 
 // OpenClaw gateway embed proxies (server.ts proxyEmbeddedGateway +

--- a/backend-api/portAllocations.ts
+++ b/backend-api/portAllocations.ts
@@ -17,12 +17,26 @@ const DEFAULT_RANGE_MIN = 19000;
 const DEFAULT_RANGE_MAX = 19999;
 const LOCAL_HOST_KEY = "local";
 const MAX_RACE_RETRIES = 5;
+// A purpose lets one agent reserve more than one published port on the SAME
+// physical host (host_key). Port uniqueness stays per-host (UNIQUE(host_key,
+// port)), so a second purpose never collides with the first on that machine.
+//   - GATEWAY: the primary published port (OpenClaw gateway / Hermes runtime API).
+//   - DASHBOARD: the Hermes dashboard UI port, published only for remote hosts.
+const GATEWAY_PORT_PURPOSE = "gateway";
+const DASHBOARD_PORT_PURPOSE = "dashboard";
 
 function normalizeHostKey(value) {
   const key = String(value || "")
     .trim()
     .toLowerCase();
   return key || LOCAL_HOST_KEY;
+}
+
+function normalizePurpose(value) {
+  const purpose = String(value || "")
+    .trim()
+    .toLowerCase();
+  return purpose || GATEWAY_PORT_PURPOSE;
 }
 
 async function getGatewayPortAllocation(agentId) {
@@ -45,27 +59,31 @@ async function getGatewayPortAllocation(agentId) {
 async function allocateGatewayPort({
   hostKey,
   agentId,
+  purpose = GATEWAY_PORT_PURPOSE,
   rangeMin = DEFAULT_RANGE_MIN,
   rangeMax = DEFAULT_RANGE_MAX,
 } = {}) {
   if (!agentId) throw new Error("agentId is required to allocate a gateway port");
   const key = normalizeHostKey(hostKey);
+  const slot = normalizePurpose(purpose);
 
-  // Idempotent: an agent keeps its port across redeploys on the same host.
+  // Idempotent per (agent, host, purpose): a redeploy keeps the same port, and a
+  // second purpose on the same host gets its own row rather than reusing the first.
   const existing = await db.query(
-    "SELECT port FROM gateway_port_allocations WHERE agent_id = $1 AND host_key = $2",
-    [agentId, key],
+    "SELECT port FROM gateway_port_allocations WHERE agent_id = $1 AND host_key = $2 AND purpose = $3",
+    [agentId, key, slot],
   );
   if (existing.rows[0]) return existing.rows[0].port;
 
   for (let attempt = 0; attempt < MAX_RACE_RETRIES; attempt++) {
     try {
-      // Claim the lowest free port for this host in one statement. The
-      // UNIQUE(host_key, port) constraint makes concurrent claims race-safe:
-      // the loser hits a unique violation and retries against the new state.
+      // Claim the lowest free port for this host in one statement. The NOT EXISTS
+      // scans ALL purposes on the host so a second purpose never lands on a port
+      // already held by another, and UNIQUE(host_key, port) makes concurrent
+      // claims race-safe: the loser hits a unique violation and retries.
       const result = await db.query(
-        `INSERT INTO gateway_port_allocations (host_key, agent_id, port)
-         SELECT $1, $2, candidate.port
+        `INSERT INTO gateway_port_allocations (host_key, agent_id, port, purpose)
+         SELECT $1, $2, candidate.port, $5
            FROM generate_series($3, $4) AS candidate(port)
           WHERE NOT EXISTS (
             SELECT 1 FROM gateway_port_allocations existing
@@ -74,7 +92,7 @@ async function allocateGatewayPort({
           ORDER BY candidate.port
           LIMIT 1
          RETURNING port`,
-        [key, agentId, rangeMin, rangeMax],
+        [key, agentId, rangeMin, rangeMax, slot],
       );
       if (result.rows[0]) return result.rows[0].port;
       // No row inserted → every port in the range is taken on this host.
@@ -109,6 +127,8 @@ module.exports = {
   LOCAL_HOST_KEY,
   DEFAULT_RANGE_MIN,
   DEFAULT_RANGE_MAX,
+  GATEWAY_PORT_PURPOSE,
+  DASHBOARD_PORT_PURPOSE,
   allocateGatewayPort,
   releaseGatewayPort,
   getGatewayPortAllocation,

--- a/backend-api/server.ts
+++ b/backend-api/server.ts
@@ -1359,11 +1359,16 @@ async function migrateDB() {
        host_key TEXT NOT NULL,
        agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
        port INTEGER NOT NULL,
+       purpose TEXT NOT NULL DEFAULT 'gateway',
        created_at TIMESTAMPTZ DEFAULT NOW(),
        UNIQUE(host_key, port)
      )`,
     `CREATE INDEX IF NOT EXISTS idx_gateway_port_allocations_agent
        ON gateway_port_allocations(agent_id)`,
+    `DO $$ BEGIN
+       ALTER TABLE gateway_port_allocations ADD COLUMN purpose TEXT NOT NULL DEFAULT 'gateway';
+     EXCEPTION WHEN duplicate_column THEN NULL;
+     END $$`,
     `DO $$ BEGIN ALTER TABLE agents ADD COLUMN vcpu INTEGER DEFAULT 1; EXCEPTION WHEN duplicate_column THEN NULL; END $$`,
     `DO $$ BEGIN ALTER TABLE agents ADD COLUMN ram_mb INTEGER DEFAULT 1024; EXCEPTION WHEN duplicate_column THEN NULL; END $$`,
     `DO $$ BEGIN ALTER TABLE agents ADD COLUMN disk_gb INTEGER DEFAULT 10; EXCEPTION WHEN duplicate_column THEN NULL; END $$`,
@@ -1823,6 +1828,10 @@ async function migrateDB() {
      END $$`,
     `DO $$ BEGIN
        ALTER TABLE agents ADD COLUMN mcp_servers JSONB DEFAULT '[]';
+     EXCEPTION WHEN duplicate_column THEN NULL;
+     END $$`,
+    `DO $$ BEGIN
+       ALTER TABLE agents ADD COLUMN dashboard_port INTEGER;
      EXCEPTION WHEN duplicate_column THEN NULL;
      END $$`,
     `DO $$ BEGIN

--- a/infra/helm/nora/files/db_schema.sql
+++ b/infra/helm/nora/files/db_schema.sql
@@ -36,6 +36,7 @@ CREATE TABLE IF NOT EXISTS agents (
   gateway_host TEXT,
   gateway_port INTEGER,
   gateway_host_port INTEGER,
+  dashboard_port INTEGER,
   gateway_token TEXT,
   container_id TEXT,
   container_name TEXT,
@@ -113,6 +114,10 @@ CREATE TABLE IF NOT EXISTS gateway_port_allocations (
   host_key TEXT NOT NULL,
   agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
   port INTEGER NOT NULL,
+  -- Which published port this row holds for the agent on host_key. Lets one
+  -- agent reserve several collision-safe ports on the same physical host
+  -- (e.g. remote Hermes: 'gateway' = runtime API 8642, 'dashboard' = UI 9119).
+  purpose TEXT NOT NULL DEFAULT 'gateway',
   created_at TIMESTAMPTZ DEFAULT NOW(),
   UNIQUE(host_key, port)
 );

--- a/workers/provisioner/backends/remote-hermes.ts
+++ b/workers/provisioner/backends/remote-hermes.ts
@@ -8,18 +8,23 @@
 //   1. the dockerode client talks to the remote daemon over SSH;
 //   2. no Nora compose network (default bridge);
 //   3. the Hermes RUNTIME port (8642 — the API the post-deploy readiness probe
-//      hits at /health) is PUBLISHED on the remote host (local Hermes publishes
-//      nothing — it's reached via the container IP on the shared compose
-//      network, which isn't possible across SSH);
-//   4. create() advertises the remote machine's address + published runtime port
-//      so readiness passes and the control plane targets the remote host.
+//      hits at /health) AND the dashboard port (9119 — the embed UI) are both
+//      PUBLISHED on the remote host, each on its own worker-allocated host port
+//      (local Hermes publishes nothing — it's reached via the container IP on the
+//      shared compose network, which isn't possible across SSH);
+//   4. create() advertises the remote machine's address + the published runtime
+//      and dashboard ports so readiness passes, the control plane targets the
+//      remote host, and the dashboard embed proxy resolves the right address.
 //
-// The dashboard (9119) embed reach over remote — and its pre-existing SSRF gap —
-// is a separate pass (B2c); this PR makes Hermes deploy + stay healthy remotely.
+// The dashboard embed proxy enforces the SSRF allowlist (closed in #207/#208);
+// a remote agent's own registered host is owner-scoped-allowed there.
 
 const HermesBackend = require("./hermes");
 const { buildRemoteDockerOptions } = require("./remote-docker");
-const { HERMES_RUNTIME_PORT } = require("../../../agent-runtime/lib/contracts");
+const {
+  HERMES_RUNTIME_PORT,
+  HERMES_DASHBOARD_PORT,
+} = require("../../../agent-runtime/lib/contracts");
 
 class RemoteHermesBackend extends HermesBackend {
   constructor(profile = {}) {
@@ -57,27 +62,38 @@ class RemoteHermesBackend extends HermesBackend {
     return null;
   }
 
-  // Publish the Hermes RUNTIME port on the worker-allocated host port so the
-  // control-plane readiness probe ({runtime_host}:{runtime_port}/health) can
-  // reach it across the network. (The dashboard port is published by B2c.)
+  // Publish the Hermes RUNTIME port (readiness/API) and DASHBOARD port (embed UI)
+  // on their worker-allocated host ports so both are reachable across the network
+  // ({runtime_host}:{runtime_port}/health for readiness; the dashboard via its own
+  // published port). A missing/invalid allocation simply omits that binding.
   _hermesPortBindings(config) {
-    const port = Number(config?.gatewayHostPort);
-    if (!Number.isInteger(port) || port < 1 || port > 65535) return undefined;
-    return { [`${HERMES_RUNTIME_PORT}/tcp`]: [{ HostPort: String(port) }] };
+    const bindings = {};
+    const runtimePort = Number(config?.gatewayHostPort);
+    if (Number.isInteger(runtimePort) && runtimePort >= 1 && runtimePort <= 65535) {
+      bindings[`${HERMES_RUNTIME_PORT}/tcp`] = [{ HostPort: String(runtimePort) }];
+    }
+    const dashboardPort = Number(config?.dashboardHostPort);
+    if (Number.isInteger(dashboardPort) && dashboardPort >= 1 && dashboardPort <= 65535) {
+      bindings[`${HERMES_DASHBOARD_PORT}/tcp`] = [{ HostPort: String(dashboardPort) }];
+    }
+    return Object.keys(bindings).length ? bindings : undefined;
   }
 
   async create(config = {}) {
     const result = await super.create(config);
-    // Advertise the remote machine's address + the published runtime port so the
-    // control plane targets the remote host instead of the container's internal
-    // (unreachable) compose IP, and readiness probes the right address.
+    // Advertise the remote machine's address + the published runtime and dashboard
+    // ports so the control plane targets the remote host instead of the container's
+    // internal (unreachable) compose IP, readiness probes the right address, and the
+    // dashboard embed proxy resolves {runtime_host}:{dashboard_port}.
     const advertisedHost = this.profile.gatewayHost || this.profile.sshHost;
     const publishedRuntimePort = Number(config?.gatewayHostPort) || null;
+    const publishedDashboardPort = Number(config?.dashboardHostPort) || null;
     return {
       ...result,
       host: advertisedHost,
       runtimeHost: advertisedHost,
       runtimePort: publishedRuntimePort || result.runtimePort,
+      dashboardPort: publishedDashboardPort,
     };
   }
 }

--- a/workers/provisioner/worker.ts
+++ b/workers/provisioner/worker.ts
@@ -25,7 +25,11 @@ const {
 } = require("../../backend-api/hermesUi");
 const { getKubernetesClusterProfile } = require("../../backend-api/kubernetesClusters");
 const { getRemoteHostProfile } = require("../../backend-api/remoteHosts");
-const { allocateGatewayPort, LOCAL_HOST_KEY } = require("../../backend-api/portAllocations");
+const {
+  allocateGatewayPort,
+  LOCAL_HOST_KEY,
+  DASHBOARD_PORT_PURPOSE,
+} = require("../../backend-api/portAllocations");
 const {
   buildIntegrationSyncEntry,
   decryptSensitiveConfig,
@@ -1753,7 +1757,8 @@ const worker = new Worker(
         runtimeHost,
         runtimePort,
         gatewayHost,
-        gatewayPort;
+        gatewayPort,
+        dashboardPort;
       try {
         const abortController = new AbortController();
         let provisionTimeoutHandle = null;
@@ -1764,6 +1769,7 @@ const worker = new Worker(
         // agents (k8s/proxmox manage their own ports). Idempotent per agent+host,
         // so redeploys keep the same port; released via ON DELETE CASCADE.
         let allocatedGatewayPort;
+        let allocatedDashboardPort;
         {
           const deployTarget = resolvedRuntimeFields.deploy_target;
           const allocationHostKey =
@@ -1779,6 +1785,21 @@ const worker = new Worker(
               hostKey: allocationHostKey,
               agentId: id,
             });
+            // Remote Hermes needs a SECOND published host port for its dashboard
+            // UI (9119), distinct from the runtime API port (8642 = the 'gateway'
+            // slot used for the readiness probe). Local Hermes reaches the
+            // dashboard on the compose network (no host publish), and OpenClaw has
+            // no separate dashboard, so neither allocates this slot.
+            if (
+              deployTarget === "remote-docker" &&
+              resolvedRuntimeFields.runtime_family === "hermes"
+            ) {
+              allocatedDashboardPort = await allocateGatewayPort({
+                hostKey: allocationHostKey,
+                agentId: id,
+                purpose: DASHBOARD_PORT_PURPOSE,
+              });
+            }
           }
         }
         const createPromise = provisioner.create({
@@ -1790,6 +1811,7 @@ const worker = new Worker(
           disk_gb,
           container_name,
           gatewayHostPort: allocatedGatewayPort,
+          dashboardHostPort: allocatedDashboardPort,
           gatewayToken: agentRow.gateway_token || undefined,
           templatePayload,
           mcpServers: mcpServerEntries,
@@ -1844,6 +1866,7 @@ const worker = new Worker(
         runtimePort = result.runtimePort || null;
         gatewayHost = result.gatewayHost || null;
         gatewayPort = result.gatewayPort || null;
+        dashboardPort = result.dashboardPort || null;
 
         // Persist container_id immediately so that if the worker crashes or the
         // final status UPDATE fails below, the container can still be located
@@ -1948,6 +1971,7 @@ const worker = new Worker(
                 gateway_host_port: gatewayHostPort,
                 gateway_host: gatewayHost,
                 gateway_port: gatewayPort,
+                dashboard_port: dashboardPort,
               },
               persistedHermesState,
               { restart: true },
@@ -1997,7 +2021,8 @@ const worker = new Worker(
               deploy_target = $14,
               execution_target_id = $15,
               sandbox_profile = $16,
-              sandbox_type = $17
+              sandbox_type = $17,
+              dashboard_port = $18
         WHERE id = $1`,
           [
             id,
@@ -2017,6 +2042,7 @@ const worker = new Worker(
             resolvedRuntimeFields.execution_target_id,
             resolvedRuntimeFields.sandbox_profile,
             resolvedRuntimeFields.sandbox_type,
+            dashboardPort ? parseInt(dashboardPort, 10) : null,
           ],
         );
         await db.query("UPDATE deployments SET status = 'completed' WHERE agent_id = $1", [id]);


### PR DESCRIPTION
## What

Completes **BYOC B2c**: the remote Hermes **dashboard** UI now loads end-to-end. B2a (#206) published the Hermes *runtime* port (8642) on a remote host for the readiness probe, but the dashboard (9119) was never published or addressable — so the embed proxy resolved `{runtime_host}:9119`, the in-container port, which isn't reachable on the remote machine.

## How

- **Port allocation gains a `purpose` discriminator** (`portAllocations.ts` + additive column on `gateway_port_allocations`). One agent can now hold more than one collision-safe port on the *same physical host* (`host_key`). The free-port scan spans all purposes on the host and `UNIQUE(host_key, port)` is unchanged, so the `dashboard` slot never lands on the `gateway` (runtime) slot's port. A separate `host_key` would have broken per-host port uniqueness, so `purpose` is the correct seam. Idempotent per `(agent, host, purpose)` → stable across redeploys.
- **`RemoteHermesBackend`** publishes **both** `8642` (runtime/readiness) and `9119` (dashboard) on their own allocated host ports and advertises the published dashboard port. The worker allocates the second port **only for remote-docker Hermes** (local Hermes uses the compose network; OpenClaw has no separate dashboard) and persists it.
- **New additive `agents.dashboard_port`** column. `resolveHermesDashboardAddress` already reads it (the docker-family branch resolves `{runtime_host, dashboard_port}`); added to `HERMES_EMBED_AGENT_COLUMNS` so the embed lookup loads it — otherwise the proxy targets the in-container 9119 (the same lookup-omission class fixed in #207). Local Hermes leaves it null → falls back to 9119 (correct for compose-network reach); k8s Hermes keeps using `gateway_host/gateway_port` (its exposure model) — the resolver's two branches cover both.

The dashboard embed proxy enforces the SSRF allowlist from #207/#208: a remote agent's own registered host is owner-scoped-allowed, and the published dashboard port is in the gateway range. `db_schema.sql` + the vendored Helm copy stay byte-synced (validate-infra green); the column is also added via an idempotent boot migration for existing installs.

## Tests

- `portAllocations`: purpose defaulting, a second `dashboard` slot claiming its own port, idempotent reuse per purpose, the host-wide free-port scan.
- `remoteHermes`: dual-port publishing (both / runtime-only / dashboard-only / none) and `dashboardPort` advertisement from `create()`.
- `embedAgentColumns`: `dashboard_port` in the Hermes column contract.
- `agentEndpoints`: `resolveHermesDashboardAddress` for the remote case (`runtime_host` + persisted `dashboard_port`).
- `remoteHostGatewayAllowlist`: the remote-Hermes SSRF case now uses a real published dashboard port.

Backend suite **1115 green**; backend + worker typecheck, eslint, prettier, and infra validation all clean.

## Coverage note

The worker glue (allocate second port → pass to `create()` → persist `dashboard_port`) has no worker-level unit test — the provisioner deploy path is integration-tested via e2e, not unit-mocked in this repo. The component pieces it wires (allocation purpose, adapter publishing/return, resolver) are each unit-covered.
