### PR TITLE
feat(external): health-poll reconcile for adopted runtimes (BYOC Phase C2a)

### DIFF
--- a/backend-api/__tests__/backgroundTasks.test.ts
+++ b/backend-api/__tests__/backgroundTasks.test.ts
@@ -8,10 +8,14 @@ jest.mock("../containerManager", () => mockContainerManager);
 jest.mock("../agentTelemetry", () => ({
   collectAgentTelemetrySample: mockCollectTelemetry,
 }));
+// Mocked so backgroundTasks doesn't pull in the real gatewayProxy chain; the
+// external reconcile tests inject their own healthProbe anyway.
+jest.mock("../externalHealth", () => ({ probeExternalAgentHealth: jest.fn() }));
 
 const {
   collectBackgroundTelemetry,
   reconcileBackgroundAgentStatuses,
+  reconcileExternalAgentStatuses,
 } = require("../backgroundTasks");
 
 describe("background tasks", () => {
@@ -41,7 +45,7 @@ describe("background tasks", () => {
         id: "agent-k8s-1",
         backend_type: "k8s",
         container_id: "oclaw-agent-123",
-      })
+      }),
     );
     expect(mockDb.query).toHaveBeenCalledTimes(1);
   });
@@ -62,11 +66,10 @@ describe("background tasks", () => {
 
     await reconcileBackgroundAgentStatuses();
 
-    expect(mockDb.query).toHaveBeenNthCalledWith(
-      2,
-      "UPDATE agents SET status = $1 WHERE id = $2",
-      ["stopped", "agent-err-1"]
-    );
+    expect(mockDb.query).toHaveBeenNthCalledWith(2, "UPDATE agents SET status = $1 WHERE id = $2", [
+      "stopped",
+      "agent-err-1",
+    ]);
   });
 
   it("collects telemetry for running agents and prunes old samples", async () => {
@@ -91,11 +94,79 @@ describe("background tasks", () => {
       expect.objectContaining({
         id: "agent-run-1",
         backend_type: "docker",
-      })
+      }),
     );
     expect(mockDb.query).toHaveBeenNthCalledWith(
       2,
-      "DELETE FROM container_stats WHERE recorded_at < NOW() - INTERVAL '7 days'"
+      "DELETE FROM container_stats WHERE recorded_at < NOW() - INTERVAL '7 days'",
     );
+  });
+
+  describe("external runtime reconciliation", () => {
+    it("only queries external agents (not provisioned ones)", async () => {
+      mockDb.query.mockResolvedValueOnce({ rows: [] });
+      await reconcileExternalAgentStatuses({ healthProbe: jest.fn() });
+      expect(mockDb.query.mock.calls[0][0]).toMatch(/deploy_target = 'external'/);
+    });
+
+    it("recovers a reachable external agent to running", async () => {
+      mockDb.query.mockResolvedValueOnce({
+        rows: [{ id: "ext-1", status: "stopped", deploy_target: "external" }],
+      });
+      mockDb.query.mockResolvedValueOnce({ rows: [] });
+      const healthProbe = jest.fn().mockResolvedValue({ running: true });
+
+      await reconcileExternalAgentStatuses({ healthProbe });
+
+      expect(healthProbe).toHaveBeenCalledWith(expect.objectContaining({ id: "ext-1" }));
+      expect(mockDb.query).toHaveBeenNthCalledWith(
+        2,
+        "UPDATE agents SET status = $1 WHERE id = $2",
+        ["running", "ext-1"],
+      );
+    });
+
+    it("marks an unreachable external agent as stopped", async () => {
+      mockDb.query.mockResolvedValueOnce({
+        rows: [{ id: "ext-2", status: "running", deploy_target: "external" }],
+      });
+      mockDb.query.mockResolvedValueOnce({ rows: [] });
+      const healthProbe = jest.fn().mockResolvedValue({ running: false });
+
+      await reconcileExternalAgentStatuses({ healthProbe });
+
+      expect(mockDb.query).toHaveBeenNthCalledWith(
+        2,
+        "UPDATE agents SET status = $1 WHERE id = $2",
+        ["stopped", "ext-2"],
+      );
+    });
+
+    it("treats a probe that throws as not running (best-effort)", async () => {
+      mockDb.query.mockResolvedValueOnce({
+        rows: [{ id: "ext-3", status: "running", deploy_target: "external" }],
+      });
+      mockDb.query.mockResolvedValueOnce({ rows: [] });
+      const healthProbe = jest.fn().mockRejectedValue(new Error("boom"));
+
+      await reconcileExternalAgentStatuses({ healthProbe });
+
+      expect(mockDb.query).toHaveBeenNthCalledWith(
+        2,
+        "UPDATE agents SET status = $1 WHERE id = $2",
+        ["stopped", "ext-3"],
+      );
+    });
+
+    it("leaves an unchanged status alone (no UPDATE)", async () => {
+      mockDb.query.mockResolvedValueOnce({
+        rows: [{ id: "ext-4", status: "running", deploy_target: "external" }],
+      });
+      const healthProbe = jest.fn().mockResolvedValue({ running: true });
+
+      await reconcileExternalAgentStatuses({ healthProbe });
+
+      expect(mockDb.query).toHaveBeenCalledTimes(1); // only the SELECT
+    });
   });
 });

