### PR TITLE
feat(security): SSH host-key pinning for BYOC remote backends

### DIFF
--- a/backend-api/__tests__/remoteDocker.test.ts
+++ b/backend-api/__tests__/remoteDocker.test.ts
@@ -44,6 +44,25 @@ describe("buildRemoteDockerOptions", () => {
     expect(opts.sshOptions.privateKey).toBeUndefined();
   });
 
+  describe("hostVerifier (host-key pinning)", () => {
+    it("accepts any key when no pin exists yet (trust-on-first-use)", () => {
+      const opts = buildRemoteDockerOptions(keyProfile({ sshHostKey: null }));
+      expect(opts.sshOptions.hostVerifier(Buffer.from("anything"))).toBe(true);
+    });
+
+    it("accepts a matching pinned key", () => {
+      const pin = Buffer.from("GOOD-KEY").toString("base64");
+      const opts = buildRemoteDockerOptions(keyProfile({ sshHostKey: pin }));
+      expect(opts.sshOptions.hostVerifier(Buffer.from("GOOD-KEY"))).toBe(true);
+    });
+
+    it("rejects a key that differs from the pin (MITM)", () => {
+      const pin = Buffer.from("GOOD-KEY").toString("base64");
+      const opts = buildRemoteDockerOptions(keyProfile({ sshHostKey: pin }));
+      expect(opts.sshOptions.hostVerifier(Buffer.from("EVIL-KEY"))).toBe(false);
+    });
+  });
+
   it("defaults the SSH port to 22 when unset", () => {
     expect(buildRemoteDockerOptions(keyProfile({ sshPort: null })).port).toBe(22);
   });

