### PR TITLE
feat(ui): render + operate adopted external runtimes correctly (BYOC C2b-1)

### DIFF
--- a/frontend-dashboard/components/agents/OverviewTab.tsx
+++ b/frontend-dashboard/components/agents/OverviewTab.tsx
@@ -124,6 +124,9 @@ export default function OverviewTab({
   const runtimeAddress = formatRuntimeAddress(agent);
   const isKubernetesAgent = isKubernetesTarget(agent, executionTarget);
   const replicas = isKubernetesAgent ? resolveKubernetesReplicaSnapshot(agent) : null;
+  // Adopted external runtimes are not provisioned by Nora, so lifecycle controls
+  // (start/stop/restart/redeploy/duplicate) don't apply — Nora only monitors + proxies.
+  const isExternal = String(agent?.deploy_target || "").toLowerCase() === "external";
 
   // Fetch last error event when agent is in error state
   useEffect(() => {
@@ -253,11 +256,26 @@ export default function OverviewTab({
         </div>
       )}
 
+      {/* External runtime notice */}
+      {isExternal && (
+        <div className="flex items-start gap-3 rounded-2xl border border-blue-200 bg-blue-50 px-5 py-3">
+          <Globe size={18} className="mt-0.5 shrink-0 text-blue-600" />
+          <div>
+            <p className="text-sm font-bold text-blue-800">External runtime</p>
+            <p className="text-xs text-blue-600">
+              This runtime was adopted by URL and runs outside Nora. Nora monitors and proxies it,
+              but lifecycle controls (start, stop, restart, redeploy) are unavailable. Use
+              “Deregister” in Settings to remove it from Nora — the runtime itself is not stopped.
+            </p>
+          </div>
+        </div>
+      )}
+
       {/* Quick Actions */}
       <div className="flex items-center gap-3 flex-wrap">
         <button
           onClick={onDuplicate}
-          disabled={!!actionLoading}
+          disabled={!!actionLoading || isExternal}
           className="flex items-center gap-2 px-4 py-2.5 bg-slate-50 border border-slate-200 text-slate-700 hover:bg-slate-100 text-xs font-bold rounded-xl transition-all disabled:opacity-50"
         >
           {actionLoading === "duplicate" ? (
@@ -281,7 +299,7 @@ export default function OverviewTab({
             Share to Agent Hub
           </button>
         ) : null}
-        {agent.status === "running" && (
+        {!isExternal && agent.status === "running" && (
           <>
             <button
               onClick={onStop}
@@ -309,7 +327,7 @@ export default function OverviewTab({
             </button>
           </>
         )}
-        {agent.status === "stopped" && (
+        {!isExternal && agent.status === "stopped" && (
           <button
             onClick={onStart}
             disabled={!!actionLoading}
@@ -323,7 +341,7 @@ export default function OverviewTab({
             Start Agent
           </button>
         )}
-        {(agent.status === "error" || agent.status === "stopped") && (
+        {!isExternal && (agent.status === "error" || agent.status === "stopped") && (
           <button
             onClick={onRedeploy}
             disabled={!!actionLoading}

--- a/frontend-dashboard/components/agents/SettingsTab.tsx
+++ b/frontend-dashboard/components/agents/SettingsTab.tsx
@@ -35,6 +35,10 @@ export default function SettingsTab({
   );
   const sandboxLabel = formatSandboxProfileLabel(resolveAgentSandboxProfile(agent));
   const canDelete = agent.isDirectOwner !== false;
+  // External (adopted) runtimes aren't provisioned by Nora, so "delete" only
+  // removes the adoption record — surface it as "Deregister", and the
+  // duplicate/clone action doesn't apply.
+  const isExternal = String(agent?.deploy_target || "").toLowerCase() === "external";
 
   useEffect(() => {
     setAgentName(agent.name || "");
@@ -55,9 +59,13 @@ export default function SettingsTab({
     <div className="space-y-8">
       <ConfirmDialog
         open={showDeleteConfirm}
-        title="Delete Agent"
-        message="Are you sure you want to permanently delete this agent? This will destroy the container and all data. This action cannot be undone."
-        confirmLabel="Delete Agent"
+        title={isExternal ? "Deregister runtime" : "Delete Agent"}
+        message={
+          isExternal
+            ? "Remove this external runtime from Nora? Nora stops monitoring and proxying it, but the runtime itself keeps running — it is not stopped or destroyed."
+            : "Are you sure you want to permanently delete this agent? This will destroy the container and all data. This action cannot be undone."
+        }
+        confirmLabel={isExternal ? "Deregister" : "Delete Agent"}
         onConfirm={() => {
           setShowDeleteConfirm(false);
           onDelete();
@@ -96,19 +104,21 @@ export default function SettingsTab({
               )}
               Save Name
             </button>
-            <button
-              type="button"
-              onClick={onDuplicate}
-              disabled={!!actionLoading}
-              className="flex items-center gap-2 px-4 py-2.5 bg-slate-100 text-slate-800 text-xs font-bold rounded-xl hover:bg-slate-200 transition-all disabled:opacity-50"
-            >
-              {actionLoading === "duplicate" ? (
-                <Loader2 size={14} className="animate-spin" />
-              ) : (
-                <Copy size={14} />
-              )}
-              Duplicate Agent
-            </button>
+            {!isExternal ? (
+              <button
+                type="button"
+                onClick={onDuplicate}
+                disabled={!!actionLoading}
+                className="flex items-center gap-2 px-4 py-2.5 bg-slate-100 text-slate-800 text-xs font-bold rounded-xl hover:bg-slate-200 transition-all disabled:opacity-50"
+              >
+                {actionLoading === "duplicate" ? (
+                  <Loader2 size={14} className="animate-spin" />
+                ) : (
+                  <Copy size={14} />
+                )}
+                Duplicate Agent
+              </button>
+            ) : null}
             {supportsAgentHub ? (
               <button
                 type="button"
@@ -237,8 +247,9 @@ export default function SettingsTab({
         <section className="bg-red-50 border border-red-200 rounded-2xl p-6 space-y-4">
           <h3 className="text-sm font-bold text-red-700">Danger Zone</h3>
           <p className="text-xs text-red-600">
-            Deleting this agent will permanently destroy the container and all associated data
-            including integrations, channels, and message history.
+            {isExternal
+              ? "Deregistering removes this external runtime from Nora (monitoring, proxy access, and its record). The runtime itself keeps running — Nora does not stop or destroy it."
+              : "Deleting this agent will permanently destroy the container and all associated data including integrations, channels, and message history."}
           </p>
           <button
             onClick={() => setShowDeleteConfirm(true)}
@@ -250,7 +261,7 @@ export default function SettingsTab({
             ) : (
               <Trash2 size={14} />
             )}
-            Delete Agent
+            {isExternal ? "Deregister Runtime" : "Delete Agent"}
           </button>
         </section>
       ) : (

--- a/frontend-dashboard/lib/runtime.ts
+++ b/frontend-dashboard/lib/runtime.ts
@@ -40,7 +40,9 @@ export function normalizeDeployTarget(value) {
   if (normalized.startsWith("k8s:") || normalized.startsWith("kubernetes:")) return "k8s";
   if (normalized === "kubernetes" || normalized === "k3s") return "k8s";
   if (normalized.startsWith("remote:")) return "remote-docker";
-  if (["docker", "k8s", "remote-docker", "proxmox"].includes(normalized)) return normalized;
+  if (["docker", "k8s", "remote-docker", "proxmox", "external"].includes(normalized)) {
+    return normalized;
+  }
   return null;
 }
 
@@ -415,6 +417,8 @@ export function formatExecutionTargetLabel(
       return "Remote Docker host";
     case "proxmox":
       return "Proxmox";
+    case "external":
+      return "External runtime";
     default:
       return "Docker";
   }

--- a/frontend-dashboard/pages/agents/[id].tsx
+++ b/frontend-dashboard/pages/agents/[id].tsx
@@ -613,6 +613,11 @@ export default function AgentDetail() {
                 <span className="text-[10px] text-slate-500 font-bold uppercase px-2 py-0.5 bg-slate-100 rounded">
                   {executionTargetLabel}
                 </span>
+                {agent.deploy_target === "external" ? (
+                  <span className="text-[10px] text-blue-700 font-bold uppercase px-2 py-0.5 bg-blue-50 border border-blue-200 rounded">
+                    External
+                  </span>
+                ) : null}
                 {sandboxProfile !== "standard" ? (
                   <span className="text-[10px] text-emerald-700 font-bold uppercase px-2 py-0.5 bg-emerald-50 rounded">
                     {sandboxLabel}

--- a/frontend-dashboard/pages/agents/index.tsx
+++ b/frontend-dashboard/pages/agents/index.tsx
@@ -327,7 +327,9 @@ function SearchEmptyState({ search, onClear }) {
 function AgentCard({ agent, backendConfig, onAction }) {
   const isActive = agent.status === "running" || agent.status === "warning";
   const powerAction = isActive ? "stop" : "start";
-  const powerDisabled = !isActive && !agent.container_id;
+  // Adopted external runtimes aren't controlled by Nora — no start/stop.
+  const isExternal = String(agent?.deploy_target || "").toLowerCase() === "external";
+  const powerDisabled = isExternal || (!isActive && !agent.container_id);
   const runtimePathLabel = formatRuntimePathLabel(agent, backendConfig);
   const runtimeFamilyLabel = formatRuntimeFamilyLabel(agent.runtime_family);
   const executionTargetLabel = formatExecutionTargetLabel(
@@ -383,6 +385,11 @@ function AgentCard({ agent, backendConfig, onAction }) {
             <span className="inline-flex items-center rounded-full bg-white px-3 py-1 text-[11px] font-bold text-slate-700 border border-blue-100">
               {sandboxLabel}
             </span>
+            {isExternal ? (
+              <span className="inline-flex items-center rounded-full bg-blue-600/10 px-3 py-1 text-[11px] font-bold text-blue-700 border border-blue-200">
+                External
+              </span>
+            ) : null}
           </div>
         </div>
 
@@ -421,11 +428,13 @@ function AgentCard({ agent, backendConfig, onAction }) {
                 : "bg-emerald-50 border-emerald-100 text-emerald-500 hover:bg-emerald-100",
           )}
           title={
-            powerDisabled
-              ? "Start is unavailable until a container has been provisioned"
-              : isActive
-                ? "Stop agent"
-                : "Start agent"
+            isExternal
+              ? "External runtime — lifecycle controls are unavailable"
+              : powerDisabled
+                ? "Start is unavailable until a container has been provisioned"
+                : isActive
+                  ? "Stop agent"
+                  : "Start agent"
           }
         >
           <Power size={18} />


### PR DESCRIPTION
## What

Frontend half (part 1) of Phase C2b: make the operator dashboard handle **adopted external runtimes** (`deploy_target='external'` — runtimes Nora monitors + proxies but does not control). The **adopt form** (a deploy-page tab) is the focused **C2b-2** follow-up; this PR makes already-adopted agents render and behave correctly.

## Changes

- **`lib/runtime.ts`**: `normalizeDeployTarget` + `formatExecutionTargetLabel` recognize `external` → *"External runtime"*, so runtime-path labels render *"OpenClaw + External runtime"* / *"Hermes + External runtime"* instead of falling back to Docker.
- **`OverviewTab`**: an "External runtime" info banner; start/stop/restart/redeploy/duplicate hidden or disabled (no container to control).
- **`SettingsTab`**: delete relabeled **"Deregister"** (Danger Zone heading, copy, confirm dialog, button) — wording makes clear the runtime itself is **not** stopped; Duplicate hidden for external.
- **`agents/[id].tsx`**: an "External" badge in the detail header.
- **`agents/index.tsx`**: an "External" badge on the list card + the power button disabled with an explanatory tooltip.

## Verification

Frontend-only. `tsc --noEmit`, eslint, and prettier all clean. The dashboard has no jest suite, so coverage is typecheck / lint / docker-build (CI) + e2e; the changes are contained conditional-rendering + label additions.

## Next

**C2b-2**: the "Adopt existing runtime" tab on the deploy page (form → `POST /api/agents/adopt` → redirect), which is the more intricate change to the ~1700-line deploy page — kept separate for a clean review.