--- a/backend-api/__tests__/externalHealth.test.ts
+++ b/backend-api/__tests__/externalHealth.test.ts
@@ -1,0 +1,75 @@
+// @ts-nocheck
+const mockResolveGateway = jest.fn();
+const mockResolveHermes = jest.fn();
+jest.mock("../gatewayProxy", () => ({
+  resolveSafeGatewayHttpTarget: (...a) => mockResolveGateway(...a),
+  resolveSafeHermesDashboardTarget: (...a) => mockResolveHermes(...a),
+}));
+
+const { probeExternalAgentHealth } = require("../externalHealth");
+
+beforeEach(() => {
+  mockResolveGateway.mockReset();
+  mockResolveHermes.mockReset();
+});
+
+describe("probeExternalAgentHealth", () => {
+  it("resolves an OpenClaw agent through the gateway allowlist and reports running on any response", async () => {
+    mockResolveGateway.mockResolvedValue({
+      url: "http://203.0.113.5:18789/",
+      hostHeader: "203.0.113.5:18789",
+    });
+    const fetchImpl = jest.fn().mockResolvedValue({ status: 426 });
+
+    const result = await probeExternalAgentHealth(
+      { runtime_family: "openclaw", deploy_target: "external", gateway_host: "203.0.113.5" },
+      { fetchImpl },
+    );
+
+    expect(result).toEqual({ running: true });
+    expect(mockResolveGateway).toHaveBeenCalled();
+    const [url, opts] = fetchImpl.mock.calls[0];
+    expect(url).toBe("http://203.0.113.5:18789/");
+    expect(opts.headers.Host).toBe("203.0.113.5:18789");
+    expect(opts.redirect).toBe("manual"); // never follow a redirect off the allowlist
+  });
+
+  it("resolves a Hermes agent through the dashboard allowlist", async () => {
+    mockResolveHermes.mockResolvedValue({ host: "203.0.113.6", port: 9119 });
+    const fetchImpl = jest.fn().mockResolvedValue({ status: 200 });
+
+    const result = await probeExternalAgentHealth(
+      { runtime_family: "hermes", deploy_target: "external", gateway_host: "203.0.113.6" },
+      { fetchImpl },
+    );
+
+    expect(result).toEqual({ running: true });
+    expect(mockResolveHermes).toHaveBeenCalled();
+    expect(fetchImpl.mock.calls[0][0]).toBe("http://203.0.113.6:9119/");
+  });
+
+  it("reports not running when the fetch fails (connection refused / timeout)", async () => {
+    mockResolveGateway.mockResolvedValue({ url: "http://203.0.113.5:18789/", hostHeader: "x" });
+    const fetchImpl = jest.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+
+    const result = await probeExternalAgentHealth(
+      { runtime_family: "openclaw", deploy_target: "external" },
+      { fetchImpl },
+    );
+
+    expect(result).toEqual({ running: false });
+  });
+
+  it("reports not running when the endpoint can't be resolved/allowlisted", async () => {
+    mockResolveGateway.mockRejectedValue(new Error("not an allowed gateway address"));
+    const fetchImpl = jest.fn();
+
+    const result = await probeExternalAgentHealth(
+      { runtime_family: "openclaw", deploy_target: "external" },
+      { fetchImpl },
+    );
+
+    expect(result).toEqual({ running: false });
+    expect(fetchImpl).not.toHaveBeenCalled(); // never fetch an unresolved/disallowed target
+  });
+});

