### PR TITLE
feat(rbac): share-into-workspace UI for BYOC remote hosts (Phase C3b)

### DIFF
--- a/frontend-dashboard/lib/runtime.ts
+++ b/frontend-dashboard/lib/runtime.ts
@@ -325,8 +325,12 @@ export function mergeRemoteHostsIntoConfig(
   backendConfig: BackendConfig = {},
   remoteHosts: any[] = [],
 ) {
+  // Only connected hosts the caller may actually deploy to. Owned hosts always
+  // carry canDeploy=true; hosts shared into a workspace are deployable for
+  // editor+ members and read-only (canDeploy=false) for viewers — those must
+  // not appear as selectable targets even though the operator can see them.
   const hosts = Array.isArray(remoteHosts)
-    ? remoteHosts.filter((host) => host && host.available)
+    ? remoteHosts.filter((host) => host && host.available && host.canDeploy !== false)
     : [];
   if (!hosts.length) return backendConfig;
   const runtimeFamilies = Array.isArray(backendConfig?.runtimeFamilies)

--- a/frontend-dashboard/pages/remote-hosts/index.tsx
+++ b/frontend-dashboard/pages/remote-hosts/index.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
 import Layout from "../../components/layout/Layout";
 import {
   Server,
@@ -10,6 +11,9 @@ import {
   CheckCircle2,
   XCircle,
   AlertTriangle,
+  Share2,
+  Users,
+  X,
 } from "lucide-react";
 import { fetchWithAuth } from "../../lib/api";
 import { useToast } from "../../components/Toast";
@@ -64,13 +68,18 @@ function StatusBadge({ host }) {
 
 export default function RemoteHostsPage() {
   const toast = useToast();
-  const [hosts, setHosts] = useState([]);
+  const [hosts, setHosts] = useState<any[]>([]);
+  const [workspaces, setWorkspaces] = useState<any[]>([]);
+  const [sharesByHost, setSharesByHost] = useState<Record<string, any[]>>({});
   const [loading, setLoading] = useState(true);
   const [form, setForm] = useState(EMPTY_FORM);
   const [editingId, setEditingId] = useState("");
   const [saving, setSaving] = useState(false);
   const [testingId, setTestingId] = useState("");
   const [deletingId, setDeletingId] = useState("");
+  const [sharePanelId, setSharePanelId] = useState("");
+  const [shareSelection, setShareSelection] = useState("");
+  const [shareBusy, setShareBusy] = useState(false);
 
   const editing = Boolean(editingId);
 
@@ -79,7 +88,25 @@ export default function RemoteHostsPage() {
     try {
       const res = await fetchWithAuth("/api/remote-hosts");
       if (!res.ok) throw new Error((await res.json().catch(() => ({}))).error || "Failed to load");
-      setHosts(await res.json());
+      const data = await res.json();
+      setHosts(Array.isArray(data) ? data : []);
+      // Eager-load each owned host's workspace shares so the "Shared with N"
+      // indicator is accurate without expanding every panel. Shared-with-me
+      // hosts have no owner-only shares endpoint, so we skip them.
+      const owned = (Array.isArray(data) ? data : []).filter(
+        (h) => (h.access || "owned") !== "shared",
+      );
+      const entries = await Promise.all(
+        owned.map(async (h): Promise<[string, any[]]> => {
+          try {
+            const r = await fetchWithAuth(`/api/remote-hosts/${encodeURIComponent(h.id)}/shares`);
+            return [h.id, r.ok ? await r.json() : []];
+          } catch {
+            return [h.id, []];
+          }
+        }),
+      );
+      setSharesByHost(Object.fromEntries(entries));
     } catch (error) {
       toast.error(error.message || "Failed to load remote hosts");
     } finally {
@@ -87,9 +114,21 @@ export default function RemoteHostsPage() {
     }
   }, [toast]);
 
+  const loadWorkspaces = useCallback(async () => {
+    try {
+      const res = await fetchWithAuth("/api/workspaces");
+      if (!res.ok) return;
+      const data = await res.json();
+      setWorkspaces(Array.isArray(data) ? data : []);
+    } catch {
+      // Sharing is optional — a workspace fetch failure just hides the picker.
+    }
+  }, []);
+
   useEffect(() => {
     loadHosts();
-  }, [loadHosts]);
+    loadWorkspaces();
+  }, [loadHosts, loadWorkspaces]);
 
   function updateField(key, value) {
     setForm((prev) => ({ ...prev, [key]: value }));
@@ -191,6 +230,127 @@ export default function RemoteHostsPage() {
     } finally {
       setDeletingId("");
     }
+  }
+
+  function toggleSharePanel(host) {
+    setShareSelection("");
+    setSharePanelId((prev) => (prev === host.id ? "" : host.id));
+  }
+
+  async function addShare(host) {
+    if (!shareSelection) return;
+    setShareBusy(true);
+    try {
+      const res = await fetchWithAuth(`/api/remote-hosts/${encodeURIComponent(host.id)}/shares`, {
+        method: "POST",
+        body: JSON.stringify({ workspace_id: shareSelection }),
+      });
+      const payload = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(payload.error || "Failed to share host");
+      setSharesByHost((prev) => ({ ...prev, [host.id]: Array.isArray(payload) ? payload : [] }));
+      setShareSelection("");
+      toast.success("Host shared with workspace");
+    } catch (error) {
+      toast.error(error.message || "Failed to share host");
+    } finally {
+      setShareBusy(false);
+    }
+  }
+
+  async function removeShare(host, workspaceId) {
+    setShareBusy(true);
+    try {
+      const res = await fetchWithAuth(
+        `/api/remote-hosts/${encodeURIComponent(host.id)}/shares/${encodeURIComponent(workspaceId)}`,
+        { method: "DELETE" },
+      );
+      const payload = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(payload.error || "Failed to remove share");
+      setSharesByHost((prev) => ({ ...prev, [host.id]: Array.isArray(payload) ? payload : [] }));
+      toast.success("Stopped sharing host");
+    } catch (error) {
+      toast.error(error.message || "Failed to remove share");
+    } finally {
+      setShareBusy(false);
+    }
+  }
+
+  const ownedHosts = hosts.filter((h) => (h.access || "owned") !== "shared");
+  const sharedHosts = hosts.filter((h) => h.access === "shared");
+
+  function renderShareSection(host) {
+    const shares = sharesByHost[host.id] || [];
+    const sharedIds = new Set(shares.map((s) => s.workspaceId));
+    const available = workspaces.filter((w) => !sharedIds.has(w.id));
+    return (
+      <div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-4">
+        <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-slate-700">
+          <Users size={15} /> Workspace access
+        </div>
+        {shares.length === 0 ? (
+          <p className="text-xs text-slate-500">
+            Not shared yet. Members of a workspace you share this host with can deploy agents to it
+            using your stored credentials (editors and above) or view it read-only (viewers).
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {shares.map((share) => (
+              <li
+                key={share.workspaceId}
+                className="flex items-center justify-between rounded-lg border border-slate-200 bg-white px-3 py-2"
+              >
+                <span className="truncate text-sm text-slate-700">
+                  {share.workspaceName || share.workspaceId}
+                </span>
+                <button
+                  onClick={() => removeShare(host, share.workspaceId)}
+                  disabled={shareBusy}
+                  className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-red-600 hover:bg-red-50 disabled:opacity-60"
+                  aria-label="Stop sharing with this workspace"
+                >
+                  <X size={13} /> Remove
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+
+        {workspaces.length === 0 ? (
+          <p className="mt-3 text-xs text-slate-500">
+            You aren&apos;t a member of any workspace yet.{" "}
+            <Link href="/workspaces" className="font-medium text-blue-600 hover:underline">
+              Create one
+            </Link>{" "}
+            to share this host with a team.
+          </p>
+        ) : available.length === 0 ? (
+          <p className="mt-3 text-xs text-slate-500">Shared with all of your workspaces.</p>
+        ) : (
+          <div className="mt-3 flex items-center gap-2">
+            <select
+              value={shareSelection}
+              onChange={(e) => setShareSelection(e.target.value)}
+              className="flex-1 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm"
+            >
+              <option value="">Select a workspace…</option>
+              {available.map((w) => (
+                <option key={w.id} value={w.id}>
+                  {w.name}
+                </option>
+              ))}
+            </select>
+            <button
+              onClick={() => addShare(host)}
+              disabled={shareBusy || !shareSelection}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-blue-600 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-60"
+            >
+              {shareBusy ? <Loader2 size={14} className="animate-spin" /> : <Share2 size={14} />}
+              Share
+            </button>
+          </div>
+        )}
+      </div>
+    );
   }
 
   return (
@@ -364,68 +524,127 @@ export default function RemoteHostsPage() {
           <div className="flex items-center gap-2 rounded-2xl border border-slate-200 bg-white p-8 text-slate-500">
             <Loader2 size={18} className="animate-spin" /> Loading remote hosts…
           </div>
-        ) : hosts.length === 0 ? (
+        ) : ownedHosts.length === 0 ? (
           <div className="rounded-2xl border border-dashed border-slate-300 bg-white p-8 text-center text-sm text-slate-500">
             No remote hosts yet. Register one above to deploy agents to your own machine.
           </div>
         ) : (
           <div className="space-y-3">
-            {hosts.map((host) => (
-              <div
-                key={host.id}
-                className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm"
-              >
-                <div className="flex flex-wrap items-start justify-between gap-3">
-                  <div className="min-w-0">
-                    <div className="flex items-center gap-2">
-                      <span className="font-semibold text-slate-900">{host.label}</span>
-                      <StatusBadge host={host} />
-                    </div>
-                    <p className="mt-1 font-mono text-xs text-slate-500">
-                      {sshTarget(host)} · {host.executionTargetId}
-                    </p>
-                    {host.lastTestStatus === "failed" && host.lastTestMessage && (
-                      <p className="mt-2 rounded-lg bg-red-50 px-3 py-2 text-xs text-red-700">
-                        {host.lastTestMessage}
+            {ownedHosts.map((host) => {
+              const shareCount = (sharesByHost[host.id] || []).length;
+              return (
+                <div
+                  key={host.id}
+                  className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm"
+                >
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="font-semibold text-slate-900">{host.label}</span>
+                        <StatusBadge host={host} />
+                        {shareCount > 0 && (
+                          <span className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2.5 py-0.5 text-xs font-medium text-blue-700">
+                            <Users size={12} /> Shared · {shareCount}
+                          </span>
+                        )}
+                      </div>
+                      <p className="mt-1 font-mono text-xs text-slate-500">
+                        {sshTarget(host)} · {host.executionTargetId}
                       </p>
-                    )}
+                      {host.lastTestStatus === "failed" && host.lastTestMessage && (
+                        <p className="mt-2 rounded-lg bg-red-50 px-3 py-2 text-xs text-red-700">
+                          {host.lastTestMessage}
+                        </p>
+                      )}
+                    </div>
+                    <div className="flex shrink-0 items-center gap-2">
+                      <button
+                        onClick={() => testHost(host)}
+                        disabled={testingId === host.id}
+                        className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-60"
+                      >
+                        {testingId === host.id ? (
+                          <Loader2 size={14} className="animate-spin" />
+                        ) : (
+                          <PlugZap size={14} />
+                        )}
+                        Test
+                      </button>
+                      <button
+                        onClick={() => toggleSharePanel(host)}
+                        className={`inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm font-medium ${
+                          sharePanelId === host.id
+                            ? "border-blue-200 bg-blue-50 text-blue-700"
+                            : "border-slate-200 text-slate-700 hover:bg-slate-50"
+                        }`}
+                      >
+                        <Share2 size={14} /> Share
+                      </button>
+                      <button
+                        onClick={() => startEdit(host)}
+                        className="rounded-lg border border-slate-200 px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50"
+                      >
+                        Edit
+                      </button>
+                      <button
+                        onClick={() => deleteHost(host)}
+                        disabled={deletingId === host.id}
+                        className="rounded-lg border border-red-200 px-2.5 py-1.5 text-red-600 hover:bg-red-50 disabled:opacity-60"
+                        aria-label="Delete host"
+                      >
+                        {deletingId === host.id ? (
+                          <Loader2 size={14} className="animate-spin" />
+                        ) : (
+                          <Trash2 size={14} />
+                        )}
+                      </button>
+                    </div>
                   </div>
-                  <div className="flex shrink-0 items-center gap-2">
-                    <button
-                      onClick={() => testHost(host)}
-                      disabled={testingId === host.id}
-                      className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-60"
-                    >
-                      {testingId === host.id ? (
-                        <Loader2 size={14} className="animate-spin" />
-                      ) : (
-                        <PlugZap size={14} />
-                      )}
-                      Test
-                    </button>
-                    <button
-                      onClick={() => startEdit(host)}
-                      className="rounded-lg border border-slate-200 px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50"
-                    >
-                      Edit
-                    </button>
-                    <button
-                      onClick={() => deleteHost(host)}
-                      disabled={deletingId === host.id}
-                      className="rounded-lg border border-red-200 px-2.5 py-1.5 text-red-600 hover:bg-red-50 disabled:opacity-60"
-                      aria-label="Delete host"
-                    >
-                      {deletingId === host.id ? (
-                        <Loader2 size={14} className="animate-spin" />
-                      ) : (
-                        <Trash2 size={14} />
-                      )}
-                    </button>
+                  {sharePanelId === host.id && renderShareSection(host)}
+                </div>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Hosts shared with the caller's workspaces (read-only) */}
+        {sharedHosts.length > 0 && (
+          <>
+            <div className="mb-3 mt-8 flex items-center gap-2">
+              <h2 className="text-lg font-semibold text-slate-900">Shared with you</h2>
+              <span className="rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-500">
+                via your workspaces
+              </span>
+            </div>
+            <div className="space-y-3">
+              {sharedHosts.map((host) => (
+                <div
+                  key={host.id}
+                  className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm"
+                >
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="font-semibold text-slate-900">{host.label}</span>
+                        <StatusBadge host={host} />
+                        <span className="inline-flex items-center gap-1 rounded-full bg-blue-50 px-2.5 py-0.5 text-xs font-medium text-blue-700">
+                          <Users size={12} /> Shared
+                        </span>
+                      </div>
+                      <p className="mt-1 font-mono text-xs text-slate-500">
+                        {sshTarget(host)} · {host.executionTargetId}
+                      </p>
+                      <p className="mt-2 text-xs text-slate-500">
+                        {host.canDeploy
+                          ? "You can deploy agents to this host using the owner's credentials."
+                          : "Read-only access — ask a workspace editor or the host owner to deploy."}
+                      </p>
+                    </div>
                   </div>
                 </div>
-              </div>
-            ))}
-          </div>
+              ))}
+            </div>
+          </>
         )}
       </div>
     </Layout>

--- a/frontend-dashboard/pages/remote-hosts/index.tsx
+++ b/frontend-dashboard/pages/remote-hosts/index.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import Link from "next/link";
 import Layout from "../../components/layout/Layout";
 import {
@@ -79,7 +79,13 @@ export default function RemoteHostsPage() {
   const [deletingId, setDeletingId] = useState("");
   const [sharePanelId, setSharePanelId] = useState("");
   const [shareSelection, setShareSelection] = useState("");
-  const [shareBusy, setShareBusy] = useState(false);
+  // Host id whose share/unshare request is in flight (""=none), so a slow
+  // request on one host never disables another host's controls.
+  const [shareBusyId, setShareBusyId] = useState("");
+  // Monotonic token bumped by every shares write (eager load + add/remove). An
+  // in-flight eager load checks it before committing, so a slow load can't
+  // clobber a share/unshare the operator made while it was running.
+  const shareSeq = useRef(0);
 
   const editing = Boolean(editingId);
 
@@ -96,6 +102,7 @@ export default function RemoteHostsPage() {
       const owned = (Array.isArray(data) ? data : []).filter(
         (h) => (h.access || "owned") !== "shared",
       );
+      const startSeq = ++shareSeq.current;
       const entries = await Promise.all(
         owned.map(async (h): Promise<[string, any[]]> => {
           try {
@@ -106,7 +113,12 @@ export default function RemoteHostsPage() {
           }
         }),
       );
-      setSharesByHost(Object.fromEntries(entries));
+      // A newer eager load or an add/remove bumped the token while we awaited —
+      // its fresher data wins; drop this now-stale snapshot. Merge (not replace)
+      // so any host not in this batch keeps its existing entry.
+      if (shareSeq.current === startSeq) {
+        setSharesByHost((prev) => ({ ...prev, ...Object.fromEntries(entries) }));
+      }
     } catch (error) {
       toast.error(error.message || "Failed to load remote hosts");
     } finally {
@@ -239,7 +251,7 @@ export default function RemoteHostsPage() {
 
   async function addShare(host) {
     if (!shareSelection) return;
-    setShareBusy(true);
+    setShareBusyId(host.id);
     try {
       const res = await fetchWithAuth(`/api/remote-hosts/${encodeURIComponent(host.id)}/shares`, {
         method: "POST",
@@ -247,18 +259,25 @@ export default function RemoteHostsPage() {
       });
       const payload = await res.json().catch(() => ({}));
       if (!res.ok) throw new Error(payload.error || "Failed to share host");
-      setSharesByHost((prev) => ({ ...prev, [host.id]: Array.isArray(payload) ? payload : [] }));
+      // On a success status with an unexpected (non-array) body, keep the
+      // existing shares rather than wiping them to []. Bump the token so an
+      // in-flight eager load doesn't overwrite this fresh value.
+      shareSeq.current += 1;
+      setSharesByHost((prev) => ({
+        ...prev,
+        [host.id]: Array.isArray(payload) ? payload : prev[host.id] || [],
+      }));
       setShareSelection("");
       toast.success("Host shared with workspace");
     } catch (error) {
       toast.error(error.message || "Failed to share host");
     } finally {
-      setShareBusy(false);
+      setShareBusyId("");
     }
   }
 
   async function removeShare(host, workspaceId) {
-    setShareBusy(true);
+    setShareBusyId(host.id);
     try {
       const res = await fetchWithAuth(
         `/api/remote-hosts/${encodeURIComponent(host.id)}/shares/${encodeURIComponent(workspaceId)}`,
@@ -266,12 +285,16 @@ export default function RemoteHostsPage() {
       );
       const payload = await res.json().catch(() => ({}));
       if (!res.ok) throw new Error(payload.error || "Failed to remove share");
-      setSharesByHost((prev) => ({ ...prev, [host.id]: Array.isArray(payload) ? payload : [] }));
+      shareSeq.current += 1;
+      setSharesByHost((prev) => ({
+        ...prev,
+        [host.id]: Array.isArray(payload) ? payload : prev[host.id] || [],
+      }));
       toast.success("Stopped sharing host");
     } catch (error) {
       toast.error(error.message || "Failed to remove share");
     } finally {
-      setShareBusy(false);
+      setShareBusyId("");
     }
   }
 
@@ -282,6 +305,7 @@ export default function RemoteHostsPage() {
     const shares = sharesByHost[host.id] || [];
     const sharedIds = new Set(shares.map((s) => s.workspaceId));
     const available = workspaces.filter((w) => !sharedIds.has(w.id));
+    const busy = shareBusyId === host.id;
     return (
       <div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-4">
         <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-slate-700">
@@ -304,7 +328,7 @@ export default function RemoteHostsPage() {
                 </span>
                 <button
                   onClick={() => removeShare(host, share.workspaceId)}
-                  disabled={shareBusy}
+                  disabled={busy}
                   className="inline-flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-red-600 hover:bg-red-50 disabled:opacity-60"
                   aria-label="Stop sharing with this workspace"
                 >
@@ -330,6 +354,7 @@ export default function RemoteHostsPage() {
             <select
               value={shareSelection}
               onChange={(e) => setShareSelection(e.target.value)}
+              aria-label="Workspace to share this host with"
               className="flex-1 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm"
             >
               <option value="">Select a workspace…</option>
@@ -341,10 +366,10 @@ export default function RemoteHostsPage() {
             </select>
             <button
               onClick={() => addShare(host)}
-              disabled={shareBusy || !shareSelection}
+              disabled={busy || !shareSelection}
               className="inline-flex items-center gap-1.5 rounded-lg bg-blue-600 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-60"
             >
-              {shareBusy ? <Loader2 size={14} className="animate-spin" /> : <Share2 size={14} />}
+              {busy ? <Loader2 size={14} className="animate-spin" /> : <Share2 size={14} />}
               Share
             </button>
           </div>


### PR DESCRIPTION
## What

Surfaces the **C3a** (#227) remote-host workspace-grant model in the operator dashboard — the UI half of BYOC Phase C3 (RBAC).

## Changes

**`frontend-dashboard/pages/remote-hosts/index.tsx`**
- **Share panel** on each owned host: lists the workspaces the host is shared into (each with a remove control) and a workspace picker to add a new share. Wired to the owner-only `GET/POST/DELETE /api/remote-hosts/:id/shares` routes from #227.
- **"Shared · N" indicator** chip on owned-host cards. Shares are eager-loaded after the host list so the count is accurate without expanding every panel.
- **"Shared with you" section** — a read-only list of hosts shared into the caller's workspaces, with a *deployable* vs *view-only* hint driven by the backend `canDeploy` flag (editor+ can deploy using the owner's stored credentials; viewers are read-only).
- Workspace picker is populated from `GET /api/workspaces`; empty-state links to `/workspaces`.

**`frontend-dashboard/lib/runtime.ts`**
- `mergeRemoteHostsIntoConfig` now also requires `canDeploy !== false`, so a viewer's read-only shared host is no longer offered as a selectable deploy target. The backend deploy gate (`userCanUseRemoteHost`, editor+) already rejected such a deploy; this removes the misleading option from the picker.

## Scope & safety

Frontend-only; no backend, schema, or shared-zone changes. All enforcement stays server-side (#227) — this PR only presents what the backend already authorizes. Host config/SSH/delete/share remain owner-only; shared hosts render without edit/test/delete/share controls.

## Verification

`typecheck` + `eslint` + `prettier` + full `next build` all clean (the dashboard has no jest suite).