### PR TITLE
feat(mcp): list @noraai/mcp-server in the official MCP Registry

### DIFF
--- a/.github/workflows/release-mcp-registry.yml
+++ b/.github/workflows/release-mcp-registry.yml
@@ -1,0 +1,128 @@
+name: Publish to MCP Registry
+
+# Lists @noraai/mcp-server in the official MCP Registry
+# (registry.modelcontextprotocol.io) so PulseMCP / Glama / MCP-aware clients can
+# discover it. Runs after a GitHub release is published, alongside the npm
+# release (release-npm.yml) — it polls npm until the released version is visible
+# because the registry validates ownership by fetching the published package's
+# `mcpName` field. Auth is GitHub OIDC (no secret): the io.github.solomon2773/*
+# namespace is authorized by the workflow's OIDC identity, which must match the
+# `name` in mcp-server/server.json and `mcpName` in mcp-server/package.json.
+#
+# Idempotent: a version already in the registry is skipped, and a published npm
+# tarball without `mcpName` is skipped (with a notice) rather than failing the
+# release. The MCP Registry is in preview; pin mcp-publisher below as needed.
+
+on:
+  release:
+    types:
+      - published
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write # GitHub OIDC for `mcp-publisher login github-oidc`
+
+env:
+  MCP_PUBLISHER_VERSION: v1.7.9
+  NPM_VISIBILITY_TIMEOUT_SECS: "180"
+
+jobs:
+  publish-mcp-registry:
+    name: Publish server.json to the MCP Registry
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Read package metadata
+        id: meta
+        working-directory: mcp-server
+        run: |
+          set -euo pipefail
+          name="$(node -p "require('./package.json').name")"
+          version="$(node -p "require('./package.json').version")"
+          mcp_name="$(node -p "require('./package.json').mcpName || ''")"
+          echo "name=${name}" >> "$GITHUB_OUTPUT"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "mcp_name=${mcp_name}" >> "$GITHUB_OUTPUT"
+          # Skip prerelease versions (e.g. 0.2.0-rc.1) — they don't belong in the registry.
+          if [[ "${version}" == *-* ]]; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Skipping MCP Registry publish for prerelease ${name}@${version}."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Wait for the npm version to be visible (registry validates mcpName from it)
+        if: steps.meta.outputs.skip == 'false'
+        id: npmwait
+        run: |
+          set -euo pipefail
+          name="${{ steps.meta.outputs.name }}"
+          version="${{ steps.meta.outputs.version }}"
+          deadline=$(( SECONDS + ${NPM_VISIBILITY_TIMEOUT_SECS} ))
+          until npm view "${name}@${version}" version >/dev/null 2>&1; do
+            if (( SECONDS >= deadline )); then
+              echo "::warning::${name}@${version} not visible on npm after ${NPM_VISIBILITY_TIMEOUT_SECS}s; skipping registry publish."
+              echo "ready=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "Waiting for ${name}@${version} to appear on npm..."
+            sleep 10
+          done
+          # The registry reads the package.json mcpName from the published tarball;
+          # an older tarball without it would fail validation, so guard on it.
+          published_mcp_name="$(npm view "${name}@${version}" mcpName 2>/dev/null || true)"
+          if [[ "${published_mcp_name}" != "${{ steps.meta.outputs.mcp_name }}" ]]; then
+            echo "::warning::Published ${name}@${version} has mcpName='${published_mcp_name}', expected '${{ steps.meta.outputs.mcp_name }}'; skipping registry publish."
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+
+      - name: Sync the published version into server.json
+        if: steps.meta.outputs.skip == 'false' && steps.npmwait.outputs.ready == 'true'
+        working-directory: mcp-server
+        run: |
+          set -euo pipefail
+          version="${{ steps.meta.outputs.version }}"
+          tmp="$(mktemp)"
+          jq --arg v "${version}" '.version = $v | (.packages[]?.version) = $v' server.json > "${tmp}"
+          mv "${tmp}" server.json
+          echo "server.json now at version ${version}:"
+          jq '{name, version, package: .packages[0].identifier}' server.json
+
+      - name: Install mcp-publisher
+        if: steps.meta.outputs.skip == 'false' && steps.npmwait.outputs.ready == 'true'
+        run: |
+          set -euo pipefail
+          os="$(uname -s | tr '[:upper:]' '[:lower:]')"
+          arch="$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/')"
+          url="https://github.com/modelcontextprotocol/registry/releases/download/${MCP_PUBLISHER_VERSION}/mcp-publisher_${os}_${arch}.tar.gz"
+          echo "Downloading ${url}"
+          curl -fsSL "${url}" | tar xz mcp-publisher
+          ./mcp-publisher --version || true
+
+      - name: Authenticate to the MCP Registry (GitHub OIDC)
+        if: steps.meta.outputs.skip == 'false' && steps.npmwait.outputs.ready == 'true'
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server.json (tolerate an already-listed version)
+        if: steps.meta.outputs.skip == 'false' && steps.npmwait.outputs.ready == 'true'
+        run: |
+          set -uo pipefail
+          out="$(./mcp-publisher publish mcp-server/server.json 2>&1)" || rc=$?
+          echo "${out}"
+          rc=${rc:-0}
+          if [[ ${rc} -ne 0 ]]; then
+            # Re-publishing the same version is a no-op for us, not a failure.
+            if echo "${out}" | grep -qiE "already exists|already published|duplicate|version .* exists"; then
+              echo "::notice::${{ steps.meta.outputs.mcp_name }}@${{ steps.meta.outputs.version }} already in the registry — skipping."
+              exit 0
+            fi
+            echo "::error::mcp-publisher publish failed (exit ${rc})."
+            exit ${rc}
+          fi
+          echo "::notice::Published ${{ steps.meta.outputs.mcp_name }}@${{ steps.meta.outputs.version }} to the MCP Registry."

