### PR TITLE
feat(schedules): control-plane scheduled agent runs (recurring cron triggers)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -210,6 +210,13 @@ OTEL_SERVICE_NAME=nora-control-plane
 NORA_OTEL_PROMETHEUS_PORT=9464
 NORA_OTEL_PROMETHEUS_HOST=127.0.0.1
 
+# ── Scheduled agent runs (recurring cron triggers) ──────────
+# Minimum seconds between fires for any schedule — a guardrail so a too-frequent
+# cron can't thrash an agent (and its budget). Default 60s.
+NORA_SCHEDULE_MIN_INTERVAL_SECONDS=60
+# Worker concurrency for executing due scheduled runs (default 5).
+SCHEDULE_RUN_WORKER_CONCURRENCY=5
+
 # ── Runtime families, deploy targets, and sandbox profiles ───
 # High-level runtime contracts. Supported ids: openclaw, hermes.
 ENABLED_RUNTIME_FAMILIES=openclaw

--- a/backend-api/__tests__/agentSchedules.test.ts
+++ b/backend-api/__tests__/agentSchedules.test.ts
@@ -1,0 +1,166 @@
+// @ts-nocheck
+// Unit coverage for agentSchedules: cron validation + next-run, the min-interval
+// guardrail, input validation, and the replica-safe sweep (claim -> bump -> enqueue).
+
+const mockDb = { query: jest.fn(), connect: jest.fn() };
+jest.mock("../db", () => mockDb);
+
+const schedules = require("../agentSchedules");
+
+beforeEach(() => {
+  mockDb.query.mockReset();
+  mockDb.connect.mockReset();
+});
+
+describe("cron validation + next-run", () => {
+  it("computes the next fire in the given timezone", () => {
+    const next = schedules.computeNextRun("0 9 * * *", "UTC", new Date("2026-06-22T00:00:00Z"));
+    expect(next.toISOString()).toBe("2026-06-22T09:00:00.000Z");
+  });
+
+  it("accepts a daily cron", () => {
+    expect(() => schedules.validateCron("0 9 * * *", "UTC")).not.toThrow();
+  });
+
+  it("rejects a sub-minute cron (min-interval guardrail)", () => {
+    expect(() => schedules.validateCron("*/30 * * * * *", "UTC")).toThrow(/too frequently/i);
+  });
+
+  it("rejects an unparseable cron with a 400", () => {
+    try {
+      schedules.validateCron("not a cron");
+      throw new Error("should have thrown");
+    } catch (e) {
+      expect(e.statusCode).toBe(400);
+      expect(e.message).toMatch(/invalid cron/i);
+    }
+  });
+});
+
+describe("createSchedule validation", () => {
+  it("requires a prompt for the prompt action", async () => {
+    await expect(
+      schedules.createSchedule("a1", "u1", { name: "x", cron: "0 9 * * *", action_type: "prompt" }),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it("rejects an unknown action_type", async () => {
+    await expect(
+      schedules.createSchedule("a1", "u1", { name: "x", cron: "0 9 * * *", action_type: "nuke" }),
+    ).rejects.toMatchObject({ statusCode: 400 });
+  });
+
+  it("inserts a valid prompt schedule with a computed next_run_at", async () => {
+    mockDb.query.mockResolvedValueOnce({
+      rows: [{ id: "s1", agent_id: "a1", name: "x", action_type: "prompt", enabled: true }],
+    });
+    const out = await schedules.createSchedule("a1", "u1", {
+      name: "x",
+      cron: "0 9 * * *",
+      action_type: "prompt",
+      prompt: "hello",
+    });
+    expect(out.id).toBe("s1");
+    const insert = mockDb.query.mock.calls[0];
+    expect(insert[0]).toMatch(/INSERT INTO agent_schedules/);
+    // next_run_at (last param) is a Date, not null, for an enabled schedule.
+    expect(insert[1][insert[1].length - 1]).toBeInstanceOf(Date);
+  });
+
+  it("allows a lifecycle action with no prompt", async () => {
+    mockDb.query.mockResolvedValueOnce({ rows: [{ id: "s2", action_type: "restart" }] });
+    const out = await schedules.createSchedule("a1", "u1", {
+      name: "nightly restart",
+      cron: "0 3 * * *",
+      action_type: "restart",
+    });
+    expect(out.id).toBe("s2");
+  });
+});
+
+describe("sweepDueSchedules", () => {
+  function fakeClient(dueRows) {
+    const calls = [];
+    return {
+      calls,
+      query: jest.fn(async (sql, params) => {
+        calls.push([sql, params]);
+        if (/SELECT \* FROM agent_schedules/.test(sql)) return { rows: dueRows };
+        return { rows: [] };
+      }),
+      release: jest.fn(),
+    };
+  }
+
+  it("claims due rows, bumps next_run_at, and enqueues each run", async () => {
+    const due = [
+      {
+        id: "s1",
+        agent_id: "a1",
+        cron: "0 9 * * *",
+        timezone: "UTC",
+        action_type: "prompt",
+        prompt: "hi",
+        created_by: "u1",
+        name: "morning",
+      },
+      {
+        id: "s2",
+        agent_id: "a2",
+        cron: "0 * * * *",
+        timezone: "UTC",
+        action_type: "restart",
+        prompt: null,
+        created_by: "u2",
+        name: "hourly restart",
+      },
+    ];
+    const client = fakeClient(due);
+    mockDb.connect.mockResolvedValue(client);
+    const enqueue = jest.fn().mockResolvedValue(undefined);
+
+    const n = await schedules.sweepDueSchedules({
+      dbClient: mockDb,
+      enqueue,
+      now: new Date("2026-06-22T10:00:00Z"),
+    });
+
+    expect(n).toBe(2);
+    expect(enqueue).toHaveBeenCalledTimes(2);
+    expect(enqueue).toHaveBeenCalledWith(
+      expect.objectContaining({ scheduleId: "s1", agentId: "a1", actionType: "prompt" }),
+    );
+    // BEGIN + SELECT + 2 UPDATE(next_run_at) + COMMIT
+    expect(client.calls.some((c) => /BEGIN/.test(c[0]))).toBe(true);
+    expect(client.calls.some((c) => /COMMIT/.test(c[0]))).toBe(true);
+    expect(client.calls.filter((c) => /SET next_run_at = \$2/.test(c[0])).length).toBe(2);
+    expect(client.release).toHaveBeenCalled();
+  });
+
+  it("auto-disables a row whose cron is now invalid (no enqueue)", async () => {
+    const due = [
+      {
+        id: "s9",
+        agent_id: "a9",
+        cron: "garbage",
+        timezone: "UTC",
+        action_type: "prompt",
+        prompt: "x",
+        created_by: "u1",
+      },
+    ];
+    const client = fakeClient(due);
+    mockDb.connect.mockResolvedValue(client);
+    const enqueue = jest.fn();
+
+    const n = await schedules.sweepDueSchedules({ dbClient: mockDb, enqueue });
+
+    expect(n).toBe(0);
+    expect(enqueue).not.toHaveBeenCalled();
+    expect(client.calls.some((c) => /SET enabled = FALSE.*invalid_cron/s.test(c[0]))).toBe(true);
+  });
+
+  it("requires an enqueue function", async () => {
+    await expect(schedules.sweepDueSchedules({ dbClient: mockDb })).rejects.toThrow(/enqueue/);
+  });
+});

--- a/backend-api/__tests__/scheduleRunner.test.ts
+++ b/backend-api/__tests__/scheduleRunner.test.ts
@@ -1,0 +1,112 @@
+// @ts-nocheck
+// Coverage for the scheduled-run executor: action dispatch (prompt/lifecycle),
+// failure -> markRun + throw (so BullMQ retries), and missing-agent handling.
+
+const mockDb = { query: jest.fn() };
+jest.mock("../db", () => mockDb);
+
+const mockMarkRun = jest.fn().mockResolvedValue(undefined);
+jest.mock("../agentSchedules", () => ({ markRun: mockMarkRun }));
+
+const mockLogEvent = jest.fn().mockResolvedValue(undefined);
+jest.mock("../monitoring", () => ({ logEvent: mockLogEvent }));
+
+const mockRecordTokenUsage = jest.fn().mockResolvedValue(undefined);
+jest.mock("../metrics", () => ({ recordTokenUsage: mockRecordTokenUsage }));
+
+const mockContainer = {
+  restart: jest.fn().mockResolvedValue(undefined),
+  stop: jest.fn().mockResolvedValue(undefined),
+  start: jest.fn().mockResolvedValue(undefined),
+};
+jest.mock("../containerManager", () => mockContainer);
+
+const mockAddDeploymentJob = jest.fn().mockResolvedValue(undefined);
+jest.mock("../redisQueue", () => ({ addDeploymentJob: mockAddDeploymentJob }));
+
+const mockRpcCall = jest.fn().mockResolvedValue({ result: { message: { usage: {} } } });
+jest.mock("../gatewayProxy", () => ({ rpcCall: mockRpcCall }));
+
+jest.mock("../runtimeAuth", () => ({ runtimeAuthHeaders: jest.fn().mockResolvedValue({}) }));
+jest.mock("../agentRuntimeFields", () => ({
+  resolveAgentRuntimeFamily: (a) => a.runtime_family || "openclaw",
+}));
+jest.mock("../../agent-runtime/lib/agentEndpoints", () => ({
+  runtimeUrlForAgent: (a, p) => `http://runtime${p}`,
+}));
+
+const { runScheduledAction } = require("../scheduleRunner");
+
+const OPENCLAW_AGENT = { id: "a1", name: "Op", user_id: "u1", runtime_family: "openclaw" };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDb.query.mockResolvedValue({ rows: [OPENCLAW_AGENT] });
+});
+
+it("delivers a prompt to an OpenClaw agent via rpcCall and records the run", async () => {
+  const out = await runScheduledAction({
+    scheduleId: "s1",
+    agentId: "a1",
+    actionType: "prompt",
+    prompt: "hello",
+    createdBy: "u1",
+  });
+  expect(out).toEqual({ ok: true, status: "success" });
+  expect(mockRpcCall).toHaveBeenCalledWith(
+    OPENCLAW_AGENT,
+    "chat.send",
+    expect.objectContaining({ message: "hello" }),
+    expect.any(Number),
+  );
+  expect(mockMarkRun).toHaveBeenCalledWith("s1", "success");
+  expect(mockLogEvent).toHaveBeenCalledWith(
+    "agent.schedule.run",
+    expect.any(String),
+    expect.objectContaining({ result: expect.objectContaining({ ok: true }) }),
+  );
+});
+
+it.each([
+  ["restart", "restart"],
+  ["stop", "stop"],
+  ["start", "start"],
+])("dispatches the %s lifecycle action to containerManager", async (action, fn) => {
+  const out = await runScheduledAction({ scheduleId: "s1", agentId: "a1", actionType: action });
+  expect(out.ok).toBe(true);
+  expect(mockContainer[fn]).toHaveBeenCalledWith(OPENCLAW_AGENT);
+});
+
+it("redeploy enqueues a deployment job", async () => {
+  await runScheduledAction({ scheduleId: "s1", agentId: "a1", actionType: "redeploy" });
+  expect(mockAddDeploymentJob).toHaveBeenCalledWith(OPENCLAW_AGENT);
+});
+
+it("records agent_missing without throwing when the agent is gone", async () => {
+  mockDb.query.mockResolvedValue({ rows: [] });
+  const out = await runScheduledAction({
+    scheduleId: "s1",
+    agentId: "gone",
+    actionType: "restart",
+  });
+  expect(out).toEqual({ ok: false, status: "agent_missing" });
+  expect(mockMarkRun).toHaveBeenCalledWith("s1", "agent_missing");
+  expect(mockContainer.restart).not.toHaveBeenCalled();
+});
+
+it("on action failure, records the failure and rethrows (for BullMQ retry)", async () => {
+  mockContainer.restart.mockRejectedValueOnce(new Error("boom"));
+  await expect(
+    runScheduledAction({ scheduleId: "s1", agentId: "a1", actionType: "restart" }),
+  ).rejects.toThrow("boom");
+  expect(mockMarkRun).toHaveBeenCalledWith("s1", expect.stringContaining("failed: boom"));
+  expect(mockLogEvent).toHaveBeenCalledWith(
+    "agent.schedule.run",
+    expect.stringContaining("failed"),
+    expect.objectContaining({ result: expect.objectContaining({ ok: false }) }),
+  );
+});
+
+it("rejects a payload missing required fields", async () => {
+  await expect(runScheduledAction({ scheduleId: "s1" })).rejects.toThrow(/requires/);
+});

--- a/backend-api/__tests__/scheduleRunner.test.ts
+++ b/backend-api/__tests__/scheduleRunner.test.ts
@@ -25,14 +25,17 @@ const mockAddDeploymentJob = jest.fn().mockResolvedValue(undefined);
 jest.mock("../redisQueue", () => ({ addDeploymentJob: mockAddDeploymentJob }));
 
 const mockRpcCall = jest.fn().mockResolvedValue({ result: { message: { usage: {} } } });
-jest.mock("../gatewayProxy", () => ({ rpcCall: mockRpcCall }));
+const mockResolveHost = jest.fn().mockResolvedValue("10.0.0.7");
+const mockAllowedHosts = jest.fn().mockResolvedValue(new Set(["10.0.0.7"]));
+jest.mock("../gatewayProxy", () => ({
+  rpcCall: mockRpcCall,
+  resolveGatewayHostForProxy: mockResolveHost,
+  allowedGatewayHostsForAgent: mockAllowedHosts,
+}));
 
 jest.mock("../runtimeAuth", () => ({ runtimeAuthHeaders: jest.fn().mockResolvedValue({}) }));
 jest.mock("../agentRuntimeFields", () => ({
   resolveAgentRuntimeFamily: (a) => a.runtime_family || "openclaw",
-}));
-jest.mock("../../agent-runtime/lib/agentEndpoints", () => ({
-  runtimeUrlForAgent: (a, p) => `http://runtime${p}`,
 }));
 
 const { runScheduledAction } = require("../scheduleRunner");
@@ -109,4 +112,48 @@ it("on action failure, records the failure and rethrows (for BullMQ retry)", asy
 
 it("rejects a payload missing required fields", async () => {
   await expect(runScheduledAction({ scheduleId: "s1" })).rejects.toThrow(/requires/);
+});
+
+it("delivers a Hermes prompt through the SSRF-safe resolved host", async () => {
+  const HERMES = {
+    id: "h1",
+    name: "Hermes",
+    user_id: "u1",
+    runtime_family: "hermes",
+    runtime_host: "hermes.internal",
+    runtime_port: 8642,
+  };
+  mockDb.query.mockResolvedValue({ rows: [HERMES] });
+  global.fetch = jest.fn().mockResolvedValue({ ok: true, json: async () => ({ usage: {} }) });
+
+  const out = await runScheduledAction({
+    scheduleId: "s1",
+    agentId: "h1",
+    actionType: "prompt",
+    prompt: "hi",
+    createdBy: "u1",
+  });
+
+  expect(out.ok).toBe(true);
+  // Host must be validated/pinned via the gateway SSRF resolver, not used raw.
+  expect(mockResolveHost).toHaveBeenCalledWith(
+    "hermes.internal",
+    "hermes runtime",
+    expect.anything(),
+  );
+  expect(global.fetch).toHaveBeenCalledWith(
+    "http://10.0.0.7:8642/v1/chat/completions",
+    expect.objectContaining({ method: "POST" }),
+  );
+  delete global.fetch;
+});
+
+it("skips a revive action on a budget-paused agent (does not fight the budget)", async () => {
+  mockDb.query.mockResolvedValue({
+    rows: [{ ...OPENCLAW_AGENT, paused_reason: "budget_exceeded" }],
+  });
+  const out = await runScheduledAction({ scheduleId: "s1", agentId: "a1", actionType: "restart" });
+  expect(out).toEqual({ ok: false, status: "skipped: budget_exceeded" });
+  expect(mockContainer.restart).not.toHaveBeenCalled();
+  expect(mockMarkRun).toHaveBeenCalledWith("s1", "skipped: budget_exceeded");
 });

--- a/backend-api/agentSchedules.ts
+++ b/backend-api/agentSchedules.ts
@@ -1,0 +1,309 @@
+// @ts-nocheck
+// Control-plane scheduled agent runs (recurring cron triggers).
+//
+// This module owns the schedule MODEL (CRUD), cron validation, next-fire
+// computation, and the replica-safe SWEEP that claims due schedules and hands
+// each run to an enqueue callback (the agent-schedules BullMQ queue). The actual
+// action (prompt / lifecycle) is executed by the worker — see the queue handler.
+//
+// NOT to be confused with scheduler.ts (the node bin-packer) or the Hermes
+// runtime's own /api/jobs cron — this is Nora-control-plane scheduling.
+
+const { CronExpressionParser } = require("cron-parser");
+const db = require("./db");
+
+const ACTION_TYPES = Object.freeze(["prompt", "restart", "stop", "start", "redeploy"]);
+const PROMPT_MAX = 8000;
+const NAME_MAX = 120;
+// A too-frequent cron can thrash an agent (and its budget). Floor the fire
+// interval; overridable for ops that genuinely need tighter cadences.
+const MIN_INTERVAL_SECONDS = (() => {
+  const n = Number.parseInt(process.env.NORA_SCHEDULE_MIN_INTERVAL_SECONDS, 10);
+  return Number.isFinite(n) && n >= 1 ? n : 60;
+})();
+
+function httpError(message, statusCode = 400) {
+  const err = new Error(message);
+  err.statusCode = statusCode;
+  return err;
+}
+
+/** Next fire after `fromDate` for a cron in a timezone. Throws on a bad cron. */
+function computeNextRun(cron, timezone = "UTC", fromDate = new Date()) {
+  const it = CronExpressionParser.parse(String(cron), {
+    tz: timezone || "UTC",
+    currentDate: fromDate,
+  });
+  return it.next().toDate();
+}
+
+/** Validate the cron parses and doesn't fire more often than the min interval. */
+function validateCron(cron, timezone = "UTC") {
+  let it;
+  try {
+    it = CronExpressionParser.parse(String(cron), { tz: timezone || "UTC" });
+  } catch (e) {
+    throw httpError(`Invalid cron expression: ${e.message}`, 400);
+  }
+  const a = it.next().toDate();
+  const b = it.next().toDate();
+  if ((b.getTime() - a.getTime()) / 1000 < MIN_INTERVAL_SECONDS) {
+    throw httpError(
+      `Schedule fires too frequently — minimum interval is ${MIN_INTERVAL_SECONDS}s`,
+      400,
+    );
+  }
+}
+
+function normalizeInput(input = {}, { partial = false } = {}) {
+  const out = {};
+  const has = (k) => Object.prototype.hasOwnProperty.call(input, k);
+
+  if (has("name") || !partial) {
+    const name = String(input.name || "").trim();
+    if (!name) throw httpError("Schedule name is required", 400);
+    if (name.length > NAME_MAX) throw httpError(`Name must be <= ${NAME_MAX} chars`, 400);
+    out.name = name;
+  }
+  if (has("timezone") || !partial) {
+    out.timezone = String(input.timezone || "UTC").trim() || "UTC";
+  }
+  if (has("action_type") || has("actionType") || !partial) {
+    const action = String(input.action_type || input.actionType || "prompt").trim();
+    if (!ACTION_TYPES.includes(action)) {
+      throw httpError(`action_type must be one of: ${ACTION_TYPES.join(", ")}`, 400);
+    }
+    out.action_type = action;
+  }
+  if (has("prompt")) {
+    const prompt = input.prompt == null ? null : String(input.prompt);
+    if (prompt && prompt.length > PROMPT_MAX) {
+      throw httpError(`prompt must be <= ${PROMPT_MAX} chars`, 400);
+    }
+    out.prompt = prompt;
+  }
+  if (has("enabled")) out.enabled = Boolean(input.enabled);
+  if (has("cron") || !partial) {
+    const cron = String(input.cron || "").trim();
+    if (!cron) throw httpError("cron expression is required", 400);
+    out.cron = cron;
+  }
+
+  // A 'prompt' action requires prompt text; lifecycle actions ignore it.
+  const effectiveAction = out.action_type;
+  if (effectiveAction === "prompt") {
+    if ((has("prompt") || !partial) && !String(out.prompt || "").trim()) {
+      throw httpError("A prompt is required for the 'prompt' action", 400);
+    }
+  }
+  return out;
+}
+
+function serializeSchedule(row) {
+  if (!row) return null;
+  return {
+    id: row.id,
+    agent_id: row.agent_id,
+    created_by: row.created_by,
+    name: row.name,
+    cron: row.cron,
+    timezone: row.timezone,
+    action_type: row.action_type,
+    prompt: row.prompt,
+    enabled: row.enabled,
+    last_run_at: row.last_run_at,
+    last_status: row.last_status,
+    next_run_at: row.next_run_at,
+    created_at: row.created_at,
+    updated_at: row.updated_at,
+  };
+}
+
+async function listSchedules(agentId) {
+  const result = await db.query(
+    "SELECT * FROM agent_schedules WHERE agent_id = $1 ORDER BY created_at",
+    [agentId],
+  );
+  return result.rows.map(serializeSchedule);
+}
+
+async function getSchedule(agentId, scheduleId) {
+  const result = await db.query("SELECT * FROM agent_schedules WHERE id = $1 AND agent_id = $2", [
+    scheduleId,
+    agentId,
+  ]);
+  return serializeSchedule(result.rows[0]);
+}
+
+async function createSchedule(agentId, createdBy, input = {}) {
+  const fields = normalizeInput(input, { partial: false });
+  validateCron(fields.cron, fields.timezone);
+  const enabled = input.enabled === undefined ? true : Boolean(input.enabled);
+  const nextRun = enabled ? computeNextRun(fields.cron, fields.timezone) : null;
+  const result = await db.query(
+    `INSERT INTO agent_schedules
+       (agent_id, created_by, name, cron, timezone, action_type, prompt, enabled, next_run_at)
+     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+     RETURNING *`,
+    [
+      agentId,
+      createdBy || null,
+      fields.name,
+      fields.cron,
+      fields.timezone,
+      fields.action_type,
+      fields.prompt ?? null,
+      enabled,
+      nextRun,
+    ],
+  );
+  return serializeSchedule(result.rows[0]);
+}
+
+async function updateSchedule(agentId, scheduleId, input = {}) {
+  const existing = await getSchedule(agentId, scheduleId);
+  if (!existing) return null;
+  const fields = normalizeInput({ action_type: existing.action_type, ...input }, { partial: true });
+
+  const cron = fields.cron ?? existing.cron;
+  const timezone = fields.timezone ?? existing.timezone;
+  if (fields.cron || fields.timezone) validateCron(cron, timezone);
+
+  const enabled = fields.enabled ?? existing.enabled;
+  // Recompute the next fire when the schedule's timing or enabled state changes.
+  const timingChanged =
+    fields.cron !== undefined ||
+    fields.timezone !== undefined ||
+    (fields.enabled !== undefined && fields.enabled !== existing.enabled);
+  const nextRun = !enabled ? null : timingChanged ? computeNextRun(cron, timezone) : undefined;
+
+  const sets = [];
+  const vals = [];
+  let i = 1;
+  const set = (col, val) => {
+    sets.push(`${col} = $${i++}`);
+    vals.push(val);
+  };
+  if (fields.name !== undefined) set("name", fields.name);
+  if (fields.cron !== undefined) set("cron", fields.cron);
+  if (fields.timezone !== undefined) set("timezone", fields.timezone);
+  if (fields.action_type !== undefined) set("action_type", fields.action_type);
+  if (fields.prompt !== undefined) set("prompt", fields.prompt);
+  if (fields.enabled !== undefined) set("enabled", fields.enabled);
+  if (nextRun !== undefined) set("next_run_at", nextRun);
+  set("updated_at", new Date());
+
+  vals.push(scheduleId, agentId);
+  const result = await db.query(
+    `UPDATE agent_schedules SET ${sets.join(", ")} WHERE id = $${i++} AND agent_id = $${i} RETURNING *`,
+    vals,
+  );
+  return serializeSchedule(result.rows[0]);
+}
+
+async function deleteSchedule(agentId, scheduleId) {
+  const result = await db.query(
+    "DELETE FROM agent_schedules WHERE id = $1 AND agent_id = $2 RETURNING id",
+    [scheduleId, agentId],
+  );
+  return result.rows.length > 0;
+}
+
+/** Record the outcome of a run (called by the worker after executing). */
+async function markRun(scheduleId, status) {
+  await db.query(
+    "UPDATE agent_schedules SET last_run_at = NOW(), last_status = $2, updated_at = NOW() WHERE id = $1",
+    [scheduleId, String(status || "").slice(0, 200)],
+  );
+}
+
+/**
+ * Claim due schedules and enqueue each run. Replica-safe: rows are claimed with
+ * FOR UPDATE SKIP LOCKED inside a transaction and their next_run_at is bumped
+ * before commit, so concurrent sweepers never double-fire. Enqueue happens AFTER
+ * commit so a rollback can't leave an orphaned job. Returns the number enqueued.
+ */
+async function sweepDueSchedules({
+  dbClient = db,
+  enqueue,
+  batchSize = 50,
+  now = new Date(),
+} = {}) {
+  if (typeof enqueue !== "function") throw new Error("sweepDueSchedules requires an enqueue fn");
+  const client = await dbClient.connect();
+  const claimed = [];
+  try {
+    await client.query("BEGIN");
+    const due = await client.query(
+      `SELECT * FROM agent_schedules
+        WHERE enabled = TRUE AND next_run_at IS NOT NULL AND next_run_at <= $1
+        ORDER BY next_run_at
+        FOR UPDATE SKIP LOCKED
+        LIMIT $2`,
+      [now, batchSize],
+    );
+    for (const row of due.rows) {
+      let next;
+      try {
+        next = computeNextRun(row.cron, row.timezone, now);
+      } catch {
+        // A row with a now-invalid cron: disable it rather than spin forever.
+        await client.query(
+          "UPDATE agent_schedules SET enabled = FALSE, last_status = 'invalid_cron', updated_at = NOW() WHERE id = $1",
+          [row.id],
+        );
+        continue;
+      }
+      await client.query(
+        "UPDATE agent_schedules SET next_run_at = $2, updated_at = NOW() WHERE id = $1",
+        [row.id, next],
+      );
+      claimed.push(row);
+    }
+    await client.query("COMMIT");
+  } catch (err) {
+    try {
+      await client.query("ROLLBACK");
+    } catch {
+      /* ignore rollback failure */
+    }
+    throw err;
+  } finally {
+    client.release();
+  }
+
+  let enqueued = 0;
+  for (const row of claimed) {
+    try {
+      await enqueue({
+        scheduleId: row.id,
+        agentId: row.agent_id,
+        actionType: row.action_type,
+        prompt: row.prompt,
+        createdBy: row.created_by,
+        name: row.name,
+      });
+      enqueued += 1;
+    } catch (err) {
+      // Best-effort: a failed enqueue is retried on the next sweep once the
+      // bumped next_run_at comes due again; log via markRun for visibility.
+      await markRun(row.id, `enqueue_failed: ${err?.message || err}`).catch(() => {});
+    }
+  }
+  return enqueued;
+}
+
+module.exports = {
+  ACTION_TYPES,
+  MIN_INTERVAL_SECONDS,
+  computeNextRun,
+  validateCron,
+  serializeSchedule,
+  listSchedules,
+  getSchedule,
+  createSchedule,
+  updateSchedule,
+  deleteSchedule,
+  markRun,
+  sweepDueSchedules,
+};

--- a/backend-api/agentSchedules.ts
+++ b/backend-api/agentSchedules.ts
@@ -285,9 +285,15 @@ async function sweepDueSchedules({
       });
       enqueued += 1;
     } catch (err) {
-      // Best-effort: a failed enqueue is retried on the next sweep once the
-      // bumped next_run_at comes due again; log via markRun for visibility.
-      await markRun(row.id, `enqueue_failed: ${err?.message || err}`).catch(() => {});
+      // The claim already bumped next_run_at to the NEXT cron fire. If the
+      // enqueue fails (e.g. Redis blip), don't silently skip until then — pull
+      // next_run_at back to ~now so the next sweep re-claims and retries it.
+      await db
+        .query(
+          "UPDATE agent_schedules SET next_run_at = NOW(), last_status = $2, updated_at = NOW() WHERE id = $1",
+          [row.id, `enqueue_failed: ${err?.message || err}`.slice(0, 200)],
+        )
+        .catch(() => {});
     }
   }
   return enqueued;

