### PR TITLE
feat(nemoclaw): production-readiness — GHCR image, remote NemoClaw, K8s, CVE-patched base

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -264,10 +264,9 @@ NVIDIA_API_KEY=                                     # from build.nvidia.com
 NEMOCLAW_DEFAULT_MODEL=nvidia/nemotron-3-super-120b-a12b
 # Default: Nora-built image layering tsx + sandbox-writable runtime dirs on
 # top of the upstream OpenShell base (agent-runtime/Dockerfile.nemoclaw-agent).
-# Built automatically by setup.sh when ENABLED_SANDBOX_PROFILES contains nemoclaw.
-# For K3s/Kubernetes targets, set this to a registry image your nodes can pull
-# or preload nora-nemoclaw-agent:local onto the target nodes.
-NEMOCLAW_SANDBOX_IMAGE=nora-nemoclaw-agent:local
+# Defaults to the Nora-published GHCR image. For offline hosts or private
+# clusters, build/preload nora-nemoclaw-agent:local and override this value.
+NEMOCLAW_SANDBOX_IMAGE=ghcr.io/solomon2773/nora-nemoclaw-agent:latest
 
 # ── Security ─────────────────────────────────────────────────
 CORS_ORIGINS=http://localhost:8080                # comma-separated; use your public origin when exposed on a domain

--- a/.github/workflows/release-docker.yml
+++ b/.github/workflows/release-docker.yml
@@ -107,6 +107,8 @@ jobs:
             dockerfile: workers/provisioner/Dockerfile.prod
           - image: nora-worker-backup
             dockerfile: workers/backup/Dockerfile.prod
+          - image: nora-nemoclaw-agent
+            dockerfile: agent-runtime/Dockerfile.nemoclaw-agent
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/agent-runtime/Dockerfile.nemoclaw-agent
+++ b/agent-runtime/Dockerfile.nemoclaw-agent
@@ -1,7 +1,8 @@
-# Reproducible build for `nora-nemoclaw-agent:local` — an overlay on top of
-# the upstream NVIDIA OpenShell sandbox that adds `tsx` (already has openclaw
-# preinstalled) so the runtime bootstrap's fast-path check succeeds at the
-# non-root, Landlock-restricted user that the sandbox runs as.
+# Reproducible build for `nora-nemoclaw-agent` — an overlay on top of the
+# upstream NVIDIA OpenShell sandbox that adds `tsx` and upgrades the base's
+# bundled `openclaw` to a patched release (the base ships an older OpenClaw with
+# sandbox-escape CVEs), so the runtime bootstrap's fast-path check succeeds at
+# the non-root, Landlock-restricted user that the sandbox runs as.
 #
 # Why this is necessary: the OpenShell base image ships with `openclaw`
 # installed globally but NOT `tsx`. Our bootstrap's `ensureOpenClawCmd` tries
@@ -14,19 +15,31 @@
 #
 # Build (once per host, or after bumping upstream):
 #   docker build \
-#     --build-arg NEMOCLAW_SANDBOX_BASE=ghcr.io/nvidia/openshell-community/sandboxes/openclaw:latest \
 #     --build-arg TSX_VERSION=4.21.0 \
+#     --build-arg OPENCLAW_VERSION=2026.6.9 \
 #     -f agent-runtime/Dockerfile.nemoclaw-agent \
 #     -t nora-nemoclaw-agent:local \
 #     agent-runtime/
+# (the base is digest-pinned in the ARG below; override NEMOCLAW_SANDBOX_BASE
+#  only to deliberately move to a newer OpenShell sandbox build)
 #
-# Override the tag the NemoClaw adapter reads via:
+# The production default is the GHCR-published nora-nemoclaw-agent image.
+# Use the local tag only for offline hosts or private cluster preloads:
 #   NEMOCLAW_SANDBOX_IMAGE=nora-nemoclaw-agent:local
 
-ARG NEMOCLAW_SANDBOX_BASE=ghcr.io/nvidia/openshell-community/sandboxes/openclaw:latest
+# Base pinned by digest for reproducibility AND CVE control. The floating
+# :latest tag currently ships OpenClaw 2026.3.11, which carries fixable CRITICAL
+# sandbox-escape CVEs (CVE-2026-41296 / -41329 / -41294 / -43585 / -44109). We
+# pin the digest for a deterministic build and upgrade OpenClaw to a patched
+# release below. Re-resolve the digest after an intentional base bump with:
+#   docker buildx imagetools inspect ghcr.io/nvidia/openshell-community/sandboxes/openclaw:latest
+ARG NEMOCLAW_SANDBOX_BASE=ghcr.io/nvidia/openshell-community/sandboxes/openclaw:latest@sha256:c116946b3f9e84791630f21f115ac35c9c9f669af70ec0eef3035d79833a9550
 FROM ${NEMOCLAW_SANDBOX_BASE}
 
 ARG TSX_VERSION=4.21.0
+# Patched OpenClaw: >= 2026.4.15 clears the base image's sandbox-escape CVEs.
+# Pinned exactly (not a floating tag) so the build stays reproducible.
+ARG OPENCLAW_VERSION=2026.6.9
 
 # Need to install as root; the base image's final layer is `USER sandbox`.
 USER root
@@ -35,8 +48,9 @@ USER root
 # uses `/usr` as its global prefix (not `/usr/local`) — `which openclaw` on
 # the base resolves to `/usr/bin/openclaw` for the same reason.  We inherit
 # that prefix and let the install drop `tsx` alongside.
-RUN npm install -g "tsx@${TSX_VERSION}" \
+RUN npm install -g "tsx@${TSX_VERSION}" "openclaw@${OPENCLAW_VERSION}" \
  && /usr/bin/tsx --version \
+ && /usr/bin/openclaw --version \
  && npm cache clean --force \
  && rm -rf /root/.npm
 

--- a/agent-runtime/lib/agentImages.ts
+++ b/agent-runtime/lib/agentImages.ts
@@ -7,6 +7,7 @@ const {
   normalizeRuntimeFamilyName,
   normalizeSandboxProfileName,
 } = require("./backendCatalog");