--- a/.github/workflows/release-mcp-registry.yml
+++ b/.github/workflows/release-mcp-registry.yml
@@ -89,7 +89,12 @@ jobs:
           set -euo pipefail
           version="${{ steps.meta.outputs.version }}"
           tmp="$(mktemp)"
-          jq --arg v "${version}" '.version = $v | (.packages[]?.version) = $v' server.json > "${tmp}"
+          # Fail loudly if server.json ever loses its packages array rather than
+          # silently syncing only the top-level version.
+          jq --arg v "${version}" '
+            if (.packages | length) == 0 then error("server.json has no packages[] to version")
+            else .version = $v | (.packages[].version) = $v end
+          ' server.json > "${tmp}"
           mv "${tmp}" server.json
           echo "server.json now at version ${version}:"
           jq '{name, version, package: .packages[0].identifier}' server.json

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,7 +1,8 @@
 {
   "name": "@noraai/mcp-server",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "MCP server for the Nora agent ops control plane — operate your agent fleet from Claude Code, Claude Desktop, Cursor, or any MCP client.",
+  "mcpName": "io.github.solomon2773/nora",
   "license": "Apache-2.0",
   "type": "module",
   "publishConfig": {

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -1,0 +1,43 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.solomon2773/nora",
+  "title": "Nora",
+  "description": "Operate your self-hosted Nora AI-agent fleet from Claude Code, Claude Desktop, Cursor, or any MCP client — deploy, start/stop, inspect, and read metrics/cost/monitoring via the Nora public REST API.",
+  "version": "0.1.1",
+  "websiteUrl": "https://noradocs.solomontsao.com",
+  "repository": {
+    "url": "https://github.com/solomon2773/nora",
+    "source": "github",
+    "subfolder": "mcp-server"
+  },
+  "packages": [
+    {
+      "registryType": "npm",
+      "registryBaseUrl": "https://registry.npmjs.org",
+      "identifier": "@noraai/mcp-server",
+      "version": "0.1.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "runtimeHint": "npx",
+      "environmentVariables": [
+        {
+          "name": "NORA_API_URL",
+          "description": "Base URL of your Nora backend API (e.g. https://nora.example.com). Falls back to NORA_HOST, then the Nora CLI config at ~/.nora/config.json.",
+          "isRequired": true
+        },
+        {
+          "name": "NORA_API_KEY",
+          "description": "Nora workspace API key (nora_…) used to authenticate against the Nora public REST API. Falls back to NORA_TOKEN, then the Nora CLI config.",
+          "isRequired": true,
+          "isSecret": true
+        },
+        {
+          "name": "NORA_MCP_ALLOW_DESTRUCTIVE",
+          "description": "Set to \"true\" to enable destructive tools (e.g. delete_agent). Disabled by default.",
+          "isRequired": false
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What

Lists **`@noraai/mcp-server`** in the official [MCP Registry](https://registry.modelcontextprotocol.io). Per `.private/LAUNCH.md`, this is the flagged *"🔑 key that unlocks 5+ channels · do this early"* item: the registry is auto-ingested by **PulseMCP** and **Glama**, and a listing strengthens the r/mcp + Anthropic Discord posts. The package is already on npm (published 2026-06-15); this wires the registry listing on top.

## How

- **`mcp-server/server.json`** — the registry manifest (schema `2025-12-11`): npm package `@noraai/mcp-server`, `stdio` transport, `NORA_API_URL`/`NORA_API_KEY` (+ optional `NORA_MCP_ALLOW_DESTRUCTIVE`) env, `repository.subfolder: "mcp-server"`. It's **not** in the package's `files` allowlist, so it ships only in the repo (where the publish step reads it), not the npm tarball.
- **`mcp-server/package.json`** — `"mcpName": "io.github.solomon2773/nora"`. The registry validates ownership by reading `mcpName` from the **published npm package**, and it must equal `server.json` `name` byte-for-byte. The namespace is **auth-driven, not npm-scope-driven**: publishing under the `solomon2773` GitHub identity (OIDC) authorizes `io.github.solomon2773/*`, so the `@noraai` npm scope is irrelevant to the registry name (confirmed against the official docs and two real scoped-npm servers, e.g. `io.github.0xsims/rubric-protocol` published from `@rubric-protocol/mcp-server`). Version bumped **0.1.0 → 0.1.1** so the next release republishes a tarball carrying `mcpName` — `release-npm.yml` skips already-published versions, so without the bump the npm tarball would never gain the field and registry validation would always fail.
- **`.github/workflows/release-mcp-registry.yml`** — runs on `release: published` (decoupled from `release-npm.yml`). It polls npm until the released version is visible **and** carries the expected `mcpName` (the registry fetches the tarball to validate), syncs the version into `server.json`, then publishes with `mcp-publisher` via **GitHub OIDC** (`id-token: write`, no secret to manage). Idempotent: skips prereleases, a tarball missing `mcpName`, and an already-listed version.

## Important: this PR publishes nothing by itself

The registry listing happens on the **next GitHub release**, which publishes `@noraai/mcp-server@0.1.1` (with `mcpName`) via the existing npm release, then the new workflow lists it. No external publish occurs at merge time.

> One-time alternative: if you'd rather list it immediately without waiting for a release, run `npm publish` of 0.1.1 then `mcp-publisher login github` (device flow) + `mcp-publisher publish mcp-server/server.json` locally. The CI path is the durable option.

## Verification

`server.json`/`package.json` JSON + cross-field consistency (`name`==`mcpName`, versions, identifier, transport, name pattern), mcp-server tests (10) + typecheck, workflow YAML parse, prettier — all clean.

## Caveat

The MCP Registry is officially in **preview** (breaking changes / data resets possible before GA); `mcp-publisher` is pinned to `v1.7.9` and the schema to `2025-12-11` — both bump-as-needed.
