### PR TITLE
docs(launch): surface MCP/A2A/OTel + isolation model on first screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   <img src="https://img.shields.io/badge/docker-compose-2496ED.svg" alt="Docker Compose" />
   <img src="https://img.shields.io/badge/self--hosted-first-0ea5e9.svg" alt="Self-hosted first" />
   <img src="https://img.shields.io/badge/commercial%20use-Apache%202.0%20allowed-6d28d9.svg" alt="Commercial use allowed" />
+  <img src="https://img.shields.io/badge/MCP-server%20%2B%20per--agent-7c3aed.svg" alt="MCP server and per-agent MCP" />
 </p>
 
 <p align="center">
@@ -37,7 +38,12 @@
   <sub>▶ <b><a href="https://github.com/solomon2773/nora/raw/master/.github/readme-assets/walkthrough.mp4">Watch the walkthrough</a></b></sub>
 </p>
 
+## Standards & isolation
 
+- **MCP — shipped.** A control-plane [MCP](https://modelcontextprotocol.io) server (`@noraai/mcp-server`, published to the official [MCP Registry](https://github.com/modelcontextprotocol/registry)) plus per-agent MCP server management — operate the fleet from Claude Code / Desktop / Cursor, and wire MCP tools into individual agents.
+- **OpenTelemetry GenAI — on the roadmap.** OTLP export of runtime telemetry under the `gen_ai.*` semantic conventions, so agent traces and per-agent token/cost attribution flow into the Grafana / Datadog / Langfuse stack you already run.
+- **A2A — on the roadmap.** Agent Cards / Agent-to-Agent discovery for managed OpenClaw and Hermes agents.
+- **Isolation, per deploy target.** Standard Docker and Kubernetes runs use container namespaces plus operator-set CPU / RAM / disk limits; the experimental **NemoClaw** profile hardens untrusted code with a non-root user, all Linux capabilities dropped, `no-new-privileges`, Landlock + seccomp, and default-deny egress; Proxmox VM placement (planned) is the future hardware-isolation tier. See the [isolation model](https://noradocs.solomontsao.com/concepts/security#runtime-isolation).
 
 ## What Is Nora?
 

--- a/docs/compare.mdx
+++ b/docs/compare.mdx
@@ -68,7 +68,7 @@ Dedicated sandbox projects focus on the isolation primitive itself. Nora package
     It has runtime monitoring, logs, terminal, events, and cost controls. Full trace/eval platforms are adjacent integrations, not the current core lane.
   </Accordion>
   <Accordion title="What about MCP?">
-    Nora manages runtime integrations and tool wiring through its integrations module (69+ providers) and the runtimes' own tool ecosystems (for example ClawHub skills for OpenClaw). It does not ship an MCP marketplace of its own.
+    MCP is first-class in both directions. Nora ships a control-plane MCP server (`@noraai/mcp-server`, published to the official MCP Registry) so you can operate the fleet — deploy agents, control their lifecycle, read metrics, events, and per-agent cost — from Claude Code, Claude Desktop, or Cursor; `nora mcp` launches it from the CLI. It also offers per-agent MCP server management, wiring MCP tools into individual agents. That sits alongside the integrations module (69+ providers) and the runtimes' own tool ecosystems (for example ClawHub skills for OpenClaw). Nora is not a public MCP-server marketplace — it exposes and manages MCP for the runtimes it operates.
   </Accordion>
   <Accordion title="Which backend should I try first?">
     Docker + OpenClaw. The [quickstart](/quickstart) gets you from install to a deployed, chat-ready agent in about 15 minutes.

--- a/docs/concepts/security.mdx
+++ b/docs/concepts/security.mdx
@@ -34,9 +34,40 @@ Nora is built to be trustworthy in real operator environments: you run it on you
 
 ## Runtime isolation
 
-- **Each agent runs in its own container** (Docker or Kubernetes) with operator-configured CPU, RAM, and disk limits.
-- **Sandbox profiles** layer on the deploy target: `standard` is the default; `nemoclaw` is an experimental hardened profile. Proxmox VM placement is a planned, currently release-blocked target for stronger isolation.
-- **The control plane and workers are separate services**: the API coordinates state in PostgreSQL while provisioning runs in a dedicated worker over a Redis/BullMQ queue, so runtime credentials and Docker/Kubernetes access stay in the worker boundary.
+Isolation strength is a property of the **deploy target + sandbox profile**, not a single global setting. Pick the tier that matches how much you trust the agent's code.
+
+### Standard profile — Docker and Kubernetes (GA)
+
+- **Each agent runs in its own container** with its own namespaces (PID, mount, network, IPC, UTS) and **operator-set CPU, RAM, and disk limits** (Docker `NanoCpus`/`Memory`; Kubernetes `resources.limits`). The host kernel's default container protections apply (Docker's default seccomp profile, dropped ambient capabilities).
+- This is **shared-kernel** isolation: appropriate for first-party or trusted agent code, the same trust boundary you'd give any container you deploy. It is **not** intended as a hard boundary for arbitrary untrusted code — for that, use the NemoClaw profile or a VM-grade target.
+
+### NemoClaw profile — hardened sandbox (experimental, OpenClaw only)
+
+The `nemoclaw` profile is the hardened tier for running less-trusted agent code. On top of the standard limits it adds, verifiably in the provisioner:
+
+- **Non-root execution** as a dedicated unprivileged user (UID 998) under **Landlock** filesystem restrictions and a **seccomp** syscall filter (baked into the runtime image).
+- **All Linux capabilities dropped** (`CapDrop: ["ALL"]`), adding back only `NET_BIND_SERVICE`, with **`no-new-privileges`** set so a child process can never regain privilege.
+- **`noexec,nosuid` tmpfs** for the sandbox's writable directories, so dropped payloads can't be executed from scratch space.
+- **Default-deny egress**: the sandbox runs with no general bridge network; outbound access is mediated by the OpenShell network policy (deny by default), not open to the internet.
+
+### VM-grade target — Proxmox (planned, release-blocked)
+
+Proxmox VM placement is the planned **hardware-boundary** isolation tier (a separate kernel per agent), tracked but currently release-blocked. It is the future home for workloads that need a stronger boundary than a shared-kernel container.
+
+### Roadmap
+
+- **gVisor / Kata via Kubernetes `RuntimeClass`** — syscall-interception and microVM isolation for the standard Kubernetes target, selectable per agent. Not wired today; on the roadmap.
+- **Default-deny egress `NetworkPolicy` templates** for the standard Kubernetes target.
+
+### Control-plane / worker separation
+
+**The control plane and workers are separate services**: the API coordinates state in PostgreSQL while provisioning runs in a dedicated worker over a Redis/BullMQ queue, so runtime credentials and Docker/Kubernetes access stay inside the worker boundary.
+
+## Standards and protocols
+
+- **MCP is first-class and shipped** — Nora publishes a control-plane MCP server (`@noraai/mcp-server`, in the official MCP Registry) and supports per-agent MCP server management. See [Operating Nora over MCP](https://github.com/solomon2773/nora/tree/master/mcp-server).
+- **OpenTelemetry GenAI (`gen_ai.*` / OTLP export)** — on the roadmap: export runtime telemetry under the OTel GenAI semantic conventions so traces and per-agent token/cost attribution flow into your existing observability backend. Nora is designed to be OTel-conformant and backend-neutral rather than a replacement for your tracing stack.
+- **A2A (Agent-to-Agent)** — on the roadmap: serve Agent Cards / A2A discovery for managed OpenClaw and Hermes agents.
 
 ## Backups and audit
 


### PR DESCRIPTION
## What

Pre-launch **signal sweep** — the three days-effort, no-code recommendations from the 2026-06-21 market research (§8 recs #2 / #3 / #5). 2026 technical evaluators grep the README first screen and the security doc for MCP + A2A + OpenTelemetry + an isolation story in the first 30 minutes; today MCP first appears on README **screen 2** (line 122), A2A/OTel/isolation are absent up top, and `compare.mdx` carries a trust-damaging MCP contradiction.

## Changes (docs-only)

**`README.md`** — new **"Standards & isolation"** block on the first screen + an MCP badge. Now on screen 1: MCP (shipped, registry-listed), OpenTelemetry GenAI / OTLP (roadmap), A2A (roadmap), and a crisp per-deploy-target isolation sentence.

**`docs/compare.mdx`** — fix the **MCP contradiction**. The "What about MCP?" accordion claimed *"It does not ship an MCP marketplace of its own"*, but `@noraai/mcp-server` shipped (in the official MCP Registry) with per-agent MCP. Rewritten to describe the real bidirectional support (control-plane MCP server + `nora mcp` + per-agent MCP wiring).

**`docs/concepts/security.mdx`** — expand the thin "Runtime isolation" section into a **per-deploy-target isolation model**, grounded in the provisioner code:
- *Standard (Docker/K8s GA):* container namespaces + operator-set CPU/RAM/disk limits — shared-kernel, for trusted code.
- *NemoClaw (experimental):* non-root UID 998, `CapDrop: ALL`, `no-new-privileges`, Landlock + seccomp, `noexec,nosuid` tmpfs, default-deny egress — for untrusted code.
- *Proxmox (planned):* future VM-grade / hardware-boundary tier.
- *Roadmap:* gVisor/Kata via Kubernetes `RuntimeClass`; default-deny `NetworkPolicy` templates.

Plus a "Standards and protocols" note (MCP shipped; OTel + A2A on roadmap).

## Honesty note

Every isolation claim is verified against the provisioner (`workers/provisioner/backends/nemoclaw.ts`, `docker.ts`, `k8s.ts`) — standard Docker/K8s deliberately documented as namespaces + resource limits (no over-claiming seccomp hardening it doesn't add), and gVisor/Kata explicitly labeled roadmap (not wired today).

## Scope

Docs/README only — no code, no schema, no tests. Closes the README-signals half of launch readiness; the binding gate remains social proof (17★), and the substantive build items (OTel export #17, scheduled agents #12, SBOM scan #15) are tracked separately.