### PR TITLE
feat(agents): adopt an existing OpenClaw/Hermes runtime by URL + token (BYOC Phase C)

### DIFF
--- a/agent-runtime/lib/backendCatalog.ts
+++ b/agent-runtime/lib/backendCatalog.ts
@@ -3,6 +3,12 @@ const DEFAULT_RUNTIME_FAMILY = "openclaw";
 const KNOWN_RUNTIME_FAMILIES = Object.freeze(["openclaw", "hermes"]);
 const KNOWN_DEPLOY_TARGETS = Object.freeze(["docker", "k8s", "remote-docker", "proxmox"]);
 const KNOWN_BACKENDS = KNOWN_DEPLOY_TARGETS;
+// "external" is a recognized deploy_target VALUE for an adopted, already-running
+// runtime (BYOC Phase C). It is deliberately NOT in KNOWN_DEPLOY_TARGETS: you do
+// not "deploy to" external (no provisioner, no deploy-catalog card) — you adopt a
+// runtime by URL + token. It only needs to normalize, carry metadata, and resolve
+// a maturity tier for an existing agent row.
+const EXTERNAL_DEPLOY_TARGET = "external";
 const KNOWN_SANDBOX_PROFILES = Object.freeze(["standard", "nemoclaw"]);
 const PROXMOX_RELEASE_BLOCKER_ISSUE =
   "Proxmox execution target is not supported in this Nora release.";
@@ -121,6 +127,16 @@ const EXECUTION_TARGET_METADATA = Object.freeze({
       "Proxmox is tracked as a roadmap execution target. Current releases keep it visible for operator awareness, but block normal onboarding and deploy selection.",
     badges: ["Roadmap", "LXC", "Proxmox API"],
   }),
+  external: Object.freeze({
+    id: "external",
+    label: "External runtime",
+    shortLabel: "External",
+    summary:
+      "An already-running OpenClaw or Hermes runtime that Nora did not provision, adopted by its reachable URL and gateway token.",
+    detail:
+      "Nora monitors and proxies access to the external runtime but does not control its lifecycle. Register it from the operator console; deregistering only removes it from Nora.",
+    badges: ["Bring your own compute", "Adopted", "Not provisioned"],
+  }),
 });
 
 const SANDBOX_PROFILE_METADATA = Object.freeze({
@@ -164,6 +180,7 @@ function normalizeDeployTargetName(value) {
     .toLowerCase();
   if (normalized.startsWith("k8s:")) return "k8s";
   if (normalized.startsWith("remote:")) return "remote-docker";
+  if (normalized === EXTERNAL_DEPLOY_TARGET) return EXTERNAL_DEPLOY_TARGET;
   return KNOWN_DEPLOY_TARGETS.includes(normalized) ? normalized : "docker";
 }
 
@@ -192,6 +209,7 @@ function normalizeExecutionTargetId(value) {
       .replace(/^-|-$/g, "");
     return hostId ? `remote:${hostId}` : "remote-docker";
   }
+  if (normalized === EXTERNAL_DEPLOY_TARGET) return EXTERNAL_DEPLOY_TARGET;
   return KNOWN_DEPLOY_TARGETS.includes(normalized) ? normalized : null;
 }
 
@@ -220,6 +238,7 @@ function isKnownDeployTarget(value) {
   return (
     normalized.startsWith("k8s:") ||
     normalized.startsWith("remote:") ||
+    normalized === EXTERNAL_DEPLOY_TARGET ||
     KNOWN_DEPLOY_TARGETS.includes(normalized)
   );
 }
@@ -405,6 +424,7 @@ function resolveMaturityTier({ deployTarget, sandboxProfile }) {
 
   if (normalizedDeployTarget === "proxmox") return "blocked";
   if (normalizedDeployTarget === "remote-docker") return "experimental";
+  if (normalizedDeployTarget === EXTERNAL_DEPLOY_TARGET) return "experimental";
   if (normalizeSandboxProfileName(sandboxProfile) === "nemoclaw") return "experimental";
   return "ga";
 }

--- a/backend-api/__tests__/agents.test.ts
+++ b/backend-api/__tests__/agents.test.ts
@@ -2103,6 +2103,91 @@ describe("GET /agents/:id/stats/history", () => {
   });
 });
 