+const { getNemoClawSandboxImage } = require("./nemoclawDefaults");
 
 function getProvisionerBackendName() {
   return getDefaultDeployTarget(process.env, {
@@ -28,10 +29,7 @@ function getHermesDockerAgentImage() {
 }
 
 function getNemoClawAgentImage() {
-  return (
-    process.env.NEMOCLAW_SANDBOX_IMAGE ||
-    "ghcr.io/nvidia/openshell-community/sandboxes/openclaw"
-  );
+  return getNemoClawSandboxImage(process.env);
 }
 
 function getDefaultAgentImage({
@@ -45,13 +43,13 @@ function getDefaultAgentImage({
   backend,
 } = {}) {
   const resolvedRuntimeFamily = normalizeRuntimeFamilyName(
-    runtime_family ?? runtimeFamily ?? getDefaultRuntimeFamily(process.env)
+    runtime_family ?? runtimeFamily ?? getDefaultRuntimeFamily(process.env),
   );
   const resolvedSandboxProfile = normalizeSandboxProfileName(
     sandbox_profile ??
       sandboxProfile ??
       sandbox ??
-      getDefaultSandboxProfile(process.env, { runtimeFamily: resolvedRuntimeFamily })
+      getDefaultSandboxProfile(process.env, { runtimeFamily: resolvedRuntimeFamily }),
   );
   const resolvedDeployTarget = normalizeDeployTargetName(
     deploy_target ??
@@ -60,7 +58,7 @@ function getDefaultAgentImage({
       getDefaultDeployTarget(process.env, {
         runtimeFamily: resolvedRuntimeFamily,
         sandbox: resolvedSandboxProfile,
-      })
+      }),
   );
 
   if (resolvedRuntimeFamily === "hermes") {
@@ -80,7 +78,9 @@ function getDefaultAgentImage({
   }
 
   if (resolvedDeployTarget === "proxmox") {
-    return process.env.PROXMOX_TEMPLATE || "local:vztmpl/ubuntu-22.04-standard_22.04-1_amd64.tar.zst";
+    return (
+      process.env.PROXMOX_TEMPLATE || "local:vztmpl/ubuntu-22.04-standard_22.04-1_amd64.tar.zst"
+    );
   }
 
   return process.env.OPENCLAW_STANDARD_IMAGE || "node:24-slim";

--- a/agent-runtime/lib/backendCatalog.ts
+++ b/agent-runtime/lib/backendCatalog.ts
@@ -1,5 +1,10 @@
 // @ts-nocheck
 const DEFAULT_RUNTIME_FAMILY = "openclaw";
+const {
+  NEMOCLAW_DEFAULT_MODEL,
+  getNemoClawDefaultModel,
+  getNemoClawSandboxImage,
+} = require("./nemoclawDefaults");
 const KNOWN_RUNTIME_FAMILIES = Object.freeze(["openclaw", "hermes"]);
 const KNOWN_DEPLOY_TARGETS = Object.freeze(["docker", "k8s", "remote-docker", "proxmox"]);
 const KNOWN_BACKENDS = KNOWN_DEPLOY_TARGETS;
@@ -161,7 +166,7 @@ const SANDBOX_PROFILE_METADATA = Object.freeze({
 });
 
 const NEMOCLAW_MODELS = Object.freeze([
-  "nvidia/nemotron-3-super-120b-a12b",
+  NEMOCLAW_DEFAULT_MODEL,
   "nvidia/llama-3.1-nemotron-ultra-253b-v1",
   "nvidia/llama-3.3-nemotron-super-49b-v1.5",
   "nvidia/nemotron-3-nano-30b-a3b",
@@ -767,14 +772,8 @@ function buildSandboxProfileOption(runtimeFamily, deployTarget, sandboxProfile, 
     selectionId: `${normalizedRuntimeFamily}:${normalizedDeployTarget}:${normalizedSandboxProfile}`,
     selectionType: "sandbox_profile",
     models: normalizedSandboxProfile === "nemoclaw" ? [...NEMOCLAW_MODELS] : [],
-    defaultModel:
-      normalizedSandboxProfile === "nemoclaw"
-        ? env.NEMOCLAW_DEFAULT_MODEL || NEMOCLAW_MODELS[0]
-        : null,
-    sandboxImage:
-      normalizedSandboxProfile === "nemoclaw"
-        ? env.NEMOCLAW_SANDBOX_IMAGE || "ghcr.io/nvidia/openshell-community/sandboxes/openclaw"
-        : null,
+    defaultModel: normalizedSandboxProfile === "nemoclaw" ? getNemoClawDefaultModel(env) : null,
+    sandboxImage: normalizedSandboxProfile === "nemoclaw" ? getNemoClawSandboxImage(env) : null,
     availableForOnboarding: maturityFields.onboardingVisible && status.available,
     ...maturityFields,
   };
@@ -1001,12 +1000,8 @@ function getSandboxProfileCatalog(env = process.env, options = {}) {
           : null,
       executionTargets: relatedTargets.map((target) => target.id),
       models: sandboxProfile === "nemoclaw" ? [...NEMOCLAW_MODELS] : [],
-      defaultModel:
-        sandboxProfile === "nemoclaw" ? env.NEMOCLAW_DEFAULT_MODEL || NEMOCLAW_MODELS[0] : null,
-      sandboxImage:
-        sandboxProfile === "nemoclaw"
-          ? env.NEMOCLAW_SANDBOX_IMAGE || "ghcr.io/nvidia/openshell-community/sandboxes/openclaw"
-          : null,
+      defaultModel: sandboxProfile === "nemoclaw" ? getNemoClawDefaultModel(env) : null,
+      sandboxImage: sandboxProfile === "nemoclaw" ? getNemoClawSandboxImage(env) : null,
       availableForOnboarding:
         maturityFields.onboardingVisible && relatedOptions.some((option) => option.available),
       ...maturityFields,

--- a/agent-runtime/lib/nemoclawDefaults.ts
+++ b/agent-runtime/lib/nemoclawDefaults.ts
@@ -1,0 +1,22 @@
+// @ts-nocheck
+// Shared NemoClaw defaults used by the catalog, provisioners, setup, and tests.
+
+const NEMOCLAW_DEFAULT_MODEL = "nvidia/nemotron-3-super-120b-a12b";
+const NEMOCLAW_SANDBOX_IMAGE_DEFAULT = "ghcr.io/solomon2773/nora-nemoclaw-agent:latest";
+const NEMOCLAW_SANDBOX_IMAGE_LOCAL = "nora-nemoclaw-agent:local";
+
+function getNemoClawDefaultModel(env = process.env) {
+  return env.NEMOCLAW_DEFAULT_MODEL || NEMOCLAW_DEFAULT_MODEL;
+}
+
+function getNemoClawSandboxImage(env = process.env) {
+  return env.NEMOCLAW_SANDBOX_IMAGE || NEMOCLAW_SANDBOX_IMAGE_DEFAULT;
+}
+
+module.exports = {
+  NEMOCLAW_DEFAULT_MODEL,
+  NEMOCLAW_SANDBOX_IMAGE_DEFAULT,
+  NEMOCLAW_SANDBOX_IMAGE_LOCAL,
+  getNemoClawDefaultModel,
+  getNemoClawSandboxImage,
+};

--- a/backend-api/__tests__/agents.test.ts
+++ b/backend-api/__tests__/agents.test.ts
@@ -1894,7 +1894,7 @@ describe("GET /agents/:id/stats", () => {
           ok: true,
           json: async () => ({
             sandbox: "nemoclaw",
-            model: "nvidia/nvidia/nemotron-3-super-120b-a12b",
+            model: "nvidia/nemotron-3-super-120b-a12b",
             inferenceConfigured: true,
             policyActive: true,
             uptime: 120,
@@ -1967,7 +1967,7 @@ describe("GET /agents/:id/stats", () => {
     expect(res.body.nemo).toEqual(
       expect.objectContaining({
         available: true,
-        model: "nvidia/nvidia/nemotron-3-super-120b-a12b",
+        model: "nvidia/nemotron-3-super-120b-a12b",
         inferenceConfigured: true,
         policyActive: true,
         policyRuleCount: 2,

--- a/backend-api/__tests__/containerManager.test.ts
+++ b/backend-api/__tests__/containerManager.test.ts
@@ -26,6 +26,7 @@ const mockK8sLogs = jest.fn();
 const mockK8sExec = jest.fn();
 const mockRemoteStart = jest.fn();
 const mockRemoteHermesStart = jest.fn();
+const mockRemoteNemoStart = jest.fn();
 const mockGetRemoteHostProfile = jest.fn();
 
 jest.mock("../remoteHosts", () => ({
@@ -125,6 +126,20 @@ describe("containerManager NemoClaw routing", () => {
     const localRemoteHermesPath = path.resolve(__dirname, "../backends/remote-hermes");
     jest.doMock(localRemoteHermesPath, remoteHermesFactory, { virtual: true });
     jest.doMock(`${localRemoteHermesPath}.ts`, remoteHermesFactory, { virtual: true });
+    const remoteNemoFactory = () =>
+      jest.fn().mockImplementation(() => ({
+        start: mockRemoteNemoStart,
+      }));
+    const remoteNemoPath = path.resolve(
+      __dirname,
+      "../../workers/provisioner/backends/remote-nemoclaw",
+    );
+    jest.doMock(remoteNemoPath, remoteNemoFactory);
+    jest.doMock(`${remoteNemoPath}.ts`, remoteNemoFactory);
+    const localRemoteNemoPath = path.resolve(__dirname, "../backends/remote-nemoclaw");
+    jest.doMock(localRemoteNemoPath, remoteNemoFactory, { virtual: true });
+    jest.doMock(`${localRemoteNemoPath}.ts`, remoteNemoFactory, { virtual: true });
+    mockRemoteNemoStart.mockReset().mockResolvedValue(undefined);
     mockRemoteHermesStart.mockReset().mockResolvedValue(undefined);
     mockRemoteStart.mockReset().mockResolvedValue(undefined);
     mockGetRemoteHostProfile.mockReset();
@@ -309,6 +324,31 @@ describe("containerManager NemoClaw routing", () => {
 
     expect(mockRemoteHermesStart).toHaveBeenCalledWith("hermes-agent-remote");
     // must NOT use the OpenClaw remote-docker backend or the local docker backend
+    expect(mockRemoteStart).not.toHaveBeenCalled();
+    expect(mockStart).not.toHaveBeenCalled();
+  });
+
+  it("routes a remote NemoClaw agent to the remote-nemoclaw backend", async () => {
+    mockGetRemoteHostProfile.mockResolvedValue({
+      id: "my-laptop",
+      executionTargetId: "remote:my-laptop",
+      sshHost: "100.64.0.5",
+      sshUser: "operator",
+      configured: true,
+    });
+    const containerManager = require("../containerManager");
+    const agent = {
+      runtime_family: "openclaw",
+      deploy_target: "remote-docker",
+      execution_target_id: "remote:my-laptop",
+      sandbox_profile: "nemoclaw",
+      backend_type: "remote-docker",
+      container_id: "nemo-agent-remote",
+    };
+
+    await containerManager.start(agent);
+
+    expect(mockRemoteNemoStart).toHaveBeenCalledWith("nemo-agent-remote");
     expect(mockRemoteStart).not.toHaveBeenCalled();
     expect(mockStart).not.toHaveBeenCalled();
   });

--- a/backend-api/__tests__/otel.test.ts
+++ b/backend-api/__tests__/otel.test.ts
@@ -38,6 +38,7 @@ describe("otel GenAI exporter", () => {
         model: "gpt-5.5",
         provider: "openai",
         runtimeFamily: "openclaw",
+        sandboxProfile: "nemoclaw",
         source: "openclaw.gateway",
         sessionId: "sess-1",
         agentId: "agent-1",
@@ -48,6 +49,7 @@ describe("otel GenAI exporter", () => {
         "gen_ai.request.model": "gpt-5.5",
         "nora.agent.id": "agent-1",
         "nora.runtime.family": "openclaw",
+        "nora.sandbox.profile": "nemoclaw",
         "nora.source": "openclaw.gateway",
         "gen_ai.conversation.id": "sess-1",
       });

--- a/backend-api/__tests__/provisioning.test.ts
+++ b/backend-api/__tests__/provisioning.test.ts
@@ -24,6 +24,10 @@ const mockCreateNamespacedConfigMap = jest.fn();
 const mockReadNamespacedConfigMap = jest.fn();
 const mockReplaceNamespacedConfigMap = jest.fn();
 const mockDeleteNamespacedConfigMap = jest.fn();
+const mockCreateNamespacedSecret = jest.fn();
+const mockReadNamespacedSecret = jest.fn();
+const mockReplaceNamespacedSecret = jest.fn();
+const mockDeleteNamespacedSecret = jest.fn();
 const mockGetNamespacedCustomObject = jest.fn();
 const mockLoadKubeconfigFromFile = jest.fn();
 
@@ -68,6 +72,10 @@ jest.mock(
             readNamespacedConfigMap: mockReadNamespacedConfigMap,
             replaceNamespacedConfigMap: mockReplaceNamespacedConfigMap,
             deleteNamespacedConfigMap: mockDeleteNamespacedConfigMap,
+            createNamespacedSecret: mockCreateNamespacedSecret,
+            readNamespacedSecret: mockReadNamespacedSecret,
+            replaceNamespacedSecret: mockReplaceNamespacedSecret,
+            deleteNamespacedSecret: mockDeleteNamespacedSecret,
           };
         }
         if (api === AppsV1Api) {
@@ -118,6 +126,12 @@ describe("provisioning runtime/gateway contracts", () => {
     });
     mockReplaceNamespacedConfigMap.mockReset().mockResolvedValue({});
     mockDeleteNamespacedConfigMap.mockReset().mockResolvedValue({});
+    mockCreateNamespacedSecret.mockReset().mockResolvedValue({});
+    mockReadNamespacedSecret.mockReset().mockResolvedValue({
+      body: { metadata: { resourceVersion: "secret-rv" } },
+    });
+    mockReplaceNamespacedSecret.mockReset().mockResolvedValue({});
+    mockDeleteNamespacedSecret.mockReset().mockResolvedValue({});
     mockGetNamespacedCustomObject.mockReset().mockResolvedValue({});
     mockLoadKubeconfigFromFile.mockReset().mockReturnValue(undefined);
     delete process.env.GATEWAY_HOST;
@@ -579,8 +593,14 @@ describe("provisioning runtime/gateway contracts", () => {
 
     const deployment = mockCreateNamespacedDeployment.mock.calls[0][0].body;
     const configMap = mockCreateNamespacedConfigMap.mock.calls[0][0].body;
+    const secret = mockCreateNamespacedSecret.mock.calls[0][0].body;
     const container = deployment.spec.template.spec.containers[0];
     const envVars = Object.fromEntries(container.env.map((entry) => [entry.name, entry.value]));
+    const secretEnvVars = Object.fromEntries(
+      container.env
+        .filter((entry) => entry.valueFrom?.secretKeyRef)
+        .map((entry) => [entry.name, entry.valueFrom.secretKeyRef]),
+    );
 
     expect(container.image).toBe("registry.example.com/nora-nemoclaw-agent:stable");
     expect(container.workingDir).toBe("/sandbox");
@@ -590,9 +610,19 @@ describe("provisioning runtime/gateway contracts", () => {
         OPENCLAW_CLI_PATH: "/usr/bin/openclaw",
         OPENCLAW_TSX_BIN: "/usr/bin/tsx",
         NEMOCLAW_MODEL: "nvidia/test-model",
+      }),
+    );
+    expect(envVars.NVIDIA_API_KEY).toBeUndefined();
+    expect(secret.metadata.name).toBe("nora-oclaw-nemo-loadbalancer-qa-nemo-env");
+    expect(secret.stringData).toEqual(
+      expect.objectContaining({
         NVIDIA_API_KEY: "test-nvidia-key",
       }),
     );
+    expect(secretEnvVars.NVIDIA_API_KEY).toEqual({
+      name: "nora-oclaw-nemo-loadbalancer-qa-nemo-env",
+      key: "NVIDIA_API_KEY",
+    });
     expect(container.args).toEqual([". /opt/nora-bootstrap/bootstrap.sh"]);
     expect(configMap.data["bootstrap.sh"]).toContain("nemoclaw@latest");
   });
@@ -784,9 +814,11 @@ describe("provisioning runtime/gateway contracts", () => {
     mockDeleteNamespacedDeployment.mockImplementation(deleteIfLegacyNamespace);
     mockDeleteNamespacedService.mockImplementation(deleteIfLegacyNamespace);
     mockDeleteNamespacedConfigMap.mockImplementation(deleteIfLegacyNamespace);
+    mockDeleteNamespacedSecret.mockImplementation(deleteIfLegacyNamespace);
     mockReadNamespacedDeployment.mockRejectedValue(notFound);
     mockReadNamespacedService.mockRejectedValue(notFound);
     mockReadNamespacedConfigMap.mockRejectedValue(notFound);
+    mockReadNamespacedSecret.mockRejectedValue(notFound);
 
     const K8sBackend = require("../../workers/provisioner/backends/k8s");
     const backend = new K8sBackend(
@@ -818,6 +850,13 @@ describe("provisioning runtime/gateway contracts", () => {
     expect(mockDeleteNamespacedConfigMap).toHaveBeenCalledWith(
       expect.objectContaining({
         name: "nora-oclaw-legacy-agent-bootstrap",
+        namespace: "openclaw-agents",
+        propagationPolicy: "Foreground",
+      }),
+    );
+    expect(mockDeleteNamespacedSecret).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "nora-oclaw-legacy-agent-env",
         namespace: "openclaw-agents",
         propagationPolicy: "Foreground",
       }),

--- a/backend-api/__tests__/remoteDocker.test.ts
+++ b/backend-api/__tests__/remoteDocker.test.ts
@@ -2,7 +2,9 @@
 const path = require("path");
 
 const RemoteDockerBackend = require("../../workers/provisioner/backends/remote-docker");
+const RemoteNemoClawBackend = require("../../workers/provisioner/backends/remote-nemoclaw");
 const DockerBackend = require("../../workers/provisioner/backends/docker");
+const NemoClawBackend = require("../../workers/provisioner/backends/nemoclaw");
 const { buildRemoteDockerOptions } = RemoteDockerBackend;
 
 function keyProfile(overrides = {}) {
@@ -102,6 +104,7 @@ describe("RemoteDockerBackend.create", () => {
       gatewayToken: "tok",
       containerName: "oclaw-agent-x",
       gatewayHostPort: 19042,
+      runtimeHostPort: 19043,
     });
     const backend = new RemoteDockerBackend(keyProfile());
 
@@ -109,6 +112,8 @@ describe("RemoteDockerBackend.create", () => {
 
     expect(result.gatewayHost).toBe("laptop.tail-scale.ts.net");
     expect(result.gatewayPort).toBe(19042);
+    expect(result.runtimeHost).toBe("laptop.tail-scale.ts.net");
+    expect(result.runtimePort).toBe(19043);
     // base fields preserved
     expect(result.containerId).toBe("oclaw-agent-x");
     expect(result.gatewayHostPort).toBe(19042);
@@ -121,10 +126,41 @@ describe("RemoteDockerBackend.create", () => {
       gatewayToken: "t",
       containerName: "c",
       gatewayHostPort: 19000,
+      runtimeHostPort: 19001,
     });
     const backend = new RemoteDockerBackend(keyProfile({ gatewayHost: "" }));
 
     const result = await backend.create({ id: "x" });
     expect(result.gatewayHost).toBe("100.64.0.5");
+  });
+});
+
+describe("RemoteNemoClawBackend", () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it("uses the NemoClaw backend path and advertises the remote gateway endpoint", async () => {
+    jest.spyOn(NemoClawBackend.prototype, "create").mockResolvedValue({
+      containerId: "nemo-agent-x",
+      host: "172.18.0.5",
+      gatewayToken: "tok",
+      containerName: "nemo-agent-x",
+      gatewayHostPort: 19077,
+      runtimeHostPort: 19078,
+    });
+    const backend = new RemoteNemoClawBackend(keyProfile());
+
+    const result = await backend.create({ id: "x", name: "Nemo" });
+
+    expect(result.host).toBe("laptop.tail-scale.ts.net");
+    expect(result.gatewayHost).toBe("laptop.tail-scale.ts.net");
+    expect(result.gatewayPort).toBe(19077);
+    expect(result.runtimeHost).toBe("laptop.tail-scale.ts.net");
+    expect(result.runtimePort).toBe(19078);
+    expect(result.containerId).toBe("nemo-agent-x");
+  });
+
+  it("never discovers a compose network on the remote daemon", async () => {
+    const backend = new RemoteNemoClawBackend(keyProfile());
+    await expect(backend._findComposeNetwork()).resolves.toBeNull();
   });
 });

--- a/backend-api/__tests__/remoteDockerCatalog.test.ts
+++ b/backend-api/__tests__/remoteDockerCatalog.test.ts
@@ -112,6 +112,20 @@ describe("remote-docker deploy target recognition", () => {
       expect(status.issue).toBeNull();
       expect(status.deployTarget).toBe("remote-docker");
     });
+
+    it("lets NemoClaw target a registered remote Docker host when the sandbox is enabled", () => {
+      process.env.ENABLED_SANDBOX_PROFILES = "standard,nemoclaw";
+      const status = getRuntimeSelectionStatus({
+        runtime_family: "openclaw",
+        deploy_target: "remote-docker",
+        execution_target_id: "remote:my-laptop",
+        sandbox_profile: "nemoclaw",
+      });
+      expect(status.available).toBe(true);
+      expect(status.issue).toBeNull();
+      expect(status.deployTarget).toBe("remote-docker");
+      expect(status.sandboxProfile).toBe("nemoclaw");
+    });
   });
 
   describe("catalog surfacing", () => {

--- a/backend-api/authSync.ts
+++ b/backend-api/authSync.ts
@@ -18,6 +18,7 @@ const {
   mapNoraProviderIdToOpenClaw,
 } = require("../agent-runtime/lib/runtimeBootstrap");
 const { buildHermesRuntimeBootstrapEnv } = require("../agent-runtime/lib/hermesRuntimeBootstrap");
+const { NEMOCLAW_DEFAULT_MODEL } = require("../agent-runtime/lib/nemoclawDefaults");
 
 const providerCatalog = Array.isArray(llmProviders.PROVIDERS)
   ? llmProviders.PROVIDERS
@@ -38,7 +39,7 @@ const PROVIDER_MODEL_DEFAULTS = {
   together: "together/moonshotai/Kimi-K2.5",
   cohere: "command-r-plus",
   xai: "grok-4",
-  nvidia: "nvidia/nvidia/nemotron-3-super-120b-a12b",
+  nvidia: NEMOCLAW_DEFAULT_MODEL,
   moonshot: "kimi-k2.5",
   zai: "glm-5",
   minimax: "MiniMax-M2.7",

--- a/backend-api/containerManager.ts
+++ b/backend-api/containerManager.ts
@@ -134,8 +134,8 @@ async function getBackendInstance(type, agent = {}) {
   const cacheKey =
     type === "k8s" || type === "k3s" || type === "kubernetes" || type === "remote-docker"
       ? resolveAgentExecutionTargetId(agent)
-      : type === "remote-hermes"
-        ? `hermes:${resolveAgentExecutionTargetId(agent)}`
+      : type === "remote-hermes" || type === "remote-nemoclaw"
+        ? `${type}:${resolveAgentExecutionTargetId(agent)}`
         : type;
   if (backendCache[cacheKey]) return backendCache[cacheKey];
 
@@ -187,6 +187,21 @@ async function getBackendInstance(type, agent = {}) {
       backendCache[cacheKey] = new RemoteDockerBackend(profile);
       break;
     }
+    case "remote-nemoclaw": {
+      const RemoteNemoClawBackend = require(resolveBackendPath("remote-nemoclaw"));
+      const executionTargetId = resolveAgentExecutionTargetId(agent);
+      const profile = await getRemoteHostProfile(executionTargetId);
+      if (!profile) {
+        throw new Error(
+          "Remote NemoClaw lifecycle operations require a registered remote host execution target.",
+        );
+      }
+      if (!profile.configured) {
+        throw new Error(profile.issue || "Remote host is not configured for lifecycle operations.");
+      }
+      backendCache[cacheKey] = new RemoteNemoClawBackend(profile);
+      break;
+    }
     case "remote-hermes": {
       const RemoteHermesBackend = require(resolveBackendPath("remote-hermes"));
       const executionTargetId = resolveAgentExecutionTargetId(agent);
@@ -226,6 +241,9 @@ async function backendFor(agent) {
   }
   if (type === "remote-docker" && resolveAgentRuntimeFamily(agent) === "hermes") {
     return getBackendInstance("remote-hermes", agent);
+  }
+  if (type === "remote-docker" && resolveAgentSandboxProfile(agent) === "nemoclaw") {
+    return getBackendInstance("remote-nemoclaw", agent);
   }
   return getBackendInstance(type, agent);
 }

--- a/backend-api/llmProviders.ts
+++ b/backend-api/llmProviders.ts
@@ -4,6 +4,7 @@
 const db = require("./db");
 const { encrypt, decrypt, ensureEncryptionConfigured } = require("./crypto");
 const { DEMO_PROVIDER_ID, DEMO_MODEL_ID, deriveDemoToken, demoLlmBaseUrl } = require("./demoLlm");
+const { NEMOCLAW_DEFAULT_MODEL } = require("../agent-runtime/lib/nemoclawDefaults");
 
 // Approved LLM providers and their env var names
 // Models updated per https://docs.openclaw.ai/providers (April 2026)
@@ -62,7 +63,7 @@ const PROVIDERS = [
     envVar: "NVIDIA_API_KEY",
     endpoint: "https://integrate.api.nvidia.com/v1",
     models: [
-      "nvidia/nvidia/nemotron-3-super-120b-a12b",
+      NEMOCLAW_DEFAULT_MODEL,
       "nvidia/moonshotai/kimi-k2.5",
       "nvidia/minimaxai/minimax-m2.5",
       "nvidia/z-ai/glm5",

--- a/backend-api/metrics.ts
+++ b/backend-api/metrics.ts
@@ -108,8 +108,13 @@ async function recordTokenUsage(agentOrId, userId, payload = {}, defaults = {}) 
   if (!agentId || !userId) return null;
   const runtimeFamily =
     defaults.runtimeFamily || (typeof agentOrId === "object" ? agentOrId?.runtime_family : null);
+  const sandboxProfile =
+    defaults.sandboxProfile || (typeof agentOrId === "object" ? agentOrId?.sandbox_profile : null);
   const usage = extractTokenUsage(payload, { ...defaults, runtimeFamily });
   if (!usage) return null;
+  if (sandboxProfile) {
+    usage.metadata.sandbox_profile = String(sandboxProfile);
+  }
   await recordMetric(agentId, userId, "tokens_used", usage.totalTokens, usage.metadata);
   // Mirror the exchange to the OpenTelemetry GenAI exporter (no-op when
   // disabled; never throws). Cost is estimated in-process from the same pricing
@@ -121,6 +126,7 @@ async function recordTokenUsage(agentOrId, userId, payload = {}, defaults = {}) 
       model: m.model,
       provider: m.provider,
       runtimeFamily,
+      sandboxProfile: m.sandbox_profile,
       source: m.source,
       sessionId: m.session_id,
       inputTokens: m.input_tokens,

--- a/backend-api/otel.ts
+++ b/backend-api/otel.ts
@@ -37,6 +37,7 @@ const ATTR = Object.freeze({
   // Nora-scoped attribution
   AGENT_ID: "nora.agent.id",
   RUNTIME_FAMILY: "nora.runtime.family",
+  SANDBOX_PROFILE: "nora.sandbox.profile",
   SOURCE: "nora.source",
 });
 
@@ -72,7 +73,7 @@ function toCount(value) {
  * event, not an aggregated series), so the span path keeps it.
  */
 function chatAttributes(
-  { model, provider, runtimeFamily, source, sessionId, agentId } = {},
+  { model, provider, runtimeFamily, sandboxProfile, source, sessionId, agentId } = {},
   { includeConversation = true } = {},
 ) {
   const attrs = { [ATTR.GEN_AI_OPERATION]: "chat" };
@@ -80,6 +81,7 @@ function chatAttributes(
   if (model) attrs[ATTR.GEN_AI_REQUEST_MODEL] = String(model);
   if (agentId) attrs[ATTR.AGENT_ID] = String(agentId);
   if (runtimeFamily) attrs[ATTR.RUNTIME_FAMILY] = String(runtimeFamily);
+  if (sandboxProfile) attrs[ATTR.SANDBOX_PROFILE] = String(sandboxProfile);
   if (source) attrs[ATTR.SOURCE] = String(source);
   if (includeConversation && sessionId) attrs[ATTR.GEN_AI_CONVERSATION_ID] = String(sessionId);
   return attrs;
@@ -272,6 +274,7 @@ function recordChatExchange({
   model,
   provider,
   runtimeFamily,
+  sandboxProfile,
   source,
   sessionId,
   inputTokens,
@@ -284,7 +287,7 @@ function recordChatExchange({
   try {
     const input = toCount(inputTokens);
     const output = toCount(outputTokens);
-    const id = { model, provider, runtimeFamily, source, sessionId, agentId };
+    const id = { model, provider, runtimeFamily, sandboxProfile, source, sessionId, agentId };
     // Metric labels MUST be bounded — exclude the unbounded session id.
     const metricAttrs = chatAttributes(id, { includeConversation: false });
 

--- a/backend-api/portAllocations.ts
+++ b/backend-api/portAllocations.ts
@@ -21,8 +21,10 @@ const MAX_RACE_RETRIES = 5;
 // physical host (host_key). Port uniqueness stays per-host (UNIQUE(host_key,
 // port)), so a second purpose never collides with the first on that machine.
 //   - GATEWAY: the primary published port (OpenClaw gateway / Hermes runtime API).
+//   - RUNTIME: the OpenClaw runtime sidecar API when the agent runs on a remote host.
 //   - DASHBOARD: the Hermes dashboard UI port, published only for remote hosts.
 const GATEWAY_PORT_PURPOSE = "gateway";
+const RUNTIME_PORT_PURPOSE = "runtime";
 const DASHBOARD_PORT_PURPOSE = "dashboard";
 
 function normalizeHostKey(value) {
@@ -128,6 +130,7 @@ module.exports = {
   DEFAULT_RANGE_MIN,
   DEFAULT_RANGE_MAX,
   GATEWAY_PORT_PURPOSE,
+  RUNTIME_PORT_PURPOSE,
   DASHBOARD_PORT_PURPOSE,
   allocateGatewayPort,
   releaseGatewayPort,

--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -19,13 +19,13 @@ node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
 
 These variables must be set before the stack will start. Without them, JWTs cannot be signed, stored credentials cannot be encrypted, backup archives cannot be sealed, and Agent Hub source-catalog API keys cannot be hashed.
 
-| Variable                             | Required | Default | Description                                                                                                                                                                                       |
-| ------------------------------------ | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Variable                             | Required | Default | Description                                                                                                                                                                                                                                                                                       |
+| ------------------------------------ | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `JWT_SECRET`                         | Yes      | —       | Secret used to sign all JWTs. Minimum 32 characters. In production the backend refuses to boot when this is missing, too short, or looks like a placeholder (e.g. an unedited `.env.example` value). In development a generated secret is persisted in the database so sessions survive restarts. |
 | `ENCRYPTION_KEY`                     | Yes      | —       | 32-byte hex key (64 hex characters) for AES-256-GCM encryption of stored provider keys, integration credentials, and other sensitive values. In production the backend refuses to boot when this is missing or invalid unless `NORA_ALLOW_PLAINTEXT_SECRETS=true` is set explicitly.              |
-| `NORA_BACKUP_ENCRYPTION_KEY`         | Yes      | —       | 32-byte hex key for sealing managed backup archives. Required to create or restore backups. Do not rotate casually — archives encrypted with the previous key cannot be decrypted with a new one. |
-| `NORA_AGENT_HUB_API_KEY_HASH_SECRET` | Yes      | —       | HMAC secret for hashing Agent Hub source-catalog API keys at rest. `setup.sh` auto-generates this on first run; rotating it invalidates every issued Agent Hub key.                               |
-| `NORA_ALLOW_PLAINTEXT_SECRETS`       | No       | `false` | Explicit override to boot a production instance without a valid `ENCRYPTION_KEY` (credentials are then stored unencrypted). Only for throwaway/demo environments.                                 |
+| `NORA_BACKUP_ENCRYPTION_KEY`         | Yes      | —       | 32-byte hex key for sealing managed backup archives. Required to create or restore backups. Do not rotate casually — archives encrypted with the previous key cannot be decrypted with a new one.                                                                                                 |
+| `NORA_AGENT_HUB_API_KEY_HASH_SECRET` | Yes      | —       | HMAC secret for hashing Agent Hub source-catalog API keys at rest. `setup.sh` auto-generates this on first run; rotating it invalidates every issued Agent Hub key.                                                                                                                               |
+| `NORA_ALLOW_PLAINTEXT_SECRETS`       | No       | `false` | Explicit override to boot a production instance without a valid `ENCRYPTION_KEY` (credentials are then stored unencrypted). Only for throwaway/demo environments.                                                                                                                                 |
 
 ## Bootstrap admin account
 
@@ -57,36 +57,36 @@ PostgreSQL connection settings. Defaults match the Docker Compose service name a
 
 Redis backs BullMQ for deployment, ClawHub install, backup, and alert-delivery jobs.
 
-| Variable                            | Required | Default   | Description                                                                                                                                        |
-| ----------------------------------- | -------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `REDIS_HOST`                        | No       | `redis`   | Redis hostname.                                                                                                                                    |
-| `REDIS_PORT`                        | No       | `6379`    | Redis port.                                                                                                                                        |
-| `REDIS_PASSWORD`                    | No       | —         | Optional Redis password. Set when Redis is exposed outside the compose network.                                                                    |
-| `PORT`                              | No       | `4000`    | Backend-api listen port inside the container.                                                                                                      |
-| `BACKEND_API_PORT`                  | No       | `4100`    | Host-only backend API port mapped to container `PORT`. Setup auto-picks another free port when `127.0.0.1:4100` is busy.                           |
-| `DEPLOYMENT_WORKER_CONCURRENCY`     | No       | `6`       | How many deployment jobs the provisioner worker runs in parallel. Higher values reduce queued time but increase image-pull and bootstrap pressure. |
-| `DEPLOYMENT_JOB_TIMEOUT_MS`         | No       | `900000`  | Timeout per deployment job, in milliseconds. Aliased by `PROVISION_TIMEOUT_MS` for legacy deployments.                                             |
-| `CLAWHUB_INSTALL_TIMEOUT_MS`        | No       | `300000`  | Timeout per ClawHub skill install job, in milliseconds.                                                                                            |
-| `BACKUP_WORKER_CONCURRENCY`         | No       | `2`       | Backup worker concurrency.                                                                                                                         |
-| `NORA_BACKUP_JOB_TIMEOUT_MS`        | No       | `1800000` | Backup job hard timeout. The backup worker enforces this via `Promise.race` because BullMQ v5 ignores `defaultJobOptions.timeout`.                 |
-| `NORA_BACKUP_SCHEDULE_POLL_MS`      | No       | `60000`   | How often the backup worker checks for due scheduled backups.                                                                                      |
-| `ALERT_DELIVERY_ATTEMPTS`           | No       | `5`       | Number of retry attempts for an alert webhook delivery before the worker records a terminal failure on the rule. Clamped to `[1, 10]`.             |
-| `ALERT_DELIVERY_WORKER_CONCURRENCY` | No       | `5`       | Concurrency of the alert-deliveries worker.                                                                                                        |
-| `WORKER_HEALTH_PORT`                | No       | `4001`    | Provisioner worker health-check port.                                                                                                              |
-| `BACKUP_WORKER_HEALTH_PORT`         | No       | `4002`    | Backup worker health-check port.                                                                                                                   |
+| Variable                            | Required | Default   | Description                                                                                                                                                                                                   |
+| ----------------------------------- | -------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `REDIS_HOST`                        | No       | `redis`   | Redis hostname.                                                                                                                                                                                               |
+| `REDIS_PORT`                        | No       | `6379`    | Redis port.                                                                                                                                                                                                   |
+| `REDIS_PASSWORD`                    | No       | —         | Optional Redis password. Set when Redis is exposed outside the compose network.                                                                                                                               |
+| `PORT`                              | No       | `4000`    | Backend-api listen port inside the container.                                                                                                                                                                 |
+| `BACKEND_API_PORT`                  | No       | `4100`    | Host-only backend API port mapped to container `PORT`. Setup auto-picks another free port when `127.0.0.1:4100` is busy.                                                                                      |
+| `DEPLOYMENT_WORKER_CONCURRENCY`     | No       | `6`       | How many deployment jobs the provisioner worker runs in parallel. Higher values reduce queued time but increase image-pull and bootstrap pressure.                                                            |
+| `DEPLOYMENT_JOB_TIMEOUT_MS`         | No       | `900000`  | Timeout per deployment job, in milliseconds. Aliased by `PROVISION_TIMEOUT_MS` for legacy deployments.                                                                                                        |
+| `CLAWHUB_INSTALL_TIMEOUT_MS`        | No       | `300000`  | Timeout per ClawHub skill install job, in milliseconds.                                                                                                                                                       |
+| `BACKUP_WORKER_CONCURRENCY`         | No       | `2`       | Backup worker concurrency.                                                                                                                                                                                    |
+| `NORA_BACKUP_JOB_TIMEOUT_MS`        | No       | `1800000` | Backup job hard timeout. The backup worker enforces this via `Promise.race` because BullMQ v5 ignores `defaultJobOptions.timeout`.                                                                            |
+| `NORA_BACKUP_SCHEDULE_POLL_MS`      | No       | `60000`   | How often the backup worker checks for due scheduled backups.                                                                                                                                                 |
+| `ALERT_DELIVERY_ATTEMPTS`           | No       | `5`       | Number of retry attempts for an alert webhook delivery before the worker records a terminal failure on the rule. Clamped to `[1, 10]`.                                                                        |
+| `ALERT_DELIVERY_WORKER_CONCURRENCY` | No       | `5`       | Concurrency of the alert-deliveries worker.                                                                                                                                                                   |
+| `WORKER_HEALTH_PORT`                | No       | `4001`    | Provisioner worker health-check port.                                                                                                                                                                         |
+| `BACKUP_WORKER_HEALTH_PORT`         | No       | `4002`    | Backup worker health-check port.                                                                                                                                                                              |
 | `CLAWHUB_PRUNE_ORPHANED_SKILLS`     | No       | `false`   | When `true`, the provisioner reconciler uninstalls ClawHub skills present in a runtime container but not tracked in the agents table. Off by default — orphans are surfaced in the UI and removed explicitly. |
 
 ## Access and URL
 
 These variables control which nginx configuration is mounted, the listening port, and the public-facing base URL.
 
-| Variable            | Required | Default                 | Description                                                                                                                                                               |
-| ------------------- | -------- | ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `NGINX_CONFIG_FILE` | No       | `nginx.conf`            | Nginx configuration to mount. Use `nginx.conf` for local-only mode and `nginx.public.conf` for public-domain mode.                                                        |
-| `NGINX_HTTP_PORT`   | No       | `8080`                  | Host port mapped to the nginx HTTP listener. Use `8080` locally and `80` when deploying on a public domain. Setup auto-picks another free local port when `8080` is busy. |
-| `NEXTAUTH_URL`      | No       | `http://localhost:8080` | Canonical browser-facing URL of your Nora deployment. Set to your `https://` origin when exposing on a domain.                                                            |
-| `NORA_PUBLIC_URL`   | No       | —                       | Optional explicit public origin used by emails, OAuth callbacks, and audit links when it differs from `NEXTAUTH_URL`.                                                     |
-| `NORA_FORCE_SECURE_COOKIES` | No | —              | When set to `1`, forces the `Secure` flag on session cookies regardless of inbound scheme. Set for always-on-TLS public deployments behind a proxy/CDN that may strip `X-Forwarded-Proto`; leave empty for local HTTP.                              |
+| Variable                    | Required | Default                 | Description                                                                                                                                                                                                            |
+| --------------------------- | -------- | ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NGINX_CONFIG_FILE`         | No       | `nginx.conf`            | Nginx configuration to mount. Use `nginx.conf` for local-only mode and `nginx.public.conf` for public-domain mode.                                                                                                     |
+| `NGINX_HTTP_PORT`           | No       | `8080`                  | Host port mapped to the nginx HTTP listener. Use `8080` locally and `80` when deploying on a public domain. Setup auto-picks another free local port when `8080` is busy.                                              |
+| `NEXTAUTH_URL`              | No       | `http://localhost:8080` | Canonical browser-facing URL of your Nora deployment. Set to your `https://` origin when exposing on a domain.                                                                                                         |
+| `NORA_PUBLIC_URL`           | No       | —                       | Optional explicit public origin used by emails, OAuth callbacks, and audit links when it differs from `NEXTAUTH_URL`.                                                                                                  |
+| `NORA_FORCE_SECURE_COOKIES` | No       | —                       | When set to `1`, forces the `Secure` flag on session cookies regardless of inbound scheme. Set for always-on-TLS public deployments behind a proxy/CDN that may strip `X-Forwarded-Proto`; leave empty for local HTTP. |
 
 ## OAuth
 
@@ -243,11 +243,11 @@ Proxmox is planned but not supported in the current release. These values are re
 
 Read when `ENABLED_SANDBOX_PROFILES` includes `nemoclaw`.
 
-| Variable                 | Required | Default                             | Description                                                                                                  |
-| ------------------------ | -------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------------ |
-| `NVIDIA_API_KEY`         | No       | —                                   | API key from [build.nvidia.com](https://build.nvidia.com) for accessing NVIDIA-hosted Nemotron models.       |
-| `NEMOCLAW_DEFAULT_MODEL` | No       | `nvidia/nemotron-3-super-120b-a12b` | Default Nemotron model used by NemoClaw agents.                                                              |
-| `NEMOCLAW_SANDBOX_IMAGE` | No       | `nora-nemoclaw-agent:local`         | Container image for NemoClaw sandbox runtime. `setup.sh` builds this automatically when NemoClaw is enabled. |
+| Variable                 | Required | Default                                          | Description                                                                                                                   |
+| ------------------------ | -------- | ------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
+| `NVIDIA_API_KEY`         | No       | —                                                | API key from [build.nvidia.com](https://build.nvidia.com) for accessing NVIDIA-hosted Nemotron models.                        |
+| `NEMOCLAW_DEFAULT_MODEL` | No       | `nvidia/nemotron-3-super-120b-a12b`              | Default Nemotron model used by NemoClaw agents.                                                                               |
+| `NEMOCLAW_SANDBOX_IMAGE` | No       | `ghcr.io/solomon2773/nora-nemoclaw-agent:latest` | Container image for NemoClaw sandbox runtime. Use `nora-nemoclaw-agent:local` only when you build/preload the image yourself. |
 
 ## OpenClaw runtime
 
@@ -373,10 +373,10 @@ Optional; only relevant when nginx terminates TLS directly inside the stack.
 
 Optional privacy-light analytics for the public marketing site, powered by [Plausible](https://plausible.io). Off by default — self-hosted deployments ship zero tracking unless `NEXT_PUBLIC_ANALYTICS_DOMAIN` is set at build time.
 
-| Variable                       | Required | Default                              | Description                                                                                |
-| ------------------------------ | -------- | ------------------------------------ | ------------------------------------------------------------------------------------------ |
-| `NEXT_PUBLIC_ANALYTICS_DOMAIN` | No       | —                                    | Plausible domain for the public marketing site. Empty (default) ships zero tracking.       |
-| `NEXT_PUBLIC_ANALYTICS_SRC`    | No       | `https://plausible.io/js/script.js`  | Plausible script URL; point at a self-hosted Plausible instance if you run one.             |
+| Variable                       | Required | Default                             | Description                                                                          |
+| ------------------------------ | -------- | ----------------------------------- | ------------------------------------------------------------------------------------ |
+| `NEXT_PUBLIC_ANALYTICS_DOMAIN` | No       | —                                   | Plausible domain for the public marketing site. Empty (default) ships zero tracking. |
+| `NEXT_PUBLIC_ANALYTICS_SRC`    | No       | `https://plausible.io/js/script.js` | Plausible script URL; point at a self-hosted Plausible instance if you run one.      |
 
 ## Cost reporting
 
@@ -399,9 +399,9 @@ Use `input_per_1k` and `output_per_1k` when Nora records prompt/completion token
 
 These variables are read by older platform-settings code paths for backward compatibility. New deployments should use the `NORA_BACKUP_S3_*` family above instead.
 
-| Variable                | Required | Default | Description                         |
-| ----------------------- | -------- | ------- | ----------------------------------- |
-| `AWS_S3_BUCKET`         | No       | —       | Legacy S3 bucket alias for backups. |
-| `AWS_ACCESS_KEY_ID`     | No       | —       | Legacy AWS access key ID.           |
-| `AWS_SECRET_ACCESS_KEY` | No       | —       | Legacy AWS secret access key.       |
+| Variable                | Required | Default | Description                            |
+| ----------------------- | -------- | ------- | -------------------------------------- |
+| `AWS_S3_BUCKET`         | No       | —       | Legacy S3 bucket alias for backups.    |
+| `AWS_ACCESS_KEY_ID`     | No       | —       | Legacy AWS access key ID.              |
+| `AWS_SECRET_ACCESS_KEY` | No       | —       | Legacy AWS secret access key.          |
 | `AWS_SESSION_TOKEN`     | No       | —       | Legacy optional AWS STS session token. |

--- a/docs/configuration/provisioner-backends/kubernetes-aks.mdx
+++ b/docs/configuration/provisioner-backends/kubernetes-aks.mdx
@@ -210,7 +210,7 @@ cd e2e
 KUBECONFIG_PATH=$PWD/../.secrets/aks-kubeconfig npm run smoke:k8s-aks
 ```
 
-This script is operator-run only — it provisions real workloads against a live AKS cluster and is not part of CI. Set `K8S_SMOKE_RUNTIME_FAMILIES=openclaw` for a single-runtime check, or `KEEP_ENV=true` to leave the stack running after the script finishes.
+This script is operator-run only — it provisions real workloads against a live AKS cluster and is not part of CI. Set `K8S_SMOKE_RUNTIME_FAMILIES=openclaw` for a single-runtime check, `K8S_SMOKE_CELLS=openclaw:nemoclaw` plus `NVIDIA_API_KEY` for a NemoClaw run, or `KEEP_ENV=true` to leave the stack running after the script finishes.
 
 ## Promote to production
 

--- a/docs/configuration/provisioner-backends/kubernetes-k3s.mdx
+++ b/docs/configuration/provisioner-backends/kubernetes-k3s.mdx
@@ -144,6 +144,16 @@ cd e2e
 KUBECONFIG_PATH=$PWD/../.secrets/k3s-kubeconfig npm run smoke:k8s-k3s
 ```
 
+To include NemoClaw in the same adapter path, enable the sandbox profile on the Nora stack, export
+`NVIDIA_API_KEY`, and run:
+
+```bash theme={null}
+cd e2e
+K8S_SMOKE_CELLS=openclaw:nemoclaw \
+  KUBECONFIG_PATH=$PWD/../.secrets/k3s-kubeconfig \
+  npm run smoke:k8s-k3s
+```
+
 The script brings up the Compose stack with `docker-compose.kubernetes.yml`, registers the K3s cluster in Admin, deploys an agent, verifies Kubernetes objects, and exercises stop/start/restart. It exits non-zero on any failure. Set `KEEP_ENV=true` to leave the stack running for inspection.
 
 ## Promote to production

--- a/docs/configuration/provisioner-backends/kubernetes-kind.mdx
+++ b/docs/configuration/provisioner-backends/kubernetes-kind.mdx
@@ -82,14 +82,14 @@ docker compose -f docker-compose.yml -f docker-compose.kubernetes.yml -f docker-
 
 Then register the Kind cluster in **Admin -> Kubernetes**:
 
-| Field | Value |
-| ----- | ----- |
-| Credential mode | `Mounted kubeconfig path` |
-| Kubeconfig path | `/kubeconfigs/nora-kind.container.kubeconfig` |
-| Exposure mode | `NodePort` |
-| Runtime host | `host.docker.internal`, or the Kind control-plane container name on Linux |
-| Runtime node port | `30909` |
-| Gateway node port | `31879` |
+| Field             | Value                                                                     |
+| ----------------- | ------------------------------------------------------------------------- |
+| Credential mode   | `Mounted kubeconfig path`                                                 |
+| Kubeconfig path   | `/kubeconfigs/nora-kind.container.kubeconfig`                             |
+| Exposure mode     | `NodePort`                                                                |
+| Runtime host      | `host.docker.internal`, or the Kind control-plane container name on Linux |
+| Runtime node port | `30909`                                                                   |
+| Gateway node port | `31879`                                                                   |
 
 The Admin **Runtime host** must be reachable from the Compose containers. On Linux without `host.docker.internal` support, set it to the Kind control-plane container name (`nora-kind-control-plane` by default) and join the `kind` Docker network.
 
@@ -123,6 +123,9 @@ docker compose -f docker-compose.yml -f docker-compose.kubernetes.yml -f docker-
 ```
 
 The smoke script exits with `{"ok":true,...}` on success. Per-agent objects follow the generated naming convention `nora-oclaw-<agent-name>-<suffix>` in the `openclaw-agents` namespace.
+
+To smoke NemoClaw on the same Kind adapter path, run the script with
+`K8S_SMOKE_CELLS=openclaw:nemoclaw` and `NVIDIA_API_KEY` set in the shell that starts the stack.
 
 If the agent reaches `running` but the gateway is unreachable, confirm the NodePort values match the port mappings in `infra/kind/nora-kind.yaml`.
 

--- a/docs/guides/nemoclaw.mdx
+++ b/docs/guides/nemoclaw.mdx
@@ -33,9 +33,25 @@ NemoClaw agents use NVIDIA's Nemotron family of models via the NVIDIA API. The f
 | `nvidia/nemotron-3-nano-30b-a3b`           | Lightweight 30B Nemotron Nano                    |
 
 <Note>
-  To use these models you must have an NVIDIA API key saved in **Settings** under the NVIDIA
-  provider. See [Add and sync LLM provider keys](/guides/manage-providers).
+  To use these models, save an NVIDIA API key in **Settings** under the NVIDIA provider. If no user
+  key is saved, self-hosted operators may provide a platform fallback with `NVIDIA_API_KEY`, but
+  user keys are preferred because they keep usage attribution tied to the deploying account.
 </Note>
+
+## Supported deploy targets
+
+NemoClaw runs as an OpenClaw sandbox profile on these deploy targets:
+
+| Target           | Status    | Notes                                                                                                                    |
+| ---------------- | --------- | ------------------------------------------------------------------------------------------------------------------------ |
+| Local Docker     | Supported | Uses the local Docker socket and the NemoClaw sandbox image.                                                             |
+| Remote Docker    | Supported | Requires a connected remote host target such as `remote:gpu-vps`; Nora publishes the gateway port on that host.          |
+| K3s / Kubernetes | Supported | Uses the Kubernetes adapter with `sandbox_profile=nemoclaw`; API keys are injected through per-agent Kubernetes Secrets. |
+| AKS / GKE / EKS  | Supported | Same Kubernetes adapter as K3s; use LoadBalancer exposure or the cluster exposure mode configured in Admin.              |
+
+The default sandbox image is `ghcr.io/solomon2773/nora-nemoclaw-agent:latest`. For air-gapped
+hosts or private clusters, build `nora-nemoclaw-agent:local`, preload it onto the target nodes, and
+set `NEMOCLAW_SANDBOX_IMAGE=nora-nemoclaw-agent:local`.
 
 ## Deploy a NemoClaw agent
 

--- a/docs/guides/opentelemetry.mdx
+++ b/docs/guides/opentelemetry.mdx
@@ -11,20 +11,23 @@ It is **disabled by default** and **fail-open**: a collector outage or misconfig
 
 ## What gets exported
 
-**Spans (OTLP only):** one `chat` span per recorded LLM exchange, with `gen_ai.operation.name=chat`, `gen_ai.request.model`, `gen_ai.system` (provider), `gen_ai.usage.input_tokens` / `output_tokens`, `gen_ai.conversation.id` (session), and `nora.agent.id` / `nora.runtime.family` / `nora.source`. The span is bracketed around the runtime call, so its duration reflects real latency.
+**Spans (OTLP only):** one `chat` span per recorded LLM exchange, with `gen_ai.operation.name=chat`, `gen_ai.request.model`, `gen_ai.system` (provider), `gen_ai.usage.input_tokens` / `output_tokens`, `gen_ai.conversation.id` (session), and `nora.agent.id` / `nora.runtime.family` / `nora.sandbox.profile` / `nora.source`. The span is bracketed around the runtime call, so its duration reflects real latency.
 
 **Metrics (OTLP and/or Prometheus):**
 
-| Instrument | Type | Notes |
-| --- | --- | --- |
-| `gen_ai.client.token.usage` | histogram | Tokens per exchange, split by `gen_ai.token.type` (`input` / `output`) |
-| `nora.agent.cost.usd` | counter | Estimated spend, attributed by agent + model, using the same model-aware pricing as `/app/cost` |
-| `nora.agent.cpu.percent` | gauge | Latest sampled container CPU per running agent |
-| `nora.agent.memory.percent` | gauge | Latest sampled container memory percent per running agent |
-| `nora.agent.memory.usage` | gauge | Latest sampled container memory (MB) per running agent |
+| Instrument                  | Type      | Notes                                                                                           |
+| --------------------------- | --------- | ----------------------------------------------------------------------------------------------- |
+| `gen_ai.client.token.usage` | histogram | Tokens per exchange, split by `gen_ai.token.type` (`input` / `output`)                          |
+| `nora.agent.cost.usd`       | counter   | Estimated spend, attributed by agent + model, using the same model-aware pricing as `/app/cost` |
+| `nora.agent.cpu.percent`    | gauge     | Latest sampled container CPU per running agent                                                  |
+| `nora.agent.memory.percent` | gauge     | Latest sampled container memory percent per running agent                                       |
+| `nora.agent.memory.usage`   | gauge     | Latest sampled container memory (MB) per running agent                                          |
 
 <Note>
-Nora observes telemetry at the **exchange** granularity it actually receives from the runtimes. Per-LLM-call and per-tool-call sub-spans depend on event streams OpenClaw and Hermes do not currently expose to the control plane, and are tracked as a future enhancement. A2A Agent Cards are likewise on the roadmap.
+  Nora observes telemetry at the **exchange** granularity it actually receives from the runtimes.
+  Per-LLM-call and per-tool-call sub-spans depend on event streams OpenClaw and Hermes do not
+  currently expose to the control plane, and are tracked as a future enhancement. A2A Agent Cards
+  are likewise on the roadmap.
 </Note>
 
 ## Enable it
@@ -61,4 +64,4 @@ With Prometheus enabled:
 curl -s http://localhost:9464/metrics | grep -E 'gen_ai_client_token_usage|nora_agent_cost_usd'
 ```
 
-Drive one agent chat, then re-scrape — the token histogram and cost counter will carry your agent + model labels.
+Drive one agent chat, then re-scrape — the token histogram and cost counter will carry your agent, model, runtime family, and sandbox profile labels. For a NemoClaw smoke, deploy an OpenClaw agent with `sandbox_profile=nemoclaw`; the export should show `nora.runtime.family=openclaw` and `nora.sandbox.profile=nemoclaw` without any API-key labels.

--- a/docs/support/faq.mdx
+++ b/docs/support/faq.mdx
@@ -73,7 +73,7 @@ If you are evaluating Nora or have just started self-hosting it, the questions b
   <Accordion title="What is NemoClaw?">
     NemoClaw is an experimental sandbox profile with OpenShell policy controls, powered by NVIDIA Nemotron models. It provides a secure, isolated execution environment for agent runtimes that require tighter operational controls.
 
-    NemoClaw is disabled by default. To enable it, add `nemoclaw` to `ENABLED_SANDBOX_PROFILES` (e.g. `ENABLED_SANDBOX_PROFILES=standard,nemoclaw`) and provide a valid `NVIDIA_API_KEY` in your `.env` file. See the [troubleshooting guide](/support/troubleshooting) if NemoClaw fails to start after enabling it.
+    NemoClaw is disabled by default. To enable it, add `nemoclaw` to `ENABLED_SANDBOX_PROFILES` (e.g. `ENABLED_SANDBOX_PROFILES=standard,nemoclaw`) and save an NVIDIA provider key in **Settings** or provide a platform fallback with `NVIDIA_API_KEY`. It can deploy to local Docker, remote Docker hosts, k3s, and managed Kubernetes targets once those execution targets are connected. See the [troubleshooting guide](/support/troubleshooting) if NemoClaw fails to start after enabling it.
 
   </Accordion>
 

--- a/docs/support/troubleshooting.mdx
+++ b/docs/support/troubleshooting.mdx
@@ -147,7 +147,7 @@ When digging into a specific failure, scope the log view to errors only — the 
 
     **NemoClaw sandbox fails to start**
 
-    NemoClaw is disabled by default. To enable it, add `nemoclaw` to the enabled sandbox profiles and provide a valid NVIDIA API key in your `.env` file:
+    NemoClaw is disabled by default. To enable it, add `nemoclaw` to the enabled sandbox profiles and provide a valid NVIDIA API key either as a user provider key in **Settings** or as a platform fallback in `.env`:
 
     ```bash theme={null}
     ENABLED_SANDBOX_PROFILES=standard,nemoclaw
@@ -155,6 +155,8 @@ When digging into a specific failure, scope the log view to errors only — the 
     ```
 
     Restart the stack after making these changes. If NemoClaw still fails, confirm that your NVIDIA API key is active and has access to the NVIDIA NIM endpoints Nora uses.
+
+    For Kubernetes, also confirm `NEMOCLAW_SANDBOX_IMAGE` points to an image your nodes can pull. The default is Nora's GHCR image; offline clusters must preload `nora-nemoclaw-agent:local` and override the env var.
 
     <Warning>
       Do not paste your NVIDIA API key into GitHub Issues or Discussions. Share only masked or redacted values when asking for help.

--- a/e2e/.env.real.example
+++ b/e2e/.env.real.example
@@ -11,9 +11,12 @@ REAL_LLM_PROVIDER_ID=anthropic
 REAL_ANTHROPIC_API_KEY=
 REAL_OPENAI_API_KEY=
 REAL_GOOGLE_API_KEY=
+REAL_NVIDIA_API_KEY=
 REAL_LLM_API_KEY=
 # Optional: override the model used by the provider record
 REAL_LLM_MODEL=
+# NemoClaw cells force the NVIDIA provider as the default for the deploy.
+REAL_NVIDIA_MODEL=nvidia/nemotron-3-super-120b-a12b
 
 # ─── Matrix cells ───────────────────────────────────────────────────────────
 # Turn cells on with 1, off with 0. OpenClaw+Docker is on by default.
@@ -22,8 +25,14 @@ REAL_LLM_MODEL=
 REAL_ENABLE_OPENCLAW_DOCKER=1
 REAL_ENABLE_OPENCLAW_K8S=0
 REAL_ENABLE_OPENCLAW_NEMOCLAW=0
+REAL_ENABLE_OPENCLAW_NEMOCLAW_REMOTE_DOCKER=0
+REAL_ENABLE_OPENCLAW_NEMOCLAW_K8S=0
 REAL_ENABLE_HERMES_DOCKER=0
 REAL_ENABLE_HERMES_K8S=0
+# Optional concrete execution targets. If REAL_K8S_EXECUTION_TARGET_ID is
+# blank, the suite picks the first available k8s:<id> from /api/config/platform.
+REAL_REMOTE_DOCKER_EXECUTION_TARGET_ID=remote:real-smoke
+REAL_K8S_EXECUTION_TARGET_ID=
 
 # Generous timeouts — cloud k8s and Hermes-first-run are slow.
 REAL_PROVISION_TIMEOUT_MS=600000   # 10 minutes

--- a/e2e/REAL_TESTS.md
+++ b/e2e/REAL_TESTS.md
@@ -7,7 +7,7 @@ security fixes shipped in integrations.ts / channels/adapters.ts.
 ## Files
 
 - `specs/real-deploy-matrix.spec.ts` — §3 test-plan L1-L10 across the
-  OpenClaw/Hermes × Docker/K8s/NemoClaw matrix.
+  OpenClaw/Hermes × Docker/K8s/remote-Docker/NemoClaw matrix.
 - `specs/real-integrations.spec.ts` — §4 GitHub + Slack + URL-based integration
   with real-cred success and SSRF-guard refusal.
 - `specs/real-channels.spec.ts` — §5 OpenClaw channel catalog, type metadata,
@@ -40,7 +40,7 @@ security fixes shipped in integrations.ts / channels/adapters.ts.
    cp .env.real.example .env.real
    # edit — at minimum REAL_LLM_PROVIDER_ID and its matching API key
    # (REAL_ANTHROPIC_API_KEY, REAL_OPENAI_API_KEY, REAL_GOOGLE_API_KEY,
-   # or REAL_LLM_API_KEY as a generic fallback).
+   #  REAL_NVIDIA_API_KEY for NemoClaw, or REAL_LLM_API_KEY as a generic fallback).
    ```
 
 ## Running
@@ -50,9 +50,9 @@ cd e2e
 
 # All three specs against the main compose stack on :8080
 BASE_URL=http://localhost:8080 npx playwright test \
-  specs/real-deploy-matrix.spec.ts \
-  specs/real-integrations.spec.ts \
-  specs/real-channels.spec.ts
+specs/real-deploy-matrix.spec.ts \
+specs/real-integrations.spec.ts \
+specs/real-channels.spec.ts
 
 # Just the deploy matrix
 BASE_URL=http://localhost:8080 npx playwright test specs/real-deploy-matrix.spec.ts
@@ -63,9 +63,9 @@ BASE_URL=http://localhost:8080 npx playwright test --headed specs/real-deploy-ma
 # One cell only — set the other REAL_ENABLE_* flags to 0 in .env.real, or
 # override inline:
 REAL_ENABLE_HERMES_DOCKER=1 REAL_ENABLE_OPENCLAW_DOCKER=0 \
-  BASE_URL=http://localhost:8080 \
-  npx playwright test specs/real-deploy-matrix.spec.ts
-```
+BASE_URL=http://localhost:8080 \
+npx playwright test specs/real-deploy-matrix.spec.ts
+````
 
 Setting `BASE_URL` disables the auto-managed `docker-compose.e2e.yml` stack in
 `playwright.config.ts`, so the specs talk to whichever stack you already have
@@ -73,13 +73,15 @@ up.
 
 ## What each cell expects
 
-| Cell                | Enabled by                                | Extra host requirements                                                                                                                                                                                               |
-| ------------------- | ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| OpenClaw + Docker   | `REAL_ENABLE_OPENCLAW_DOCKER=1` (default) | Docker socket reachable from `backend-api` / `worker-provisioner` (already wired in the default compose)                                                                                                              |
-| OpenClaw + K8s      | `REAL_ENABLE_OPENCLAW_K8S=1`              | Control plane started with `docker-compose.kubernetes.yml`; add `docker-compose.kind.yml` only for local Kind networking                                                                                              |
-| OpenClaw + NemoClaw | `REAL_ENABLE_OPENCLAW_NEMOCLAW=1`         | `NVIDIA_API_KEY` set in `.env` for the stack                                                                                                                                                                          |
-| Hermes + Docker     | `REAL_ENABLE_HERMES_DOCKER=1`             | First run pulls a large Hermes image — warm the cache or raise `REAL_PROVISION_TIMEOUT_MS`                                                                                                                            |
-| Hermes + K8s        | `REAL_ENABLE_HERMES_K8S=1`                | Control plane started with `docker-compose.kubernetes.yml` (add `docker-compose.kind.yml` only for local Kind networking); first run pulls a large Hermes image — warm the cache or raise `REAL_PROVISION_TIMEOUT_MS` |
+| Cell                                | Enabled by                                      | Extra host requirements                                                                                                                                           |
+| ----------------------------------- | ----------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| OpenClaw + Docker                   | `REAL_ENABLE_OPENCLAW_DOCKER=1` (default)       | Docker socket reachable from `backend-api` / `worker-provisioner` (already wired in the default compose)                                                          |
+| OpenClaw + K8s                      | `REAL_ENABLE_OPENCLAW_K8S=1`                    | Control plane started with `docker-compose.kubernetes.yml`; set `REAL_K8S_EXECUTION_TARGET_ID=k8s:<id>` or let the spec pick the first available K8s target       |
+| OpenClaw + NemoClaw + Docker        | `REAL_ENABLE_OPENCLAW_NEMOCLAW=1`               | `REAL_NVIDIA_API_KEY` or `NVIDIA_API_KEY`; stack must enable `ENABLED_SANDBOX_PROFILES=standard,nemoclaw`                                                         |
+| OpenClaw + NemoClaw + Remote Docker | `REAL_ENABLE_OPENCLAW_NEMOCLAW_REMOTE_DOCKER=1` | A connected remote host target; set `REAL_REMOTE_DOCKER_EXECUTION_TARGET_ID=remote:<id>` and provide `REAL_NVIDIA_API_KEY` or `NVIDIA_API_KEY`                    |
+| OpenClaw + NemoClaw + K8s           | `REAL_ENABLE_OPENCLAW_NEMOCLAW_K8S=1`           | A connected K8s/k3s/cloud cluster target; set `REAL_K8S_EXECUTION_TARGET_ID=k8s:<id>` when multiple targets exist, plus `REAL_NVIDIA_API_KEY` or `NVIDIA_API_KEY` |
+| Hermes + Docker                     | `REAL_ENABLE_HERMES_DOCKER=1`                   | First run pulls a large Hermes image — warm the cache or raise `REAL_PROVISION_TIMEOUT_MS`                                                                        |
+| Hermes + K8s                        | `REAL_ENABLE_HERMES_K8S=1`                      | Control plane started with `docker-compose.kubernetes.yml`; first run pulls a large Hermes image — warm the cache or raise `REAL_PROVISION_TIMEOUT_MS`            |
 
 Each cell runs in order: `[L1] deploy → [L2] reach running → [L3] gateway
 reachable → [L4] chat roundtrip → [L5] logs/events → [L7] metrics populate →
@@ -105,13 +107,16 @@ If either behavior regresses, the assertion will flip red.
 
 ## Troubleshooting
 
-- **Cells skip immediately.** Check `/api/config/platform.enabledBackends` —
-  only cells matching what your stack was booted with will run. If you want
-  all current execution targets and runtime choices, boot with
+- **Cells skip immediately.** Check `/api/config/platform.executionTargets` and
+  `/api/config/platform.enabledBackends` — only cells matching what your stack
+  exposes will run. If you want all current execution targets and runtime choices, boot with
   `ENABLED_BACKENDS=docker,proxmox`, register Kubernetes clusters in
   **Admin -> Kubernetes**,
   `ENABLED_RUNTIME_FAMILIES=openclaw,hermes`, and
   `ENABLED_SANDBOX_PROFILES=standard,nemoclaw`.
+- **NemoClaw cells skip.** Set `REAL_NVIDIA_API_KEY` in `e2e/.env.real`, or
+  export `NVIDIA_API_KEY`. The suite saves it as the user's NVIDIA provider key
+  and makes that provider default before each NemoClaw deploy.
 - **`[L2] reach running` times out.** `docker compose logs worker-provisioner`
   and `docker compose logs backend-api` are the primary signal. For k8s, also
   `kubectl -n openclaw-agents get pods`.

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -17,6 +17,7 @@
     "smoke:k8s-kind": "bash ./scripts/run-kind-k8s-smoke.sh",
     "smoke:k8s-cloud": "bash ./scripts/run-cloud-k8s-smoke.sh",
     "smoke:k8s-k3s": "NORA_K8S_PROVIDER=${NORA_K8S_PROVIDER:-k3s} bash ./scripts/run-cloud-k8s-smoke.sh",
+    "smoke:k8s-nemoclaw": "K8S_SMOKE_CELLS=${K8S_SMOKE_CELLS:-openclaw:nemoclaw} bash ./scripts/run-cloud-k8s-smoke.sh",
     "smoke:k8s-aks": "NORA_K8S_PROVIDER=${NORA_K8S_PROVIDER:-aks} K8S_SMOKE_RUNTIME_FAMILIES=${K8S_SMOKE_RUNTIME_FAMILIES:-openclaw,hermes} bash ./scripts/run-cloud-k8s-smoke.sh",
     "smoke:k8s-gke": "NORA_K8S_PROVIDER=${NORA_K8S_PROVIDER:-gke} bash ./scripts/run-cloud-k8s-smoke.sh",
     "smoke:k8s-eks": "NORA_K8S_PROVIDER=${NORA_K8S_PROVIDER:-eks} bash ./scripts/run-cloud-k8s-smoke.sh",

--- a/e2e/scripts/k8s-smoke.mts
+++ b/e2e/scripts/k8s-smoke.mts
@@ -35,6 +35,11 @@ const RUNTIME_FAMILIES = (process.env.K8S_SMOKE_RUNTIME_FAMILIES || "openclaw")
   .split(",")
   .map((value) => value.trim())
   .filter(Boolean);
+const SMOKE_CELLS = (process.env.K8S_SMOKE_CELLS || "")
+  .split(",")
+  .map((value) => value.trim())
+  .filter(Boolean);
+const NEMOCLAW_MODEL = process.env.NEMOCLAW_DEFAULT_MODEL || "nvidia/nemotron-3-super-120b-a12b";
 
 const RUNTIMES = {
   openclaw: {
@@ -50,6 +55,23 @@ const RUNTIMES = {
       `/agents/${agentId}/hermes-ui/embed?token=${encodeURIComponent(token)}`,
   },
 };
+
+function parseSmokeCells() {
+  const entries =
+    SMOKE_CELLS.length > 0
+      ? SMOKE_CELLS
+      : RUNTIME_FAMILIES.map((runtimeFamily) => `${runtimeFamily}:standard`);
+  return entries.map((entry) => {
+    const [runtimeFamilyRaw, sandboxProfileRaw] = entry.split(":");
+    const runtimeFamily = String(runtimeFamilyRaw || "").trim();
+    const sandboxProfile = String(sandboxProfileRaw || "standard").trim() || "standard";
+    return {
+      key: `${runtimeFamily}:${sandboxProfile}`,
+      runtimeFamily,
+      sandboxProfile,
+    };
+  });
+}
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -77,7 +99,9 @@ async function api(path, { method = "GET", token = null, body, expectOk = true }
   }
 
   if (expectOk && !response.ok) {
-    throw new Error(`${method} ${path} failed with ${response.status}: ${typeof parsed === "string" ? parsed : JSON.stringify(parsed)}`);
+    throw new Error(
+      `${method} ${path} failed with ${response.status}: ${typeof parsed === "string" ? parsed : JSON.stringify(parsed)}`,
+    );
   }
 
   return { response, body: parsed };
@@ -156,7 +180,9 @@ async function waitForAgentStatus(token, agentId, allowedStatuses) {
     await sleep(POLL_INTERVAL_MS);
   }
 
-  throw new Error(`Timed out waiting for agent ${agentId} to reach one of: ${allowedStatuses.join(", ")}`);
+  throw new Error(
+    `Timed out waiting for agent ${agentId} to reach one of: ${allowedStatuses.join(", ")}`,
+  );
 }
 
 async function waitForGateway(token, agentId) {
@@ -190,8 +216,8 @@ async function waitForHermesUi(token, agentId) {
 
   throw new Error(
     `Timed out waiting for Hermes UI readiness on agent ${agentId}; last response: ${JSON.stringify(
-      last
-    )}`
+      last,
+    )}`,
   );
 }
 
@@ -229,15 +255,29 @@ async function main() {
   let token = null;
   const agentIds = [];
   const results = [];
+  const cells = parseSmokeCells();
 
   try {
-    const unsupportedRuntime = RUNTIME_FAMILIES.find((runtimeFamily) => !RUNTIMES[runtimeFamily]);
+    const unsupportedRuntime = cells.find((cell) => !RUNTIMES[cell.runtimeFamily]);
     if (unsupportedRuntime) {
       throw new Error(
-        `Unsupported K8S_SMOKE_RUNTIME_FAMILIES entry: ${unsupportedRuntime}. Supported values: ${Object.keys(
-          RUNTIMES
-        ).join(", ")}`
+        `Unsupported K8s smoke runtime entry: ${unsupportedRuntime.runtimeFamily}. Supported values: ${Object.keys(
+          RUNTIMES,
+        ).join(", ")}`,
       );
+    }
+    const invalidSandbox = cells.find(
+      (cell) =>
+        cell.sandboxProfile !== "standard" &&
+        !(cell.runtimeFamily === "openclaw" && cell.sandboxProfile === "nemoclaw"),
+    );
+    if (invalidSandbox) {
+      throw new Error(
+        `Unsupported K8S_SMOKE_CELLS entry: ${invalidSandbox.key}. Use runtime:sandbox pairs such as openclaw:standard,openclaw:nemoclaw,hermes:standard.`,
+      );
+    }
+    if (cells.some((cell) => cell.sandboxProfile === "nemoclaw") && !process.env.NVIDIA_API_KEY) {
+      throw new Error("K8S_SMOKE_CELLS includes openclaw:nemoclaw but NVIDIA_API_KEY is not set");
     }
 
     await api("/auth/signup", {
@@ -253,17 +293,20 @@ async function main() {
 
     await registerKubernetesCluster(token);
 
-    for (const runtimeFamily of RUNTIME_FAMILIES) {
+    for (const cell of cells) {
+      const { runtimeFamily, sandboxProfile } = cell;
       const runtime = RUNTIMES[runtimeFamily];
       const deploy = await api("/agents/deploy", {
         method: "POST",
         token,
         body: {
-          name: `${runtime.label} K8s Smoke ${stamp}`,
+          name: `${runtime.label} ${sandboxProfile === "nemoclaw" ? "NemoClaw " : ""}K8s Smoke ${stamp}`,
           runtime_family: runtimeFamily,
           backend_type: "k8s",
           deploy_target: K8S_EXECUTION_TARGET_ID,
           execution_target_id: K8S_EXECUTION_TARGET_ID,
+          sandbox_profile: sandboxProfile,
+          ...(sandboxProfile === "nemoclaw" ? { model: NEMOCLAW_MODEL } : {}),
         },
       });
       const agentId = deploy.body.id;
@@ -279,11 +322,16 @@ async function main() {
       }
       if (runningAgent.runtime_family !== runtimeFamily) {
         throw new Error(
-          `Expected runtime_family=${runtimeFamily}, received ${runningAgent.runtime_family}`
+          `Expected runtime_family=${runtimeFamily}, received ${runningAgent.runtime_family}`,
         );
       }
       if (runningAgent.backend_type !== "k8s") {
         throw new Error(`Expected backend_type=k8s, received ${runningAgent.backend_type}`);
+      }
+      if ((runningAgent.sandbox_profile || "standard") !== sandboxProfile) {
+        throw new Error(
+          `Expected sandbox_profile=${sandboxProfile}, received ${runningAgent.sandbox_profile}`,
+        );
       }
 
       assertK8sResources(runtimeFamily, agentId);
@@ -319,18 +367,21 @@ async function main() {
 
       results.push({
         runtimeFamily,
+        sandboxProfile,
         agentId,
         surfaceUrl,
         deployment: runtime.deploymentName(agentId),
       });
     }
 
-    console.log(JSON.stringify({
-      ok: true,
-      agents: results,
-      namespace: K8S_NAMESPACE,
-      executionTarget: K8S_EXECUTION_TARGET_ID,
-    }));
+    console.log(
+      JSON.stringify({
+        ok: true,
+        agents: results,
+        namespace: K8S_NAMESPACE,
+        executionTarget: K8S_EXECUTION_TARGET_ID,
+      }),
+    );
   } finally {
     if (token) {
       for (const agentId of agentIds.reverse()) {

--- a/e2e/scripts/run-cloud-k8s-smoke.sh
+++ b/e2e/scripts/run-cloud-k8s-smoke.sh
@@ -17,6 +17,9 @@
 #                         Comma-separated runtime families to deploy.
 #                         Defaults to openclaw in the script; smoke:k8s-aks
 #                         defaults to openclaw,hermes.
+#   K8S_SMOKE_CELLS       Optional runtime:sandbox pairs. Example:
+#                         openclaw:standard,openclaw:nemoclaw,hermes:standard.
+#                         NemoClaw cells require NVIDIA_API_KEY.
 #   CONTAINER_KUBECONFIG_PATH
 #                         Defaults to KUBECONFIG_PATH (use this when the API server
 #                         URL in the kubeconfig differs between host and containers).

--- a/e2e/specs/real-deploy-matrix.spec.ts
+++ b/e2e/specs/real-deploy-matrix.spec.ts
@@ -27,10 +27,34 @@ import {
   deleteAgent,
   chatWithAgent,
   saveProviderKey,
+  setProviderDefault,
 } from "./support/agents";
 import { real } from "./support/realConfig";
 
-const CELLS = [
+type PlatformExecutionTarget = {
+  id?: string;
+  available?: boolean;
+  configured?: boolean;
+  [key: string]: unknown;
+};
+
+type PlatformConfig = {
+  executionTargets?: PlatformExecutionTarget[];
+  [key: string]: unknown;
+};
+
+type MatrixCell = {
+  key: string;
+  label: string;
+  runtimeFamily: string;
+  backend: string;
+  targetPrefix?: string;
+  executionTargetId?: () => string | null;
+  sandboxProfile: "standard" | "nemoclaw";
+  enabledFlag: () => boolean;
+};
+
+const CELLS: MatrixCell[] = [
   {
     key: "openclaw-docker",
     label: "OpenClaw + Docker",
@@ -44,16 +68,38 @@ const CELLS = [
     label: "OpenClaw + Kubernetes",
     runtimeFamily: "openclaw",
     backend: "k8s",
+    targetPrefix: "k8s:",
+    executionTargetId: () => real.k8sExecutionTargetId,
     sandboxProfile: "standard",
     enabledFlag: () => real.enableOpenclawK8s,
   },
   {
-    key: "openclaw-nemoclaw",
-    label: "OpenClaw + NemoClaw sandbox",
+    key: "openclaw-nemoclaw-docker",
+    label: "OpenClaw + NemoClaw sandbox + Docker",
     runtimeFamily: "openclaw",
     backend: "docker",
     sandboxProfile: "nemoclaw",
     enabledFlag: () => real.enableOpenclawNemoclaw,
+  },
+  {
+    key: "openclaw-nemoclaw-remote-docker",
+    label: "OpenClaw + NemoClaw sandbox + Remote Docker",
+    runtimeFamily: "openclaw",
+    backend: "remote-docker",
+    targetPrefix: "remote:",
+    executionTargetId: () => real.remoteDockerExecutionTargetId,
+    sandboxProfile: "nemoclaw",
+    enabledFlag: () => real.enableOpenclawNemoclawRemoteDocker,
+  },
+  {
+    key: "openclaw-nemoclaw-k8s",
+    label: "OpenClaw + NemoClaw sandbox + Kubernetes",
+    runtimeFamily: "openclaw",
+    backend: "k8s",
+    targetPrefix: "k8s:",
+    executionTargetId: () => real.k8sExecutionTargetId,
+    sandboxProfile: "nemoclaw",
+    enabledFlag: () => real.enableOpenclawNemoclawK8s,
   },
   {
     key: "hermes-docker",
@@ -68,19 +114,47 @@ const CELLS = [
     label: "Hermes + Kubernetes",
     runtimeFamily: "hermes",
     backend: "k8s",
+    targetPrefix: "k8s:",
+    executionTargetId: () => real.k8sExecutionTargetId,
     sandboxProfile: "standard",
     enabledFlag: () => real.enableHermesK8s,
   },
 ];
+
+function resolveExecutionTarget(platform: PlatformConfig, cell: MatrixCell) {
+  const explicit = typeof cell.executionTargetId === "function" ? cell.executionTargetId() : null;
+  if (explicit) {
+    if (!Array.isArray(platform.executionTargets)) return explicit;
+    const explicitTarget = platform.executionTargets.find((entry) => entry?.id === explicit);
+    return explicitTarget &&
+      explicitTarget.available !== false &&
+      explicitTarget.configured !== false
+      ? explicit
+      : undefined;
+  }
+  const prefix = cell.targetPrefix;
+  if (!prefix || !Array.isArray(platform.executionTargets)) return undefined;
+  const target = platform.executionTargets.find(
+    (entry) =>
+      String(entry?.id || "").startsWith(prefix) &&
+      entry.available !== false &&
+      entry.configured !== false,
+  );
+  return target?.id;
+}
 
 test.describe("Deploy matrix — real credentials", () => {
   test.describe.configure({ mode: "serial" });
 
   /** @type {{email: string, password: string, token: string, profile: any} | null} */
   let operator = null;
+  const providerRecordIds: Record<string, string | undefined> = {};
 
   test.beforeAll(async ({ request }) => {
-    test.skip(!real.llmApiKey, "REAL_LLM_API_KEY (or REAL_ANTHROPIC_API_KEY / REAL_OPENAI_API_KEY) not set");
+    test.skip(
+      !real.llmApiKey && !real.nvidiaApiKey,
+      "REAL_LLM_API_KEY (or provider-specific real API key) not set",
+    );
 
     operator = await createUserSession(request, {
       email: uniqueEmail("nora-real-matrix"),
@@ -88,11 +162,24 @@ test.describe("Deploy matrix — real credentials", () => {
     });
     operator.profile = await getCurrentUser(request, operator.token);
 
-    await saveProviderKey(request, operator.token, {
-      provider: real.llmProviderId,
-      apiKey: real.llmApiKey,
-      model: real.llmModel || undefined,
-    });
+    if (real.llmApiKey) {
+      const primaryProvider = await saveProviderKey(request, operator.token, {
+        provider: real.llmProviderId,
+        apiKey: real.llmApiKey,
+        model: real.llmModel || undefined,
+      });
+      providerRecordIds.primary = primaryProvider?.id;
+      providerRecordIds[real.llmProviderId] = primaryProvider?.id;
+    }
+
+    if (real.nvidiaApiKey && real.llmProviderId !== real.nvidiaProviderId) {
+      const nvidiaProvider = await saveProviderKey(request, operator.token, {
+        provider: real.nvidiaProviderId,
+        apiKey: real.nvidiaApiKey,
+        model: real.nvidiaModel,
+      });
+      providerRecordIds[real.nvidiaProviderId] = nvidiaProvider?.id;
+    }
   });
 
   for (const cell of CELLS) {
@@ -107,32 +194,57 @@ test.describe("Deploy matrix — real credentials", () => {
         test.skip(!cell.enabledFlag(), `Cell disabled via REAL_ENABLE_* flag`);
 
         const platform = await getPlatformConfig(request, operator.token);
+        const executionTargetId = resolveExecutionTarget(platform, cell);
         test.skip(
-          !backendSupported(platform, cell.backend),
-          `backend ${cell.backend} not in ENABLED_BACKENDS on this stack`
+          Boolean(cell.targetPrefix) && !executionTargetId,
+          `No available ${cell.backend} execution target found for ${cell.label}`,
+        );
+        test.skip(
+          !backendSupported(platform, cell.backend, executionTargetId),
+          `backend ${cell.backend} not in ENABLED_BACKENDS on this stack`,
         );
         test.skip(
           !runtimeSupported(platform, cell.runtimeFamily),
-          `runtime ${cell.runtimeFamily} not in ENABLED_RUNTIME_FAMILIES on this stack`
+          `runtime ${cell.runtimeFamily} not in ENABLED_RUNTIME_FAMILIES on this stack`,
         );
+        test.skip(
+          cell.sandboxProfile !== "nemoclaw" && !real.llmApiKey,
+          "Standard real-LLM cells require REAL_LLM_API_KEY or a provider-specific real key",
+        );
+        test.skip(
+          cell.sandboxProfile === "nemoclaw" && !real.nvidiaApiKey,
+          "NemoClaw real-key cells require REAL_NVIDIA_API_KEY or NVIDIA_API_KEY",
+        );
+
+        const defaultProviderRecordId =
+          cell.sandboxProfile === "nemoclaw"
+            ? providerRecordIds[real.nvidiaProviderId]
+            : providerRecordIds.primary;
+        if (defaultProviderRecordId) {
+          await setProviderDefault(request, operator.token, defaultProviderRecordId);
+        }
 
         try {
           agent = await deployAgent(request, operator.token, {
             name: uniqueName(`real-${cell.key}`),
             runtimeFamily: cell.runtimeFamily,
             backend: cell.backend,
+            executionTargetId,
             sandboxProfile: cell.sandboxProfile,
             vcpu: 1,
             ramMb: 1024,
             diskGb: 5,
+            model: cell.sandboxProfile === "nemoclaw" ? real.nvidiaModel : undefined,
           });
         } catch (err: any) {
           // The backend rejects unsupported runtime/backend combinations with
           // a 400 explaining the constraint. Treat that
           // as a clean skip, not a test failure.
-          if (/only supported|not supported|invalid combination|not enabled/i.test(
-            String(err?.message || "")
-          )) {
+          if (
+            /only supported|not supported|invalid combination|not enabled/i.test(
+              String(err?.message || ""),
+            )
+          ) {
             test.skip(true, `Combination unsupported by platform: ${err.message}`);
             return;
           }
@@ -150,7 +262,7 @@ test.describe("Deploy matrix — real credentials", () => {
           operator.token,
           agent.id,
           ["running", "warning"],
-          { timeoutMs: real.provisionTimeoutMs }
+          { timeoutMs: real.provisionTimeoutMs },
         );
         agent = running;
         expect(["running", "warning"]).toContain(agent.status);
@@ -171,12 +283,8 @@ test.describe("Deploy matrix — real credentials", () => {
 
         const embedPath =
           agent.runtime_family === "hermes"
-            ? `/api/agents/${agent.id}/hermes-ui/embed?token=${encodeURIComponent(
-                operator.token
-              )}`
-            : `/api/agents/${agent.id}/gateway/embed?token=${encodeURIComponent(
-                operator.token
-              )}`;
+            ? `/api/agents/${agent.id}/hermes-ui/embed?token=${encodeURIComponent(operator.token)}`
+            : `/api/agents/${agent.id}/gateway/embed?token=${encodeURIComponent(operator.token)}`;
 
         const deadline = Date.now() + real.provisionTimeoutMs;
         let lastStatus = 0;
@@ -190,8 +298,8 @@ test.describe("Deploy matrix — real credentials", () => {
         }
         throw new Error(
           `Gateway embed never returned 2xx within ${Math.round(
-            real.provisionTimeoutMs / 1000
-          )}s; last status: ${lastStatus}`
+            real.provisionTimeoutMs / 1000,
+          )}s; last status: ${lastStatus}`,
         );
       });
 
@@ -203,7 +311,7 @@ test.describe("Deploy matrix — real credentials", () => {
           request,
           operator.token,
           agent,
-          "Reply with a single short word, e.g. 'ok'."
+          "Reply with a single short word, e.g. 'ok'.",
         );
 
         // Both runtimes eventually return either a string, a { message }
@@ -219,15 +327,14 @@ test.describe("Deploy matrix — real credentials", () => {
         test.skip(!agent, "no agent from [L1]");
         // Logs are streamed via WebSocket; the HTTP metrics + events surfaces
         // give us a non-streaming signal that the agent is alive.
-        const { body } = await apiJson(
-          request,
-          `/api/monitoring/events?limit=25`,
-          { token: operator.token }
-        );
+        const { body } = await apiJson(request, `/api/monitoring/events?limit=25`, {
+          token: operator.token,
+        });
         const events = Array.isArray(body) ? body : [];
-        const touchesAgent = events.some((e) =>
-          String(e.metadata?.agentId || e.agent_id || "") === agent.id ||
-          String(e.message || "").includes(agent.name)
+        const touchesAgent = events.some(
+          (e) =>
+            String(e.metadata?.agentId || e.agent_id || "") === agent.id ||
+            String(e.message || "").includes(agent.name),
         );
         expect(touchesAgent, "expected a monitoring event touching this agent").toBe(true);
       });
@@ -248,7 +355,7 @@ test.describe("Deploy matrix — real credentials", () => {
           const { response, body } = await apiJson(
             request,
             `/api/agents/${agent.id}/metrics/summary`,
-            { token: operator.token, failOnStatus: false }
+            { token: operator.token, failOnStatus: false },
           );
           lastBody = body;
           if (!response.ok()) {
@@ -256,9 +363,7 @@ test.describe("Deploy matrix — real credentials", () => {
             continue;
           }
           const keys =
-            body && typeof body === "object" && !Array.isArray(body)
-              ? Object.keys(body)
-              : [];
+            body && typeof body === "object" && !Array.isArray(body) ? Object.keys(body) : [];
           if (!expectData) {
             expect(body && typeof body === "object" && !Array.isArray(body)).toBe(true);
             return;
@@ -267,39 +372,30 @@ test.describe("Deploy matrix — real credentials", () => {
           await new Promise((r) => setTimeout(r, 5000));
         }
         throw new Error(
-          `Timed out waiting for agent metrics summary; last body: ${JSON.stringify(lastBody)}`
+          `Timed out waiting for agent metrics summary; last body: ${JSON.stringify(lastBody)}`,
         );
       });
 
       test(`[L8] stop then start`, async ({ request }) => {
         test.skip(!agent, "no agent from [L1]");
         await stopAgent(request, operator.token, agent.id);
-        await waitForAgentStatus(
-          request,
-          operator.token,
-          agent.id,
-          ["stopped"],
-          { timeoutMs: 120000 }
-        );
+        await waitForAgentStatus(request, operator.token, agent.id, ["stopped"], {
+          timeoutMs: 120000,
+        });
         await startAgent(request, operator.token, agent.id);
-        await waitForAgentStatus(
-          request,
-          operator.token,
-          agent.id,
-          ["running", "warning"],
-          { timeoutMs: 180000 }
-        );
+        await waitForAgentStatus(request, operator.token, agent.id, ["running", "warning"], {
+          timeoutMs: 180000,
+        });
       });
 
       test(`[L10] destroy`, async ({ request }) => {
         test.skip(!agent, "no agent from [L1]");
         await deleteAgent(request, operator.token, agent.id);
         // After delete, the per-user GET should 404 or return deleted state.
-        const { response } = await apiJson(
-          request,
-          `/api/agents/${agent.id}`,
-          { token: operator.token, failOnStatus: false }
-        );
+        const { response } = await apiJson(request, `/api/agents/${agent.id}`, {
+          token: operator.token,
+          failOnStatus: false,
+        });
         expect([404, 200]).toContain(response.status());
       });
     });

--- a/e2e/specs/support/agents.ts
+++ b/e2e/specs/support/agents.ts
@@ -39,6 +39,7 @@ type DeployAgentOptions = {
   name?: string;
   runtimeFamily?: string;
   backend?: string;
+  executionTargetId?: string;
   sandboxProfile?: string;
   vcpu?: number;
   ramMb?: number;
@@ -72,6 +73,12 @@ type ChannelOptions = {
 
 type IntegrationRecord = {
   id: string;
+  provider?: string;
+  [key: string]: unknown;
+};
+
+type ProviderKeyRecord = {
+  id?: string;
   provider?: string;
   [key: string]: unknown;
 };
@@ -190,12 +197,15 @@ async function getPlatformConfig(request: APIRequestContext, token: string) {
   return normalizePlatformConfig(body);
 }
 
-function backendSupported(platform: PlatformConfig, backendId: string) {
+function backendSupported(platform: PlatformConfig, backendId: string, executionTargetId?: string) {
   if (Array.isArray(platform.executionTargets)) {
-    const target = platform.executionTargets.find((entry) => entry?.id === backendId);
+    const target = platform.executionTargets.find(
+      (entry) => entry?.id === (executionTargetId || backendId),
+    );
     if (target) {
       return target.available !== false && target.configured !== false;
     }
+    if (executionTargetId) return false;
   }
 
   const enabled = platform.enabledBackends || platform.enabledDeployTargets || [];
@@ -219,6 +229,7 @@ async function deployAgent(
     name,
     runtimeFamily = "openclaw",
     backend = "docker",
+    executionTargetId,
     sandboxProfile = "standard",
     vcpu = 1,
     ramMb = 1024,
@@ -227,6 +238,7 @@ async function deployAgent(
     model,
   }: DeployAgentOptions = {},
 ) {
+  const target = executionTargetId || backend;
   const { body } = await apiJson<AgentRecord>(request, "/api/agents/deploy", {
     method: "POST",
     token,
@@ -234,7 +246,8 @@ async function deployAgent(
       name,
       runtime_family: runtimeFamily,
       backend_type: backend,
-      deploy_target: backend,
+      deploy_target: target,
+      execution_target_id: executionTargetId,
       sandbox_profile: sandboxProfile,
       vcpu,
       ram_mb: ramMb,
@@ -388,12 +401,21 @@ async function saveProviderKey(
   token: string,
   { provider, apiKey, model }: SaveProviderKeyOptions,
 ) {
-  const { body } = await apiJson(request, "/api/llm-providers", {
+  const { body } = await apiJson<ProviderKeyRecord>(request, "/api/llm-providers", {
     method: "POST",
     token,
     data: { provider, apiKey, model },
   });
-  return body;
+  return assertJsonRecord<ProviderKeyRecord>(body, "/api/llm-providers");
+}
+
+async function setProviderDefault(request: APIRequestContext, token: string, providerId: string) {
+  const { body } = await apiJson<ProviderKeyRecord>(request, `/api/llm-providers/${providerId}`, {
+    method: "PUT",
+    token,
+    data: { is_default: true },
+  });
+  return assertJsonRecord<ProviderKeyRecord>(body, `/api/llm-providers/${providerId}`);
 }
 
 async function listProviders(request: APIRequestContext, token: string) {
@@ -613,6 +635,7 @@ export {
   chatOpenClaw,
   chatHermes,
   saveProviderKey,
+  setProviderDefault,
   listProviders,
   connectIntegration,
   testIntegration,

--- a/e2e/specs/support/realConfig.ts
+++ b/e2e/specs/support/realConfig.ts
@@ -44,6 +44,7 @@ function requireEnv(name: string) {
 }
 
 const llmProviderId = requireEnv("REAL_LLM_PROVIDER_ID") || "anthropic";
+const nvidiaProviderId = "nvidia";
 
 function providerMatchedLlmKey(providerId: string) {
   const generic = requireEnv("REAL_LLM_API_KEY");
@@ -61,6 +62,10 @@ function providerMatchedLlmKey(providerId: string) {
     return requireEnv("REAL_GOOGLE_API_KEY") || generic;
   }
 
+  if (normalized.includes("nvidia")) {
+    return requireEnv("REAL_NVIDIA_API_KEY") || requireEnv("NVIDIA_API_KEY") || generic;
+  }
+
   return (
     generic ||
     requireEnv("REAL_ANTHROPIC_API_KEY") ||
@@ -74,6 +79,9 @@ const real = {
   llmProviderId,
   llmApiKey: providerMatchedLlmKey(llmProviderId),
   llmModel: requireEnv("REAL_LLM_MODEL"),
+  nvidiaProviderId,
+  nvidiaApiKey: requireEnv("REAL_NVIDIA_API_KEY") || requireEnv("NVIDIA_API_KEY"),
+  nvidiaModel: requireEnv("REAL_NVIDIA_MODEL") || "nvidia/nemotron-3-super-120b-a12b",
 
   // Integrations (any subset is fine — each spec skips when its cred is empty)
   githubToken: requireEnv("REAL_GITHUB_TOKEN"),
@@ -110,8 +118,14 @@ const real = {
   enableOpenclawDocker: (requireEnv("REAL_ENABLE_OPENCLAW_DOCKER") || "1") !== "0",
   enableOpenclawK8s: (requireEnv("REAL_ENABLE_OPENCLAW_K8S") || "0") === "1",
   enableOpenclawNemoclaw: (requireEnv("REAL_ENABLE_OPENCLAW_NEMOCLAW") || "0") === "1",
+  enableOpenclawNemoclawRemoteDocker:
+    (requireEnv("REAL_ENABLE_OPENCLAW_NEMOCLAW_REMOTE_DOCKER") || "0") === "1",
+  enableOpenclawNemoclawK8s: (requireEnv("REAL_ENABLE_OPENCLAW_NEMOCLAW_K8S") || "0") === "1",
   enableHermesDocker: (requireEnv("REAL_ENABLE_HERMES_DOCKER") || "0") === "1",
   enableHermesK8s: (requireEnv("REAL_ENABLE_HERMES_K8S") || "0") === "1",
+  remoteDockerExecutionTargetId:
+    requireEnv("REAL_REMOTE_DOCKER_EXECUTION_TARGET_ID") || "remote:real-smoke",
+  k8sExecutionTargetId: requireEnv("REAL_K8S_EXECUTION_TARGET_ID"),
 
   // Timeouts (ms)
   provisionTimeoutMs: Number.parseInt(requireEnv("REAL_PROVISION_TIMEOUT_MS") || "600000", 10),

--- a/frontend-dashboard/lib/runtime.ts
+++ b/frontend-dashboard/lib/runtime.ts
@@ -267,21 +267,21 @@ function remoteHostTargetLabel(host: any = {}) {
 }
 
 // Clone a generic execution-target template into a concrete per-host entry that
-// the deploy picker can render and select. remote-docker only supports the
-// standard sandbox profile in this phase.
+// the deploy picker can render and select. Remote Docker now supports both the
+// standard OpenClaw path and NemoClaw through a dedicated remote sandbox backend.
 function buildRemoteHostTarget(template: any = {}, host: any = {}) {
   const sandboxProfiles = (template.sandboxProfiles || []).map((profile: any) => {
-    const isStandard = profile.id === "standard";
+    const enabled = profile.enabled !== false;
     return {
       ...profile,
       executionTargetId: host.executionTargetId,
       deployTargetLabel: host.label,
-      enabled: isStandard,
-      configured: isStandard,
-      available: isStandard,
-      availableForOnboarding: isStandard,
-      isDefault: isStandard,
-      issue: isStandard ? null : profile.issue || null,
+      enabled,
+      configured: enabled,
+      available: enabled,
+      availableForOnboarding: enabled && profile.onboardingVisible !== false,
+      isDefault: profile.id === "standard",
+      issue: enabled ? null : profile.issue || null,
       // remote-docker is experimental in this phase regardless of which template
       // was cloned (don't inherit a fallback docker template's "ga").
       maturityTier: "experimental",

--- a/setup.ps1
+++ b/setup.ps1
@@ -1379,9 +1379,9 @@ PROXMOX_SSH_PASSWORD=$PROXMOX_SSH_PASSWORD
 # ── NemoClaw / NVIDIA (when ENABLED_SANDBOX_PROFILES includes nemoclaw) ──
 NVIDIA_API_KEY=$NVIDIA_API_KEY
 NEMOCLAW_DEFAULT_MODEL=nvidia/nemotron-3-super-120b-a12b
-# For K3s/Kubernetes targets, use a registry image your nodes can pull
-# or preload nora-nemoclaw-agent:local onto the target nodes.
-NEMOCLAW_SANDBOX_IMAGE=nora-nemoclaw-agent:local
+# Defaults to the Nora-published GHCR image. For offline hosts or private
+# clusters, build/preload nora-nemoclaw-agent:local and override this value.
+NEMOCLAW_SANDBOX_IMAGE=ghcr.io/solomon2773/nora-nemoclaw-agent:latest
 
 # ── Security ─────────────────────────────────────────────────
 CORS_ORIGINS=$CORS_ORIGINS
@@ -1481,17 +1481,20 @@ docker build -f agent-runtime/Dockerfile.openclaw-agent -t nora-openclaw-agent:l
 if ($LASTEXITCODE -ne 0) { Write-Err "Failed to build nora-openclaw-agent:local"; exit 1 }
 Write-Ok "OpenClaw agent image ready"
 
-# Only build the NemoClaw variant when the operator enabled the sandbox profile.
-# The NemoClaw adapter pulls (never builds) nora-nemoclaw-agent:local, so without
-# this build a nemoclaw deploy fails — unlike the standard OpenClaw image, which
-# the Docker backend builds on demand.
+# Only build the NemoClaw fallback image when the operator enables the sandbox
+# and explicitly points NEMOCLAW_SANDBOX_IMAGE at the local tag.
 if (($ENABLED_SANDBOX_PROFILES -split ',') -contains 'nemoclaw') {
-    Write-Host ""
-    Write-Info "Building nora-nemoclaw-agent:local (OpenShell sandbox + tsx)..."
-    Write-Host ""
-    docker build -f agent-runtime/Dockerfile.nemoclaw-agent -t nora-nemoclaw-agent:local agent-runtime/
-    if ($LASTEXITCODE -ne 0) { Write-Err "Failed to build nora-nemoclaw-agent:local"; exit 1 }
-    Write-Ok "NemoClaw sandbox image ready"
+    $nemoclawImageLine = Select-String -Path $ENV_FILE -Pattern '^NEMOCLAW_SANDBOX_IMAGE=nora-nemoclaw-agent:local$' -Quiet
+    if ($nemoclawImageLine) {
+        Write-Host ""
+        Write-Info "Building nora-nemoclaw-agent:local (OpenShell sandbox + tsx)..."
+        Write-Host ""
+        docker build -f agent-runtime/Dockerfile.nemoclaw-agent -t nora-nemoclaw-agent:local agent-runtime/
+        if ($LASTEXITCODE -ne 0) { Write-Err "Failed to build nora-nemoclaw-agent:local"; exit 1 }
+        Write-Ok "NemoClaw sandbox image ready"
+    } else {
+        Write-Info "Using GHCR NemoClaw sandbox image from NEMOCLAW_SANDBOX_IMAGE"
+    }
 }
 Start-NoraComposeStack
 

--- a/setup.sh
+++ b/setup.sh
@@ -1422,9 +1422,9 @@ PROXMOX_SSH_PASSWORD=${PROXMOX_SSH_PASSWORD}
 # ── NemoClaw / NVIDIA (when ENABLED_SANDBOX_PROFILES includes nemoclaw) ──
 NVIDIA_API_KEY=${NVIDIA_API_KEY}
 NEMOCLAW_DEFAULT_MODEL=nvidia/nemotron-3-super-120b-a12b
-# For K3s/Kubernetes targets, use a registry image your nodes can pull
-# or preload nora-nemoclaw-agent:local onto the target nodes.
-NEMOCLAW_SANDBOX_IMAGE=nora-nemoclaw-agent:local
+# Defaults to the Nora-published GHCR image. For offline hosts or private
+# clusters, build/preload nora-nemoclaw-agent:local and override this value.
+NEMOCLAW_SANDBOX_IMAGE=ghcr.io/solomon2773/nora-nemoclaw-agent:latest
 
 # ── Security ─────────────────────────────────────────────────
 CORS_ORIGINS=${CORS_ORIGINS}
@@ -1524,18 +1524,22 @@ docker build \
   agent-runtime/
 ok "OpenClaw agent image ready"
 
-# Only build the NemoClaw variant when the operator actually enables the
-# sandbox profile — pulling the 2.4GB OpenShell base on every install is wasteful.
+# Only build the NemoClaw fallback image when the operator enables the sandbox
+# and explicitly points NEMOCLAW_SANDBOX_IMAGE at the local tag.
 case ",${ENABLED_SANDBOX_PROFILES:-}," in
   *,nemoclaw,*)
-    echo ""
-    info "Building nora-nemoclaw-agent:local (OpenShell sandbox + tsx)..."
-    echo ""
-    docker build \
-      -f agent-runtime/Dockerfile.nemoclaw-agent \
-      -t nora-nemoclaw-agent:local \
-      agent-runtime/
-    ok "NemoClaw sandbox image ready"
+    if grep -Eq '^NEMOCLAW_SANDBOX_IMAGE=nora-nemoclaw-agent:local$' "$ENV_FILE"; then
+      echo ""
+      info "Building nora-nemoclaw-agent:local (OpenShell sandbox + tsx)..."
+      echo ""
+      docker build \
+        -f agent-runtime/Dockerfile.nemoclaw-agent \
+        -t nora-nemoclaw-agent:local \
+        agent-runtime/
+      ok "NemoClaw sandbox image ready"
+    else
+      info "Using GHCR NemoClaw sandbox image from NEMOCLAW_SANDBOX_IMAGE"
+    fi
     ;;
 esac
 

--- a/workers/provisioner/backends/docker.ts
+++ b/workers/provisioner/backends/docker.ts
@@ -21,6 +21,7 @@ const {
   getStandardDockerAgentImage,
   getStandardDockerPackageSpec,
 } = require("../../../agent-runtime/lib/agentImages");
+const { NEMOCLAW_DEFAULT_MODEL } = require("../../../agent-runtime/lib/nemoclawDefaults");
 const {
   buildDockerTelemetry,
   buildUnavailableTelemetry,
@@ -335,6 +336,7 @@ class DockerBackend extends ProvisionerBackend {
       mcpServers: mcpServerEntries,
       abortSignal,
       gatewayHostPort: allocatedGatewayPort,
+      runtimeHostPort: allocatedRuntimePort,
     } = config;
     const containerName = container_name || safeContainerName("nora-oclaw", name, id);
     let container = null;
@@ -537,7 +539,7 @@ class DockerBackend extends ProvisionerBackend {
       together: "together/moonshotai/Kimi-K2.5",
       cohere: "cohere/command-r-plus",
       xai: "xai/grok-4",
-      nvidia: "nvidia/nvidia/nemotron-3-super-120b-a12b",
+      nvidia: NEMOCLAW_DEFAULT_MODEL,
       moonshot: "moonshot/kimi-k2.5",
       zai: "zai/glm-5",
       minimax: "minimax/MiniMax-M2.7",
@@ -571,6 +573,13 @@ class DockerBackend extends ProvisionerBackend {
       Number.isInteger(allocatedPort) && allocatedPort >= 1 && allocatedPort <= 65535
         ? allocatedPort
         : 19000 + ((parseInt(id.replace(/\D/g, "").slice(0, 4)) || 0) % 1000);
+    const allocatedRuntimePortNumber = Number(allocatedRuntimePort);
+    const runtimeHostPort =
+      Number.isInteger(allocatedRuntimePortNumber) &&
+      allocatedRuntimePortNumber >= 1 &&
+      allocatedRuntimePortNumber <= 65535
+        ? allocatedRuntimePortNumber
+        : null;
 
     const allowedOrigins = new Set([
       "http://localhost:8080",
@@ -695,7 +704,10 @@ class DockerBackend extends ProvisionerBackend {
           RestartPolicy: { Name: "unless-stopped" },
           // Publish gateway port for direct browser access (control UI).
           // Use a deterministic port based on agent ID to survive container restarts.
-          PortBindings: { "18789/tcp": [{ HostPort: String(hostPort) }] },
+          PortBindings: {
+            "18789/tcp": [{ HostPort: String(hostPort) }],
+            ...(runtimeHostPort ? { "9090/tcp": [{ HostPort: String(runtimeHostPort) }] } : {}),
+          },
           // DNS servers for internet access from within the container
           Dns: ["8.8.8.8", "8.8.4.4", "1.1.1.1"],
           Binds: [`${volumeName}:/mnt/nora-agent-state`],
@@ -739,11 +751,20 @@ class DockerBackend extends ProvisionerBackend {
       // Get the published host port for the gateway (for direct browser access to control UI)
       const portBindings = info.NetworkSettings?.Ports?.["18789/tcp"];
       const gatewayHostPort = portBindings?.[0]?.HostPort || null;
+      const runtimePortBindings = info.NetworkSettings?.Ports?.["9090/tcp"];
+      const publishedRuntimeHostPort = runtimePortBindings?.[0]?.HostPort || null;
 
       console.log(
-        `[docker] Container ${containerName} (${container.id}) started at ${host} (gateway port 18789, host port ${gatewayHostPort || "none"})`,
+        `[docker] Container ${containerName} (${container.id}) started at ${host} (gateway port 18789, host port ${gatewayHostPort || "none"}, runtime host port ${publishedRuntimeHostPort || "none"})`,
       );
-      return { containerId: containerName, host, gatewayToken, containerName, gatewayHostPort };
+      return {
+        containerId: containerName,
+        host,
+        gatewayToken,
+        containerName,
+        gatewayHostPort,
+        runtimeHostPort: publishedRuntimeHostPort,
+      };
     } catch (error) {
       if (container) {
         try {

--- a/workers/provisioner/backends/k8s.ts
+++ b/workers/provisioner/backends/k8s.ts
@@ -14,6 +14,7 @@ const {
   HERMES_DASHBOARD_PORT,
 } = require("../../../agent-runtime/lib/contracts");
 const { getHermesDockerAgentImage } = require("../../../agent-runtime/lib/agentImages");
+const { getNemoClawDefaultModel } = require("../../../agent-runtime/lib/nemoclawDefaults");
 const { buildContainerBootstrap } = require("../../../agent-runtime/lib/containerCommand");
 const {
   HERMES_MANAGED_ENV_ENV,
@@ -49,6 +50,21 @@ const K8S_UNAVAILABLE_CAPABILITIES = Object.freeze({
   disk: false,
   pids: false,
 });
+const SENSITIVE_ENV_PATTERNS = Object.freeze([
+  /API_KEY/i,
+  /TOKEN/i,
+  /PASSWORD/i,
+  /_PASS$/i,
+  /SECRET/i,
+  /PRIVATE_KEY/i,
+  /PASSPHRASE/i,
+  /CREDENTIAL/i,
+  /SERVICE_ACCOUNT/i,
+  /KUBECONFIG/i,
+  /^PGPASSWORD$/i,
+  /^API_SERVER_KEY$/i,
+  /^OPENCLAW_GATEWAY_TOKEN$/i,
+]);
 
 function parseK8sCpuCores(value) {
   if (value == null) return null;
@@ -146,6 +162,33 @@ function safeHostname(name, fallback) {
 
 function safeK8sName(name, fallback) {
   return safeHostname(name, fallback).slice(0, 63) || fallback;
+}
+
+function isSensitiveEnvName(name) {
+  return SENSITIVE_ENV_PATTERNS.some((pattern) => pattern.test(String(name || "")));
+}
+
+function buildEnvEntries(envMap = {}, secretName = "") {
+  const env = [];
+  const stringData = {};
+  for (const [key, value] of Object.entries(envMap || {})) {
+    if (!key || value == null) continue;
+    if (isSensitiveEnvName(key)) {
+      stringData[key] = String(value);
+      env.push({
+        name: key,
+        valueFrom: {
+          secretKeyRef: {
+            name: secretName,
+            key,
+          },
+        },
+      });
+      continue;
+    }
+    env.push({ name: key, value: String(value) });
+  }
+  return { env, stringData };
 }
 
 function defaultDeployNameForRuntime(runtimeFamily, id, name) {
@@ -629,6 +672,10 @@ class K8sBackend extends ProvisionerBackend {
     return `${deployName}-bootstrap`;
   }
 
+  _envSecretName(deployName) {
+    return `${deployName}-env`;
+  }
+
   _bootstrapLaunch(bootstrap) {
     const interpreter =
       Array.isArray(bootstrap?.interpreter) && bootstrap.interpreter.length > 0
@@ -695,6 +742,51 @@ class K8sBackend extends ProvisionerBackend {
       );
       body.metadata.resourceVersion = current?.metadata?.resourceVersion;
       await this.coreApi.replaceNamespacedConfigMap({
+        name,
+        namespace,
+        body,
+      });
+    }
+
+    return name;
+  }
+
+  async _upsertEnvSecret(deployName, stringData = {}, labels = {}, namespace = this.namespace) {
+    const name = this._envSecretName(deployName);
+    const body = {
+      apiVersion: "v1",
+      kind: "Secret",
+      metadata: {
+        name,
+        namespace,
+        labels: {
+          "nora.agent.id": this._agentIdFromDeployName(deployName),
+          "nora.env": "true",
+          "nora.execution.target": this.executionTargetLabelValue,
+          "nora.kubernetes.cluster": this.clusterId,
+          ...labels,
+        },
+      },
+      type: "Opaque",
+      stringData,
+    };
+
+    try {
+      await this.coreApi.createNamespacedSecret({
+        namespace,
+        body,
+      });
+    } catch (error) {
+      if (!this._isAlreadyExistsError(error)) throw error;
+
+      const current = this._serviceObject(
+        await this.coreApi.readNamespacedSecret({
+          name,
+          namespace,
+        }),
+      );
+      body.metadata.resourceVersion = current?.metadata?.resourceVersion;
+      await this.coreApi.replaceNamespacedSecret({
         name,
         namespace,
         body,
@@ -989,6 +1081,25 @@ class K8sBackend extends ProvisionerBackend {
     return true;
   }
 
+  async _deleteEnvSecretIfExists(deployName, namespace) {
+    const name = this._envSecretName(deployName);
+    try {
+      await this.coreApi.deleteNamespacedSecret({
+        name,
+        namespace,
+        propagationPolicy: "Foreground",
+      });
+    } catch (error) {
+      if (this._isNotFoundError(error)) return false;
+      throw error;
+    }
+
+    await this._waitForDeleted("Secret", name, namespace, () =>
+      this.coreApi.readNamespacedSecret({ name, namespace }),
+    );
+    return true;
+  }
+
   _isNodePortConflictError(error) {
     const text = this._errorBodyText(error);
     const status = this._errorStatus(error);
@@ -1037,7 +1148,7 @@ class K8sBackend extends ProvisionerBackend {
     );
     const hermesLaunchArgs = ["bash", "-lc", `. ${BOOTSTRAP_SCRIPT_PATH}`];
 
-    const envVars = Object.entries({
+    const hermesEnvMap = {
       ...(env || {}),
       HERMES_HOME,
       HOME: `${HERMES_HOME}/home`,
@@ -1048,7 +1159,24 @@ class K8sBackend extends ProvisionerBackend {
       GATEWAY_HEALTH_URL: `http://127.0.0.1:${HERMES_RUNTIME_PORT}`,
       MESSAGING_CWD: HERMES_WORKSPACE,
       TERMINAL_CWD: HERMES_WORKSPACE,
-    }).map(([key, value]) => ({ name: key, value: String(value) }));
+    };
+    const hermesSecretName = this._envSecretName(deployName);
+    const { env: envVars, stringData: hermesSecretData } = buildEnvEntries(
+      hermesEnvMap,
+      hermesSecretName,
+    );
+    if (Object.keys(hermesSecretData).length > 0) {
+      await this._upsertEnvSecret(
+        deployName,
+        hermesSecretData,
+        {
+          "nora.agent.id": String(id),
+          "nora.deployment.name": deployName,
+          "nora.runtime.family": "hermes",
+        },
+        namespace,
+      );
+    }
 
     const deployment = {
       apiVersion: "apps/v1",
@@ -1152,10 +1280,7 @@ class K8sBackend extends ProvisionerBackend {
     }
     const namespace = this._namespaceForRuntimeFamily("openclaw");
     const isNemoClaw = sandboxProfile === "nemoclaw";
-    const nemoModel =
-      env?.NEMOCLAW_MODEL ||
-      process.env.NEMOCLAW_DEFAULT_MODEL ||
-      "nvidia/nemotron-3-super-120b-a12b";
+    const nemoModel = env?.NEMOCLAW_MODEL || getNemoClawDefaultModel(process.env);
 
     await this._ensureNamespace(namespace);
 
@@ -1214,7 +1339,7 @@ class K8sBackend extends ProvisionerBackend {
       },
     });
 
-    const envVars = Object.entries({
+    const openClawEnvMap = {
       ...(env || {}),
       ...buildRuntimeEnv(),
       ...(isNemoClaw
@@ -1229,7 +1354,25 @@ class K8sBackend extends ProvisionerBackend {
           }
         : {}),
       OPENCLAW_GATEWAY_TOKEN: gatewayToken,
-    }).map(([k, v]) => ({ name: k, value: String(v) }));
+    };
+    const openClawSecretName = this._envSecretName(deployName);
+    const { env: envVars, stringData: openClawSecretData } = buildEnvEntries(
+      openClawEnvMap,
+      openClawSecretName,
+    );
+    if (Object.keys(openClawSecretData).length > 0) {
+      await this._upsertEnvSecret(
+        deployName,
+        openClawSecretData,
+        {
+          "nora.agent.id": String(id),
+          "nora.deployment.name": deployName,
+          "nora.runtime.family": "openclaw",
+          "nora.sandbox.profile": isNemoClaw ? "nemoclaw" : "standard",
+        },
+        namespace,
+      );
+    }
 
     // CMD: install openclaw, configure gateway with pre-paired device, start the
     // runtime sidecar, then launch the gateway.
@@ -1298,6 +1441,7 @@ class K8sBackend extends ProvisionerBackend {
         "nora.runtime.family": "openclaw",
         "nora.execution.target": this.executionTargetLabelValue,
         "nora.kubernetes.cluster": this.clusterId,
+        "nora.sandbox.profile": isNemoClaw ? "nemoclaw" : "standard",
         "openclaw.agent.id": String(id),
       },
       namespace,
@@ -1317,6 +1461,7 @@ class K8sBackend extends ProvisionerBackend {
           "nora.runtime.family": "openclaw",
           "nora.execution.target": this.executionTargetLabelValue,
           "nora.kubernetes.cluster": this.clusterId,
+          "nora.sandbox.profile": isNemoClaw ? "nemoclaw" : "standard",
           "openclaw.agent.id": String(id),
         },
       },
@@ -1334,6 +1479,7 @@ class K8sBackend extends ProvisionerBackend {
               "nora.runtime.family": "openclaw",
               "nora.execution.target": this.executionTargetLabelValue,
               "nora.kubernetes.cluster": this.clusterId,
+              "nora.sandbox.profile": isNemoClaw ? "nemoclaw" : "standard",
               "openclaw.agent.id": String(id),
             },
           },
@@ -1410,7 +1556,9 @@ class K8sBackend extends ProvisionerBackend {
       const deletedDeployment = await this._deleteDeploymentIfExists(deployName, namespace);
       const deletedService = await this._deleteServiceIfExists(deployName, namespace);
       const deletedConfigMap = await this._deleteBootstrapConfigMapIfExists(deployName, namespace);
-      deletedAny = deletedAny || deletedDeployment || deletedService || deletedConfigMap;
+      const deletedSecret = await this._deleteEnvSecretIfExists(deployName, namespace);
+      deletedAny =
+        deletedAny || deletedDeployment || deletedService || deletedConfigMap || deletedSecret;
     }
 
     console.log(

--- a/workers/provisioner/backends/nemoclaw.ts
+++ b/workers/provisioner/backends/nemoclaw.ts
@@ -19,21 +19,22 @@ const {
   AGENT_RUNTIME_PORT,
 } = require("../../../agent-runtime/lib/contracts");
 const {
+  getNemoClawDefaultModel,
+  getNemoClawSandboxImage,
+} = require("../../../agent-runtime/lib/nemoclawDefaults");
+const {
   buildDockerTelemetry,
   buildUnavailableTelemetry,
   DOCKER_CAPABILITIES,
   uptimeFromContainerInfo,
 } = require("./telemetry");
 
-// Default to the Nora-built NemoClaw image (OpenShell sandbox base +
-// tsx prebaked so the bootstrap's install fast-path check passes under
-// the non-root UID-998 + Landlock restrictions). Build it with
-// `docker build -f agent-runtime/Dockerfile.nemoclaw-agent -t nora-nemoclaw-agent:local agent-runtime/`
-// or set NEMOCLAW_SANDBOX_IMAGE to pin a different tag.
-const SANDBOX_IMAGE = process.env.NEMOCLAW_SANDBOX_IMAGE || "nora-nemoclaw-agent:local";
+// Default to the Nora-built GHCR image (OpenShell sandbox base + tsx prebaked).
+// Set NEMOCLAW_SANDBOX_IMAGE=nora-nemoclaw-agent:local to use a preloaded local
+// image on offline Docker/k3s nodes.
+const SANDBOX_IMAGE = getNemoClawSandboxImage(process.env);
 
-const DEFAULT_MODEL =
-  process.env.NEMOCLAW_DEFAULT_MODEL || "nvidia/nvidia/nemotron-3-super-120b-a12b";
+const DEFAULT_MODEL = getNemoClawDefaultModel(process.env);
 
 // Baseline network policy — only these endpoints are allowed.
 // Matches NemoClaw's openclaw-sandbox.yaml spec.
@@ -247,7 +248,18 @@ class NemoClawBackend extends ProvisionerBackend {
   }
 
   async create(config) {
-    const { id, name, vcpu, ram_mb, disk_gb, env, container_name, templatePayload } = config;
+    const {
+      id,
+      name,
+      vcpu,
+      ram_mb,
+      disk_gb,
+      env,
+      container_name,
+      templatePayload,
+      gatewayHostPort: allocatedGatewayPort,
+      runtimeHostPort: allocatedRuntimePort,
+    } = config;
     const containerName = container_name || safeContainerName("nora-oclaw", name, id);
     const model = (env && env.NEMOCLAW_MODEL) || DEFAULT_MODEL;
     let container = null;
@@ -434,6 +446,22 @@ class NemoClawBackend extends ProvisionerBackend {
     if (composeNetwork) {
       networkingConfig[composeNetwork] = {};
     }
+    const requestedHostPort = Number(allocatedGatewayPort);
+    const gatewayPortBinding =
+      !composeNetwork &&
+      Number.isInteger(requestedHostPort) &&
+      requestedHostPort >= 1 &&
+      requestedHostPort <= 65535
+        ? { "18789/tcp": [{ HostPort: String(requestedHostPort) }] }
+        : undefined;
+    const requestedRuntimeHostPort = Number(allocatedRuntimePort);
+    const runtimePortBinding =
+      !composeNetwork &&
+      Number.isInteger(requestedRuntimeHostPort) &&
+      requestedRuntimeHostPort >= 1 &&
+      requestedRuntimeHostPort <= 65535
+        ? { "9090/tcp": [{ HostPort: String(requestedRuntimeHostPort) }] }
+        : undefined;
 
     // DNS-safe hostname from agent name (avoids Bonjour conflicts across containers)
     const safeHostname =
@@ -457,6 +485,9 @@ class NemoClawBackend extends ProvisionerBackend {
           NanoCpus: (vcpu || 2) * 1e9,
           Memory: (ram_mb || 2048) * 1024 * 1024,
           RestartPolicy: { Name: "unless-stopped" },
+          ...(gatewayPortBinding || runtimePortBinding
+            ? { PortBindings: { ...(gatewayPortBinding || {}), ...(runtimePortBinding || {}) } }
+            : {}),
           // DNS only for allowed endpoints — OpenShell controls egress
           Dns: ["8.8.8.8", "8.8.4.4"],
           // Security hardening: drop all capabilities, add back only what's needed
@@ -500,11 +531,22 @@ class NemoClawBackend extends ProvisionerBackend {
       } else {
         host = info.NetworkSettings?.IPAddress || "localhost";
       }
+      const portBindings = info.NetworkSettings?.Ports?.["18789/tcp"];
+      const gatewayHostPort = portBindings?.[0]?.HostPort || null;
+      const runtimePortBindings = info.NetworkSettings?.Ports?.["9090/tcp"];
+      const runtimeHostPort = runtimePortBindings?.[0]?.HostPort || null;
 
       console.log(
-        `[nemoclaw] Container ${containerName} (${container.id}) started at ${host} (gateway port 18789, model: ${model})`,
+        `[nemoclaw] Container ${containerName} (${container.id}) started at ${host} (gateway port 18789, host port ${gatewayHostPort || "none"}, runtime host port ${runtimeHostPort || "none"}, model: ${model})`,
       );
-      return { containerId: containerName, host, gatewayToken, containerName };
+      return {
+        containerId: containerName,
+        host,
+        gatewayToken,
+        containerName,
+        gatewayHostPort,
+        runtimeHostPort,
+      };
     } catch (error) {
       if (container) {
         try {

--- a/workers/provisioner/backends/proxmox.ts
+++ b/workers/provisioner/backends/proxmox.ts
@@ -22,6 +22,7 @@ const {
 } = require("../../../agent-runtime/lib/contracts");
 const { shellSingleQuote } = require("../../../agent-runtime/lib/containerCommand");
 const { isProxmoxApiTokenId } = require("../../../agent-runtime/lib/backendCatalog");
+const { getNemoClawDefaultModel } = require("../../../agent-runtime/lib/nemoclawDefaults");
 const {
   buildTelemetry,
   buildUnavailableTelemetry,
@@ -444,10 +445,7 @@ class ProxmoxBackend extends ProvisionerBackend {
       ...(isNemoClaw
         ? {
             HOME: "/sandbox",
-            NEMOCLAW_MODEL:
-              env.NEMOCLAW_MODEL ||
-              process.env.NEMOCLAW_DEFAULT_MODEL ||
-              "nvidia/nemotron-3-super-120b-a12b",
+            NEMOCLAW_MODEL: env.NEMOCLAW_MODEL || getNemoClawDefaultModel(process.env),
             ...(process.env.NVIDIA_API_KEY && !env.NVIDIA_API_KEY
               ? { NVIDIA_API_KEY: process.env.NVIDIA_API_KEY }
               : {}),

--- a/workers/provisioner/backends/remote-docker.ts
+++ b/workers/provisioner/backends/remote-docker.ts
@@ -95,10 +95,14 @@ class RemoteDockerBackend extends DockerBackend {
     // (resolveGatewayAddress prefers gateway_host + gateway_port). Without this
     // it would fall back to host.docker.internal, which is the wrong machine.
     const gatewayHost = this.profile.gatewayHost || this.profile.sshHost;
+    const runtimeHostPort =
+      Number(result.runtimeHostPort) || Number(config.runtimeHostPort) || null;
     return {
       ...result,
       gatewayHost,
       gatewayPort: result.gatewayHostPort || null,
+      runtimeHost: gatewayHost,
+      runtimePort: runtimeHostPort || result.runtimePort || null,
     };
   }
 }

--- a/workers/provisioner/backends/remote-nemoclaw.ts
+++ b/workers/provisioner/backends/remote-nemoclaw.ts
@@ -1,0 +1,65 @@
+// @ts-nocheck
+// Remote NemoClaw backend.
+//
+// Runs the local Docker NemoClaw adapter against a registered remote Docker
+// daemon over SSH. It keeps the NemoClaw-specific OpenShell bootstrap/policy
+// path from NemoClawBackend, but disables compose-network discovery and
+// advertises the remote host's published gateway port back to the control plane.
+
+const NemoClawBackend = require("./nemoclaw");
+const { buildRemoteDockerOptions } = require("./remote-docker");
+
+class RemoteNemoClawBackend extends NemoClawBackend {
+  constructor(profile = {}) {
+    super();
+    this.profile = profile || {};
+    this.executionTargetId = String(this.profile.executionTargetId || "")
+      .trim()
+      .toLowerCase();
+    if (!this.executionTargetId.startsWith("remote:")) {
+      throw new Error("Remote NemoClaw backend requires a registered remote host profile.");
+    }
+    if (!this.profile.sshHost || !this.profile.sshUser) {
+      throw new Error(
+        `Remote host ${this.profile.label || this.executionTargetId} is missing SSH connection details.`,
+      );
+    }
+    const hasCredential =
+      this.profile.sshAuthMode === "password"
+        ? Boolean(this.profile.sshPassword)
+        : Boolean(this.profile.sshPrivateKey);
+    if (!hasCredential) {
+      throw new Error(
+        `Remote host ${this.profile.label || this.executionTargetId} is missing its SSH ` +
+          `${this.profile.sshAuthMode === "password" ? "password" : "private key"}.`,
+      );
+    }
+
+    const Docker = this.docker.constructor;
+    this.docker = new Docker(buildRemoteDockerOptions(this.profile));
+    this._composeNetwork = null;
+  }
+
+  async _findComposeNetwork() {
+    return null;
+  }
+
+  async create(config = {}) {
+    const result = await super.create(config);
+    const advertisedHost = this.profile.gatewayHost || this.profile.sshHost;
+    const publishedGatewayPort =
+      Number(result.gatewayHostPort) || Number(config.gatewayHostPort) || null;
+    const publishedRuntimePort =
+      Number(result.runtimeHostPort) || Number(config.runtimeHostPort) || null;
+    return {
+      ...result,
+      host: advertisedHost,
+      runtimeHost: advertisedHost,
+      runtimePort: publishedRuntimePort,
+      gatewayHost: advertisedHost,
+      gatewayPort: publishedGatewayPort,
+    };
+  }
+}
+
+module.exports = RemoteNemoClawBackend;

--- a/workers/provisioner/worker.ts
+++ b/workers/provisioner/worker.ts
@@ -3,6 +3,7 @@ const { Worker } = require("bullmq");
 const IORedis = require("ioredis");
 const { Pool } = require("pg");
 const { getDefaultAgentImage } = require("../../agent-runtime/lib/agentImages");
+const { NEMOCLAW_DEFAULT_MODEL } = require("../../agent-runtime/lib/nemoclawDefaults");
 const {
   runtimeUrlForAgent,
   buildRuntimeAuthHeaders,
@@ -29,6 +30,7 @@ const {
   allocateGatewayPort,
   LOCAL_HOST_KEY,
   DASHBOARD_PORT_PURPOSE,
+  RUNTIME_PORT_PURPOSE,
 } = require("../../backend-api/portAllocations");
 const {
   buildIntegrationSyncEntry,
@@ -192,7 +194,7 @@ const PROVIDER_MODEL_DEFAULTS = Object.freeze({
   together: "together/moonshotai/Kimi-K2.5",
   cohere: "command-r-plus",
   xai: "grok-4",
-  nvidia: "nvidia/nvidia/nemotron-3-super-120b-a12b",
+  nvidia: NEMOCLAW_DEFAULT_MODEL,
   moonshot: "kimi-k2.5",
   zai: "glm-5",
   minimax: "MiniMax-M2.7",
@@ -1282,9 +1284,11 @@ function backendInstanceKey(runtimeFields = {}) {
   if (backend === "remote-docker" && runtimeFields.execution_target_id) {
     const target =
       String(runtimeFields.execution_target_id).trim().toLowerCase() || "remote-docker";
-    // Encode the runtime family so an OpenClaw and a Hermes agent on the SAME
-    // remote host don't share one cached adapter (they need different backends).
-    return runtimeFields.runtime_family === "hermes" ? `hermes:${target}` : target;
+    // Encode the runtime/sandbox path so OpenClaw, Hermes, and NemoClaw agents
+    // on the SAME remote host don't share one cached adapter.
+    if (runtimeFields.runtime_family === "hermes") return `hermes:${target}`;
+    if (runtimeFields.sandbox_profile === "nemoclaw") return `nemoclaw:${target}`;
+    return target;
   }
   return backend;
 }
@@ -1333,6 +1337,20 @@ async function loadBackend(runtimeFields = {}) {
           );
         }
         instance = new (require("./backends/remote-hermes"))(profile);
+        break;
+      }
+      if (key.startsWith("nemoclaw:remote:")) {
+        const executionTargetId = key.slice("nemoclaw:".length);
+        const profile = await getRemoteHostProfile(executionTargetId);
+        if (!profile) {
+          throw new Error(`Unknown remote host execution target: ${executionTargetId}`);
+        }
+        if (!profile.configured) {
+          throw new Error(
+            profile.issue || `Remote host ${executionTargetId} is not configured for provisioning.`,
+          );
+        }
+        instance = new (require("./backends/remote-nemoclaw"))(profile);
         break;
       }
       if (key.startsWith("remote:")) {
@@ -1790,6 +1808,7 @@ const worker = new Worker(
         // agents (k8s/proxmox manage their own ports). Idempotent per agent+host,
         // so redeploys keep the same port; released via ON DELETE CASCADE.
         let allocatedGatewayPort;
+        let allocatedRuntimePort;
         let allocatedDashboardPort;
         {
           const deployTarget = resolvedRuntimeFields.deploy_target;
@@ -1821,6 +1840,16 @@ const worker = new Worker(
                 purpose: DASHBOARD_PORT_PURPOSE,
               });
             }
+            if (
+              deployTarget === "remote-docker" &&
+              resolvedRuntimeFields.runtime_family === "openclaw"
+            ) {
+              allocatedRuntimePort = await allocateGatewayPort({
+                hostKey: allocationHostKey,
+                agentId: id,
+                purpose: RUNTIME_PORT_PURPOSE,
+              });
+            }
           }
         }
         const createPromise = provisioner.create({
@@ -1832,6 +1861,7 @@ const worker = new Worker(
           disk_gb,
           container_name,
           gatewayHostPort: allocatedGatewayPort,
+          runtimeHostPort: allocatedRuntimePort,
           dashboardHostPort: allocatedDashboardPort,
           gatewayToken: agentRow.gateway_token || undefined,
           templatePayload,


### PR DESCRIPTION
Promotes the NemoClaw hardened sandbox profile from local-build-only toward production-deployable across Docker, Kubernetes, and remote BYOC hosts.

## Highlights
- **Image**: default to the GHCR-published `nora-nemoclaw-agent` (was local-build); published from `release-docker.yml`. Defaults centralized in `agent-runtime/lib/nemoclawDefaults.ts` (also fixes a doubled `nvidia/nvidia/…` model-id typo).
- **Security (CVE patch)**: the NVIDIA OpenShell base `:latest` ships **OpenClaw 2026.3.11**, carrying fixable **CRITICAL sandbox-escape** CVEs (`CVE-2026-41296/-41329/-41294/-43585/-44109`). Fixed by **pinning the base by digest** and **upgrading bundled OpenClaw to 2026.6.9**. Build-verified: `/usr/bin/openclaw` → `2026.6.9`. All hardening (non-root UID 998, CapDrop ALL, no-new-privileges, Landlock, seccomp, default-deny egress) preserved.
- **Remote NemoClaw**: new `RemoteNemoClawBackend` (BYOC over SSH) following the remote-docker/hermes pattern — fail-closed SSH cred validation, swapped docker client, disabled compose-network, advertised published ports; wired through worker `loadBackend` + `containerManager` (`nemoclaw:remote:` key).
- **K8s + ports**: NemoClaw on Kubernetes; gateway/runtime host-port publishing for non-compose/remote deploys.
- **Observability**: `nora.sandbox.profile` dimension on the OTel exporter.
- **Setup/docs/e2e**: `setup.sh`/`ps1`, env-vars + k8s + nemoclaw + otel docs, real-deploy e2e matrix.

## Review
Multi-agent adversarial pass (28 agents). Critical paths **verified**: sandbox hardening preserved on remote execution, SSH validation fail-closed, backend routing/cache-keying, compose-network disabled, CVE fix comprehensive. Cleanups applied: removed a leftover debug scratch test (`verify_env.test.ts`, was outside `__tests__/` with no assertions) and fixed a broken code fence in `e2e/REAL_TESTS.md`.

Local validation: backend suite **1182 green**; typecheck (backend/worker/agent-runtime/frontend/e2e), prettier, and eslint all clean across the touched packages.

## Known follow-ups (not blockers)
- **Runtime compat smoke**: OpenClaw 2026.3.11 → 2026.6.9 is a ~3-month jump inside the OpenShell sandbox — recommend a real NemoClaw deploy+chat smoke before relying on it (fallback: pin `2026.4.15`, the minimal fix).
- **Pre-existing**: SSH host-key verification isn't enforced in `remote-docker.ts` `buildRemoteDockerOptions` (inherited by all remote backends) — a separate hardening, predates this change.
- Local-docker NemoClaw runtime-port allocation is asymmetric (latent; compose-network path means it's not a current bug).