### PR TITLE
chore(security): bump nodemailer to ^9.0.1 (clears high advisory)

### DIFF
--- a/backend-api/package-lock.json
+++ b/backend-api/package-lock.json
@@ -17,7 +17,7 @@
         "helmet": "^8.1.0",
         "ioredis": "^5.10.1",
         "jsonwebtoken": "^9.0.2",
-        "nodemailer": "^8.0.7",
+        "nodemailer": "^9.0.1",
         "pg": "^8.11.5",
         "sanitize-html": "^2.17.4",
         "ssh2": "^1.17.0",
@@ -5899,9 +5899,9 @@
       "license": "MIT"
     },
     "node_modules/nodemailer": {
-      "version": "8.0.7",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.7.tgz",
-      "integrity": "sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-9.0.1.tgz",
+      "integrity": "sha512-Gwv8SQewT616ZM/URn0H54b8PWo/Wum7md3EW2aWy1lO27+WZCX+Xyak3J+NlmHUjDh5ME+uesJUDRbR3Ye8Bw==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"

--- a/backend-api/package.json
+++ b/backend-api/package.json
@@ -21,7 +21,7 @@
     "helmet": "^8.1.0",
     "ioredis": "^5.10.1",
     "jsonwebtoken": "^9.0.2",
-    "nodemailer": "^8.0.7",
+    "nodemailer": "^9.0.1",
     "pg": "^8.11.5",
     "sanitize-html": "^2.17.4",
     "ssh2": "^1.17.0",


### PR DESCRIPTION
## What

Nodemailer published four advisories — including a **high** (`GHSA-p6gq-j5cr-w38f`: the message-level `raw` option bypasses `disableFileAccess`/`disableUrlAccess`, enabling arbitrary file read + full-response SSRF in the delivered message), plus CRLF header injection, jsonTransport access bypass, and OAuth2 TLS-validation interception. All are fixed only in **9.0.1** (a major bump).

This was reddening the repo-wide `npm audit --omit=dev --audit-level=high` gate on **every** PR (it surfaced on the unrelated #230 E2E PR), same class as the earlier form-data (#210) / protobufjs (#212) fixes — so it gets its own `chore(security)` PR.

## Why the major bump is safe here

Our usage is the stable `createTransport({ host, port, secure, auth })` + `sendMail({ from, to, subject, text, html, replyTo })` core, across `mailer.ts`, `alertRules.ts`, `channels/adapters.ts`, the email integration provider, and `routes/admin`/`workspaces`. None of the v9-changed surfaces (`raw` message option, `jsonTransport` file/url access) are used. Node 24 satisfies nodemailer 9's engine requirement (`>=6`).

## Verification

- `npm audit --omit=dev --audit-level=high` → **high cleared** (2 pre-existing moderates remain: gray-matter/js-yaml, which need a breaking gray-matter bump and are below the gate).
- Nodemailer-consumer suites (`mailer`, `alertRules`, `workspaces`) green; **full backend suite 1167 passing**; `typecheck` clean.