### PR TITLE
feat(mcp): add get_fleet_status tool to wrap fleet status endpoint

### DIFF
--- a/mcp-server/src/tools/monitoring.js
+++ b/mcp-server/src/tools/monitoring.js
@@ -21,6 +21,18 @@ export function registerMonitoringTools(server, api) {
   );
 
   server.registerTool(
+    "get_fleet_status",
+    {
+      title: "Get fleet status",
+      description:
+        "Fleet-level status focusing on attention-required agents, listing those with warnings, errors, or alerts active.",
+      inputSchema: {},
+      annotations: { readOnlyHint: true },
+    },
+    withApi(async () => jsonResult(await api.get("/api/monitoring/fleet-status"))),
+  );
+
+  server.registerTool(
     "list_monitoring_events",
     {
       title: "List monitoring events",

--- a/mcp-server/test/tools.test.js
+++ b/mcp-server/test/tools.test.js
@@ -43,6 +43,7 @@ test("registers read and write tools; delete_agent only when destructive is allo
   assert.ok(safeNames.includes("list_agents"));
   assert.ok(safeNames.includes("deploy_agent"));
   assert.ok(safeNames.includes("get_agent_cost"));
+  assert.ok(safeNames.includes("get_fleet_status"));
   assert.ok(!safeNames.includes("delete_agent"));
 
   const destructive = await connect(
@@ -175,6 +176,16 @@ test("tool annotations mark reads read-only and destructive writes destructive",
   const byName = Object.fromEntries(tools.map((t) => [t.name, t]));
   assert.equal(byName.list_agents.annotations.readOnlyHint, true);
   assert.equal(byName.get_platform_metrics.annotations.readOnlyHint, true);
+  assert.equal(byName.get_fleet_status.annotations.readOnlyHint, true);
   assert.equal(byName.stop_agent.annotations.destructiveHint, true);
   assert.equal(byName.deploy_agent.annotations.destructiveHint, false);
+});
+
+test("monitoring fleet and platform status tools call the expected endpoints", async () => {
+  const api = mockApi();
+  const client = await connect(createServer({ api, env: {} }));
+  await client.callTool({ name: "get_platform_metrics", arguments: {} });
+  await client.callTool({ name: "get_fleet_status", arguments: {} });
+  assert.equal(api.calls[0].path, "/api/monitoring/metrics");
+  assert.equal(api.calls[1].path, "/api/monitoring/fleet-status");
 });


### PR DESCRIPTION
This PR registers the `get_fleet_status` tool on the Nora MCP server, wrapping the existing `/api/monitoring/fleet-status` endpoint.

This tool exposes fleet-wide status focusing on attention-required agents, listing those with warnings, errors, or active alerts.

Closes #217
