### PR TITLE
test(e2e): fix recurring signup-heading flake in platform journey

### DIFF
--- a/e2e/specs/platform-journey.spec.ts
+++ b/e2e/specs/platform-journey.spec.ts
@@ -48,7 +48,14 @@ test.describe("Complete platform journey", () => {
     };
 
     await page.goto("/signup");
-    await expect(page.getByRole("heading", { name: /create operator account/i })).toBeVisible();
+    // The signup heading is race-prone: it renders "Create operator account" by
+    // default, then flips to "Claim this server" once the async bootstrap-status
+    // fetch confirms a zero-user instance. On a fresh E2E stack the page settles
+    // on the claim variant, so accept either heading (same idiom as
+    // navigation.spec.ts) — this is just a "signup page is ready" gate.
+    await expect(
+      page.getByRole("heading", { name: /create operator account|claim this server/i }),
+    ).toBeVisible();
 
     await page.getByLabel(/email address/i).fill(admin.email);
     await page.getByLabel(/^password$/i).fill(admin.password);


### PR DESCRIPTION
## Root cause

`platform-journey.spec.ts:51` asserted the signup heading **"create operator account"** before interacting with the form. But that text is **transient**:

```jsx
<h2>{needsFirstAdmin ? "Claim this server" : "Create operator account"}</h2>
```

The page renders `needsFirstAdmin=false` (→ "Create operator account") on first paint, then a `useEffect` fetches `/api/auth/bootstrap-status` and flips `needsFirstAdmin` to `true` on a zero-user instance — changing the heading to **"Claim this server"**.

On a fresh E2E stack (zero users), the backend returns `needsFirstAdmin: true`, so the page **settles on "Claim this server"**. The single-state matcher was therefore racing the fetch: it passed only when the assertion beat the response, and failed (all 3 Playwright retries within the job) when the fetch won first. A fresh job re-run flipped the timing and passed — which is exactly the flake we've been seeing on #207 / #226 / #227 / #228.

## Fix

Accept either heading, matching the **existing race-tolerant idiom** already used in `navigation.spec.ts:49` (which documents "both are legitimate states for this route"). Line 51 is only a "signup page is ready" gate before the test fills the form, so either heading is a valid signal.

```js
await expect(
  page.getByRole("heading", { name: /create operator account|claim this server/i }),
).toBeVisible();
```

## Scope

E2E-test-only; no product code changed. `prettier` + e2e `typecheck` clean. The real proof is CI: the Playwright job should now pass deterministically (this run, and on the first try going forward).