--- a/backend-api/db_schema.sql
+++ b/backend-api/db_schema.sql
@@ -562,6 +562,33 @@ CREATE TABLE IF NOT EXISTS agent_budgets (
 
 CREATE INDEX IF NOT EXISTS idx_agent_budgets_agent ON agent_budgets(agent_id);
 
+-- Control-plane scheduled agent runs (recurring cron triggers). The backend
+-- sweep claims due rows (FOR UPDATE SKIP LOCKED), computes the next fire, and
+-- enqueues each run; the worker executes the action (a prompt or a lifecycle op)
+-- and records an agent.schedule.run event. min_interval is enforced in the app
+-- so a too-frequent cron can't thrash an agent.
+CREATE TABLE IF NOT EXISTS agent_schedules (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  name TEXT NOT NULL,
+  cron TEXT NOT NULL,
+  timezone TEXT NOT NULL DEFAULT 'UTC',
+  action_type TEXT NOT NULL DEFAULT 'prompt'
+    CHECK (action_type IN ('prompt', 'restart', 'stop', 'start', 'redeploy')),
+  prompt TEXT,
+  enabled BOOLEAN NOT NULL DEFAULT TRUE,
+  last_run_at TIMESTAMPTZ,
+  last_status TEXT,
+  next_run_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_schedules_due
+  ON agent_schedules(next_run_at) WHERE enabled;
+CREATE INDEX IF NOT EXISTS idx_agent_schedules_agent ON agent_schedules(agent_id);
+
 CREATE TABLE IF NOT EXISTS integration_catalog (
   id VARCHAR(50) PRIMARY KEY,
   name VARCHAR(100) NOT NULL,

--- a/backend-api/gatewayProxy.ts
+++ b/backend-api/gatewayProxy.ts
@@ -1615,4 +1615,6 @@ module.exports = {
   resolveSafeGatewayHttpTarget,
   resolveSafeHermesDashboardTarget,
   assertExternalEndpointReachable,
+  resolveGatewayHostForProxy,
+  allowedGatewayHostsForAgent,
 };

--- a/backend-api/openapi/index.js
+++ b/backend-api/openapi/index.js
@@ -36,6 +36,10 @@ function buildOpenApiDocument() {
     tags: [
       { name: "Agents", description: "Agent lifecycle: deploy, start/stop, versions." },
       { name: "Budgets", description: "Per-agent LLM spend caps with auto-pause." },
+      {
+        name: "Schedules",
+        description: "Recurring cron triggers for agent prompts and lifecycle actions.",
+      },
       { name: "Monitoring", description: "Metrics, events, cost, and the fleet roll-up." },
       { name: "LLM Providers", description: "Encrypted provider key management." },
       { name: "Auth", description: "Session endpoints (JWT + HttpOnly cookie)." },

--- a/backend-api/openapi/paths/agents.js
+++ b/backend-api/openapi/paths/agents.js
@@ -258,6 +258,37 @@ const tail = {
       ["agents:write"],
     ),
   },
+  "/agents/{id}/schedules": {
+    get: summarize("Schedules", "List the agent's scheduled runs", [agentParam], ["agents:read"]),
+    post: summarize(
+      "Schedules",
+      "Create a scheduled run (cron prompt or lifecycle action)",
+      [agentParam],
+      ["agents:write"],
+    ),
+  },
+  "/agents/{id}/schedules/{scheduleId}": {
+    put: summarize(
+      "Schedules",
+      "Update or enable/disable a schedule",
+      [agentParam, { name: "scheduleId", in: "path", required: true, schema: { type: "string" } }],
+      ["agents:write"],
+    ),
+    delete: summarize(
+      "Schedules",
+      "Delete a schedule",
+      [agentParam, { name: "scheduleId", in: "path", required: true, schema: { type: "string" } }],
+      ["agents:write"],
+    ),
+  },
+  "/agents/{id}/schedules/{scheduleId}/runs": {
+    get: summarize(
+      "Schedules",
+      "List recent runs for a schedule",
+      [agentParam, { name: "scheduleId", in: "path", required: true, schema: { type: "string" } }],
+      ["agents:read"],
+    ),
+  },
   "/agents/{id}/versions": {
     get: summarize("Agents", "List configuration version history", [agentParam], ["agents:read"]),
   },

--- a/backend-api/package-lock.json
+++ b/backend-api/package-lock.json
@@ -18,6 +18,7 @@
         "bcryptjs": "^3.0.3",
         "bullmq": "^5.76.4",
         "cors": "^2.8.5",
+        "cron-parser": "^5.6.0",
         "dockerode": "5.0.0",
         "express": "^5.2.1",
         "express-rate-limit": "^8.5.1",
@@ -3194,6 +3195,18 @@
         "node": ">=12.22.0"
       }
     },
+    "node_modules/bullmq/node_modules/cron-parser": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
+      "integrity": "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "luxon": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
@@ -3510,15 +3523,15 @@
       "license": "MIT"
     },
     "node_modules/cron-parser": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-4.9.0.tgz",
-      "integrity": "sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==",
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/cron-parser/-/cron-parser-5.6.0.tgz",
+      "integrity": "sha512-6159NDv4eDOjXYDmMTkvUtaVcIrNZI779ydTMOfDdi9fSjhPqmySx0icCHX2+nOyXgNSw6sFCsgLKxYs/2KPuQ==",
       "license": "MIT",
       "dependencies": {
-        "luxon": "^3.2.1"
+        "luxon": "^3.7.2"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/cross-spawn": {

--- a/backend-api/package.json
+++ b/backend-api/package.json
@@ -22,6 +22,7 @@
     "bcryptjs": "^3.0.3",
     "bullmq": "^5.76.4",
     "cors": "^2.8.5",
+    "cron-parser": "^5.6.0",
     "dockerode": "5.0.0",
     "express": "^5.2.1",
     "express-rate-limit": "^8.5.1",

--- a/backend-api/redisQueue.ts
+++ b/backend-api/redisQueue.ts
@@ -83,8 +83,27 @@ const alertDeliveryQueue = new Queue("alert-deliveries", {
   },
 });
 
+// Scheduled agent runs (recurring cron triggers). The backend sweep claims due
+// schedules and enqueues one job per run; the worker executes the prompt /
+// lifecycle action. Retries are bounded — a missed run is re-fired on the next
+// sweep once next_run_at comes due, so we don't want long retry storms.
+const agentScheduleQueue = new Queue("agent-schedules", {
+  connection,
+  defaultJobOptions: {
+    attempts: 2,
+    backoff: { type: "exponential", delay: 2000 },
+    removeOnComplete: { count: 200, age: 86400 },
+    removeOnFail: { count: 200, age: 86400 },
+  },
+});
+
 async function addDeploymentJob(agent) {
   await deployQueue.add("deploy-agent", agent);
+}
+
+async function addScheduleRunJob(payload) {
+  const jobId = payload?.runId || randomUUID();
+  return agentScheduleQueue.add("run-schedule", { ...payload, runId: jobId }, { jobId });
 }
 
 async function addAlertDeliveryJob(payload) {
@@ -215,7 +234,9 @@ module.exports = {
   clawhubJobsQueue,
   backupsQueue,
   alertDeliveryQueue,
+  agentScheduleQueue,
   addDeploymentJob,
+  addScheduleRunJob,
   addClawhubJob,
   addClawhubInstallJob,
   addBackupJob,

--- a/backend-api/routes/agents.ts
+++ b/backend-api/routes/agents.ts
@@ -12,6 +12,7 @@ const {
 const scheduler = require("../scheduler");
 const containerManager = require("../containerManager");
 const agentBudgets = require("../agentBudgets");
+const agentSchedules = require("../agentSchedules");
 const monitoring = require("../monitoring");
 const metrics = require("../metrics");
 const workspaces = require("../workspaces");
@@ -2133,6 +2134,107 @@ router.delete(
       agentAuditMetadata(req, agent, { result: { budgetId: req.params.budgetId } }),
     );
     res.json({ success: true });
+  }),
+);
+
+// ── Scheduled runs (recurring cron triggers) ─────────────────────────────────
+
+router.get(
+  "/:id/schedules",
+  asyncHandler(async (req, res) => {
+    const agent = await findAccessibleAgent(req.params.id, req.user.id, "viewer");
+    if (!agent) return res.status(404).json({ error: "Agent not found" });
+    res.json(await agentSchedules.listSchedules(agent.id));
+  }),
+);
+
+router.post(
+  "/:id/schedules",
+  asyncHandler(async (req, res) => {
+    const agent = await findAccessibleAgent(req.params.id, req.user.id, "editor");
+    if (!agent) return res.status(404).json({ error: "Agent not found" });
+    res.locals.auditContext = buildAgentContext(agent, { ownerEmail: req.user.email || null });
+    let schedule;
+    try {
+      schedule = await agentSchedules.createSchedule(agent.id, req.user.id, req.body || {});
+    } catch (err) {
+      if (err.statusCode === 400) return res.status(400).json({ error: err.message });
+      throw err;
+    }
+    await monitoring.logEvent(
+      "agent.schedule_created",
+      `Schedule "${schedule.name}" (${schedule.action_type}, ${schedule.cron} ${schedule.timezone}) created on agent "${agent.name}"`,
+      agentAuditMetadata(req, agent, {
+        result: { scheduleId: schedule.id, actionType: schedule.action_type, cron: schedule.cron },
+      }),
+    );
+    res.status(201).json(schedule);
+  }),
+);
+
+router.put(
+  "/:id/schedules/:scheduleId",
+  asyncHandler(async (req, res) => {
+    const agent = await findAccessibleAgent(req.params.id, req.user.id, "editor");
+    if (!agent) return res.status(404).json({ error: "Agent not found" });
+    res.locals.auditContext = buildAgentContext(agent, { ownerEmail: req.user.email || null });
+    let schedule;
+    try {
+      schedule = await agentSchedules.updateSchedule(
+        agent.id,
+        req.params.scheduleId,
+        req.body || {},
+      );
+    } catch (err) {
+      if (err.statusCode === 400) return res.status(400).json({ error: err.message });
+      throw err;
+    }
+    if (!schedule) return res.status(404).json({ error: "Schedule not found" });
+    await monitoring.logEvent(
+      "agent.schedule_updated",
+      `Schedule "${schedule.name}" updated on agent "${agent.name}"`,
+      agentAuditMetadata(req, agent, {
+        result: { scheduleId: schedule.id, enabled: schedule.enabled },
+      }),
+    );
+    res.json(schedule);
+  }),
+);
+
+router.delete(
+  "/:id/schedules/:scheduleId",
+  asyncHandler(async (req, res) => {
+    const agent = await findAccessibleAgent(req.params.id, req.user.id, "editor");
+    if (!agent) return res.status(404).json({ error: "Agent not found" });
+    res.locals.auditContext = buildAgentContext(agent, { ownerEmail: req.user.email || null });
+    const deleted = await agentSchedules.deleteSchedule(agent.id, req.params.scheduleId);
+    if (!deleted) return res.status(404).json({ error: "Schedule not found" });
+    await monitoring.logEvent(
+      "agent.schedule_removed",
+      `Schedule removed from agent "${agent.name}"`,
+      agentAuditMetadata(req, agent, { result: { scheduleId: req.params.scheduleId } }),
+    );
+    res.json({ success: true });
+  }),
+);
+
+router.get(
+  "/:id/schedules/:scheduleId/runs",
+  asyncHandler(async (req, res) => {
+    const agent = await findAccessibleAgent(req.params.id, req.user.id, "viewer");
+    if (!agent) return res.status(404).json({ error: "Agent not found" });
+    const limit = Math.max(1, Math.min(100, Number(req.query.limit) || 25));
+    // Runs are recorded as agent.schedule.run events (audit-integrated).
+    const result = await db.query(
+      `SELECT type, message, metadata, created_at
+         FROM events
+        WHERE type = 'agent.schedule.run'
+          AND metadata #>> '{result,scheduleId}' = $1
+        ORDER BY created_at DESC
+        LIMIT $2`,
+      [req.params.scheduleId, limit],
+    );
+    res.json(result.rows);
   }),
 );
 

--- a/backend-api/scheduleRunner.ts
+++ b/backend-api/scheduleRunner.ts
@@ -1,0 +1,144 @@
+// @ts-nocheck
+// Executes one scheduled agent run (enqueued by the agentSchedules sweep onto
+// the agent-schedules BullMQ queue). Lives in backend-api so it has local access
+// to the gateway RPC, containerManager, metrics, and monitoring; the provisioner
+// worker's queue handler calls runScheduledAction (same cross-package pattern as
+// alert-deliveries -> backend-api/alertRules).
+
+const { randomUUID } = require("crypto");
+const db = require("./db");
+const monitoring = require("./monitoring");
+const metrics = require("./metrics");
+const agentSchedules = require("./agentSchedules");
+const containerManager = require("./containerManager");
+const { addDeploymentJob } = require("./redisQueue");
+const { rpcCall } = require("./gatewayProxy");
+const { runtimeAuthHeaders } = require("./runtimeAuth");
+const { resolveAgentRuntimeFamily } = require("./agentRuntimeFields");
+const { runtimeUrlForAgent } = require("../agent-runtime/lib/agentEndpoints");
+
+const CHAT_TIMEOUT_MS = 240000;
+
+async function loadAgent(agentId) {
+  const result = await db.query("SELECT * FROM agents WHERE id = $1", [agentId]);
+  return result.rows[0] || null;
+}
+
+async function deliverPrompt(agent, prompt, userId) {
+  const text = String(prompt || "").trim();
+  if (!text) throw new Error("Schedule has no prompt to deliver");
+  const family = resolveAgentRuntimeFamily(agent);
+  const startedAtMs = Date.now();
+
+  if (family === "hermes") {
+    const url = runtimeUrlForAgent(agent, "/v1/chat/completions");
+    if (!url) throw new Error("Hermes runtime endpoint unavailable");
+    const resp = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", ...(await runtimeAuthHeaders(agent)) },
+      body: JSON.stringify({ stream: false, messages: [{ role: "user", content: text }] }),
+      signal: AbortSignal.timeout(CHAT_TIMEOUT_MS),
+    });
+    const data = await resp.json().catch(() => ({}));
+    if (!resp.ok) throw new Error(`Hermes chat returned ${resp.status}`);
+    // Token usage flows to budgets + OTel exactly like an interactive chat.
+    await metrics
+      .recordTokenUsage?.(agent, userId || agent.user_id, data, {
+        runtimeFamily: "hermes",
+        source: "schedule",
+        startedAtMs,
+      })
+      .catch(() => {});
+    return;
+  }
+
+  // OpenClaw: deliver over the gateway WS-RPC (same call the chat route uses).
+  const result = await rpcCall(
+    agent,
+    "chat.send",
+    { sessionKey: "schedule", idempotencyKey: randomUUID(), message: text },
+    CHAT_TIMEOUT_MS,
+  );
+  await metrics
+    .recordTokenUsage?.(agent, userId || agent.user_id, result, {
+      source: "schedule.openclaw",
+      sessionId: "schedule",
+      startedAtMs,
+    })
+    .catch(() => {});
+}
+
+async function performAction(agent, actionType, prompt, userId) {
+  switch (actionType) {
+    case "prompt":
+      return deliverPrompt(agent, prompt, userId);
+    case "restart":
+      return containerManager.restart(agent);
+    case "stop":
+      return containerManager.stop(agent);
+    case "start":
+      return containerManager.start(agent);
+    case "redeploy":
+      return addDeploymentJob(agent);
+    default:
+      throw new Error(`Unknown schedule action: ${actionType}`);
+  }
+}
+
+/**
+ * Run one scheduled action. Records the outcome on the schedule (markRun) and as
+ * an agent.schedule.run event (audit + alert rules). Throws on failure so BullMQ
+ * applies its bounded retry; a permanently-missing agent is recorded, not thrown
+ * (retrying can't fix it).
+ */
+async function runScheduledAction(payload = {}) {
+  const { scheduleId, agentId, actionType, prompt, createdBy, name } = payload;
+  if (!scheduleId || !agentId || !actionType) {
+    throw new Error("runScheduledAction requires scheduleId, agentId, actionType");
+  }
+
+  const agent = await loadAgent(agentId);
+  if (!agent) {
+    await agentSchedules.markRun(scheduleId, "agent_missing").catch(() => {});
+    return { ok: false, status: "agent_missing" };
+  }
+
+  const eventMeta = (ok, detail) => ({
+    result: {
+      scheduleId,
+      agentId,
+      action: actionType,
+      name: name || null,
+      ok,
+      detail: detail || null,
+    },
+    agent: { id: agent.id, name: agent.name, ownerUserId: agent.user_id },
+  });
+
+  try {
+    await performAction(agent, actionType, prompt, createdBy);
+  } catch (err) {
+    const status = `failed: ${err?.message || err}`.slice(0, 180);
+    await agentSchedules.markRun(scheduleId, status).catch(() => {});
+    await monitoring
+      .logEvent(
+        "agent.schedule.run",
+        `Scheduled ${actionType} on "${agent.name}" failed`,
+        eventMeta(false, status),
+      )
+      .catch(() => {});
+    throw err; // surface to BullMQ for bounded retry
+  }
+
+  await agentSchedules.markRun(scheduleId, "success").catch(() => {});
+  await monitoring
+    .logEvent(
+      "agent.schedule.run",
+      `Scheduled ${actionType} ran on "${agent.name}"`,
+      eventMeta(true),
+    )
+    .catch(() => {});
+  return { ok: true, status: "success" };
+}
+
+module.exports = { runScheduledAction, deliverPrompt };

