### PR TITLE
test(backend): add unit tests for authCookie and networkSafety

### DIFF
--- a/backend-api/__tests__/authCookie.test.ts
+++ b/backend-api/__tests__/authCookie.test.ts
@@ -1,0 +1,250 @@
+// @ts-nocheck
+const {
+  AUTH_COOKIE_NAME,
+  readAuthCookie,
+  setAuthCookie,
+  clearAuthCookie,
+  parseCookieHeader,
+  extractSessionTokenFromUpgrade,
+} = require("../authCookie");
+
+describe("authCookie", () => {
+  describe("AUTH_COOKIE_NAME", () => {
+    it("is defined as nora_auth", () => {
+      expect(AUTH_COOKIE_NAME).toBe("nora_auth");
+    });
+  });
+
+  describe("parseCookieHeader", () => {
+    it("returns empty object for empty or missing header", () => {
+      expect(parseCookieHeader("")).toEqual({});
+      expect(parseCookieHeader(null)).toEqual({});
+      expect(parseCookieHeader(undefined)).toEqual({});
+    });
+
+    it("parses single key-value cookie", () => {
+      expect(parseCookieHeader("foo=bar")).toEqual({ foo: "bar" });
+    });
+
+    it("trims keys and values", () => {
+      expect(parseCookieHeader("  foo  =  bar  ")).toEqual({ foo: "bar" });
+    });
+
+    it("parses multiple cookies", () => {
+      expect(parseCookieHeader("foo=bar; baz=qux; abc=123")).toEqual({
+        foo: "bar",
+        baz: "qux",
+        abc: "123",
+      });
+    });
+
+    it("handles cookies with multiple = symbols in value", () => {
+      expect(parseCookieHeader("foo=bar=baz")).toEqual({ foo: "bar=baz" });
+    });
+
+    it("ignores cookie strings without = symbol", () => {
+      expect(parseCookieHeader("invalid-cookie")).toEqual({});
+      expect(parseCookieHeader("valid=yes; invalid")).toEqual({ valid: "yes" });
+    });
+
+    it("decodes URL encoded values", () => {
+      expect(parseCookieHeader("msg=hello%20world")).toEqual({ msg: "hello world" });
+    });
+
+    it("falls back to raw value if decoding fails", () => {
+      expect(parseCookieHeader("bad=%E0%A4%A")).toEqual({ bad: "%E0%A4%A" });
+    });
+  });
+
+  describe("readAuthCookie", () => {
+    it("returns null if no cookies header is present", () => {
+      expect(readAuthCookie({})).toBeNull();
+      expect(readAuthCookie({ headers: {} })).toBeNull();
+    });
+
+    it("returns value of the auth cookie if present", () => {
+      const req = {
+        headers: {
+          cookie: "other=val; nora_auth=my-jwt-token; another=val",
+        },
+      };
+      expect(readAuthCookie(req)).toBe("my-jwt-token");
+    });
+
+    it("returns null if auth cookie is missing but other cookies are present", () => {
+      const req = {
+        headers: {
+          cookie: "other=val; test=cookie",
+        },
+      };
+      expect(readAuthCookie(req)).toBeNull();
+    });
+  });
+
+  describe("extractSessionTokenFromUpgrade", () => {
+    it("prefers the auth cookie over query parameter", () => {
+      const req = {
+        headers: {
+          cookie: "nora_auth=cookie-token",
+        },
+      };
+      const searchParams = {
+        get: jest.fn(() => "query-token"),
+      };
+      const token = extractSessionTokenFromUpgrade(req, searchParams);
+      expect(token).toBe("cookie-token");
+      expect(searchParams.get).not.toHaveBeenCalled();
+    });
+
+    it("falls back to query parameter if cookie is missing", () => {
+      const req = {
+        headers: {},
+      };
+      const searchParams = {
+        get: jest.fn((key) => (key === "token" ? "query-token" : null)),
+      };
+      const token = extractSessionTokenFromUpgrade(req, searchParams);
+      expect(token).toBe("query-token");
+      expect(searchParams.get).toHaveBeenCalledWith("token");
+    });
+
+    it("returns null if neither is present", () => {
+      const req = {
+        headers: {},
+      };
+      const searchParams = {
+        get: jest.fn(() => null),
+      };
+      const token = extractSessionTokenFromUpgrade(req, searchParams);
+      expect(token).toBeNull();
+    });
+
+    it("handles missing searchParams safely", () => {
+      const req = {
+        headers: {},
+      };
+      const token = extractSessionTokenFromUpgrade(req, null);
+      expect(token).toBeNull();
+    });
+  });
+
+  describe("setAuthCookie", () => {
+    let res;
+    let originalEnv;
+
+    beforeEach(() => {
+      res = {
+        cookie: jest.fn(),
+      };
+      originalEnv = process.env.NORA_FORCE_SECURE_COOKIES;
+    });
+
+    afterEach(() => {
+      process.env.NORA_FORCE_SECURE_COOKIES = originalEnv;
+    });
+
+    it("sets cookie with correct default options (non-secure)", () => {
+      const req = { secure: false, headers: {} };
+      setAuthCookie(res, "test-token", req);
+      expect(res.cookie).toHaveBeenCalledWith("nora_auth", "test-token", {
+        httpOnly: true,
+        secure: false,
+        sameSite: "lax",
+        path: "/",
+        maxAge: 7 * 24 * 60 * 60 * 1000,
+      });
+    });
+
+    it("sets secure: true if req.secure is true", () => {
+      const req = { secure: true, headers: {} };
+      setAuthCookie(res, "test-token", req);
+      expect(res.cookie).toHaveBeenCalledWith(
+        "nora_auth",
+        "test-token",
+        expect.objectContaining({ secure: true }),
+      );
+    });
+
+    it("sets secure: true if x-forwarded-proto header is https", () => {
+      const req = {
+        secure: false,
+        headers: { "x-forwarded-proto": "https" },
+      };
+      setAuthCookie(res, "test-token", req);
+      expect(res.cookie).toHaveBeenCalledWith(
+        "nora_auth",
+        "test-token",
+        expect.objectContaining({ secure: true }),
+      );
+    });
+
+    it("sets secure: true if NORA_FORCE_SECURE_COOKIES environment variable is 1", () => {
+      process.env.NORA_FORCE_SECURE_COOKIES = "1";
+      const req = { secure: false, headers: {} };
+      setAuthCookie(res, "test-token", req);
+      expect(res.cookie).toHaveBeenCalledWith(
+        "nora_auth",
+        "test-token",
+        expect.objectContaining({ secure: true }),
+      );
+    });
+  });
+
+  describe("clearAuthCookie", () => {
+    let res;
+    let originalEnv;
+
+    beforeEach(() => {
+      res = {
+        clearCookie: jest.fn(),
+      };
+      originalEnv = process.env.NORA_FORCE_SECURE_COOKIES;
+    });
+
+    afterEach(() => {
+      process.env.NORA_FORCE_SECURE_COOKIES = originalEnv;
+    });
+
+    it("clears cookie with correct default options (non-secure)", () => {
+      const req = { secure: false, headers: {} };
+      clearAuthCookie(res, req);
+      expect(res.clearCookie).toHaveBeenCalledWith("nora_auth", {
+        httpOnly: true,
+        secure: false,
+        sameSite: "lax",
+        path: "/",
+      });
+    });
+
+    it("sets secure: true on clearing if req.secure is true", () => {
+      const req = { secure: true, headers: {} };
+      clearAuthCookie(res, req);
+      expect(res.clearCookie).toHaveBeenCalledWith(
+        "nora_auth",
+        expect.objectContaining({ secure: true }),
+      );
+    });
+
+    it("sets secure: true on clearing if x-forwarded-proto is https", () => {
+      const req = {
+        secure: false,
+        headers: { "x-forwarded-proto": "https" },
+      };
+      clearAuthCookie(res, req);
+      expect(res.clearCookie).toHaveBeenCalledWith(
+        "nora_auth",
+        expect.objectContaining({ secure: true }),
+      );
+    });
+
+    it("sets secure: true on clearing if NORA_FORCE_SECURE_COOKIES is 1", () => {
+      process.env.NORA_FORCE_SECURE_COOKIES = "1";
+      const req = { secure: false, headers: {} };
+      clearAuthCookie(res, req);
+      expect(res.clearCookie).toHaveBeenCalledWith(
+        "nora_auth",
+        expect.objectContaining({ secure: true }),
+      );
+    });
+  });
+});