--- a/backend-api/__tests__/remoteHosts.test.ts
+++ b/backend-api/__tests__/remoteHosts.test.ts
@@ -23,9 +23,17 @@ class FakeStream extends EventEmitter {
 }
 
 class FakeSshClient extends EventEmitter {
-  connect() {
+  connect(config) {
     const scenario = sshScenario || { type: "connect-error", message: "no scenario configured" };
     process.nextTick(() => {
+      // Mimic ssh2: run hostVerifier with the presented key; reject on false.
+      if (config && typeof config.hostVerifier === "function" && scenario.hostKey !== undefined) {
+        const accepted = config.hostVerifier(Buffer.from(scenario.hostKey));
+        if (!accepted) {
+          this.emit("error", new Error("host key verification failed"));
+          return;
+        }
+      }
       if (scenario.type === "connect-error") {
         this.emit("error", new Error(scenario.message || "connection refused"));
         return;
@@ -238,6 +246,34 @@ describe("testRemoteHost", () => {
 
     expect(mockDb.query.mock.calls[1][1][1]).toBe("failed");
     expect(mockDb.query.mock.calls[1][1][2]).toMatch(/private key/i);
+  });
+
+  it("pins the SSH host key on first successful test (trust-on-first-use)", async () => {
+    sshScenario = { type: "ready", stdout: "24.0.7\n", code: 0, hostKey: "HOSTKEY-BYTES" };
+    mockDb.query.mockResolvedValueOnce({ rows: [remoteHostRow({ ssh_host_key: null })] }); // getHostRow
+    mockDb.query.mockResolvedValueOnce({ rows: [remoteHostRow()] }); // UPDATE
+
+    await remoteHosts.testRemoteHost("my-laptop");
+
+    const update = mockDb.query.mock.calls[1];
+    expect(update[1][1]).toBe("ok");
+    // 4th param is the captured host key (base64) persisted via COALESCE.
+    expect(update[1][3]).toBe(Buffer.from("HOSTKEY-BYTES").toString("base64"));
+  });
+
+  it("fails the test when the host key no longer matches the pin (MITM guard)", async () => {
+    const pinned = Buffer.from("ORIGINAL-KEY").toString("base64");
+    sshScenario = { type: "ready", stdout: "24.0.7\n", code: 0, hostKey: "ATTACKER-KEY" };
+    mockDb.query.mockResolvedValueOnce({ rows: [remoteHostRow({ ssh_host_key: pinned })] }); // getHostRow
+    mockDb.query.mockResolvedValueOnce({ rows: [remoteHostRow({ last_test_status: "failed" })] }); // UPDATE
+
+    await remoteHosts.testRemoteHost("my-laptop");
+
+    const update = mockDb.query.mock.calls[1];
+    expect(update[1][1]).toBe("failed");
+    expect(update[1][2]).toMatch(/host key does not match|man-in-the-middle/i);
+    // The pin is NOT overwritten on mismatch.
+    expect(update[1][3]).toBeNull();
   });
 });
 

--- a/backend-api/__tests__/remoteHosts.test.ts
+++ b/backend-api/__tests__/remoteHosts.test.ts
@@ -166,6 +166,9 @@ describe("updateRemoteHost", () => {
     const update = mockDb.query.mock.calls[1];
     expect(update[0]).toMatch(/UPDATE remote_hosts/);
     expect(update[1][14]).toBe(true); // resetTest flag → wipes last_test_*
+    // The host-key pin is also cleared on a connection-input change so the next
+    // test re-pins the (now different) host instead of failing as a false MITM.
+    expect(update[0]).toMatch(/ssh_host_key = CASE WHEN \$15 THEN NULL ELSE ssh_host_key END/);
   });
 
   it("keeps the prior test result when only the label changes", async () => {

--- a/backend-api/db_schema.sql
+++ b/backend-api/db_schema.sql
@@ -99,6 +99,9 @@ CREATE TABLE IF NOT EXISTS remote_hosts (
   ssh_passphrase_encrypted TEXT,
   gateway_host TEXT NOT NULL DEFAULT '',
   docker_host TEXT NOT NULL DEFAULT '',
+  -- Pinned SSH host public key (base64), captured trust-on-first-use during the
+  -- connection test and verified on every subsequent connect (MITM protection).
+  ssh_host_key TEXT,
   last_test_status TEXT,
   last_test_message TEXT,
   last_tested_at TIMESTAMPTZ,

--- a/backend-api/remoteHosts.ts
+++ b/backend-api/remoteHosts.ts
@@ -161,6 +161,7 @@ function rowToProfile(row, { includeSecret = false } = {}) {
     sshPassphrase,
     gatewayHost: normalizeText(row.gateway_host) || sshHost,
     dockerHost: normalizeText(row.docker_host),
+    sshHostKey: normalizeText(row.ssh_host_key),
     configured,
     connected: testedOk,
     available: row.enabled !== false && configured && testedOk,
@@ -437,7 +438,7 @@ async function deleteRemoteHost(hostId) {
   return maskHost(result.rows[0]);
 }
 
-function buildSshConnectConfig(profile, timeoutMs) {
+function buildSshConnectConfig(profile, timeoutMs, { onHostKey } = {}) {
   const config = {
     host: profile.sshHost,
     port: profile.sshPort || DEFAULT_SSH_PORT,
@@ -450,6 +451,21 @@ function buildSshConnectConfig(profile, timeoutMs) {
     config.privateKey = profile.sshPrivateKey || "";
     if (profile.sshPassphrase) config.passphrase = profile.sshPassphrase;
   }
+  // Host-key pinning: capture the presented key (base64) for the caller, and —
+  // when a key is already pinned — reject a mismatch (MITM / changed host).
+  const expected = normalizeText(profile.sshHostKey);
+  config.hostVerifier = (key) => {
+    const presented = Buffer.isBuffer(key) ? key.toString("base64") : String(key || "");
+    if (typeof onHostKey === "function") {
+      try {
+        onHostKey(presented);
+      } catch {
+        /* capture is best-effort */
+      }
+    }
+    if (expected) return presented === expected;
+    return true; // trust-on-first-use: no pin yet
+  };
   return config;
 }
 
@@ -460,6 +476,14 @@ function runRemoteDockerProbe(profile, { timeoutMs = DEFAULT_TEST_TIMEOUT_MS } =
     const Client = getSshClientCtor();
     const conn = new Client();
     let settled = false;
+    // Capture the presented host key (base64) and detect a mismatch vs the pin.
+    const expectedHostKey = normalizeText(profile.sshHostKey);
+    let capturedHostKey = null;
+    let hostKeyMismatch = false;
+    const onHostKey = (presented) => {
+      capturedHostKey = presented;
+      if (expectedHostKey && presented !== expectedHostKey) hostKeyMismatch = true;
+    };
     const finish = (result) => {
       if (settled) return;
       settled = true;
@@ -486,6 +510,7 @@ function runRemoteDockerProbe(profile, { timeoutMs = DEFAULT_TEST_TIMEOUT_MS } =
               finish({
                 ok: true,
                 message: `Docker ${version} is reachable over SSH at ${sshTargetLabel(profile)}.`,
+                hostKey: capturedHostKey,
               });
             } else {
               finish({
@@ -506,11 +531,21 @@ function runRemoteDockerProbe(profile, { timeoutMs = DEFAULT_TEST_TIMEOUT_MS } =
     });
 
     conn.on("error", (err) => {
+      if (hostKeyMismatch) {
+        finish({
+          ok: false,
+          hostKeyMismatch: true,
+          message:
+            "Remote host key does not match the pinned key — connection refused (possible " +
+            "man-in-the-middle, or the host was rebuilt). Delete and re-register the host if this is expected.",
+        });
+        return;
+      }
       finish({ ok: false, message: err?.message || "SSH connection failed." });
     });
 
     try {
-      conn.connect(buildSshConnectConfig(profile, timeoutMs));
+      conn.connect(buildSshConnectConfig(profile, timeoutMs, { onHostKey }));
     } catch (err) {
       finish({ ok: false, message: err?.message || "SSH connection could not be started." });
     }
@@ -526,6 +561,7 @@ async function testRemoteHost(hostId, options = {}) {
   }
   let status = "ok";
   let message = "Docker is reachable over SSH.";
+  let pinHostKey = null;
   if (!profile.configured) {
     status = "failed";
     message = profile.issue || "Remote host is not configured.";
@@ -533,16 +569,23 @@ async function testRemoteHost(hostId, options = {}) {
     const probe = await runRemoteDockerProbe(profile, options);
     status = probe.ok ? "ok" : "failed";
     message = probe.message;
+    // Trust-on-first-use: pin the host key on the first successful test. Once
+    // pinned it's never overwritten here — a changed key fails the probe above
+    // (hostKeyMismatch), so re-pinning requires an explicit re-register.
+    if (probe.ok && probe.hostKey && !normalizeText(profile.sshHostKey)) {
+      pinHostKey = probe.hostKey;
+    }
   }
   const result = await db.query(
     `UPDATE remote_hosts
         SET last_test_status = $2,
             last_test_message = $3,
+            ssh_host_key = COALESCE(ssh_host_key, $4),
             last_tested_at = NOW(),
             updated_at = NOW()
       WHERE id = $1
       RETURNING *`,
-    [profile.id, status, message],
+    [profile.id, status, message, pinHostKey],
   );
   return maskHost(result.rows[0]);
 }

--- a/backend-api/remoteHosts.ts
+++ b/backend-api/remoteHosts.ts
@@ -392,6 +392,11 @@ async function updateRemoteHost(hostId, input = {}) {
             last_test_status = CASE WHEN $15 THEN NULL ELSE last_test_status END,
             last_test_message = CASE WHEN $15 THEN NULL ELSE last_test_message END,
             last_tested_at = CASE WHEN $15 THEN NULL ELSE last_tested_at END,
+            -- Clear the host-key pin too when connection inputs change, so the
+            -- next test re-pins (trust-on-first-use) the now-different host. A
+            -- key change WITHOUT a connection-input change keeps the pin, so a
+            -- silent MITM on the same target still fails closed.
+            ssh_host_key = CASE WHEN $15 THEN NULL ELSE ssh_host_key END,
             updated_at = NOW()
       WHERE id = $1
       RETURNING *`,

--- a/backend-api/server.ts
+++ b/backend-api/server.ts
@@ -1376,6 +1376,10 @@ async function migrateDB() {
      )`,
     `CREATE INDEX IF NOT EXISTS idx_remote_hosts_owner
        ON remote_hosts(owner_user_id, enabled, is_default, label)`,
+    `DO $$ BEGIN
+       ALTER TABLE remote_hosts ADD COLUMN ssh_host_key TEXT;
+     EXCEPTION WHEN duplicate_column THEN NULL;
+     END $$`,
     `CREATE TABLE IF NOT EXISTS gateway_port_allocations (
        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
        host_key TEXT NOT NULL,

--- a/docs/concepts/security.mdx
+++ b/docs/concepts/security.mdx
@@ -31,6 +31,7 @@ Nora is built to be trustworthy in real operator environments: you run it on you
 - **The gateway proxy is the only path to a runtime's API**, and it restricts which upstream addresses can be proxied to an allowlist of ranges.
 - **Live exec, log, and metrics WebSocket streams enforce access control** — runtime terminal and log streaming are authenticated, not open sockets.
 - **Proxied agent assets are token-validated** before they are served.
+- **BYOC remote hosts pin their SSH host key.** The first successful connection test records the remote host's SSH public key (trust-on-first-use); every later connection — connection tests and deploys alike — rejects a host presenting a different key, so a changed/spoofed host (man-in-the-middle) fails closed rather than silently connecting.
 
 ## Runtime isolation
 

--- a/infra/helm/nora/files/db_schema.sql
+++ b/infra/helm/nora/files/db_schema.sql
@@ -99,6 +99,9 @@ CREATE TABLE IF NOT EXISTS remote_hosts (
   ssh_passphrase_encrypted TEXT,
   gateway_host TEXT NOT NULL DEFAULT '',
   docker_host TEXT NOT NULL DEFAULT '',
+  -- Pinned SSH host public key (base64), captured trust-on-first-use during the
+  -- connection test and verified on every subsequent connect (MITM protection).
+  ssh_host_key TEXT,
   last_test_status TEXT,
   last_test_message TEXT,
   last_tested_at TIMESTAMPTZ,

--- a/workers/provisioner/backends/remote-docker.ts
+++ b/workers/provisioner/backends/remote-docker.ts
@@ -32,6 +32,16 @@ function buildRemoteDockerOptions(profile = {}) {
     if (profile.sshPrivateKey) sshOptions.privateKey = Buffer.from(profile.sshPrivateKey);
     if (profile.sshPassphrase) sshOptions.passphrase = profile.sshPassphrase;
   }
+  // Host-key pinning (MITM protection): the connection test pins the host key
+  // (TOFU). When a pin exists, reject any connection presenting a different key.
+  // Without a pin (host registered before pinning, or test never run) we accept
+  // trust-on-first-use so existing deployments don't break.
+  const expectedHostKey = typeof profile.sshHostKey === "string" ? profile.sshHostKey.trim() : "";
+  sshOptions.hostVerifier = (key) => {
+    if (!expectedHostKey) return true;
+    const presented = Buffer.isBuffer(key) ? key.toString("base64") : String(key || "");
+    return presented === expectedHostKey;
+  };
   return {
     protocol: "ssh",
     host: profile.sshHost,


### PR DESCRIPTION
Closes task #22 (pre-existing hardening surfaced in the NemoClaw review). The dockerode-over-SSH transport for BYOC remote hosts connected **without verifying the host's SSH key** — a spoofed or rebuilt host could be trusted silently (MITM). This adds trust-on-first-use host-key pinning with enforcement on every connect.

## How it works
- **Schema**: `remote_hosts.ssh_host_key` (boot-migration + `db_schema.sql` + byte-synced Helm copy).
- **TOFU capture**: the connection test (`runRemoteDockerProbe`) reads the presented host key via an ssh2 `hostVerifier` and pins it on the first successful test (`COALESCE` — never silently overwritten).
- **Enforcement everywhere**: both the test path (`buildSshConnectConfig`) and the deploy path (`buildRemoteDockerOptions`, inherited by remote-docker / remote-hermes / remote-nemoclaw) reject any connection whose host key differs from the pin. A mismatch surfaces a clear *"host key does not match … possible man-in-the-middle"* test failure.
- **Backward-compatible**: a host with no pin yet (registered before this, or never tested) is TOFU-accepted, so existing deployments don't break; the pin establishes on the next successful test.
- The profile now carries `sshHostKey` (`rowToProfile`) so the worker backends enforce it.

## Tests
`remoteHosts.test.ts`: TOFU pin on first success + mismatch fails the test (pin not overwritten). `remoteDocker.test.ts`: `hostVerifier` accepts no-pin (TOFU) and matching key, rejects a differing key. **Backend suite 1208 green**; typecheck/eslint/prettier + infra validation + schema byte-sync pass.

## Note
Operator UX for an intentional host rebuild = delete + re-register the host (re-pins on the next test). A future enhancement could add an explicit "re-pin" action, but delete/re-register is sufficient and safe for now.