--- a/backend-api/scheduleRunner.ts
+++ b/backend-api/scheduleRunner.ts
@@ -12,10 +12,17 @@ const metrics = require("./metrics");
 const agentSchedules = require("./agentSchedules");
 const containerManager = require("./containerManager");
 const { addDeploymentJob } = require("./redisQueue");
-const { rpcCall } = require("./gatewayProxy");
+const {
+  rpcCall,
+  resolveGatewayHostForProxy,
+  allowedGatewayHostsForAgent,
+} = require("./gatewayProxy");
 const { runtimeAuthHeaders } = require("./runtimeAuth");
 const { resolveAgentRuntimeFamily } = require("./agentRuntimeFields");
-const { runtimeUrlForAgent } = require("../agent-runtime/lib/agentEndpoints");
+
+// Lifecycle actions that bring an agent UP — must not resurrect a budget-paused
+// agent (the budget sweep would just re-pause it; a schedule shouldn't fight it).
+const REVIVE_ACTIONS = new Set(["start", "restart", "redeploy"]);
 
 const CHAT_TIMEOUT_MS = 240000;
 
@@ -31,8 +38,15 @@ async function deliverPrompt(agent, prompt, userId) {
   const startedAtMs = Date.now();
 
   if (family === "hermes") {
-    const url = runtimeUrlForAgent(agent, "/v1/chat/completions");
-    if (!url) throw new Error("Hermes runtime endpoint unavailable");
+    const host = agent.runtime_host;
+    const port = agent.runtime_port;
+    if (!host || !port) throw new Error("Hermes runtime endpoint unavailable");
+    // SSRF-safe: validate + DNS-pin the runtime host through the same floor +
+    // per-agent allowlist the gateway proxy uses (the OpenClaw path gets this
+    // for free via rpcCall; the raw Hermes fetch must do it explicitly).
+    const allowed = await allowedGatewayHostsForAgent(agent);
+    const safeHost = await resolveGatewayHostForProxy(host, "hermes runtime", allowed);
+    const url = `http://${safeHost}:${port}/v1/chat/completions`;
     const resp = await fetch(url, {
       method: "POST",
       headers: { "Content-Type": "application/json", ...(await runtimeAuthHeaders(agent)) },
@@ -114,6 +128,20 @@ async function runScheduledAction(payload = {}) {
     },
     agent: { id: agent.id, name: agent.name, ownerUserId: agent.user_id },
   });
+
+  // Don't let a schedule revive a budget-paused agent — the budget sweep would
+  // immediately re-pause it, and a scheduled prompt shouldn't run up a capped bill.
+  if (agent.paused_reason && (REVIVE_ACTIONS.has(actionType) || actionType === "prompt")) {
+    await agentSchedules.markRun(scheduleId, `skipped: ${agent.paused_reason}`).catch(() => {});
+    await monitoring
+      .logEvent(
+        "agent.schedule.run",
+        `Scheduled ${actionType} on "${agent.name}" skipped (${agent.paused_reason})`,
+        eventMeta(false, `skipped: ${agent.paused_reason}`),
+      )
+      .catch(() => {});
+    return { ok: false, status: `skipped: ${agent.paused_reason}` };
+  }
 
   try {
     await performAction(agent, actionType, prompt, createdBy);

--- a/backend-api/server.ts
+++ b/backend-api/server.ts
@@ -2139,9 +2139,14 @@ if (require.main === module) {
     }, BUDGET_SWEEP_INTERVAL);
 
     // ── Schedule sweep: claim due agent_schedules and enqueue each run for the
-    // worker to execute. Replica-safe (FOR UPDATE SKIP LOCKED in the module). ──
+    // worker to execute. Replica-safe (FOR UPDATE SKIP LOCKED in the module).
+    // The re-entrancy guard prevents a slow sweep from overlapping the next
+    // tick (setInterval doesn't await), bounding concurrent enqueue load. ──
     const SCHEDULE_SWEEP_INTERVAL = 30000;
+    let scheduleSweepRunning = false;
     setInterval(async () => {
+      if (scheduleSweepRunning) return;
+      scheduleSweepRunning = true;
       try {
         await agentSchedules.sweepDueSchedules({
           dbClient: db,
@@ -2149,6 +2154,8 @@ if (require.main === module) {
         });
       } catch (err) {
         console.error("[schedules] sweep failed:", err?.message || err);
+      } finally {
+        scheduleSweepRunning = false;
       }
     }, SCHEDULE_SWEEP_INTERVAL);
   });

--- a/backend-api/server.ts
+++ b/backend-api/server.ts
@@ -24,6 +24,8 @@ const {
   reconcileExternalAgentStatuses,
 } = require("./backgroundTasks");
 const agentBudgets = require("./agentBudgets");
+const agentSchedules = require("./agentSchedules");
+const { addScheduleRunJob } = require("./redisQueue");
 // OpenTelemetry GenAI exporter — self-initializes on require (no-op unless
 // NORA_OTEL_ENABLED=true; fail-open). Wrapped so even a module load/parse error
 // (e.g. a corrupted dependency) disables OTel rather than crashing boot — the
@@ -1852,6 +1854,27 @@ async function migrateDB() {
        UNIQUE(agent_id, period)
      )`,
     `CREATE INDEX IF NOT EXISTS idx_agent_budgets_agent ON agent_budgets(agent_id)`,
+    // ─── Control-plane scheduled agent runs (recurring cron triggers) ───
+    `CREATE TABLE IF NOT EXISTS agent_schedules (
+       id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+       agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+       created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+       name TEXT NOT NULL,
+       cron TEXT NOT NULL,
+       timezone TEXT NOT NULL DEFAULT 'UTC',
+       action_type TEXT NOT NULL DEFAULT 'prompt'
+         CHECK (action_type IN ('prompt', 'restart', 'stop', 'start', 'redeploy')),
+       prompt TEXT,
+       enabled BOOLEAN NOT NULL DEFAULT TRUE,
+       last_run_at TIMESTAMPTZ,
+       last_status TEXT,
+       next_run_at TIMESTAMPTZ,
+       created_at TIMESTAMPTZ DEFAULT NOW(),
+       updated_at TIMESTAMPTZ DEFAULT NOW()
+     )`,
+    `CREATE INDEX IF NOT EXISTS idx_agent_schedules_due
+       ON agent_schedules(next_run_at) WHERE enabled`,
+    `CREATE INDEX IF NOT EXISTS idx_agent_schedules_agent ON agent_schedules(agent_id)`,
     `DO $$ BEGIN
        ALTER TABLE agents ADD COLUMN paused_reason TEXT;
      EXCEPTION WHEN duplicate_column THEN NULL;
@@ -2114,6 +2137,20 @@ if (require.main === module) {
     setInterval(async () => {
       await agentBudgets.sweepAgentBudgets({ dbClient: db });
     }, BUDGET_SWEEP_INTERVAL);
+
+    // ── Schedule sweep: claim due agent_schedules and enqueue each run for the
+    // worker to execute. Replica-safe (FOR UPDATE SKIP LOCKED in the module). ──
+    const SCHEDULE_SWEEP_INTERVAL = 30000;
+    setInterval(async () => {
+      try {
+        await agentSchedules.sweepDueSchedules({
+          dbClient: db,
+          enqueue: addScheduleRunJob,
+        });
+      } catch (err) {
+        console.error("[schedules] sweep failed:", err?.message || err);
+      }
+    }, SCHEDULE_SWEEP_INTERVAL);
   });
 
   attachLogStream(server);

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -149,6 +149,7 @@
           "guides/mcp-server",
           "guides/monitoring",
           "guides/opentelemetry",