--- a/backend-api/__tests__/networkSafety.test.ts
+++ b/backend-api/__tests__/networkSafety.test.ts
@@ -1,0 +1,141 @@
+// @ts-nocheck
+const dns = require("node:dns");
+const { assertSafeUrl, assertSafeUrlAsync, PRIVATE_IP_RE } = require("../networkSafety");
+
+jest.mock("node:dns", () => ({
+  promises: {
+    lookup: jest.fn(),
+  },
+}));
+
+describe("networkSafety", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("PRIVATE_IP_RE", () => {
+    it("matches local and private IPv4 addresses", () => {
+      expect(PRIVATE_IP_RE.test("localhost")).toBe(true);
+      expect(PRIVATE_IP_RE.test("127.0.0.1")).toBe(true);
+      expect(PRIVATE_IP_RE.test("10.0.0.1")).toBe(true);
+      expect(PRIVATE_IP_RE.test("172.16.0.1")).toBe(true);
+      expect(PRIVATE_IP_RE.test("172.31.255.255")).toBe(true);
+      expect(PRIVATE_IP_RE.test("192.168.1.50")).toBe(true);
+      expect(PRIVATE_IP_RE.test("169.254.169.254")).toBe(true);
+      expect(PRIVATE_IP_RE.test("100.64.0.1")).toBe(true);
+    });
+
+    it("matches local and private IPv6 addresses", () => {
+      expect(PRIVATE_IP_RE.test("::1")).toBe(true);
+      expect(PRIVATE_IP_RE.test("::")).toBe(true);
+      expect(PRIVATE_IP_RE.test("fc00::1")).toBe(true);
+      expect(PRIVATE_IP_RE.test("fe80::1")).toBe(true);
+    });
+
+    it("does not match public IP addresses or hostnames", () => {
+      expect(PRIVATE_IP_RE.test("google.com")).toBe(false);
+      expect(PRIVATE_IP_RE.test("8.8.8.8")).toBe(false);
+      expect(PRIVATE_IP_RE.test("1.1.1.1")).toBe(false);
+      expect(PRIVATE_IP_RE.test("172.15.255.255")).toBe(false); // Out of RFC1918 range
+      expect(PRIVATE_IP_RE.test("100.63.255.255")).toBe(false); // Out of CGNAT range
+    });
+  });
+
+  describe("assertSafeUrl", () => {
+    it("returns origin for safe URLs", () => {
+      expect(assertSafeUrl("https://google.com/search")).toBe("https://google.com");
+      expect(assertSafeUrl("http://example.org:8080/path")).toBe("http://example.org:8080");
+    });
+
+    it("throws error for invalid URLs", () => {
+      expect(() => assertSafeUrl("not-a-url")).toThrow("URL is not a valid URL");
+      expect(() => assertSafeUrl("http//missing-colon.com")).toThrow("URL is not a valid URL");
+    });
+
+    it("throws error for unsupported protocols", () => {
+      expect(() => assertSafeUrl("ftp://google.com")).toThrow("URL must use http or https");
+      expect(() => assertSafeUrl("file:///etc/passwd")).toThrow("URL must use http or https");
+      expect(() => assertSafeUrl("gopher://example.com")).toThrow("URL must use http or https");
+    });
+
+    it("throws error for hostname literal matching private/local IPs", () => {
+      expect(() => assertSafeUrl("http://localhost/")).toThrow(
+        "URL must not target internal or private network addresses",
+      );
+      expect(() => assertSafeUrl("https://127.0.0.1")).toThrow(
+        "URL must not target internal or private network addresses",
+      );
+      expect(() => assertSafeUrl("https://10.0.0.5")).toThrow(
+        "URL must not target internal or private network addresses",
+      );
+      expect(() => assertSafeUrl("https://[::1]")).toThrow(
+        "URL must not target internal or private network addresses",
+      );
+    });
+
+    it("uses custom label in error messages when provided", () => {
+      expect(() => assertSafeUrl("ftp://google.com", "TestLabel")).toThrow(
+        "TestLabel must use http or https",
+      );
+      expect(() => assertSafeUrl("http://127.0.0.1", "API endpoint")).toThrow(
+        "API endpoint must not target internal or private network addresses",
+      );
+    });
+  });
+
+  describe("assertSafeUrlAsync", () => {
+    it("propagates assertion errors from synchronous check", async () => {
+      await expect(assertSafeUrlAsync("ftp://google.com")).rejects.toThrow(
+        "URL must use http or https",
+      );
+    });
+
+    it("returns origin immediately for IP literal inputs (no DNS lookup)", async () => {
+      const origin = await assertSafeUrlAsync("https://8.8.8.8");
+      expect(origin).toBe("https://8.8.8.8");
+      expect(dns.promises.lookup).not.toHaveBeenCalled();
+    });
+
+    it("returns origin on successful validation after DNS lookup resolves to public IP", async () => {
+      dns.promises.lookup.mockResolvedValue([{ address: "93.184.216.34", family: 4 }]);
+      const origin = await assertSafeUrlAsync("https://example.com/api");
+      expect(origin).toBe("https://example.com");
+      expect(dns.promises.lookup).toHaveBeenCalledWith("example.com", {
+        all: true,
+        verbatim: true,
+      });
+    });
+
+    it("throws when hostname fails to resolve", async () => {
+      const dnsError = new Error("getaddrinfo ENOTFOUND non-existent.domain");
+      dnsError.code = "ENOTFOUND";
+      dns.promises.lookup.mockRejectedValue(dnsError);
+
+      await expect(assertSafeUrlAsync("https://non-existent.domain")).rejects.toThrow(
+        "URL hostname non-existent.domain could not be resolved (ENOTFOUND)",
+      );
+    });
+
+    it("throws when resolved IP address is a private IPv4", async () => {
+      dns.promises.lookup.mockResolvedValue([
+        { address: "93.184.216.34", family: 4 },
+        { address: "192.168.1.1", family: 4 },
+      ]);
+
+      await expect(assertSafeUrlAsync("https://example.com")).rejects.toThrow(
+        "URL resolves to a private/internal address (192.168.1.1) and cannot be used",
+      );
+    });
+
+    it("throws when resolved IP address is a private IPv6", async () => {
+      dns.promises.lookup.mockResolvedValue([
+        { address: "2001:db8::1", family: 6 },
+        { address: "fc00::1", family: 6 },
+      ]);
+
+      await expect(assertSafeUrlAsync("https://example.com")).rejects.toThrow(
+        "URL resolves to a private/internal address (fc00::1) and cannot be used",
+      );
+    });
+  });
+});

