### PR TITLE
feat(rbac): share BYOC remote hosts into workspaces (Phase C3a backend)

### DIFF
--- a/backend-api/__tests__/remoteHostGatewayAllowlist.test.ts
+++ b/backend-api/__tests__/remoteHostGatewayAllowlist.test.ts
@@ -93,6 +93,20 @@ describe("remote-host gateway allowlist (HTTP proxy)", () => {
     );
   });
 
+  it("fails closed on a null-owner host — runs the grant check, does not short-circuit", async () => {
+    mockGetRemoteHostByExecutionTarget.mockResolvedValue({
+      id: "my-vps",
+      ownerUserId: null,
+      gatewayHost: PUBLIC_IP,
+      sshHost: PUBLIC_IP,
+    });
+    // userCanUseRemoteHost defaults to false → no grant → blocked.
+    await expect(resolveSafeGatewayHttpTarget(remoteAgent(), "status")).rejects.toThrow(
+      /not an allowed gateway address/i,
+    );
+    expect(mockUserCanUseRemoteHost).toHaveBeenCalledWith("user-1", "my-vps");
+  });
+
   it("does NOT widen the allowlist for a non-remote agent with a public host", async () => {
     // A docker agent must never reach a public address — the registry lookup is
     // skipped entirely (deploy_target !== remote-docker).

--- a/backend-api/__tests__/remoteHostGatewayAllowlist.test.ts
+++ b/backend-api/__tests__/remoteHostGatewayAllowlist.test.ts
@@ -12,8 +12,10 @@ jest.mock("../agentBudgets", () => ({ checkAndEnforce: jest.fn() }));
 jest.mock("ws", () => ({ WebSocket: class {}, WebSocketServer: class {} }));
 
 const mockGetRemoteHostByExecutionTarget = jest.fn();
+const mockUserCanUseRemoteHost = jest.fn().mockResolvedValue(false);
 jest.mock("../remoteHosts", () => ({
   getRemoteHostByExecutionTarget: (...args) => mockGetRemoteHostByExecutionTarget(...args),
+  userCanUseRemoteHost: (...args) => mockUserCanUseRemoteHost(...args),
 }));
 
 const {
@@ -38,6 +40,8 @@ function remoteAgent(overrides = {}) {
 
 beforeEach(() => {
   mockGetRemoteHostByExecutionTarget.mockReset();
+  mockUserCanUseRemoteHost.mockReset();
+  mockUserCanUseRemoteHost.mockResolvedValue(false);
 });
 
 describe("remote-host gateway allowlist (HTTP proxy)", () => {
@@ -54,7 +58,8 @@ describe("remote-host gateway allowlist (HTTP proxy)", () => {
   });
 
   it("does NOT trust a remote host registered by a different operator", async () => {
-    // Cross-tenant execution_target_id reference: the host belongs to user-2.
+    // Cross-tenant execution_target_id reference: the host belongs to user-2 and is
+    // NOT shared to user-1 (userCanUseRemoteHost defaults to false).
     mockGetRemoteHostByExecutionTarget.mockResolvedValue({
       id: "my-vps",
       ownerUserId: "user-2",
@@ -64,6 +69,21 @@ describe("remote-host gateway allowlist (HTTP proxy)", () => {
     await expect(resolveSafeGatewayHttpTarget(remoteAgent(), "status")).rejects.toThrow(
       /not an allowed gateway address/i,
     );
+    expect(mockUserCanUseRemoteHost).toHaveBeenCalledWith("user-1", "my-vps");
+  });
+
+  it("trusts another operator's host when it is SHARED to the agent owner (C3 grant)", async () => {
+    // host owned by user-2 but shared into a workspace where user-1 is editor+.
+    mockGetRemoteHostByExecutionTarget.mockResolvedValue({
+      id: "my-vps",
+      ownerUserId: "user-2",
+      gatewayHost: PUBLIC_IP,
+      sshHost: PUBLIC_IP,
+    });
+    mockUserCanUseRemoteHost.mockResolvedValue(true);
+    const target = await resolveSafeGatewayHttpTarget(remoteAgent(), "status");
+    expect(target.url).toBe(`http://${PUBLIC_IP}:19042/status`);
+    expect(mockUserCanUseRemoteHost).toHaveBeenCalledWith("user-1", "my-vps");
   });
 
   it("rejects a public host when no matching remote host is registered", async () => {

--- a/backend-api/__tests__/remoteHostGrants.test.ts
+++ b/backend-api/__tests__/remoteHostGrants.test.ts
@@ -1,0 +1,87 @@
+// @ts-nocheck
+// BYOC C3: workspace-shared remote hosts. Verifies userCanUseRemoteHost (the
+// positive grant check that widens the owner-only deploy/reach gates) and the
+// share/unshare helpers.
+const mockDb = { query: jest.fn() };
+jest.mock("../db", () => mockDb);
+jest.mock("../crypto", () => ({
+  encrypt: (v) => v,
+  decrypt: (v) => v,
+  ensureEncryptionConfigured: jest.fn(),
+}));
+
+const { userCanUseRemoteHost, shareRemoteHost, unshareRemoteHost } = require("../remoteHosts");
+
+beforeEach(() => mockDb.query.mockReset());
+
+// Route db.query on SQL shape: the ownership probe vs the workspace-grant probe.
+function fakeAccess({ owned = false, sharedEditorPlus = false, grantsTableMissing = false } = {}) {
+  mockDb.query.mockImplementation(async (sql) => {
+    if (/FROM remote_hosts WHERE id = \$1 AND owner_user_id/.test(sql)) {
+      return { rows: owned ? [{ "?column?": 1 }] : [] };
+    }
+    if (/FROM workspace_remote_hosts/.test(sql)) {
+      if (grantsTableMissing) {
+        const err = new Error('relation "workspace_remote_hosts" does not exist');
+        err.code = "42P01";
+        throw err;
+      }
+      return { rows: sharedEditorPlus ? [{ "?column?": 1 }] : [] };
+    }
+    return { rows: [] };
+  });
+}
+
+describe("userCanUseRemoteHost", () => {
+  it("allows the host owner", async () => {
+    fakeAccess({ owned: true });
+    expect(await userCanUseRemoteHost("user-1", "host-1")).toBe(true);
+    // owner short-circuits before the workspace-grant query
+    expect(mockDb.query).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows an editor+ member of a workspace the host is shared into", async () => {
+    fakeAccess({ owned: false, sharedEditorPlus: true });
+    expect(await userCanUseRemoteHost("user-2", "host-1")).toBe(true);
+    // The grant query filters role = ANY(editor/admin/owner).
+    const grantCall = mockDb.query.mock.calls.find((c) => /workspace_remote_hosts/.test(c[0]));
+    expect(grantCall[0]).toMatch(/wm\.role = ANY/);
+    expect(grantCall[1]).toEqual(["host-1", "user-2", ["editor", "admin", "owner"]]);
+  });
+
+  it("denies a user with no ownership and no qualifying grant (e.g. viewer-only)", async () => {
+    fakeAccess({ owned: false, sharedEditorPlus: false });
+    expect(await userCanUseRemoteHost("user-3", "host-1")).toBe(false);
+  });
+
+  it("denies when the grants table has not been migrated yet", async () => {
+    fakeAccess({ owned: false, grantsTableMissing: true });
+    expect(await userCanUseRemoteHost("user-4", "host-1")).toBe(false);
+  });
+
+  it("denies without a userId or hostId (no query)", async () => {
+    fakeAccess();
+    expect(await userCanUseRemoteHost("", "host-1")).toBe(false);
+    expect(await userCanUseRemoteHost("user-1", "")).toBe(false);
+    expect(mockDb.query).not.toHaveBeenCalled();
+  });
+});
+
+describe("shareRemoteHost / unshareRemoteHost", () => {
+  it("inserts a workspace share idempotently", async () => {
+    mockDb.query.mockResolvedValueOnce({ rows: [] });
+    await shareRemoteHost("host-1", "ws-1", "user-1");
+    const [sql, params] = mockDb.query.mock.calls[0];
+    expect(sql).toMatch(/INSERT INTO workspace_remote_hosts/);
+    expect(sql).toMatch(/ON CONFLICT \(workspace_id, remote_host_id\) DO NOTHING/);
+    expect(params).toEqual(["ws-1", "host-1", "user-1"]);
+  });
+
+  it("deletes a workspace share", async () => {
+    mockDb.query.mockResolvedValueOnce({ rows: [] });
+    await unshareRemoteHost("host-1", "ws-1");
+    const [sql, params] = mockDb.query.mock.calls[0];
+    expect(sql).toMatch(/DELETE FROM workspace_remote_hosts/);
+    expect(params).toEqual(["host-1", "ws-1"]);
+  });
+});

--- a/backend-api/__tests__/remoteHosts.test.ts
+++ b/backend-api/__tests__/remoteHosts.test.ts
@@ -311,6 +311,18 @@ describe("assertRemoteHostExecutionTargetAvailable", () => {
     expect(profile.id).toBe("my-laptop");
   });
 
+  it("fails closed on a null-owner (orphaned) host — requires a grant, never short-circuits", async () => {
+    mockDb.query
+      .mockResolvedValueOnce({ rows: [remoteHostRow({ owner_user_id: null })] }) // null owner
+      .mockResolvedValue({ rows: [] }); // userCanUseRemoteHost probes: no ownership, no grant
+    await expect(
+      remoteHosts.assertRemoteHostExecutionTargetAvailable(
+        { deploy_target: "remote-docker", execution_target_id: "remote:my-laptop" },
+        { ownerUserId: "user-1" },
+      ),
+    ).rejects.toThrow(/Unknown remote host/i);
+  });
+
   it("allows a host owned by the requesting operator", async () => {
     mockDb.query.mockResolvedValueOnce({ rows: [remoteHostRow()] });
     const profile = await remoteHosts.assertRemoteHostExecutionTargetAvailable(

--- a/backend-api/__tests__/remoteHosts.test.ts
+++ b/backend-api/__tests__/remoteHosts.test.ts
@@ -287,14 +287,28 @@ describe("assertRemoteHostExecutionTargetAvailable", () => {
     expect(profile.available).toBe(true);
   });
 
-  it("rejects a host registered by a different operator (owner-scoped)", async () => {
-    mockDb.query.mockResolvedValueOnce({ rows: [remoteHostRow()] }); // owner = user-1
+  it("rejects a host registered by a different operator with no grant (owner-scoped)", async () => {
+    mockDb.query
+      .mockResolvedValueOnce({ rows: [remoteHostRow()] }) // getRemoteHostProfile: owner = user-1
+      .mockResolvedValue({ rows: [] }); // userCanUseRemoteHost probes: not owner, no grant
     await expect(
       remoteHosts.assertRemoteHostExecutionTargetAvailable(
         { deploy_target: "remote-docker", execution_target_id: "remote:my-laptop" },
         { ownerUserId: "user-2" },
       ),
     ).rejects.toThrow(/Unknown remote host/i);
+  });
+
+  it("allows a non-owner who has an editor+ grant via a shared workspace (C3)", async () => {
+    mockDb.query
+      .mockResolvedValueOnce({ rows: [remoteHostRow()] }) // getRemoteHostProfile: owner = user-1
+      .mockResolvedValueOnce({ rows: [] }) // userCanUseRemoteHost: ownership probe (not owner)
+      .mockResolvedValueOnce({ rows: [{ "?column?": 1 }] }); // shared editor+ grant
+    const profile = await remoteHosts.assertRemoteHostExecutionTargetAvailable(
+      { deploy_target: "remote-docker", execution_target_id: "remote:my-laptop" },
+      { ownerUserId: "user-2" },
+    );
+    expect(profile.id).toBe("my-laptop");
   });
 
   it("allows a host owned by the requesting operator", async () => {

--- a/backend-api/__tests__/remoteHostsRoutes.test.ts
+++ b/backend-api/__tests__/remoteHostsRoutes.test.ts
@@ -168,6 +168,31 @@ describe("operator remote-host routes", () => {
     expect(res.status).toBe(200);
     expect(res.body).toEqual([{ workspaceId: "ws-1", workspaceName: "Team" }]);
   });
+
+  it("rejects listing shares for a host the caller does not own (404)", async () => {
+    mockRemoteHosts.getRemoteHost.mockResolvedValue({ id: "vps-1", ownerUserId: "user-2" });
+    const res = await auth(request(app).get("/remote-hosts/vps-1/shares"), userToken);
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects unsharing for a host the caller does not own (404)", async () => {
+    mockRemoteHosts.getRemoteHost.mockResolvedValue({ id: "vps-1", ownerUserId: "user-2" });
+    const res = await auth(request(app).delete("/remote-hosts/vps-1/shares/ws-1"), userToken);
+    expect(res.status).toBe(404);
+    expect(mockRemoteHosts.unshareRemoteHost).not.toHaveBeenCalled();
+  });
+
+  it("rejects sharing into a workspace the owner is not a member of (404)", async () => {
+    mockRemoteHosts.getRemoteHost.mockResolvedValue({ id: "vps-1", ownerUserId: "user-1" });
+    // findWorkspaceMembership queries db; default mock returns no rows → not a member.
+    mockDb.query.mockResolvedValue({ rows: [] });
+    const res = await auth(
+      request(app).post("/remote-hosts/vps-1/shares").send({ workspace_id: "ws-x" }),
+      userToken,
+    );
+    expect(res.status).toBe(404);
+    expect(mockRemoteHosts.shareRemoteHost).not.toHaveBeenCalled();
+  });
 });
 
 describe("admin remote-host fleet view", () => {

--- a/backend-api/__tests__/remoteHostsRoutes.test.ts
+++ b/backend-api/__tests__/remoteHostsRoutes.test.ts
@@ -39,11 +39,15 @@ jest.mock("../billing", () => ({
 
 const mockRemoteHosts = {
   listRemoteHosts: jest.fn(),
+  listAccessibleRemoteHosts: jest.fn().mockResolvedValue([]),
   createRemoteHost: jest.fn(),
   updateRemoteHost: jest.fn(),
   deleteRemoteHost: jest.fn(),
   testRemoteHost: jest.fn(),
   getRemoteHost: jest.fn(),
+  shareRemoteHost: jest.fn().mockResolvedValue(undefined),
+  unshareRemoteHost: jest.fn().mockResolvedValue(undefined),
+  listRemoteHostShares: jest.fn().mockResolvedValue([]),
   // imported elsewhere (worker/containerManager); stubbed so server boot is happy
   getRemoteHostProfile: jest.fn(),
   isRemoteDockerTarget: jest.fn(),
@@ -70,13 +74,15 @@ describe("operator remote-host routes", () => {
     expect(res.status).toBe(401);
   });
 
-  it("lists only the caller's own hosts", async () => {
-    mockRemoteHosts.listRemoteHosts.mockResolvedValue([{ id: "my-laptop", ownerUserId: "user-1" }]);
+  it("lists hosts the caller can access (owned + shared)", async () => {
+    mockRemoteHosts.listAccessibleRemoteHosts.mockResolvedValue([
+      { id: "my-laptop", ownerUserId: "user-1", access: "owned", canDeploy: true },
+      { id: "team-vps", ownerUserId: "user-2", access: "shared", canDeploy: true },
+    ]);
     const res = await auth(request(app).get("/remote-hosts"), userToken);
     expect(res.status).toBe(200);
-    expect(mockRemoteHosts.listRemoteHosts).toHaveBeenCalledWith(
-      expect.objectContaining({ ownerUserId: "user-1", includeDisabled: true }),
-    );
+    expect(mockRemoteHosts.listAccessibleRemoteHosts).toHaveBeenCalledWith("user-1");
+    expect(res.body.map((h) => h.id)).toEqual(["my-laptop", "team-vps"]);
   });
 
   it("creates a host owned by the caller", async () => {
@@ -134,6 +140,33 @@ describe("operator remote-host routes", () => {
     const res = await auth(request(app).post("/remote-hosts/vps-1/test"), userToken);
     expect(res.status).toBe(200);
     expect(res.body.lastTestStatus).toBe("ok");
+  });
+
+  it("rejects sharing a host the caller does not own (404)", async () => {
+    mockRemoteHosts.getRemoteHost.mockResolvedValue({ id: "vps-1", ownerUserId: "user-2" });
+    const res = await auth(
+      request(app).post("/remote-hosts/vps-1/shares").send({ workspace_id: "ws-1" }),
+      userToken,
+    );
+    expect(res.status).toBe(404);
+    expect(mockRemoteHosts.shareRemoteHost).not.toHaveBeenCalled();
+  });
+
+  it("rejects a share with no workspace_id (400)", async () => {
+    mockRemoteHosts.getRemoteHost.mockResolvedValue({ id: "vps-1", ownerUserId: "user-1" });
+    const res = await auth(request(app).post("/remote-hosts/vps-1/shares").send({}), userToken);
+    expect(res.status).toBe(400);
+    expect(mockRemoteHosts.shareRemoteHost).not.toHaveBeenCalled();
+  });
+
+  it("lists a host's workspace shares (owner only)", async () => {
+    mockRemoteHosts.getRemoteHost.mockResolvedValue({ id: "vps-1", ownerUserId: "user-1" });
+    mockRemoteHosts.listRemoteHostShares.mockResolvedValue([
+      { workspaceId: "ws-1", workspaceName: "Team" },
+    ]);
+    const res = await auth(request(app).get("/remote-hosts/vps-1/shares"), userToken);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([{ workspaceId: "ws-1", workspaceName: "Team" }]);
   });
 });
 

--- a/backend-api/db_schema.sql
+++ b/backend-api/db_schema.sql
@@ -358,6 +358,22 @@ CREATE TABLE IF NOT EXISTS workspace_agents (
 CREATE INDEX IF NOT EXISTS idx_workspace_agents_agent
   ON workspace_agents(agent_id);
 
+-- Shared BYOC remote hosts (Phase C3). A host's owner can share it into a
+-- workspace they belong to; workspace members then use it per their workspace
+-- role (editor+ deploys/reaches, viewer sees read-only). Host config/credentials
+-- stay with the owner. Mirrors workspace_agents.
+CREATE TABLE IF NOT EXISTS workspace_remote_hosts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id UUID REFERENCES workspaces(id) ON DELETE CASCADE,
+  remote_host_id TEXT REFERENCES remote_hosts(id) ON DELETE CASCADE,
+  created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  created_at TIMESTAMP DEFAULT NOW(),
+  UNIQUE(workspace_id, remote_host_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_workspace_remote_hosts_host
+  ON workspace_remote_hosts(remote_host_id);
+
 -- Per-workspace membership (Phase 0 of multi-tenant RBAC).
 -- workspaces.user_id remains as the creator denormalization; permission checks
 -- read from workspace_members.role instead.

--- a/backend-api/db_schema.sql
+++ b/backend-api/db_schema.sql
@@ -86,7 +86,7 @@ CREATE INDEX IF NOT EXISTS idx_kubernetes_clusters_enabled
 
 CREATE TABLE IF NOT EXISTS remote_hosts (
   id TEXT PRIMARY KEY,
-  owner_user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+  owner_user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   label TEXT NOT NULL,
   enabled BOOLEAN NOT NULL DEFAULT true,
   is_default BOOLEAN NOT NULL DEFAULT false,

--- a/backend-api/gatewayProxy.ts
+++ b/backend-api/gatewayProxy.ts
@@ -133,8 +133,10 @@ async function allowedRemoteHostsForAgent(agent) {
     const host = await remoteHosts.getRemoteHostByExecutionTarget(agent.execution_target_id);
     if (!host) return EMPTY_ALLOWED_HOSTS;
     // Trust the host only if the agent's owner may use it: direct owner, or an
-    // editor+ grant via a workspace the host is shared into (positive check).
-    if (agent.user_id && host.ownerUserId && host.ownerUserId !== agent.user_id) {
+    // editor+ grant via a workspace the host is shared into (positive check). Fail
+    // closed on a null/foreign owner — never let the owner check short-circuit on a
+    // null owner into trusting the host.
+    if (agent.user_id && host.ownerUserId !== agent.user_id) {
       const allowed = await remoteHosts.userCanUseRemoteHost(agent.user_id, host.id);
       if (!allowed) return EMPTY_ALLOWED_HOSTS;
     }

--- a/backend-api/gatewayProxy.ts
+++ b/backend-api/gatewayProxy.ts
@@ -121,9 +121,10 @@ const EMPTY_ALLOWED_HOSTS = new Set();
 
 // A registered remote host's advertised address is operator-trusted, so allow
 // it even though it is not RFC1918/loopback. Scoped to the agent's OWN host
-// (looked up by execution target) AND to the agent's owner, so a cross-tenant
-// execution_target_id reference can't leak or reach another operator's host.
-// Blocked addresses (0.0.0.0, link-local, …) still apply.
+// (looked up by execution target) AND to a user who may use it — the agent's
+// owner, OR (C3) a workspace the host is shared into where the owner is editor+.
+// A cross-tenant execution_target_id reference still can't reach a host that was
+// never shared to the agent owner. Blocked addresses (0.0.0.0, link-local, …) still apply.
 async function allowedRemoteHostsForAgent(agent) {
   if (normalizeDeployTargetName(agent?.deploy_target) !== "remote-docker") {
     return EMPTY_ALLOWED_HOSTS;
@@ -131,9 +132,11 @@ async function allowedRemoteHostsForAgent(agent) {
   try {
     const host = await remoteHosts.getRemoteHostByExecutionTarget(agent.execution_target_id);
     if (!host) return EMPTY_ALLOWED_HOSTS;
-    // Only trust a host the agent's owner actually registered.
+    // Trust the host only if the agent's owner may use it: direct owner, or an
+    // editor+ grant via a workspace the host is shared into (positive check).
     if (agent.user_id && host.ownerUserId && host.ownerUserId !== agent.user_id) {
-      return EMPTY_ALLOWED_HOSTS;
+      const allowed = await remoteHosts.userCanUseRemoteHost(agent.user_id, host.id);
+      if (!allowed) return EMPTY_ALLOWED_HOSTS;
     }
     const allowed = new Set();
     if (host.gatewayHost) allowed.add(String(host.gatewayHost).toLowerCase());

--- a/backend-api/remoteHosts.ts
+++ b/backend-api/remoteHosts.ts
@@ -550,6 +550,112 @@ async function testRemoteHost(hostId, options = {}) {
 // Deploy-path gate, mirroring assertKubernetesExecutionTargetAvailable. Wiring
 // this into the deploy queue happens in a later Phase A PR; it lives here now so
 // the contract is defined alongside the registry.
+// Workspace roles (editor and above) that may USE a shared remote host — deploy
+// agents to it and reach them through the gateway. Mirrors WORKSPACE_ROLE_RANK in
+// middleware/ownership.ts (viewer:0, editor:1, admin:2, owner:3). Viewer can see a
+// shared host (visibility) but not deploy to it. Host config stays owner-only.
+const HOST_USE_ROLES = Object.freeze(["editor", "admin", "owner"]);
+
+// True if the user owns the host OR it's shared into a workspace where they hold an
+// editor+ role. Positive grant check — used to widen the owner-only deploy/reach
+// gates to shared hosts without ever broadening cross-tenant SSRF.
+async function userCanUseRemoteHost(userId, hostId) {
+  if (!userId || !hostId) return false;
+  const owned = await db.query(
+    "SELECT 1 FROM remote_hosts WHERE id = $1 AND owner_user_id = $2 LIMIT 1",
+    [hostId, userId],
+  );
+  if (owned.rows[0]) return true;
+  try {
+    const shared = await db.query(
+      `SELECT 1
+         FROM workspace_remote_hosts wrh
+         JOIN workspace_members wm ON wm.workspace_id = wrh.workspace_id
+        WHERE wrh.remote_host_id = $1
+          AND wm.user_id = $2
+          AND wm.role = ANY($3)
+        LIMIT 1`,
+      [hostId, userId, HOST_USE_ROLES],
+    );
+    return Boolean(shared.rows[0]);
+  } catch (error) {
+    if (error?.code === "42P01") return false; // grants table not migrated yet
+    throw error;
+  }
+}
+
+// Hosts a user can see: owned (full management) + shared into any workspace they
+// belong to (read-only). Each entry is masked (no secrets) and annotated with the
+// access kind + whether the user may deploy (editor+).
+async function listAccessibleRemoteHosts(userId) {
+  const owned = (await listRemoteHosts({ ownerUserId: userId, includeDisabled: true })).map(
+    (host) => ({
+      ...host,
+      access: "owned",
+      canDeploy: true,
+    }),
+  );
+  const ownedIds = new Set(owned.map((host) => host.id));
+  const shared = [];
+  try {
+    const rows = await db.query(
+      `SELECT wrh.remote_host_id AS host_id,
+              MAX(CASE wm.role
+                    WHEN 'owner' THEN 3 WHEN 'admin' THEN 2 WHEN 'editor' THEN 1 ELSE 0
+                  END) AS rank
+         FROM workspace_remote_hosts wrh
+         JOIN workspace_members wm ON wm.workspace_id = wrh.workspace_id
+        WHERE wm.user_id = $1
+        GROUP BY wrh.remote_host_id`,
+      [userId],
+    );
+    for (const row of rows.rows) {
+      if (ownedIds.has(row.host_id)) continue;
+      const host = await getRemoteHost(row.host_id);
+      if (!host) continue;
+      shared.push({ ...host, access: "shared", canDeploy: Number(row.rank) >= 1 });
+    }
+  } catch (error) {
+    if (error?.code !== "42P01") throw error; // grants table not migrated yet
+  }
+  return [...owned, ...shared];
+}
+
+// Share a host into a workspace (idempotent). Ownership + workspace-membership are
+// enforced by the caller (route layer).
+async function shareRemoteHost(hostId, workspaceId, byUserId) {
+  await db.query(
+    `INSERT INTO workspace_remote_hosts (workspace_id, remote_host_id, created_by)
+     VALUES ($1, $2, $3)
+     ON CONFLICT (workspace_id, remote_host_id) DO NOTHING`,
+    [workspaceId, hostId, byUserId || null],
+  );
+}
+
+async function unshareRemoteHost(hostId, workspaceId) {
+  await db.query(
+    "DELETE FROM workspace_remote_hosts WHERE remote_host_id = $1 AND workspace_id = $2",
+    [hostId, workspaceId],
+  );
+}
+
+async function listRemoteHostShares(hostId) {
+  try {
+    const rows = await db.query(
+      `SELECT wrh.workspace_id AS "workspaceId", w.name AS "workspaceName", wrh.created_at AS "createdAt"
+         FROM workspace_remote_hosts wrh
+         JOIN workspaces w ON w.id = wrh.workspace_id
+        WHERE wrh.remote_host_id = $1
+        ORDER BY w.name`,
+      [hostId],
+    );
+    return rows.rows;
+  } catch (error) {
+    if (error?.code === "42P01") return [];
+    throw error;
+  }
+}
+
 async function assertRemoteHostExecutionTargetAvailable(runtimeFields = {}, options = {}) {
   if (!isRemoteDockerTarget(runtimeFields.deploy_target ?? runtimeFields.deployTarget)) {
     return null;
@@ -566,12 +672,22 @@ async function assertRemoteHostExecutionTargetAvailable(runtimeFields = {}, opti
   }
   const profile = await getRemoteHostProfile(executionTargetId);
   const ownerUserId = options.ownerUserId || null;
-  // Owner-scoped: a host registered by another operator is treated as unknown
-  // (don't leak its existence, and never deploy onto it cross-tenant).
-  if (!profile || (ownerUserId && profile.ownerUserId && profile.ownerUserId !== ownerUserId)) {
+  // Owner-scoped, widened for sharing (C3): a host the user neither owns nor has an
+  // editor+ grant on is treated as unknown (don't leak its existence, never deploy
+  // cross-tenant). The grant check is positive — only explicit shares to a
+  // workspace the user belongs to as editor+ unlock it.
+  if (!profile) {
     const error = new Error(`Unknown remote host execution target: ${executionTargetId}`);
     error.statusCode = 400;
     throw error;
+  }
+  if (ownerUserId && profile.ownerUserId && profile.ownerUserId !== ownerUserId) {
+    const allowed = await userCanUseRemoteHost(ownerUserId, profile.id);
+    if (!allowed) {
+      const error = new Error(`Unknown remote host execution target: ${executionTargetId}`);
+      error.statusCode = 400;
+      throw error;
+    }
   }
   if (!profile.enabled) {
     const error = new Error(`${profile.label} is disabled for new deployments.`);
@@ -602,9 +718,14 @@ module.exports = {
   getRemoteHostProfile,
   isRemoteDockerTarget,
   listRemoteHosts,
+  listAccessibleRemoteHosts,
   listRemoteHostExecutionTargets,
   normalizeRemoteExecutionTargetId,
   rowToProfile,
   testRemoteHost,
   updateRemoteHost,
+  userCanUseRemoteHost,
+  shareRemoteHost,
+  unshareRemoteHost,
+  listRemoteHostShares,
 };

--- a/backend-api/remoteHosts.ts
+++ b/backend-api/remoteHosts.ts
@@ -681,7 +681,10 @@ async function assertRemoteHostExecutionTargetAvailable(runtimeFields = {}, opti
     error.statusCode = 400;
     throw error;
   }
-  if (ownerUserId && profile.ownerUserId && profile.ownerUserId !== ownerUserId) {
+  // Fail closed: a host the caller doesn't own — INCLUDING one with a null owner
+  // (orphaned/corrupt) — is only reachable via an explicit editor+ grant, never by
+  // the owner check short-circuiting on a null owner.
+  if (ownerUserId && profile.ownerUserId !== ownerUserId) {
     const allowed = await userCanUseRemoteHost(ownerUserId, profile.id);
     if (!allowed) {
       const error = new Error(`Unknown remote host execution target: ${executionTargetId}`);

--- a/backend-api/routes/remoteHosts.ts
+++ b/backend-api/routes/remoteHosts.ts
@@ -11,6 +11,7 @@ const remoteHosts = require("../remoteHosts");
 const monitoring = require("../monitoring");
 const { asyncHandler } = require("../middleware/errorHandler");
 const { requireSession } = require("../middleware/auth");
+const { findWorkspaceMembership } = require("../middleware/ownership");
 
 const router = express.Router();
 router.use(requireSession);
@@ -30,9 +31,57 @@ async function loadOwnedHost(req) {
 router.get(
   "/",
   asyncHandler(async (req, res) => {
-    res.json(
-      await remoteHosts.listRemoteHosts({ ownerUserId: req.user.id, includeDisabled: true }),
+    // Owned hosts (full management) + hosts shared into the caller's workspaces
+    // (read-only; annotated with access + canDeploy).
+    res.json(await remoteHosts.listAccessibleRemoteHosts(req.user.id));
+  }),
+);
+
+// List the workspaces a host is shared into (owner only).
+router.get(
+  "/:id/shares",
+  asyncHandler(async (req, res) => {
+    await loadOwnedHost(req);
+    res.json(await remoteHosts.listRemoteHostShares(req.params.id));
+  }),
+);
+
+// Share a host into a workspace. Owner only, and only into a workspace the owner
+// is a member of (you can't share your host into someone else's workspace).
+router.post(
+  "/:id/shares",
+  asyncHandler(async (req, res) => {
+    const owned = await loadOwnedHost(req);
+    const workspaceId = String((req.body || {}).workspace_id || (req.body || {}).workspaceId || "");
+    if (!workspaceId) {
+      return res.status(400).json({ error: "workspace_id is required" });
+    }
+    const membership = await findWorkspaceMembership(workspaceId, req.user.id);
+    if (!membership) {
+      return res.status(404).json({ error: "Workspace not found" });
+    }
+    await remoteHosts.shareRemoteHost(owned.id, workspaceId, req.user.id);
+    await monitoring.logEvent(
+      "remote_host_shared",
+      `Shared remote host "${owned.label}" with workspace ${membership.name || workspaceId}`,
+      { userId: req.user.id, remoteHost: { id: owned.id }, workspaceId },
     );
+    res.status(201).json(await remoteHosts.listRemoteHostShares(owned.id));
+  }),
+);
+
+// Stop sharing a host with a workspace (owner only).
+router.delete(
+  "/:id/shares/:workspaceId",
+  asyncHandler(async (req, res) => {
+    const owned = await loadOwnedHost(req);
+    await remoteHosts.unshareRemoteHost(owned.id, req.params.workspaceId);
+    await monitoring.logEvent(
+      "remote_host_unshared",
+      `Stopped sharing remote host "${owned.label}"`,
+      { userId: req.user.id, remoteHost: { id: owned.id }, workspaceId: req.params.workspaceId },
+    );
+    res.json(await remoteHosts.listRemoteHostShares(owned.id));
   }),
 );
 

--- a/backend-api/server.ts
+++ b/backend-api/server.ts
@@ -1338,7 +1338,7 @@ async function migrateDB() {
        ON kubernetes_clusters(enabled, is_default, label)`,
     `CREATE TABLE IF NOT EXISTS remote_hosts (
        id TEXT PRIMARY KEY,
-       owner_user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+       owner_user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
        label TEXT NOT NULL,
        enabled BOOLEAN NOT NULL DEFAULT true,
        is_default BOOLEAN NOT NULL DEFAULT false,

--- a/backend-api/server.ts
+++ b/backend-api/server.ts
@@ -1729,6 +1729,16 @@ async function migrateDB() {
        ON workspace_agents(workspace_id, agent_id)`,
     `CREATE INDEX IF NOT EXISTS idx_workspace_agents_agent
        ON workspace_agents(agent_id)`,
+    `CREATE TABLE IF NOT EXISTS workspace_remote_hosts (
+       id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+       workspace_id UUID REFERENCES workspaces(id) ON DELETE CASCADE,
+       remote_host_id TEXT REFERENCES remote_hosts(id) ON DELETE CASCADE,
+       created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+       created_at TIMESTAMP DEFAULT NOW(),
+       UNIQUE(workspace_id, remote_host_id)
+     )`,
+    `CREATE INDEX IF NOT EXISTS idx_workspace_remote_hosts_host
+       ON workspace_remote_hosts(remote_host_id)`,
     `CREATE TABLE IF NOT EXISTS workspace_members (
        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
        workspace_id UUID NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,

--- a/infra/helm/nora/files/db_schema.sql
+++ b/infra/helm/nora/files/db_schema.sql
@@ -358,6 +358,22 @@ CREATE TABLE IF NOT EXISTS workspace_agents (
 CREATE INDEX IF NOT EXISTS idx_workspace_agents_agent
   ON workspace_agents(agent_id);
 
+-- Shared BYOC remote hosts (Phase C3). A host's owner can share it into a
+-- workspace they belong to; workspace members then use it per their workspace
+-- role (editor+ deploys/reaches, viewer sees read-only). Host config/credentials
+-- stay with the owner. Mirrors workspace_agents.
+CREATE TABLE IF NOT EXISTS workspace_remote_hosts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id UUID REFERENCES workspaces(id) ON DELETE CASCADE,
+  remote_host_id TEXT REFERENCES remote_hosts(id) ON DELETE CASCADE,
+  created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  created_at TIMESTAMP DEFAULT NOW(),
+  UNIQUE(workspace_id, remote_host_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_workspace_remote_hosts_host
+  ON workspace_remote_hosts(remote_host_id);
+
 -- Per-workspace membership (Phase 0 of multi-tenant RBAC).
 -- workspaces.user_id remains as the creator denormalization; permission checks
 -- read from workspace_members.role instead.

--- a/infra/helm/nora/files/db_schema.sql
+++ b/infra/helm/nora/files/db_schema.sql
@@ -86,7 +86,7 @@ CREATE INDEX IF NOT EXISTS idx_kubernetes_clusters_enabled
 
 CREATE TABLE IF NOT EXISTS remote_hosts (
   id TEXT PRIMARY KEY,
-  owner_user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+  owner_user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
   label TEXT NOT NULL,
   enabled BOOLEAN NOT NULL DEFAULT true,
   is_default BOOLEAN NOT NULL DEFAULT false,


### PR DESCRIPTION
## What

Phase C3a: make a registered remote host **shareable** beyond its single owner, so a team can share BYOC compute. Per the design we locked, this **reuses the existing workspace RBAC** (no new `user_groups` primitive) — the mapping confirmed workspaces already *are* the grouping primitive (roles, membership, invitations, and `workspace_agents` which shares *agents* the same way).

A host owner shares the host into a workspace they belong to; workspace members then use it **per their workspace role** — editor/admin/owner can deploy to it + reach it through the gateway; viewer sees it read-only. Host config (SSH creds, test, delete, un/share) stays **owner-only**.

## How

- **Schema:** new `workspace_remote_hosts` table mirroring `workspace_agents` (FK CASCADE on workspace + host), + vendored Helm copy + boot migration.
- **`remoteHosts.ts` helpers:** `userCanUseRemoteHost(userId, hostId)` — owner **or** editor+ grant via a shared workspace (the positive check that widens the gates); `listAccessibleRemoteHosts` (owned + shared, annotated `access`/`canDeploy`); `shareRemoteHost`/`unshareRemoteHost`/`listRemoteHostShares`.
- **Widened the two SSRF/deploy enforcement points** from owner-only to *owner-or-editor+-grant*: `assertRemoteHostExecutionTargetAvailable` (deploy gate) and `gatewayProxy.allowedRemoteHostsForAgent` (HTTP/RPC/WS allowlist). Stays **positive + owner-scoped** — a cross-tenant `execution_target_id` only resolves via an explicit share to the agent owner's workspace, and the `isBlockedGatewayIP` floor still applies.
- **Routes:** `GET /remote-hosts` now returns accessible hosts (owned + shared); new owner-gated `GET/POST/DELETE /remote-hosts/:id/shares` (you can only share into a workspace you're a member of).

## Security notes

- The widened allowlist is the SSRF-sensitive change; it remains a *positive* grant (never broadens beyond explicit shares), preserves the cross-tenant block, and keeps the IP floor. Covered by allowlist tests (reject cross-tenant, allow shared).
- **Credential sharing (documented limitation):** grantees deploy using the owner's stored SSH creds (all-or-nothing); per-workspace SSH isolation is deferred to a later phase.

## Tests

`userCanUseRemoteHost` (owner / editor+ / viewer / none / unmigrated table), the widened deploy gate (reject non-shared, allow shared editor+), the widened SSRF allowlist (reject cross-tenant, allow shared), and the share routes (owner-gating + validation). Backend suite **1154 green**; backend + worker typecheck, eslint, prettier, and infra validation all clean.

## Next

**C3b** — the share UI: a "Share with workspace" control on the remote-hosts page, a shared-host indicator, and the deploy picker surfacing shared hosts.