+          "guides/scheduled-agents",
           "guides/doctor",
           "guides/alert-rules",
           "guides/backups",

--- a/docs/guides/scheduled-agents.mdx
+++ b/docs/guides/scheduled-agents.mdx
@@ -1,0 +1,52 @@
+---
+title: Scheduled agent runs
+description: Run a prompt or a lifecycle action on an agent on a recurring cron schedule — control-plane-native, audited, and budget-aware.
+---
+
+# Scheduled agent runs
+
+Nora can run an agent on a recurring **cron** schedule from the control plane — no human in the loop. Use it for daily summaries, hourly health/triage prompts, nightly reports, or scheduled lifecycle maintenance. Every run is recorded in the agent's events, and prompt runs flow through the same token/cost accounting (and budget auto-pause) as interactive chat.
+
+Schedules live on the **Schedules** tab of an agent, or via the API.
+
+## What you can schedule
+
+Each schedule has a **cron expression** (5-field, standard), a **timezone**, and an **action**:
+
+| Action | What it does |
+| --- | --- |
+| `prompt` | Sends a prompt to the agent (OpenClaw via the gateway, Hermes via its runtime API). Requires prompt text. |
+| `restart` / `stop` / `start` | Lifecycle control of the agent's runtime. |
+| `redeploy` | Re-provisions the agent. |
+
+<Note>
+A guardrail enforces a **minimum interval** between fires (`NORA_SCHEDULE_MIN_INTERVAL_SECONDS`, default 60s) so a too-frequent cron can't thrash an agent or run away with its budget. Hermes also has its own runtime-native cron (`/api/jobs`); control-plane schedules are independent of it.
+</Note>
+
+## How it runs
+
+A backend sweep (every ~30s) atomically claims any schedules whose next fire is due (replica-safe), computes the next fire, and enqueues each run. The provisioner worker executes the action and records an `agent.schedule.run` event — so runs show up in monitoring, can trigger alert rules, and (for prompts) appear in cost/OpenTelemetry telemetry.
+
+## API
+
+```bash
+# List schedules for an agent
+curl -H "Authorization: Bearer $NORA_TOKEN" \
+  https://your-nora.example.com/api/agents/$AGENT_ID/schedules
+
+# Create a daily 9am summary prompt (UTC)
+curl -X POST -H "Authorization: Bearer $NORA_TOKEN" -H "Content-Type: application/json" \
+  https://your-nora.example.com/api/agents/$AGENT_ID/schedules \
+  -d '{"name":"Daily summary","cron":"0 9 * * *","timezone":"UTC","action_type":"prompt","prompt":"Summarize today's open issues."}'
+
+# Pause / resume
+curl -X PUT  .../api/agents/$AGENT_ID/schedules/$SCHEDULE_ID -d '{"enabled":false}'
+
+# Delete
+curl -X DELETE .../api/agents/$AGENT_ID/schedules/$SCHEDULE_ID
+
+# Recent runs
+curl .../api/agents/$AGENT_ID/schedules/$SCHEDULE_ID/runs
+```
+
+`GET`/run-listing need the `agents:read` scope; create/update/delete need `agents:write`. See the [API reference](/api/overview).