+describe("POST /agents/adopt (external runtime)", () => {
+  it("adopts a reachable OpenClaw runtime without provisioning", async () => {
+    mockDb.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: "a-ext",
+          name: "Prod OpenClaw",
+          status: "running",
+          user_id: "user-1",
+          runtime_family: "openclaw",
+          deploy_target: "external",
+          execution_target_id: "external",
+          gateway_host: "203.0.113.5",
+          gateway_port: 18789,
+        },
+      ],
+    });
+
+    const res = await auth(
+      request(app).post("/agents/adopt").send({
+        name: "Prod OpenClaw",
+        runtime_family: "openclaw",
+        url: "https://203.0.113.5:18789",
+        gateway_token: "secret-token",
+      }),
+    );
+
+    expect(res.status).toBe(201);
+    expect(res.body).toMatchObject({ id: "a-ext", deploy_target: "external", status: "running" });
+    // No provisioning job for an adopted runtime.
+    expect(mockAddDeploymentJob).not.toHaveBeenCalled();
+    // The INSERT carries deploy_target='external' + the validated endpoint.
+    const insert = mockDb.query.mock.calls.find((c) => /INSERT INTO agents/i.test(c[0]));
+    expect(insert[0]).toMatch(/'external', 'external'/);
+    expect(insert[1]).toEqual(
+      expect.arrayContaining(["user-1", "openclaw", "203.0.113.5", 18789, "secret-token"]),
+    );
+  });
+
+  it("rejects adoption without a gateway token", async () => {
+    const res = await auth(
+      request(app)
+        .post("/agents/adopt")
+        .send({ runtime_family: "openclaw", url: "https://203.0.113.5:18789" }),
+    );
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/gateway_token/i);
+    expect(mockDb.query).not.toHaveBeenCalled();
+  });
+
+  it("rejects an endpoint on a non-allowed port (SSRF gate)", async () => {
+    const res = await auth(
+      request(app)
+        .post("/agents/adopt")
+        .send({ runtime_family: "openclaw", url: "http://203.0.113.5:8080", gateway_token: "t" }),
+    );
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/port is not allowed/i);
+    expect(mockDb.query).not.toHaveBeenCalled();
+  });
+
+  it("rejects an endpoint that resolves to a blocked address (SSRF floor)", async () => {
+    const res = await auth(
+      request(app).post("/agents/adopt").send({
+        runtime_family: "openclaw",
+        url: "http://169.254.169.254:18789",
+        gateway_token: "t",
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/not an allowed gateway address/i);
+    expect(mockDb.query).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unsupported runtime family", async () => {
+    const res = await auth(
+      request(app)
+        .post("/agents/adopt")
+        .send({ runtime_family: "nope", url: "https://203.0.113.5:18789", gateway_token: "t" }),
+    );
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/runtime_family/i);
+  });
+});
+
 describe("POST /agents/deploy", () => {
   it("rejects unauthenticated request", async () => {
     const res = await request(app).post("/agents/deploy").send({});

--- a/backend-api/__tests__/agents.test.ts
+++ b/backend-api/__tests__/agents.test.ts
@@ -2186,6 +2186,23 @@ describe("POST /agents/adopt (external runtime)", () => {
     expect(res.status).toBe(400);
     expect(res.body.error).toMatch(/runtime_family/i);
   });
+
+  it("enforces the agent quota (adopted runtimes still occupy a slot)", async () => {
+    require("../billing").enforceLimits.mockResolvedValueOnce({
+      allowed: false,
+      error: "Agent limit reached",
+      subscription: { plan: "free" },
+    });
+    const res = await auth(
+      request(app).post("/agents/adopt").send({
+        runtime_family: "openclaw",
+        url: "https://203.0.113.5:18789",
+        gateway_token: "t",
+      }),
+    );
+    expect(res.status).toBe(402);
+    expect(mockDb.query).not.toHaveBeenCalled();
+  });
 });
 
 describe("POST /agents/deploy", () => {

--- a/backend-api/__tests__/externalCatalog.test.ts
+++ b/backend-api/__tests__/externalCatalog.test.ts
@@ -1,0 +1,48 @@
+// @ts-nocheck
+const {
+  getBackendCatalog,
+  getExecutionTargetMetadata,
+  isKnownDeployTarget,
+  normalizeDeployTargetName,
+  normalizeExecutionTargetId,
+} = require("../../agent-runtime/lib/backendCatalog");
+
+// BYOC Phase C: 'external' is a recognized deploy_target/execution_target VALUE
+// for an ADOPTED, already-running runtime — but deliberately NOT a deployable
+// target (no provisioner, no deploy-catalog card).
+describe("external (adopted runtime) catalog recognition", () => {
+  it("normalizes the external deploy target", () => {
+    expect(normalizeDeployTargetName("external")).toBe("external");
+    expect(normalizeDeployTargetName("EXTERNAL")).toBe("external");
+    // unknown values still fall back to docker (external did not widen the fallback)
+    expect(normalizeDeployTargetName("moon")).toBe("docker");
+  });
+
+  it("normalizes the external execution target id", () => {
+    expect(normalizeExecutionTargetId("external")).toBe("external");
+    expect(normalizeExecutionTargetId("unknown")).toBeNull();
+    // existing prefixes intact
+    expect(normalizeExecutionTargetId("remote:my-vps")).toBe("remote:my-vps");
+    expect(normalizeExecutionTargetId("k8s:prod")).toBe("k8s:prod");
+  });
+
+  it("recognizes external as a known deploy target", () => {
+    expect(isKnownDeployTarget("external")).toBe(true);
+    expect(isKnownDeployTarget("docker")).toBe(true);
+    expect(isKnownDeployTarget("nope")).toBe(false);
+  });
+
+  it("exposes external execution-target metadata", () => {
+    const meta = getExecutionTargetMetadata("external");
+    expect(meta).toMatchObject({ id: "external", label: "External runtime" });
+  });
+
+  it("does NOT surface external as a deployable catalog card", () => {
+    const catalog = getBackendCatalog();
+    expect(catalog.some((b) => b.id === "external")).toBe(false);
+    // existing deployable targets remain
+    expect(catalog.some((b) => b.id === "docker")).toBe(true);
+    expect(catalog.some((b) => b.id === "remote-docker")).toBe(true);
+    expect(catalog.some((b) => b.id === "proxmox")).toBe(true);
+  });
+});

--- a/backend-api/__tests__/remoteHostGatewayAllowlist.test.ts
+++ b/backend-api/__tests__/remoteHostGatewayAllowlist.test.ts
@@ -19,6 +19,7 @@ jest.mock("../remoteHosts", () => ({
 const {
   resolveSafeGatewayHttpTarget,
   resolveSafeHermesDashboardTarget,
+  assertExternalEndpointReachable,
 } = require("../gatewayProxy");
 
 const PUBLIC_IP = "203.0.113.5";
@@ -236,6 +237,62 @@ describe("hermes dashboard embed-proxy allowlist (SSRF)", () => {
     };
     const target = await resolveSafeHermesDashboardTarget(agent);
     expect(target).toEqual({ host: "203.0.113.20", port: 30119 });
+    expect(mockGetRemoteHostByExecutionTarget).not.toHaveBeenCalled();
+  });
+});
+
+describe("external runtime adoption (BYOC Phase C)", () => {
+  describe("assertExternalEndpointReachable (registration gate)", () => {
+    it("allows a public endpoint on the gateway port (selfhosted)", async () => {
+      await expect(
+        assertExternalEndpointReachable({ host: PUBLIC_IP, port: 18789 }, { paas: false }),
+      ).resolves.toEqual({ host: PUBLIC_IP, port: 18789 });
+    });
+
+    it("allows a private endpoint in selfhosted mode (operator's own network)", async () => {
+      await expect(
+        assertExternalEndpointReachable({ host: "10.0.0.7", port: 18789 }, { paas: false }),
+      ).resolves.toEqual({ host: "10.0.0.7", port: 18789 });
+    });
+
+    it("rejects a private endpoint in hosted (PaaS) mode (no internal pivot)", async () => {
+      await expect(
+        assertExternalEndpointReachable({ host: "10.0.0.7", port: 18789 }, { paas: true }),
+      ).rejects.toThrow(/public address in hosted mode/i);
+    });
+
+    it("rejects a blocked (metadata/link-local) endpoint regardless of mode (floor)", async () => {
+      await expect(
+        assertExternalEndpointReachable({ host: "169.254.169.254", port: 18789 }, { paas: false }),
+      ).rejects.toThrow(/not an allowed gateway address/i);
+    });
+
+    it("rejects a non-allowed port", async () => {
+      await expect(
+        assertExternalEndpointReachable({ host: PUBLIC_IP, port: 80 }, { paas: false }),
+      ).rejects.toThrow(/port is not allowed/i);
+    });
+
+    it("allows the Hermes dashboard port (9119)", async () => {
+      await expect(
+        assertExternalEndpointReachable({ host: PUBLIC_IP, port: 9119 }, { paas: false }),
+      ).resolves.toEqual({ host: PUBLIC_IP, port: 9119 });
+    });
+  });
+
+  it("the proxy trusts an adopted external agent's own declared endpoint", async () => {
+    // deploy_target='external' ⇒ allowedGatewayHostsForAgent trusts the agent's own
+    // gateway_host (owner-scoped via the row); the public endpoint is reachable.
+    const agent = {
+      id: "agent-ext",
+      user_id: "user-1",
+      deploy_target: "external",
+      execution_target_id: "external",
+      gateway_host: PUBLIC_IP,
+      gateway_port: 18789,
+    };
+    const target = await resolveSafeGatewayHttpTarget(agent, "status");
+    expect(target.url).toBe(`http://${PUBLIC_IP}:18789/status`);
     expect(mockGetRemoteHostByExecutionTarget).not.toHaveBeenCalled();
   });
 });

--- a/backend-api/gatewayProxy.ts
+++ b/backend-api/gatewayProxy.ts
@@ -151,11 +151,17 @@ async function allowedRemoteHostsForAgent(agent) {
 //    NodePort / ClusterIP host the k8s adapter recorded). Trusting it matches
 //    the prior RPC/WS behavior (they did no host check), so k8s chat — incl.
 //    public LoadBalancer IPs — does not regress.
+//  - external: the operator-declared endpoint of an adopted runtime (BYOC C),
+//    trusted from the agent's OWN row. Owner-scoped inherently (the agent row is
+//    loaded user-scoped, so you can only reach YOUR external agent's endpoint),
+//    and the hard isBlockedGatewayIP floor + port allowlist still apply. In PaaS
+//    mode the endpoint is forced to a public IP at registration (no RFC1918
+//    pivot); selfhosted may adopt RFC1918 runtimes on the operator's own network.
 //  - docker / other: none — falls through to the RFC1918/loopback floor.
 async function allowedGatewayHostsForAgent(agent) {
   const target = normalizeDeployTargetName(agent?.deploy_target);
   if (target === "remote-docker") return allowedRemoteHostsForAgent(agent);
-  if (target === "k8s") {
+  if (target === "external" || target === "k8s") {
     const allowed = new Set();
     if (agent?.gateway_host) allowed.add(String(agent.gateway_host).toLowerCase());
     if (agent?.runtime_host) allowed.add(String(agent.runtime_host).toLowerCase());
@@ -288,6 +294,35 @@ async function resolveSafeHermesDashboardTarget(agent) {
     extraAllowedHosts,
   );
   return { host: resolvedHost, port: addr.port };
+}
+
+// Registration-time gate for adopting an EXTERNAL runtime (BYOC Phase C). Applied
+// when an operator registers an already-running OpenClaw/Hermes endpoint by URL,
+// so the stored endpoint can never be one the proxy would later refuse — and so a
+// PaaS tenant can't register a private-network pivot. Enforces the same hard floor
+// (isBlockedGatewayIP, via resolveGatewayHostForProxy) + port allowlist the proxy
+// uses; trusts the operator's own host (passed as an extra allowed host); and in
+// hosted (PaaS) mode additionally requires the endpoint to resolve to a PUBLIC IP
+// (selfhosted may adopt RFC1918 runtimes on the operator's own network). Throws if
+// disallowed. Returns the validated {host, port}.
+async function assertExternalEndpointReachable(address, { paas = false } = {}) {
+  const addr = assertSafeAgentAddress(address, "external runtime");
+  if (addr.port !== HERMES_DASHBOARD_PORT && !isAllowedGatewayPort(addr.port)) {
+    throw new Error(
+      "external runtime port is not allowed — use the gateway port, the Hermes dashboard port, or a published port",
+    );
+  }
+  const resolved = await resolveGatewayHostForProxy(
+    addr.host,
+    "external runtime",
+    new Set([addr.host.toLowerCase()]),
+  );
+  if (paas && (isAllowedGatewayIPv4(resolved) || isAllowedGatewayIPv6(resolved))) {
+    throw new Error(
+      "external runtime endpoint must be a public address in hosted mode (private/RFC1918 addresses are not allowed)",
+    );
+  }
+  return { host: addr.host, port: addr.port };
 }
 
 // ─── Device Identity (Ed25519 keypair for Gateway auth) ──────────
@@ -1560,4 +1595,5 @@ module.exports = {
   evictConnection,
   resolveSafeGatewayHttpTarget,
   resolveSafeHermesDashboardTarget,
+  assertExternalEndpointReachable,
 };

--- a/backend-api/gatewayProxy.ts
+++ b/backend-api/gatewayProxy.ts
@@ -301,10 +301,15 @@ async function resolveSafeHermesDashboardTarget(agent) {
 // so the stored endpoint can never be one the proxy would later refuse — and so a
 // PaaS tenant can't register a private-network pivot. Enforces the same hard floor
 // (isBlockedGatewayIP, via resolveGatewayHostForProxy) + port allowlist the proxy
-// uses; trusts the operator's own host (passed as an extra allowed host); and in
-// hosted (PaaS) mode additionally requires the endpoint to resolve to a PUBLIC IP
-// (selfhosted may adopt RFC1918 runtimes on the operator's own network). Throws if
-// disallowed. Returns the validated {host, port}.
+// uses; and in hosted (PaaS) mode additionally requires the endpoint to resolve to
+// a PUBLIC IP (selfhosted may adopt RFC1918 runtimes on the operator's own network).
+//
+// Returns the RESOLVED IP (not the hostname): the caller pins this IP on the agent
+// row so the proxy connects to the exact validated address at reach time. Storing
+// the hostname instead would reopen a DNS-rebinding/TOCTOU hole — the proxy would
+// re-resolve it later and trust whatever it then points at (incl. loopback/RFC1918)
+// because the hostname sits in the allowlist. Pinning the IP closes that window
+// (re-adopt if a runtime's address legitimately changes). Throws if disallowed.
 async function assertExternalEndpointReachable(address, { paas = false } = {}) {
   const addr = assertSafeAgentAddress(address, "external runtime");
   if (addr.port !== HERMES_DASHBOARD_PORT && !isAllowedGatewayPort(addr.port)) {
@@ -322,7 +327,7 @@ async function assertExternalEndpointReachable(address, { paas = false } = {}) {
       "external runtime endpoint must be a public address in hosted mode (private/RFC1918 addresses are not allowed)",
     );
   }
-  return { host: addr.host, port: addr.port };
+  return { host: resolved, port: addr.port };
 }
 
 // ─── Device Identity (Ed25519 keypair for Gateway auth) ──────────

--- a/backend-api/openapi/paths/agents.js
+++ b/backend-api/openapi/paths/agents.js
@@ -96,6 +96,50 @@ module.exports = {
       responses: ok("The created agent (status 'queued')", agentSummary),
     },
   },
+  "/agents/adopt": {
+    post: {
+      tags: ["Agents"],
+      summary: "Adopt an already-running external runtime",
+      description:
+        "Registers an existing OpenClaw or Hermes runtime that Nora did not provision, by its reachable URL + gateway token. Creates an agent with deploy_target='external' and status='running' (no provisioning). Nora monitors and proxies it; lifecycle actions are unavailable and delete is a deregister.",
+      "x-required-scopes": ["agents:write"],
+      requestBody: {
+        required: true,
+        content: {
+          "application/json": {
+            schema: {
+              type: "object",
+              required: ["runtime_family", "gateway_token"],
+              properties: {
+                name: { type: "string", maxLength: 100 },
+                runtime_family: { type: "string", enum: ["openclaw", "hermes"] },
+                url: {
+                  type: "string",
+                  description:
+                    "Reachable runtime URL — e.g. https://host:18789 (OpenClaw gateway) or https://host:9119 (Hermes dashboard). Provide this or host (+ port).",
+                },
+                host: { type: "string", description: "Runtime host (alternative to url)." },
+                port: {
+                  type: "integer",
+                  description: "Runtime port (defaults to the family's gateway/dashboard port).",
+                },
+                gateway_token: {
+                  type: "string",
+                  description: "Gateway/API token for the existing runtime.",
+                },
+              },
+            },
+          },
+        },
+      },
+      responses: {
+        201: {
+          description: "The adopted external agent (status 'running')",
+          content: { "application/json": { schema: agentSummary } },
+        },
+      },
+    },
+  },
   "/agents/{id}": {
     get: {
       tags: ["Agents"],

--- a/backend-api/routes/agents.ts
+++ b/backend-api/routes/agents.ts
@@ -1507,6 +1507,12 @@ router.post("/deploy", async (req, res) => {
 router.post("/adopt", async (req, res) => {
   try {
     const body = req.body || {};
+    // An adopted runtime still occupies an agent slot, so it counts against the
+    // operator's quota even though Nora doesn't provision its compute.
+    const limits = await billing.enforceLimits(req.user.id);
+    if (!limits.allowed) {
+      return res.status(402).json({ error: limits.error, subscription: limits.subscription });
+    }
     const runtimeFamily = normalizeRequestedRuntimeFamily(body.runtime_family);
     if (runtimeFamily == null) {
       return res.status(400).json({
@@ -1566,13 +1572,15 @@ router.post("/adopt", async (req, res) => {
     // resolveGatewayAddress (OpenClaw) and resolveHermesDashboardAddress (Hermes),
     // so one mapping covers chat + dashboard reach for either family. status starts
     // 'running' (optimistic); the external health-poll (Phase C2) reconciles it.
+    // dashboard_port mirrors the published port so resolveHermesDashboardAddress is
+    // correct even via its runtime_host fallback (not just the gateway_host branch).
     const result = await db.query(
       `INSERT INTO agents(
          user_id, name, status, runtime_family, deploy_target, execution_target_id,
          sandbox_profile, sandbox_type, backend_type, gateway_host, gateway_port,
-         runtime_host, gateway_token
+         runtime_host, dashboard_port, gateway_token
        ) VALUES($1, $2, 'running', $3, 'external', 'external', 'standard', 'standard',
-                'external', $4, $5, $4, $6) RETURNING *`,
+                'external', $4, $5, $4, $5, $6) RETURNING *`,
       [req.user.id, name, runtimeFamily, endpoint.host, endpoint.port, token],
     );
     const agent = result.rows[0];

--- a/backend-api/routes/agents.ts
+++ b/backend-api/routes/agents.ts
@@ -30,6 +30,7 @@ const {
   materializeManagedMigrationState,
 } = require("../agentMigrations");
 const { isGatewayAvailableStatus, reconcileAgentStatus } = require("../agentStatus");
+const { assertExternalEndpointReachable } = require("../gatewayProxy");
 const {
   HERMES_DASHBOARD_PORT,
   OPENCLAW_GATEWAY_PORT,
@@ -1493,6 +1494,102 @@ router.post("/deploy", async (req, res) => {
     );
 
     res.json(serializeAgent(agent));
+  } catch (e) {
+    res.status(e.statusCode || 500).json({ error: e.message });
+  }
+});
+
+// Adopt an already-running OpenClaw/Hermes runtime that Nora did NOT provision,
+// by its reachable URL + gateway token (BYOC Phase C). Creates an agent row with
+// deploy_target='external' and status='running' — NO provisioning job, no
+// container. Nora monitors + proxies access; lifecycle mutations are blocked (no
+// container_id ⇒ canMutate() is false) and delete is effectively a deregister.
+router.post("/adopt", async (req, res) => {
+  try {
+    const body = req.body || {};
+    const runtimeFamily = normalizeRequestedRuntimeFamily(body.runtime_family);
+    if (runtimeFamily == null) {
+      return res.status(400).json({
+        error: `Unsupported runtime_family. Nora currently supports: ${KNOWN_RUNTIME_FAMILIES.map((v) => `"${v}"`).join(", ")}.`,
+      });
+    }
+    const name = sanitizeAgentName(
+      body.name,
+      runtimeFamily === "hermes" ? "Hermes-Agent" : "OpenClaw-Agent",
+    );
+    if (name.length > 100) {
+      return res.status(400).json({ error: "Agent name must be 100 characters or less" });
+    }
+
+    const token = String(body.gateway_token || body.token || "").trim();
+    if (!token) {
+      return res
+        .status(400)
+        .json({ error: "gateway_token is required to adopt an external runtime" });
+    }
+
+    // Accept either a full URL or an explicit host (+ optional port). Default the
+    // port to the runtime family's contract port (OpenClaw gateway / Hermes dashboard).
+    const defaultPort = runtimeFamily === "hermes" ? HERMES_DASHBOARD_PORT : OPENCLAW_GATEWAY_PORT;
+    let host;
+    let port;
+    const rawUrl = typeof body.url === "string" ? body.url.trim() : "";
+    if (rawUrl) {
+      let parsed;
+      try {
+        parsed = new URL(/^[a-z][a-z0-9+.-]*:\/\//i.test(rawUrl) ? rawUrl : `https://${rawUrl}`);
+      } catch {
+        return res.status(400).json({ error: "Invalid runtime URL" });
+      }
+      host = parsed.hostname;
+      port = parsed.port ? Number(parsed.port) : defaultPort;
+    } else if (body.host) {
+      host = String(body.host).trim();
+      port = body.port != null && body.port !== "" ? Number(body.port) : defaultPort;
+    } else {
+      return res.status(400).json({ error: "Provide the runtime URL (or host) to adopt" });
+    }
+    if (!host || !Number.isInteger(port)) {
+      return res.status(400).json({ error: "Provide a valid runtime host and port to adopt" });
+    }
+
+    // Registration-time SSRF gate — the same hard floor + port allowlist the proxy
+    // enforces at reach time, plus public-only in hosted (PaaS) mode.
+    let endpoint;
+    try {
+      endpoint = await assertExternalEndpointReachable({ host, port }, { paas: billing.IS_PAAS });
+    } catch (e) {
+      return res.status(400).json({ error: e.message });
+    }
+
+    // gateway_host/gateway_port are the first fields read by BOTH
+    // resolveGatewayAddress (OpenClaw) and resolveHermesDashboardAddress (Hermes),
+    // so one mapping covers chat + dashboard reach for either family. status starts
+    // 'running' (optimistic); the external health-poll (Phase C2) reconciles it.
+    const result = await db.query(
+      `INSERT INTO agents(
+         user_id, name, status, runtime_family, deploy_target, execution_target_id,
+         sandbox_profile, sandbox_type, backend_type, gateway_host, gateway_port,
+         runtime_host, gateway_token
+       ) VALUES($1, $2, 'running', $3, 'external', 'external', 'standard', 'standard',
+                'external', $4, $5, $4, $6) RETURNING *`,
+      [req.user.id, name, runtimeFamily, endpoint.host, endpoint.port, token],
+    );
+    const agent = result.rows[0];
+
+    await monitoring.logEvent(
+      "agent_adopted",
+      `Adopted external ${runtimeFamily} runtime "${name}" at ${endpoint.host}:${endpoint.port}`,
+      agentAuditMetadata(req, agent, {
+        adopt: {
+          runtimeFamily,
+          deployTarget: "external",
+          endpoint: `${endpoint.host}:${endpoint.port}`,
+        },
+      }),
+    );
+
+    res.status(201).json(serializeAgent(agent));
   } catch (e) {
     res.status(e.statusCode || 500).json({ error: e.message });
   }

--- a/backend-api/server.ts
+++ b/backend-api/server.ts
@@ -602,7 +602,11 @@ const mutationLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: "Too many requests, please slow down" },
-  skip: (req) => req.method === "GET" || req.method === "HEAD" || req.method === "OPTIONS",
+  // Skip in tests: the unit suites fire far more than 60 mutations/min from a
+  // single IP, and the global limiter is not what they exercise (the signup
+  // limiter has its own dedicated test). Fully active outside test environments.
+  skip: (req) =>
+    IS_TEST_ENV || req.method === "GET" || req.method === "HEAD" || req.method === "OPTIONS",
 });
 app.use(mutationLimiter);
 


### PR DESCRIPTION
## What

Starts **BYOC Phase C** with **adopt-existing-runtime**: an operator can register an **already-running** OpenClaw or Hermes runtime that Nora did **not** provision, by its reachable URL + gateway token. `POST /agents/adopt` creates an agent row with `deploy_target='external'`, `status='running'`, `container_id=NULL` — **no provisioning job, no schema migration** (reuses existing columns). Nora then monitors + proxies it.

## How

- **Catalog (shared `backendCatalog.ts`):** `external` is a recognized `deploy_target`/`execution_target` *value* (normalize + metadata + experimental maturity + `isKnownDeployTarget`), but deliberately **not** in `KNOWN_DEPLOY_TARGETS` — you *adopt*, not deploy, so it never becomes a deploy-catalog card or a provisioner route. (Shared zone — worker typecheck verified.)
- **Lifecycle falls out for free:** `containerManager.canMutate()/canDestroy()` already return false without a `container_id`, so start/stop/restart are blocked and delete is a clean deregister; the status reconciler already filters `container_id IS NOT NULL`, so external agents aren't mislabeled.
- **New SSRF trust boundary** (the one risky piece, per the design you approved — *floor + owner-scoped*):
  - `allowedGatewayHostsForAgent` gains an `external` branch trusting the agent's **own** declared `gateway_host`/`runtime_host` — owner-scoped inherently (the row is loaded user-scoped) — behind the unchanged `isBlockedGatewayIP` floor + port allowlist.
  - New `assertExternalEndpointReachable()` gates **registration** with the same floor + port checks, and in **PaaS** mode requires a **public** endpoint (no RFC1918 pivot); **selfhosted** may adopt private-network runtimes.
- `gateway_host`/`gateway_port` serve **both** families (OpenClaw's `resolveGatewayAddress` and Hermes's `resolveHermesDashboardAddress` both read them first) → one mapping covers chat + dashboard reach.
- **OpenAPI:** documented `POST /agents/adopt` (keeps the drift test green).
- **server.ts:** skip the global *mutation* rate limiter in **test env** only (the unit suites fire >60 mutations/min from one IP; the signup limiter keeps its own dedicated test). Fully active outside tests.

## Scope (this is C1 of 3)

Backend foundation only. Follow-ups: **C2** — active `/health` poll reconcile for external agents + the "Adopt existing runtime" deploy-UI tab, "External" badge, disabled lifecycle buttons, "Deregister"; **C3** — RBAC (`user_groups`, host grants, shared hosts). C1 sets `status='running'` optimistically; C2 adds the health poll.

## Tests

External catalog recognition (and that it's **not** a deployable card); `assertExternalEndpointReachable` (public ok, selfhosted-private ok, **PaaS-private rejected**, floor + non-allowed-port rejected, Hermes dashboard port ok); the proxy trusting an external agent's own endpoint; and the `/agents/adopt` route (adopts **without** a deployment job, validation, SSRF rejections). Backend suite **1132 green**; agent-runtime + backend + worker typecheck, eslint, prettier clean.