--- a/backend-api/backgroundTasks.ts
+++ b/backend-api/backgroundTasks.ts
@@ -3,6 +3,7 @@ const db = require("./db");
 const containerManager = require("./containerManager");
 const { reconcileAgentStatus } = require("./agentStatus");
 const { collectAgentTelemetrySample } = require("./agentTelemetry");
+const { probeExternalAgentHealth } = require("./externalHealth");
 
 async function collectBackgroundTelemetry({
   dbClient = db,
@@ -72,7 +73,46 @@ async function reconcileBackgroundAgentStatuses({
   }
 }
 
+// Reconcile ADOPTED external runtimes (BYOC Phase C2). They have no container, so
+// the container reconciler above skips them (container_id IS NULL). Liveness comes
+// from an SSRF-safe HTTP probe of the operator-declared endpoint instead, then the
+// same reconcileAgentStatus transitions apply (reachable -> running / recovers;
+// unreachable -> stopped). Best-effort.
+async function reconcileExternalAgentStatuses({
+  dbClient = db,
+  healthProbe = probeExternalAgentHealth,
+} = {}) {
+  try {
+    const agents = await dbClient.query(
+      `SELECT id, status, runtime_family, deploy_target, execution_target_id, user_id,
+              gateway_host, gateway_port, runtime_host, runtime_port, dashboard_port
+         FROM agents
+        WHERE deploy_target = 'external'
+          AND status IN ('running','warning','stopped','error')`,
+    );
+
+    for (const agent of agents.rows) {
+      let live = { running: false };
+      try {
+        live = await healthProbe(agent);
+      } catch {
+        live = { running: false };
+      }
+      const reconciledStatus = reconcileAgentStatus(agent.status, Boolean(live?.running));
+      if (reconciledStatus !== agent.status) {
+        await dbClient.query("UPDATE agents SET status = $1 WHERE id = $2", [
+          reconciledStatus,
+          agent.id,
+        ]);
+      }
+    }
+  } catch {
+    // Reconciliation is best-effort only.
+  }
+}
+
 module.exports = {
   collectBackgroundTelemetry,
   reconcileBackgroundAgentStatuses,
+  reconcileExternalAgentStatuses,
 };

--- a/backend-api/externalHealth.ts
+++ b/backend-api/externalHealth.ts
@@ -1,0 +1,49 @@
+// @ts-nocheck
+// Health probe for ADOPTED external runtimes (BYOC Phase C2). Nora does not
+// provision these, so there is no container to inspect — liveness is whether the
+// operator-declared endpoint answers. The probe goes through the SAME SSRF-safe
+// resolvers the proxy uses (resolveSafeGatewayHttpTarget / resolveSafeHermesDashboard
+// Target), so it can only ever hit the agent's own allowlisted, IP-pinned endpoint.
+// Any HTTP response (any status — even 4xx/5xx) means the endpoint is alive;
+// a connection error / timeout means it is down. Redirects are NOT followed
+// (redirect: "manual") so a 3xx can't bounce the probe to a non-allowlisted host.
+
+const {
+  resolveSafeGatewayHttpTarget,
+  resolveSafeHermesDashboardTarget,
+} = require("./gatewayProxy");
+const { joinHttpUrl } = require("../agent-runtime/lib/agentEndpoints");
+
+async function probeExternalAgentHealth(agent, { fetchImpl, timeoutMs = 5000 } = {}) {
+  const doFetch = fetchImpl || globalThis.fetch;
+
+  let url;
+  const headers = {};
+  try {
+    if (String(agent?.runtime_family || "").toLowerCase() === "hermes") {
+      const { host, port } = await resolveSafeHermesDashboardTarget(agent);
+      url = joinHttpUrl(host, port, "/");
+    } else {
+      const target = await resolveSafeGatewayHttpTarget(agent, "");
+      url = target.url;
+      if (target.hostHeader) headers.Host = target.hostHeader;
+    }
+  } catch {
+    // Endpoint can't be resolved or isn't allowlisted → treat as not reachable.
+    return { running: false };
+  }
+
+  try {
+    await doFetch(url, {
+      method: "GET",
+      headers,
+      redirect: "manual",
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    return { running: true };
+  } catch {
+    return { running: false };
+  }
+}
+
+module.exports = { probeExternalAgentHealth };

--- a/backend-api/server.ts
+++ b/backend-api/server.ts
@@ -21,6 +21,7 @@ const { collectAgentTelemetrySample } = require("./agentTelemetry");
 const {
   collectBackgroundTelemetry,
   reconcileBackgroundAgentStatuses,
+  reconcileExternalAgentStatuses,
 } = require("./backgroundTasks");
 const agentBudgets = require("./agentBudgets");
 const { listKubernetesExecutionTargets } = require("./kubernetesClusters");
@@ -2073,6 +2074,12 @@ if (require.main === module) {
     const RECONCILE_INTERVAL = 30000;
     setInterval(async () => {
       await reconcileBackgroundAgentStatuses({ dbClient: db });
+    }, RECONCILE_INTERVAL);
+
+    // ── External runtime reconciler: adopted runtimes have no container, so probe
+    // their endpoint over HTTP (SSRF-safe) and reconcile status every 30s. ──
+    setInterval(async () => {
+      await reconcileExternalAgentStatuses({ dbClient: db });
     }, RECONCILE_INTERVAL);
 
     // ── Budget sweep: re-enforce per-agent hard caps every 60s. The status


### PR DESCRIPTION
## What

Phase C2a: reconcile the status of **adopted external runtimes** from a real liveness signal. C1 created them at `status='running'` (optimistic) and the container reconciler skips them (`container_id IS NULL`), so without this they'd never reflect reality.

## How

- **`externalHealth.ts` — `probeExternalAgentHealth(agent)`**: builds the endpoint URL via the **same SSRF-safe resolvers the proxy uses** (`resolveSafeGatewayHttpTarget` for OpenClaw, `resolveSafeHermesDashboardTarget` for Hermes), so it can only ever hit the agent's own **allowlisted, IP-pinned** endpoint. Any HTTP response (any status) = alive; connection error/timeout = down. `redirect: "manual"` so a 3xx can't bounce the probe off the allowlist.
- **`backgroundTasks.ts` — `reconcileExternalAgentStatuses()`**: selects **only** external agents, probes each, and applies the **existing** `reconcileAgentStatus` transitions (reachable → running/recovers; unreachable → stopped). Best-effort — a throwing probe degrades to 'not running'.
- **`server.ts`**: registered on the same 30s cadence as the container reconciler.

## Scope

C2a is the backend half of C2. **C2b** (the "Adopt existing runtime" deploy-UI tab + External badge + disabled lifecycle + Deregister labeling) is the follow-up. Status transitions reuse the platform's existing reconcile semantics (a single failed probe → stopped, a later success → running), matching the container reconciler.

## Tests

Probe: OpenClaw + Hermes resolution paths, response→running, fetch-fail→down, unresolvable/disallowed→down (without fetching). Reconcile loop: external-only query, recover (stopped→running), stop (running→stopped), throw→down, no-op when unchanged. Backend suite **1142 green**; typecheck, eslint, prettier clean.