### PR TITLE
refactor(cli): extract duplicated table helper into a shared module

### DIFF
--- a/cli/src/commands/agents.js
+++ b/cli/src/commands/agents.js
@@ -1,18 +1,5 @@
 const api = require("../client");
-
-function table(rows, columns) {
-  if (rows.length === 0) {
-    console.log("(none)");
-    return;
-  }
-  const widths = columns.map((col) =>
-    Math.max(col.header.length, ...rows.map((row) => String(col.value(row) ?? "").length)),
-  );
-  const fmt = (cells) => cells.map((cell, i) => String(cell ?? "").padEnd(widths[i])).join("  ");
-  console.log(fmt(columns.map((c) => c.header)));
-  console.log(fmt(widths.map((w) => "-".repeat(w))));
-  for (const row of rows) console.log(fmt(columns.map((c) => c.value(row))));
-}
+const table = require("../table");
 
 async function list() {
   const rows = await api.get("/api/agents");

--- a/cli/src/commands/agents.js
+++ b/cli/src/commands/agents.js
@@ -42,8 +42,7 @@ async function versions(args) {
 async function rollback(args) {
   const id = args[0];
   const versionId = args[1];
-  if (!id || !versionId)
-    throw new Error("usage: nora agents rollback <agent-id> <version-id>");
+  if (!id || !versionId) throw new Error("usage: nora agents rollback <agent-id> <version-id>");
   const result = await api.post(`/api/agents/${id}/rollback/${versionId}`);
   console.log(`Rolled back to v${result.restored.versionNumber}.`);
   if (result.redeployed) console.log("Redeploy queued.");

--- a/cli/src/commands/workspaces.js
+++ b/cli/src/commands/workspaces.js
@@ -1,19 +1,6 @@
 const api = require("../client");
 const { load, save } = require("../config");
-
-function table(rows, columns) {
-  if (rows.length === 0) {
-    console.log("(none)");
-    return;
-  }
-  const widths = columns.map((col) =>
-    Math.max(col.header.length, ...rows.map((row) => String(col.value(row) ?? "").length)),
-  );
-  const fmt = (cells) => cells.map((cell, i) => String(cell ?? "").padEnd(widths[i])).join("  ");
-  console.log(fmt(columns.map((c) => c.header)));
-  console.log(fmt(widths.map((w) => "-".repeat(w))));
-  for (const row of rows) console.log(fmt(columns.map((c) => c.value(row))));
-}
+const table = require("../table");
 
 async function list() {
   const rows = await api.get("/api/workspaces");

--- a/cli/src/table.js
+++ b/cli/src/table.js
@@ -1,0 +1,15 @@
+function table(rows, columns) {
+  if (rows.length === 0) {
+    console.log("(none)");
+    return;
+  }
+  const widths = columns.map((col) =>
+    Math.max(col.header.length, ...rows.map((row) => String(col.value(row) ?? "").length)),
+  );
+  const fmt = (cells) => cells.map((cell, i) => String(cell ?? "").padEnd(widths[i])).join("  ");
+  console.log(fmt(columns.map((c) => c.header)));
+  console.log(fmt(widths.map((w) => "-".repeat(w))));
+  for (const row of rows) console.log(fmt(columns.map((c) => c.value(row))));
+}
+
+module.exports = table;

--- a/cli/src/table.test.js
+++ b/cli/src/table.test.js
@@ -1,0 +1,41 @@
+const test = require("node:test");
+const assert = require("node:assert");
+const table = require("./table");
+
+test("table with empty rows prints (none)", () => {
+  const logs = [];
+  const originalLog = console.log;
+  console.log = (msg) => logs.push(msg);
+
+  try {
+    table([], [{ header: "ID", value: (r) => r.id }]);
+    assert.deepStrictEqual(logs, ["(none)"]);
+  } finally {
+    console.log = originalLog;
+  }
+});
+
+test("table with rows formats output correctly", () => {
+  const logs = [];
+  const originalLog = console.log;
+  console.log = (msg) => logs.push(msg);
+
+  try {
+    const rows = [
+      { id: "1", name: "Alice" },
+      { id: "100", name: "Bob" }
+    ];
+    table(rows, [
+      { header: "ID", value: (r) => r.id },
+      { header: "NAME", value: (r) => r.name }
+    ]);
+    assert.deepStrictEqual(logs, [
+      "ID   NAME ",
+      "---  -----",
+      "1    Alice",
+      "100  Bob  "
+    ]);
+  } finally {
+    console.log = originalLog;
+  }
+});

--- a/cli/src/table.test.js
+++ b/cli/src/table.test.js
@@ -23,18 +23,13 @@ test("table with rows formats output correctly", () => {
   try {
     const rows = [
       { id: "1", name: "Alice" },
-      { id: "100", name: "Bob" }
+      { id: "100", name: "Bob" },
     ];
     table(rows, [
       { header: "ID", value: (r) => r.id },
-      { header: "NAME", value: (r) => r.name }
+      { header: "NAME", value: (r) => r.name },
     ]);
-    assert.deepStrictEqual(logs, [
-      "ID   NAME ",
-      "---  -----",
-      "1    Alice",
-      "100  Bob  "
-    ]);
+    assert.deepStrictEqual(logs, ["ID   NAME ", "---  -----", "1    Alice", "100  Bob  "]);
   } finally {
     console.log = originalLog;
   }


### PR DESCRIPTION
This PR refactors the CLI to extract the duplicated `table` function defined in `cli/src/commands/agents.js` and `cli/src/commands/workspaces.js` into a single, shared module `cli/src/table.js` as requested in issue #216.

Changes:
1. Created `cli/src/table.js` and exported the shared `table(rows, columns)` helper.
2. Updated `cli/src/commands/agents.js` and `cli/src/commands/workspaces.js` to require and use the new shared utility, removing the duplicated local helper definitions.
3. Added unit tests for the shared table helper in `cli/src/table.test.js` to verify standard formatting output and handle empty rows gracefully, ensuring we maintain high test coverage and prevent future regressions.