--- a/frontend-dashboard/components/agents/SchedulesTab.tsx
+++ b/frontend-dashboard/components/agents/SchedulesTab.tsx
@@ -1,0 +1,288 @@
+import { useState, useEffect, useCallback } from "react";
+import { CalendarClock, Plus, Trash2, Loader2, Play, Pause, AlertTriangle } from "lucide-react";
+import { fetchWithAuth } from "../../lib/api";
+import { useToast } from "../Toast";
+
+const ACTION_TYPES = [
+  { value: "prompt", label: "Send a prompt" },
+  { value: "restart", label: "Restart agent" },
+  { value: "stop", label: "Stop agent" },
+  { value: "start", label: "Start agent" },
+  { value: "redeploy", label: "Redeploy agent" },
+];
+
+const EMPTY_FORM = {
+  name: "",
+  cron: "0 9 * * *",
+  timezone: "UTC",
+  action_type: "prompt",
+  prompt: "",
+};
+
+function fmt(ts) {
+  if (!ts) return "—";
+  try {
+    return new Date(ts).toLocaleString();
+  } catch {
+    return String(ts);
+  }
+}
+
+export default function SchedulesTab({ agentId }) {
+  const toast = useToast();
+  const [schedules, setSchedules] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [form, setForm] = useState(EMPTY_FORM);
+  const [saving, setSaving] = useState(false);
+  const [busyId, setBusyId] = useState("");
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetchWithAuth(`/api/agents/${agentId}/schedules`);
+      if (!res.ok) throw new Error((await res.json().catch(() => ({}))).error || "Failed to load");
+      const data = await res.json();
+      setSchedules(Array.isArray(data) ? data : []);
+    } catch (e) {
+      toast.error(e.message || "Failed to load schedules");
+    } finally {
+      setLoading(false);
+    }
+  }, [agentId, toast]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  function update(key, value) {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  }
+
+  async function create(event) {
+    event.preventDefault();
+    if (!form.name.trim() || !form.cron.trim()) {
+      toast.error("Name and cron are required");
+      return;
+    }
+    if (form.action_type === "prompt" && !form.prompt.trim()) {
+      toast.error("A prompt is required for the prompt action");
+      return;
+    }
+    setSaving(true);
+    try {
+      const payload = {
+        name: form.name,
+        cron: form.cron,
+        timezone: form.timezone || "UTC",
+        action_type: form.action_type,
+        ...(form.action_type === "prompt" ? { prompt: form.prompt } : {}),
+      };
+      const res = await fetchWithAuth(`/api/agents/${agentId}/schedules`, {
+        method: "POST",
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) throw new Error((await res.json().catch(() => ({}))).error || "Create failed");
+      toast.success("Schedule created");
+      setForm(EMPTY_FORM);
+      await load();
+    } catch (e) {
+      toast.error(e.message || "Failed to create schedule");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function toggle(schedule) {
+    setBusyId(schedule.id);
+    try {
+      const res = await fetchWithAuth(`/api/agents/${agentId}/schedules/${schedule.id}`, {
+        method: "PUT",
+        body: JSON.stringify({ enabled: !schedule.enabled }),
+      });
+      if (!res.ok) throw new Error((await res.json().catch(() => ({}))).error || "Update failed");
+      await load();
+    } catch (e) {
+      toast.error(e.message || "Failed to update schedule");
+    } finally {
+      setBusyId("");
+    }
+  }
+
+  async function remove(schedule) {
+    if (typeof window !== "undefined" && !window.confirm(`Delete schedule "${schedule.name}"?`)) {
+      return;
+    }
+    setBusyId(schedule.id);
+    try {
+      const res = await fetchWithAuth(`/api/agents/${agentId}/schedules/${schedule.id}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) throw new Error((await res.json().catch(() => ({}))).error || "Delete failed");
+      toast.success("Schedule deleted");
+      await load();
+    } catch (e) {
+      toast.error(e.message || "Failed to delete schedule");
+    } finally {
+      setBusyId("");
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-2 text-slate-900">
+        <CalendarClock size={18} className="text-blue-600" />
+        <h3 className="text-lg font-bold">Scheduled runs</h3>
+      </div>
+      <p className="text-sm text-slate-500">
+        Run a prompt or a lifecycle action on this agent on a recurring cron schedule. Each run is
+        recorded in the agent&apos;s events, and prompt runs count toward any budget you&apos;ve
+        set.
+      </p>
+
+      {/* Create form */}
+      <form
+        onSubmit={create}
+        className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm"
+      >
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          <label className="block">
+            <span className="mb-1 block text-sm font-medium text-slate-700">Name</span>
+            <input
+              type="text"
+              value={form.name}
+              onChange={(e) => update("name", e.target.value)}
+              placeholder="Daily standup summary"
+              className="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-sm"
+            />
+          </label>
+          <label className="block">
+            <span className="mb-1 block text-sm font-medium text-slate-700">Action</span>
+            <select
+              value={form.action_type}
+              onChange={(e) => update("action_type", e.target.value)}
+              className="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-sm"
+            >
+              {ACTION_TYPES.map((a) => (
+                <option key={a.value} value={a.value}>
+                  {a.label}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="block">
+            <span className="mb-1 block text-sm font-medium text-slate-700">Cron (5-field)</span>
+            <input
+              type="text"
+              value={form.cron}
+              onChange={(e) => update("cron", e.target.value)}
+              placeholder="0 9 * * *"
+              className="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2.5 font-mono text-sm"
+            />
+          </label>
+          <label className="block">
+            <span className="mb-1 block text-sm font-medium text-slate-700">Timezone</span>
+            <input
+              type="text"
+              value={form.timezone}
+              onChange={(e) => update("timezone", e.target.value)}
+              placeholder="UTC"
+              className="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-sm"
+            />
+          </label>
+        </div>
+        {form.action_type === "prompt" && (
+          <label className="mt-4 block">
+            <span className="mb-1 block text-sm font-medium text-slate-700">Prompt</span>
+            <textarea
+              value={form.prompt}
+              onChange={(e) => update("prompt", e.target.value)}
+              rows={3}
+              placeholder="Summarize today's open issues and post the highlights."
+              className="w-full rounded-xl border border-slate-200 bg-slate-50 px-4 py-2.5 text-sm"
+            />
+          </label>
+        )}
+        <button
+          type="submit"
+          disabled={saving}
+          className="mt-4 inline-flex items-center gap-2 rounded-xl bg-blue-600 px-5 py-2.5 text-sm font-semibold text-white hover:bg-blue-700 disabled:opacity-60"
+        >
+          {saving ? <Loader2 size={16} className="animate-spin" /> : <Plus size={16} />}
+          Add schedule
+        </button>
+      </form>
+
+      {/* List */}
+      {loading ? (
+        <div className="flex items-center gap-2 rounded-2xl border border-slate-200 bg-white p-8 text-slate-500">
+          <Loader2 size={18} className="animate-spin" /> Loading schedules…
+        </div>
+      ) : schedules.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-slate-300 bg-white p-8 text-center text-sm text-slate-500">
+          No schedules yet. Add one above to run this agent on a cron.
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {schedules.map((s) => (
+            <div key={s.id} className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+              <div className="flex flex-wrap items-start justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="font-semibold text-slate-900">{s.name}</span>
+                    <span className="rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-600">
+                      {ACTION_TYPES.find((a) => a.value === s.action_type)?.label || s.action_type}
+                    </span>
+                    {s.enabled ? (
+                      <span className="rounded-full bg-emerald-50 px-2.5 py-0.5 text-xs font-medium text-emerald-700">
+                        Enabled
+                      </span>
+                    ) : (
+                      <span className="rounded-full bg-slate-100 px-2.5 py-0.5 text-xs font-medium text-slate-500">
+                        Paused
+                      </span>
+                    )}
+                  </div>
+                  <p className="mt-1 font-mono text-xs text-slate-500">
+                    {s.cron} · {s.timezone}
+                  </p>
+                  <p className="mt-1 text-xs text-slate-500">
+                    Next: {s.enabled ? fmt(s.next_run_at) : "—"} · Last: {fmt(s.last_run_at)}
+                    {s.last_status && s.last_status !== "success" && (
+                      <span className="ml-2 inline-flex items-center gap-1 text-amber-700">
+                        <AlertTriangle size={12} /> {s.last_status}
+                      </span>
+                    )}
+                  </p>
+                </div>
+                <div className="flex shrink-0 items-center gap-2">
+                  <button
+                    onClick={() => toggle(s)}
+                    disabled={busyId === s.id}
+                    className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-60"
+                  >
+                    {busyId === s.id ? (
+                      <Loader2 size={14} className="animate-spin" />
+                    ) : s.enabled ? (
+                      <Pause size={14} />
+                    ) : (
+                      <Play size={14} />
+                    )}
+                    {s.enabled ? "Pause" : "Resume"}
+                  </button>
+                  <button
+                    onClick={() => remove(s)}
+                    disabled={busyId === s.id}
+                    className="rounded-lg border border-red-200 px-2.5 py-1.5 text-red-600 hover:bg-red-50 disabled:opacity-60"
+                    aria-label="Delete schedule"
+                  >
+                    <Trash2 size={14} />
+                  </button>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend-dashboard/components/agents/TabBar.tsx
+++ b/frontend-dashboard/components/agents/TabBar.tsx
@@ -9,6 +9,7 @@ import {
   BarChart3,
   FolderTree,
   Archive,
+  CalendarClock,
 } from "lucide-react";
 import { runtimeSupportsGateway } from "../../lib/runtime";
 
@@ -21,6 +22,7 @@ const baseTabs = [
   { id: "hermes-webui", label: "Hermes WebUI", icon: Bot, hermesOnly: true },
   { id: "nemoclaw", label: "NemoClaw", icon: ShieldCheck, needsNemoClaw: true },
   { id: "files", label: "Files", icon: FolderTree },
+  { id: "schedules", label: "Schedules", icon: CalendarClock },
   { id: "backups", label: "Backups", icon: Archive },
   { id: "settings", label: "Settings", icon: Settings },
 ];

--- a/frontend-dashboard/pages/agents/[id].tsx
+++ b/frontend-dashboard/pages/agents/[id].tsx
@@ -13,6 +13,7 @@ import SettingsTab from "../../components/agents/SettingsTab";
 import NemoClawTab from "../../components/agents/NemoClawTab";
 import AgentFilesTab from "../../components/agents/AgentFilesTab";
 import BackupsTab from "../../components/agents/BackupsTab";
+import SchedulesTab from "../../components/agents/SchedulesTab";
 import StatusBadge from "../../components/agents/StatusBadge";
 import { useToast } from "../../components/Toast";
 import { fetchWithAuth } from "../../lib/api";
@@ -757,6 +758,8 @@ export default function AgentDetail() {
               agentContainerId={agent.container_id}
             />
           )}
+
+          {activeTab === "schedules" && <SchedulesTab agentId={id} />}
 
           {activeTab === "backups" && <BackupsTab agentId={id} />}
 

--- a/infra/helm/nora/files/db_schema.sql
+++ b/infra/helm/nora/files/db_schema.sql
@@ -562,6 +562,33 @@ CREATE TABLE IF NOT EXISTS agent_budgets (
 
 CREATE INDEX IF NOT EXISTS idx_agent_budgets_agent ON agent_budgets(agent_id);
 
+-- Control-plane scheduled agent runs (recurring cron triggers). The backend
+-- sweep claims due rows (FOR UPDATE SKIP LOCKED), computes the next fire, and
+-- enqueues each run; the worker executes the action (a prompt or a lifecycle op)
+-- and records an agent.schedule.run event. min_interval is enforced in the app
+-- so a too-frequent cron can't thrash an agent.
+CREATE TABLE IF NOT EXISTS agent_schedules (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  agent_id UUID NOT NULL REFERENCES agents(id) ON DELETE CASCADE,
+  created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+  name TEXT NOT NULL,
+  cron TEXT NOT NULL,
+  timezone TEXT NOT NULL DEFAULT 'UTC',
+  action_type TEXT NOT NULL DEFAULT 'prompt'
+    CHECK (action_type IN ('prompt', 'restart', 'stop', 'start', 'redeploy')),
+  prompt TEXT,
+  enabled BOOLEAN NOT NULL DEFAULT TRUE,
+  last_run_at TIMESTAMPTZ,
+  last_status TEXT,
+  next_run_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_schedules_due
+  ON agent_schedules(next_run_at) WHERE enabled;
+CREATE INDEX IF NOT EXISTS idx_agent_schedules_agent ON agent_schedules(agent_id);
+
 CREATE TABLE IF NOT EXISTS integration_catalog (
   id VARCHAR(50) PRIMARY KEY,
   name VARCHAR(100) NOT NULL,

--- a/workers/provisioner/worker.ts
+++ b/workers/provisioner/worker.ts
@@ -2556,7 +2556,10 @@ const HEALTH_PORT = parseInt(process.env.WORKER_HEALTH_PORT || "4001");
 const healthServer = http.createServer((req, res) => {
   if (req.url === "/health") {
     const isReady =
-      worker.isRunning() && clawhubJobsWorker.isRunning() && alertDeliveryWorker.isRunning();
+      worker.isRunning() &&
+      clawhubJobsWorker.isRunning() &&
+      alertDeliveryWorker.isRunning() &&
+      scheduleRunWorker.isRunning();
     res.writeHead(isReady ? 200 : 503, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ status: isReady ? "ok" : "not_ready", uptime: process.uptime() }));
   } else {

--- a/workers/provisioner/worker.ts
+++ b/workers/provisioner/worker.ts
@@ -2519,6 +2519,37 @@ alertDeliveryWorker.on("completed", (job) => {
   console.log(`[alert-deliveries] Job ${job.id} delivered`);
 });
 
+// ── Scheduled Agent Run Worker ───────────────────────────────────
+// The backend sweep enqueues one job per due schedule; runScheduledAction
+// (backend-api) executes the prompt/lifecycle action against the agent. It
+// throws on failure so BullMQ applies the queue's bounded retry.
+const { runScheduledAction } = require("../../backend-api/scheduleRunner");
+const SCHEDULE_RUN_CONCURRENCY = parsePositiveInteger(
+  process.env.SCHEDULE_RUN_WORKER_CONCURRENCY,
+  5,
+);
+
+const scheduleRunWorker = new Worker(
+  "agent-schedules",
+  async (job) => runScheduledAction(job.data),
+  { connection, concurrency: SCHEDULE_RUN_CONCURRENCY },
+);
+
+scheduleRunWorker.on("failed", (job, err) => {
+  if (!job) return;
+  const attemptsMade = job.attemptsMade || 0;
+  const maxAttempts = job.opts?.attempts || 2;
+  console.error(
+    `[agent-schedules] Job ${job.id} (schedule ${job.data?.scheduleId}) attempt ${attemptsMade}/${maxAttempts} failed: ${err.message}`,
+  );
+});
+
+scheduleRunWorker.on("completed", (job) => {
+  console.log(
+    `[agent-schedules] Job ${job.id} ran (${job.data?.actionType} on agent ${job.data?.agentId})`,
+  );
+});
+
 // ── Health Check Server ──────────────────────────────────────────
 const http = require("http");
 const HEALTH_PORT = parseInt(process.env.WORKER_HEALTH_PORT || "4001");


### PR DESCRIPTION
Adds Nora-native scheduling — run a prompt or a lifecycle action on an agent on a recurring **cron**, audited and budget-aware. Closes the OpenClaw scheduling gap (OpenClaw has none; Hermes keeps its own runtime cron) that every comparable control plane (Paperclip routines, Multica Autopilots, LobeHub schedules, kagent) ships. From the 2026-06-21 market research §8 #6.

## Architecture
- **Schema** `agent_schedules` — `action_type` ∈ {prompt, restart, stop, start, redeploy}; boot-migration + `db_schema.sql` + **byte-synced Helm copy** (infra validation passes).
- **`agentSchedules.ts`** — CRUD + cron validation (`cron-parser`) with a **min-interval guardrail** so a too-frequent cron can't thrash an agent/budget, + a **replica-safe sweep** (`FOR UPDATE SKIP LOCKED`, bump-before-commit, enqueue-after-commit, auto-disable invalid crons).
- **Queue + sweep** — new `agent-schedules` BullMQ queue (bounded retries); a 30s sweep in server.ts (beside the budget sweep) enqueues due runs.
- **`scheduleRunner.ts`** (backend-api, invoked by the **provisioner worker** — same cross-package pattern as alert-deliveries): executes **prompt** (OpenClaw `rpcCall` / Hermes runtime-fetch — token usage flows to **budgets + the OTel exporter**) or **lifecycle** (containerManager / redeploy); records an `agent.schedule.run` event (audit + alert rules).
- **API** `GET/POST/PUT/DELETE /agents/:id/schedules` + runs view (`scopeByMethod` + `findAccessibleAgent`) — documented in the **OpenAPI spec** (the drift test enforces it).
- **UI** — "Schedules" tab (create / pause / resume / delete + last-run status).

## Decisions (yours)
OpenClaw **+ Hermes**; **DB-sweep + BullMQ queue**; **prompt + lifecycle** actions — all implemented.

## Tests / validation
`agentSchedules.test.ts` (validation, min-interval, sweep claim/enqueue/auto-disable) + `scheduleRunner.test.ts` (action dispatch, failure→retry, agent_missing). **Full backend suite 1201 green**; typecheck/eslint/prettier clean across backend + worker + frontend; infra validation + schema byte-sync pass.

## Coverage note
Route handlers are thin wrappers over `findAccessibleAgent` (tested across the codebase) + the now-unit-tested `agentSchedules`, so I did not add a brittle server-boot route test (would need hand-crafted `findAccessibleAgent` mockDb responses). Flagging for review.

## Follow-ups (not blockers)
- `redeploy` action enqueues a deploy job with the agent row — verify the redeploy path is happy with that payload shape under a real deploy.
- Local-docker NemoClaw runtime-port allocation asymmetry (pre-existing, latent) is unrelated.