### PR TITLE
feat(security): encrypt agent gateway_token at rest (AES-256-GCM)

### DIFF
--- a/backend-api/__tests__/agents.test.ts
+++ b/backend-api/__tests__/agents.test.ts
@@ -63,6 +63,16 @@ const mockGetDeploymentDefaults = jest.fn().mockResolvedValue({
 const mockGetAgentHubSourceApiKey = jest.fn().mockResolvedValue("nora_hub_test_key");
 const mockAssertKubernetesExecutionTargetAvailable = jest.fn().mockResolvedValue();
 jest.mock("../db", () => mockDb);
+// Marked, transparent crypto so we can assert gateway_token is encrypted on
+// write (enc(...) wrapper) while legacy/plaintext values still pass through
+// decrypt unchanged — keeping every existing plaintext-token assertion valid.
+jest.mock("../crypto", () => ({
+  encrypt: (v) => (v == null || v === "" ? v : `enc(${v})`),
+  decrypt: (v) => (typeof v === "string" && v.startsWith("enc(") ? v.slice(4, -1) : v),
+  isEncryptionConfigured: () => true,
+  ensureEncryptionConfigured: () => {},
+  DecryptionError: class DecryptionError extends Error {},
+}));
 jest.mock("../redisQueue", () => ({
   addDeploymentJob: mockAddDeploymentJob,
   getDLQJobs: jest.fn(),
@@ -2137,9 +2147,12 @@ describe("POST /agents/adopt (external runtime)", () => {
     // The INSERT carries deploy_target='external' + the validated endpoint.
     const insert = mockDb.query.mock.calls.find((c) => /INSERT INTO agents/i.test(c[0]));
     expect(insert[0]).toMatch(/'external', 'external'/);
+    // gateway_token must be ENCRYPTED on write — the param carries enc(...),
+    // not the plaintext. This fails if the encrypt() call is ever dropped.
     expect(insert[1]).toEqual(
-      expect.arrayContaining(["user-1", "openclaw", "203.0.113.5", 18789, "secret-token"]),
+      expect.arrayContaining(["user-1", "openclaw", "203.0.113.5", 18789, "enc(secret-token)"]),
     );
+    expect(insert[1]).not.toContain("secret-token");
   });
 
   it("rejects adoption without a gateway token", async () => {

--- a/backend-api/__tests__/controlPlane.test.ts
+++ b/backend-api/__tests__/controlPlane.test.ts
@@ -87,6 +87,16 @@ function kubernetesClusterRow(overrides = {}) {
 }
 
 jest.mock("../db", () => mockDb);
+// Marked, transparent crypto: enc(...) on write, passthrough on read for any
+// non-enc value. gateway_token is encrypted at rest, so the embed/gateway read
+// paths must decrypt before use; plaintext rows in existing tests are unaffected.
+jest.mock("../crypto", () => ({
+  encrypt: (v) => (v == null || v === "" ? v : `enc(${v})`),
+  decrypt: (v) => (typeof v === "string" && v.startsWith("enc(") ? v.slice(4, -1) : v),
+  isEncryptionConfigured: () => true,
+  ensureEncryptionConfigured: () => {},
+  DecryptionError: class DecryptionError extends Error {},
+}));
 jest.mock("../redisQueue", () => ({
   addDeploymentJob: jest.fn(),
   getDLQJobs: jest.fn(),
@@ -764,6 +774,32 @@ describe("gateway control-plane embed", () => {
     expect(res.text).toContain("form.requestSubmit");
     expect(res.text).toContain("new MutationObserver");
     expect(res.text).not.toContain("localStorage.setItem('oc-gateway-url',R)");
+  });
+
+  it("decrypts an encrypted gateway_token before inlining it into the bootstrap script", async () => {
+    // gateway_token is stored encrypted; the embed bootstrap must inline the
+    // DECRYPTED value (the browser uses it as the gateway WS password), never
+    // the ciphertext.
+    mockDb.query.mockResolvedValueOnce({
+      rows: [
+        {
+          host: "10.0.0.10",
+          gateway_token: "enc(gateway-password)",
+          gateway_host_port: null,
+          status: "running",
+        },
+      ],
+    });
+
+    const res = await request(app)
+      .get(`/agents/agent-1/gateway/embed/bootstrap.js?token=${encodeURIComponent(token)}`)
+      .set("Host", "nora.test")
+      .set("X-Forwarded-Proto", "https");
+
+    expect(res.status).toBe(200);
+    // P is the inlined password; it must be the plaintext, not the stored enc(...).
+    expect(res.text).toContain('var P="gateway-password"');
+    expect(res.text).not.toContain("enc(gateway-password)");
   });
 
   it("uses the published gateway host port when one is recorded", async () => {

--- a/backend-api/__tests__/gatewayTokenEncryption.test.ts
+++ b/backend-api/__tests__/gatewayTokenEncryption.test.ts
@@ -1,0 +1,92 @@
+// @ts-nocheck
+// Verifies agents.gateway_token is encrypted at rest (AES-256-GCM) and
+// transparently decrypted on read. The repo's jest env sets no ENCRYPTION_KEY,
+// so crypto is a no-op by default; these tests set a key explicitly (and reset
+// modules) because crypto.ts reads the key once at module-load time.
+
+const VALID_KEY = "a".repeat(64); // 64 hex chars → AES-256-GCM
+
+describe("gateway_token encryption at rest", () => {
+  let originalKey;
+  beforeAll(() => {
+    originalKey = process.env.ENCRYPTION_KEY;
+  });
+  afterAll(() => {
+    if (originalKey === undefined) delete process.env.ENCRYPTION_KEY;
+    else process.env.ENCRYPTION_KEY = originalKey;
+    jest.resetModules();
+  });
+
+  describe("with ENCRYPTION_KEY configured", () => {
+    let crypto;
+    beforeEach(() => {
+      jest.resetModules();
+      jest.dontMock("../db");
+      process.env.ENCRYPTION_KEY = VALID_KEY;
+      crypto = require("../crypto");
+    });
+
+    it("encrypt() produces a 3-part iv:tag:ciphertext blob distinct from the token", () => {
+      const token = "0123456789abcdef0123456789abcdef"; // 32-hex gateway token
+      const enc = crypto.encrypt(token);
+      expect(enc).not.toBe(token);
+      expect(enc.split(":")).toHaveLength(3);
+    });
+
+    it("decrypt(encrypt(token)) round-trips for both 32- and 64-char hex tokens", () => {
+      const short = "deadbeef".repeat(4); // 32 hex chars (NemoClaw)
+      const long = "deadbeef".repeat(8); // 64 hex chars (Docker/Hermes/Proxmox/k8s)
+      expect(crypto.decrypt(crypto.encrypt(short))).toBe(short);
+      expect(crypto.decrypt(crypto.encrypt(long))).toBe(long);
+    });
+
+    it("decrypt() passes a legacy plaintext (colon-free hex) token through unchanged", () => {
+      // Existing rows are plaintext hex; the lazy (no-migration) design relies on
+      // decrypt() being a safe no-op for them until the next redeploy re-encrypts.
+      const legacy = "0123456789abcdef0123456789abcdef";
+      expect(crypto.decrypt(legacy)).toBe(legacy);
+    });
+
+    it("runtimeAuthHeaders decrypts an encrypted gateway_token into the Bearer header", async () => {
+      jest.doMock("../db", () => ({ query: jest.fn() }));
+      const { runtimeAuthHeaders } = require("../runtimeAuth");
+      const token = "feedface".repeat(8);
+      const headers = await runtimeAuthHeaders({ id: "a1", gateway_token: crypto.encrypt(token) });
+      expect(headers.Authorization).toBe(`Bearer ${token}`);
+    });
+
+    it("runtimeAuthHeaders passes a legacy plaintext token through (no regression)", async () => {
+      jest.doMock("../db", () => ({ query: jest.fn() }));
+      const { runtimeAuthHeaders } = require("../runtimeAuth");
+      const legacy = "abc123".repeat(6);
+      const headers = await runtimeAuthHeaders({ id: "a1", gateway_token: legacy });
+      expect(headers.Authorization).toBe(`Bearer ${legacy}`);
+    });
+
+    it("runtimeAuthHeaders falls back to the DB and decrypts when the agent omits the token", async () => {
+      const token = "0a1b2c3d".repeat(8);
+      const encrypted = crypto.encrypt(token);
+      jest.doMock("../db", () => ({
+        query: jest.fn().mockResolvedValue({ rows: [{ gateway_token: encrypted }] }),
+      }));
+      const { runtimeAuthHeaders } = require("../runtimeAuth");
+      const headers = await runtimeAuthHeaders({ id: "a1" });
+      expect(headers.Authorization).toBe(`Bearer ${token}`);
+    });
+  });
+
+  describe("without ENCRYPTION_KEY (keyless dev/test — lazy, no migration)", () => {
+    let crypto;
+    beforeEach(() => {
+      jest.resetModules();
+      delete process.env.ENCRYPTION_KEY;
+      crypto = require("../crypto");
+    });
+
+    it("encrypt()/decrypt() are no-ops so existing plaintext rows are unaffected", () => {
+      const token = "0123456789abcdef0123456789abcdef";
+      expect(crypto.encrypt(token)).toBe(token);
+      expect(crypto.decrypt(token)).toBe(token);
+    });
+  });
+});

--- a/backend-api/gatewayProxy.ts
+++ b/backend-api/gatewayProxy.ts
@@ -9,6 +9,7 @@ const crypto = require("crypto");
 const dns = require("node:dns").promises;
 const net = require("node:net");
 const db = require("./db");
+const { decrypt } = require("./crypto");
 const integrations = require("./integrations");
 const { resolveAgentRuntimeFamily } = require("./agentRuntimeFields");
 const remoteHosts = require("./remoteHosts");
@@ -676,7 +677,9 @@ async function getConnection(agent) {
     "agent gateway",
     extraAllowedHosts,
   );
-  conn = new GatewayConnection(connectHost, agent.gateway_token, addr.port);
+  // gateway_token is encrypted at rest; decrypt() is transparent to legacy
+  // plaintext, so it is safe regardless of the token's storage form.
+  conn = new GatewayConnection(connectHost, decrypt(agent.gateway_token), addr.port);
   pool.set(key, conn);
   try {
     await conn.connect();
@@ -1370,7 +1373,9 @@ function attachGatewayWS(server) {
         return;
       }
 
-      const identity = deriveDeviceIdentity(agent.gateway_token);
+      // Decrypt once; reused for the device identity and the relay connect auth.
+      const gatewayToken = decrypt(agent.gateway_token);
+      const identity = deriveDeviceIdentity(gatewayToken);
       let handshakeComplete = false;
       let connectPayload = null; // stored relay handshake payload
       let pendingClientConnect = null; // client's connect msg awaiting relay handshake
@@ -1431,7 +1436,7 @@ function attachGatewayWS(server) {
               scopes,
               caps: ["thinking-events"],
               commands: [],
-              auth: agent.gateway_token ? { password: agent.gateway_token } : {},
+              auth: gatewayToken ? { password: gatewayToken } : {},
               device,
             },
           }),

--- a/backend-api/routes/agents.ts
+++ b/backend-api/routes/agents.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 const express = require("express");
 const db = require("../db");
+const { encrypt, decrypt } = require("../crypto");
 const { addDeploymentJob } = require("../redisQueue");
 const billing = require("../billing");
 const {
@@ -626,7 +627,17 @@ function resolveHermesChannelConfig(body = {}) {
 }
 
 async function resolveHermesApiToken(agent) {
-  const storedToken = String(agent?.gateway_token || "").trim();
+  // gateway_token is encrypted at rest; decrypt() is transparent to legacy
+  // plaintext. A rotated/corrupted key would throw — fall through to the
+  // container-env inspection below rather than failing the whole call.
+  let storedToken = "";
+  if (agent?.gateway_token) {
+    try {
+      storedToken = String(decrypt(agent.gateway_token) || "").trim();
+    } catch {
+      storedToken = "";
+    }
+  }
   if (storedToken) return storedToken;
   if (!agent?.container_id) return null;
 
@@ -646,7 +657,7 @@ async function resolveHermesApiToken(agent) {
     try {
       await db.query("UPDATE agents SET gateway_token = $2 WHERE id = $1", [
         agent.id,
-        resolvedToken,
+        encrypt(resolvedToken),
       ]);
     } catch {
       // Best-effort cache only.
@@ -1581,7 +1592,8 @@ router.post("/adopt", async (req, res) => {
          runtime_host, dashboard_port, gateway_token
        ) VALUES($1, $2, 'running', $3, 'external', 'external', 'standard', 'standard',
                 'external', $4, $5, $4, $5, $6) RETURNING *`,
-      [req.user.id, name, runtimeFamily, endpoint.host, endpoint.port, token],
+      // gateway_token is encrypted at rest (no-op when ENCRYPTION_KEY is unset).
+      [req.user.id, name, runtimeFamily, endpoint.host, endpoint.port, encrypt(token)],
     );
     const agent = result.rows[0];
 

--- a/backend-api/routes/agents.ts
+++ b/backend-api/routes/agents.ts
@@ -634,7 +634,13 @@ async function resolveHermesApiToken(agent) {
   if (agent?.gateway_token) {
     try {
       storedToken = String(decrypt(agent.gateway_token) || "").trim();
-    } catch {
+    } catch (err) {
+      // Surface the root cause (e.g. ENCRYPTION_KEY rotation) before falling
+      // back to container inspection, so a "token unavailable" downstream error
+      // is traceable. err.message carries no secret material.
+      console.warn(
+        `[hermes-token] Could not decrypt stored gateway_token for agent ${agent.id} — falling back to runtime inspection: ${err.message}`,
+      );
       storedToken = "";
     }
   }

--- a/backend-api/runtimeAuth.ts
+++ b/backend-api/runtimeAuth.ts
@@ -7,14 +7,20 @@
 // empty token and get a 401.
 
 const db = require("./db");
+const { decrypt } = require("./crypto");
 const { buildRuntimeAuthHeaders } = require("../agent-runtime/lib/agentEndpoints");
 
 async function runtimeAuthHeaders(agent) {
-  let token = agent && agent.gateway_token ? agent.gateway_token : null;
+  // gateway_token is encrypted at rest (AES-256-GCM). decrypt() is transparent
+  // to legacy plaintext tokens (colon-free hex), so it is safe to call here
+  // whether the value came from an encrypted column or an in-memory plaintext
+  // token. This is the central choke point for backend → runtime auth headers
+  // (channels, integration sync, Hermes API, etc.).
+  let token = agent && agent.gateway_token ? decrypt(agent.gateway_token) : null;
   if (!token && agent && agent.id) {
     try {
       const result = await db.query("SELECT gateway_token FROM agents WHERE id = $1", [agent.id]);
-      token = result.rows[0]?.gateway_token || null;
+      token = result.rows[0]?.gateway_token ? decrypt(result.rows[0].gateway_token) : null;
     } catch {
       token = null;
     }

--- a/backend-api/server.ts
+++ b/backend-api/server.ts
@@ -833,12 +833,16 @@ gatewayUIAssetProxy.get("/agents/:agentId/gateway/embed/bootstrap.js", async (re
     res.setHeader("Referrer-Policy", "no-referrer");
     res.setHeader("X-Content-Type-Options", "nosniff");
     res.setHeader("Vary", "Cookie");
+    // gateway_token is encrypted at rest; decrypt before inlining it into the
+    // embed bootstrap JS that the browser uses for the gateway WS handshake.
+    // decrypt() is transparent to legacy plaintext tokens.
+    const { decrypt } = require("./crypto");
     res.send(
       buildEmbedBootstrapScript({
         agentId: access.agentId,
         requestHost: req.headers.host,
         requestScheme: requestProtocol(req),
-        gatewayToken: access.agent.gateway_token,
+        gatewayToken: decrypt(access.agent.gateway_token),
       }),
     );
   } catch (err) {

--- a/docs/concepts/security.mdx
+++ b/docs/concepts/security.mdx
@@ -6,7 +6,7 @@ Nora is built to be trustworthy in real operator environments: you run it on you
 
 ## Secrets and credentials
 
-- **LLM provider keys and integration credentials are encrypted at rest** with AES-256-GCM before they are stored in PostgreSQL. The encryption key is the operator-owned `ENCRYPTION_KEY` generated during setup — Nora never stores plaintext credentials.
+- **LLM provider keys, integration credentials, remote-host SSH credentials, and per-agent runtime gateway tokens are encrypted at rest** with AES-256-GCM before they are stored in PostgreSQL. The encryption key is the operator-owned `ENCRYPTION_KEY` generated during setup — Nora never stores plaintext credentials. Gateway tokens (the bearer that authenticates the control plane to each runtime sidecar) are encrypted on write and decrypted only at the point of use; they are never returned in API responses.
 - **Key sync to runtimes is explicit.** Provider keys are pushed to a runtime on demand as part of provisioning or an operator-triggered sync, not broadcast.
 - **Setup generates strong secrets.** The installer creates `JWT_SECRET` and `ENCRYPTION_KEY` with OpenSSL and preserves existing secrets on re-runs.
 - **Production refuses weak secrets.** In production the backend will not boot when `JWT_SECRET` is missing, too short, or a placeholder, or when `ENCRYPTION_KEY` is missing or malformed — so a copy-pasted `.env.example` can never reach the internet. The only way around the encryption requirement is the explicit `NORA_ALLOW_PLAINTEXT_SECRETS=true` override.

--- a/workers/provisioner/worker.ts
+++ b/workers/provisioner/worker.ts
@@ -659,11 +659,17 @@ async function runRuntimeCommand(agent, command, { timeout = 30000 } = {}) {
     throw new Error("Agent runtime endpoint unavailable");
   }
 
+  // gateway_token is encrypted at rest; decrypt() is transparent to legacy
+  // plaintext, so it is safe whether the agent row was freshly selected
+  // (encrypted) or carries an in-memory plaintext token.
+  const { decrypt } = require("./crypto");
   const response = await fetch(runtimeUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
-      ...buildRuntimeAuthHeaders(agent && agent.gateway_token),
+      ...buildRuntimeAuthHeaders(
+        agent && agent.gateway_token ? decrypt(agent.gateway_token) : null,
+      ),
     },
     body: JSON.stringify({
       command,
@@ -1437,6 +1443,21 @@ const worker = new Worker(
         [id],
       );
       const agentRow = agentRowResult.rows[0] || {};
+      // gateway_token is encrypted at rest. Decrypt the stored value in place so
+      // the reuse path (k8s/Hermes pass it back into the container as the runtime
+      // password) gets plaintext. A rotated/corrupted key → treat as no reusable
+      // token so the backend generates a fresh one rather than failing the deploy.
+      if (agentRow.gateway_token) {
+        const { decrypt } = require("./crypto");
+        try {
+          agentRow.gateway_token = decrypt(agentRow.gateway_token);
+        } catch (err) {
+          console.warn(
+            `[provisioner] Could not decrypt stored gateway_token for agent ${id} — generating a fresh token: ${err.message}`,
+          );
+          agentRow.gateway_token = null;
+        }
+      }
       const storedRuntimeFields = buildAgentRuntimeFields(agentRow);
       const resolvedRuntimeFields = buildAgentRuntimeFields({
         runtime_family: storedRuntimeFields.runtime_family,
@@ -2001,7 +2022,11 @@ const worker = new Worker(
         throw err;
       }
 
-      // Update agent with real container info
+      // Update agent with real container info. gateway_token is encrypted at
+      // rest (no-op when ENCRYPTION_KEY is unset); the in-memory gatewayToken
+      // stays plaintext for the integration-sync auth call below.
+      const { encrypt } = require("./crypto");
+      const gatewayTokenForStorage = gatewayToken ? encrypt(gatewayToken) : gatewayToken;
       try {
         await db.query(
           `UPDATE agents
@@ -2029,7 +2054,7 @@ const worker = new Worker(
             containerId,
             host,
             resolvedRuntimeFields.backend_type,
-            gatewayToken,
+            gatewayTokenForStorage,
             containerName || null,
             gatewayHostPort ? parseInt(gatewayHostPort, 10) : null,
             runtimeHost || null,


### PR DESCRIPTION
## What

The per-agent `gateway_token` — the bearer that authenticates the control plane (and the embed iframe) to each runtime sidecar — was stored **plaintext** for every agent. This encrypts it at rest with the existing `crypto.ts` AES-256-GCM helper, mirroring how SSH credentials and integration tokens are already handled. This was the long-standing tracked hardening flagged across the BYOC epic.

## Design

**Encrypt on write, decrypt at point of use.** Two properties make this low-risk and migration-free:
- `decrypt()` is **transparent to legacy plaintext** (it returns any non-`iv:tag:ct` string unchanged), and all generated tokens are pure hex (no colons) → existing plaintext rows keep working and re-encrypt on their next redeploy. **No bulk migration.**
- When `ENCRYPTION_KEY` is unset (keyless dev/test), `encrypt`/`decrypt` are **no-ops** → behavior unchanged. Production already refuses to boot without `ENCRYPTION_KEY`, so production always encrypts.

## Write sites (encrypt)
- `workers/provisioner/worker.ts` — the deploy `UPDATE` after `backend.create()` returns the token.
- `routes/agents.ts` — the adopt `INSERT` (user-provided token) and the Hermes token cache `UPDATE`.

## Read / use sites (decrypt)
- `runtimeAuth.runtimeAuthHeaders` — the central choke point for backend→runtime auth (covers channels, integration sync, Hermes API, etc.).
- `gatewayProxy.ts` — the RPC-pool `GatewayConnection` and the WS relay (device identity + connect `auth.password`).
- `server.ts` — the gateway-embed bootstrap inlined into the iframe JS.
- `routes/agents.ts` `resolveHermesApiToken` — stored-token read (guarded; falls back to container inspection on decrypt failure).
- `workers/provisioner/worker.ts` — the reuse-from-DB path (decrypt in place; generate a fresh token on decrypt failure rather than failing the deploy) and `runRuntimeCommand` exec auth.

## Safety
- `gateway_token` is **never serialized to clients** — `serializeAgent` strips it; this PR adds no new exposure.
- The worker reuse path degrades gracefully on a rotated/corrupted key (fresh token on next deploy) instead of hard-failing.
- Shared-zone (`workers/provisioner/`) edited — both backend-api and worker typecheck verified.

## Tests
New `__tests__/gatewayTokenEncryption.test.ts`: encrypt/decrypt round-trip (32- and 64-char hex), legacy-plaintext passthrough, `runtimeAuthHeaders` decrypt + DB-fallback decrypt, and the keyless no-op path. **Full backend suite 1166 green** (1159 + 7); backend + worker `typecheck`/`eslint`/`prettier` clean. Docs: `concepts/security.mdx` updated.