### PR TITLE
Fix gateway port allocation SQL cast

### DIFF
--- a/backend-api/__tests__/portAllocations.test.ts
+++ b/backend-api/__tests__/portAllocations.test.ts
@@ -49,9 +49,11 @@ describe("allocateGatewayPort", () => {
   });
 
   it("claims the lowest free port for a fresh agent", async () => {
-    fakeDb({ existing: [], insertResponses: [{ rows: [{ port: 19000 }] }] });
+    const { calls } = fakeDb({ existing: [], insertResponses: [{ rows: [{ port: 19000 }] }] });
     const port = await allocateGatewayPort({ hostKey: "remote:my-vps", agentId: "a2" });
     expect(port).toBe(19000);
+    const insert = calls.find((c) => c.sql.includes("INSERT INTO gateway_port_allocations"));
+    expect(insert.sql).toContain("generate_series($3::integer, $4::integer)");
   });
 
   it("retries on a UNIQUE-violation race and succeeds", async () => {

--- a/backend-api/portAllocations.ts
+++ b/backend-api/portAllocations.ts
@@ -86,7 +86,7 @@ async function allocateGatewayPort({
       const result = await db.query(
         `INSERT INTO gateway_port_allocations (host_key, agent_id, port, purpose)
          SELECT $1, $2, candidate.port, $5
-           FROM generate_series($3, $4) AS candidate(port)
+           FROM generate_series($3::integer, $4::integer) AS candidate(port)
           WHERE NOT EXISTS (
             SELECT 1 FROM gateway_port_allocations existing
              WHERE existing.host_key = $1 AND existing.port = candidate.port


### PR DESCRIPTION
## Summary
- cast gateway port range placeholders before calling Postgres generate_series
- add a regression assertion for the allocation SQL shape

## Why
Echo deploys were failing during port reservation with `function generate_series(unknown, unknown) is not unique`. The allocator used bind params directly in `generate_series(, )`, which can leave Postgres unable to choose the integer overload.

## Validation
- `npm test -- --runInBand __tests__/portAllocations.test.ts`
- `npx prettier --check portAllocations.ts __tests__/portAllocations.test.ts`
- `git diff --check`
- `/root/.codex/skills/nora-ci-checks/scripts/run-nora-ci-checks.sh --repo /home/projects/nora`

Local full CI passed. CodeQL must be verified on GitHub after push.