--- a/backend-api/networkSafety.ts
+++ b/backend-api/networkSafety.ts
@@ -51,7 +51,9 @@ function assertSafeUrl(rawUrl, label = "URL") {
   }
 
   const hostname = parsed.hostname;
-  if (PRIVATE_IP_RE.test(hostname)) {
+  const cleanHostname =
+    hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
+  if (PRIVATE_IP_RE.test(cleanHostname)) {
     throw new Error(`${label} must not target internal or private network addresses`);
   }
 
@@ -84,14 +86,14 @@ async function assertSafeUrlAsync(rawUrl, label = "URL") {
     // is pointing at a made-up name. Refuse — a later `fetch` would fail
     // anyway, and refusing here gives a cleaner error.
     throw new Error(
-      `${label} hostname ${hostname} could not be resolved (${err.code || err.message})`
+      `${label} hostname ${hostname} could not be resolved (${err.code || err.message})`,
     );
   }
 
   const offending = addresses.find((addr) => PRIVATE_IP_RE.test(addr.address));
   if (offending) {
     throw new Error(
-      `${label} resolves to a private/internal address (${offending.address}) and cannot be used`
+      `${label} resolves to a private/internal address (${offending.address}) and cannot be used`,
     );
   }
 


### PR DESCRIPTION
This PR adds comprehensive unit test suites for two core backend helper modules:

1. `backend-api/authCookie.ts`: Tests cookie parsing, reading, setting, and clearing.
2. `backend-api/networkSafety.ts`: Tests URL and protocol validation, lexical IP matches, and async DNS resolution.

Additionally, this resolves a minor bug in the synchronous check within `assertSafeUrl` to properly strip square brackets from IPv6 hostnames (e.g. `[::1]`), ensuring literal local IPv6 addresses are blocked synchronously in the fast pass.

Closes #220
Closes #221
