### PR TITLE
docs: action-first README hook + good-first-issue entry points (launch prep)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,6 +13,8 @@ By participating in this project, you agree to follow the [Code of Conduct](./CO
 
 ## Good First Contribution Types
 
+Looking for a concrete starting point? Browse the [`good first issue`](https://github.com/solomon2773/nora/labels/good%20first%20issue) label — small, self-contained tasks with a clear done-state. More broadly, valuable contributions include:
+
 - Fix a reproducible bug
 - Improve onboarding or self-hosted docs
 - Add tests for an existing behavior

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <div align="center">
   <img src=".github/readme-assets/nora-logo.png" alt="Nora" width="112" height="112" />
   <h1>Nora</h1>
-  <p><strong>The self-hosted AI agent ops platform.</strong></p>
+  <p><strong>Deploy &amp; operate AI agent fleets on infrastructure you control.</strong></p>
   <p>
-    Deploy, monitor, and operate OpenClaw and Hermes runtimes from one operator surface — runtime-neutral, Apache 2.0, and on infrastructure you control. Run agents on Docker or Kubernetes today, use NemoClaw sandboxes experimentally, and track Proxmox as a planned execution target.
+    The self-hosted, runtime-neutral control plane for OpenClaw and Hermes agents — deploy, monitor, and operate them from one operator surface, Apache 2.0. Run on Docker or Kubernetes today, use NemoClaw sandboxes experimentally, and track Proxmox as a planned execution target.
   </p>
 </div>
 
@@ -168,6 +168,8 @@ cd e2e && npm test
 Detailed contributor guidance, subtree ownership, and development commands live in [`CLAUDE.md`](./CLAUDE.md). For deeper repo work, read [`CONTRIBUTING.md`](./CONTRIBUTING.md), the root [`AGENTS.md`](./AGENTS.md), and the nearest subtree `AGENTS.md`.
 
 ## Contributing
+
+New here? Browse [**good first issues**](https://github.com/solomon2773/nora/labels/good%20first%20issue) for small, self-contained starting points, then skim [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 Strong contribution areas: runtime adapter work · operator and admin UX · provisioning and lifecycle orchestration · integrations and channels · test and CI hardening · self-hosted deployment ergonomics.
 


### PR DESCRIPTION
## What

Launch-readiness repo-prep (per `.private/LAUNCH.md`'s pre-launch checklist + contributor-funnel mechanics):

- **README hero hook** now leads with the action/ownership — *"Deploy & operate AI agent fleets on infrastructure you control."* — instead of the category line ("The self-hosted AI agent ops platform."). This matches the playbook's explicit *5-second-hook* guidance ("lead with what it does"). The runtime-neutral + honest-maturity subhead (Docker/K8s GA · NemoClaw experimental · Proxmox planned) and the walkthrough GIF are unchanged.
- **Good-first-issue entry point** added to the README Contributing section and to CONTRIBUTING.md — both now point newcomers at the [`good first issue`](https://github.com/solomon2773/nora/labels/good%20first%20issue) label.

## Note on the rest of the funnel

Most contributor scaffolding already exists (CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md, SUPPORT.md, issue + PR templates), so this PR only adds the hook + entry points. A curated set of **8 verified good-first-issues** (CLI, MCP, docs, backend tests, frontend UX) is ready to file against the label — surfaced separately for review before creating them (publishing public issues).

## Verification

Docs-only. README.md / CONTRIBUTING.md are outside the CI prettier scope (`.js/.ts/.css/.json/.yml/.yaml` only), and README was already non-prettier-conformant on master, so no formatting churn was introduced.