### PR TITLE
Fix OpenClaw SQLite auth sync

### DIFF
--- a/agent-runtime/lib/runtimeBootstrap.ts
+++ b/agent-runtime/lib/runtimeBootstrap.ts
@@ -53,6 +53,7 @@ const INTEGRATION_TOOL_WRAPPER_B64 = Buffer.from(INTEGRATION_TOOL_WRAPPER_SOURCE
 
 const OPENCLAW_WORKSPACE_ROOT = "/root/.openclaw/workspace";
 const OPENCLAW_LEGACY_AGENT_TEMPLATE_ROOT = "/root/.openclaw/agents/main/agent";
+const OPENCLAW_AUTH_PROFILES_PATH = `${OPENCLAW_LEGACY_AGENT_TEMPLATE_ROOT}/auth-profiles.json`;
 const NORA_INTEGRATIONS_CONTEXT_FILE = "integrations/NORA_INTEGRATIONS.md";
 const NORA_INTEGRATIONS_PROMPT_BEGIN = "<!-- NORA_INTEGRATIONS_BEGIN -->";
 const NORA_INTEGRATIONS_PROMPT_END = "<!-- NORA_INTEGRATIONS_END -->";
@@ -500,6 +501,84 @@ function mapNoraProviderIdToOpenClaw(noraProviderId) {
   return NORA_TO_OPENCLAW_PROVIDER_ID[noraProviderId] || noraProviderId;
 }
 
+const OPENCLAW_SQLITE_AUTH_SKIP_PROVIDERS = Object.freeze([
+  "microsoft-foundry",
+  FOUNDRY_OPENCLAW_PROVIDER_ID,
+  "demo",
+  DEMO_OPENCLAW_PROVIDER_ID,
+]);
+
+function buildOpenClawAuthImportFromFileCommand(options = {}) {
+  const authPath = options.authPath || OPENCLAW_AUTH_PROFILES_PATH;
+  const agentId = options.agentId || "main";
+  const requireCli = options.requireCli === true;
+
+  return [
+    'OPENCLAW_BIN="${OPENCLAW_CLI_PATH:-/usr/local/bin/openclaw}"',
+    'if [ ! -x "$OPENCLAW_BIN" ]; then OPENCLAW_BIN="$(command -v openclaw 2>/dev/null || true)"; fi',
+    requireCli
+      ? '[ -n "$OPENCLAW_BIN" ] && [ -x "$OPENCLAW_BIN" ] || exit 127'
+      : 'if [ -n "$OPENCLAW_BIN" ] && [ -x "$OPENCLAW_BIN" ]; then',
+    "export HOME=/root",
+    "export OPENCLAW_BIN",
+    "node <<'__NORA_OPENCLAW_AUTH_SQLITE_IMPORT__'",
+    "const fs = require('fs');",
+    "const { spawnSync } = require('child_process');",
+    `const authPath = ${JSON.stringify(authPath)};`,
+    `const agentId = ${JSON.stringify(agentId)};`,
+    `const skipProviders = new Set(${JSON.stringify(OPENCLAW_SQLITE_AUTH_SKIP_PROVIDERS)});`,
+    "let auth = {};",
+    "try { auth = JSON.parse(fs.readFileSync(authPath, 'utf8')); } catch { process.exit(0); }",
+    "const profiles = auth && auth.profiles && typeof auth.profiles === 'object' ? auth.profiles : {};",
+    "for (const [profileId, profile] of Object.entries(profiles)) {",
+    "  if (!profile || profile.type !== 'api_key' || !profile.key) continue;",
+    "  const provider = String(profile.provider || '').trim();",
+    "  if (!provider || skipProviders.has(provider)) continue;",
+    "  const result = spawnSync(process.env.OPENCLAW_BIN, [",
+    "    'models',",
+    "    'auth',",
+    "    '--agent',",
+    "    agentId,",
+    "    'paste-api-key',",
+    "    '--provider',",
+    "    provider,",
+    "    '--profile-id',",
+    "    String(profileId),",
+    "  ], {",
+    "    input: `${String(profile.key)}\\n`,",
+    "    encoding: 'utf8',",
+    "    stdio: ['pipe', 'pipe', 'pipe'],",
+    "    env: process.env,",
+    "  });",
+    "  if (result.status !== 0) {",
+    "    if (result.stderr) process.stderr.write(result.stderr);",
+    "    if (result.stdout) process.stderr.write(result.stdout);",
+    "    process.exit(result.status || 1);",
+    "  }",
+    "}",
+    "__NORA_OPENCLAW_AUTH_SQLITE_IMPORT__",
+    requireCli ? "" : "fi",
+  ]
+    .filter((line) => line !== "")
+    .join("\n");
+}
+
+function buildOpenClawAuthProfilesWriteCommand(authProfiles, options = {}) {
+  const authPath = options.authPath || OPENCLAW_AUTH_PROFILES_PATH;
+  const authDir = authPath.slice(0, authPath.lastIndexOf("/")) || ".";
+  const authJsonB64 = Buffer.from(
+    JSON.stringify(authProfiles || { version: 1, profiles: {} }),
+  ).toString("base64");
+
+  return [
+    "set -eu",
+    `mkdir -p ${shellSingleQuote(authDir)}`,
+    `printf '%s' '${authJsonB64}' | base64 -d > ${shellSingleQuote(authPath)}`,
+    `chmod 0600 ${shellSingleQuote(authPath)}`,
+    buildOpenClawAuthImportFromFileCommand({ ...options, authPath }),
+  ].join("\n");
+}
+
 function buildOpenClawConfigMergeScript(gatewayConfig) {
   return [
     "cat <<'__NORA_MANAGED_OPENCLAW_CONFIG__' > /tmp/nora-managed-openclaw.json",
@@ -666,6 +745,8 @@ module.exports = {
   buildIntegrationToolWrapperScript,
   buildOpenClawConfigMergeScript,
   buildOpenClawConfigMergeCommand,
+  buildOpenClawAuthImportFromFileCommand,
+  buildOpenClawAuthProfilesWriteCommand,
   buildMcpServersConfig,
   buildOpenClawCustomProviders,
   mapNoraProviderIdToOpenClaw,

--- a/backend-api/__tests__/authSync.test.ts
+++ b/backend-api/__tests__/authSync.test.ts
@@ -148,6 +148,10 @@ describe("auth sync", () => {
       }),
     );
     expect(JSON.parse(global.fetch.mock.calls[0][1].body).command).toContain("auth-profiles.json");
+    expect(JSON.parse(global.fetch.mock.calls[0][1].body).command).toContain("paste-api-key");
+    expect(JSON.parse(global.fetch.mock.calls[0][1].body).command).toContain(
+      "__NORA_OPENCLAW_AUTH_SQLITE_IMPORT__",
+    );
     expect(mockRestart).toHaveBeenCalledWith(
       expect.objectContaining({
         id: "agent-k8s-1",

--- a/backend-api/__tests__/dockerBootstrap.test.ts
+++ b/backend-api/__tests__/dockerBootstrap.test.ts
@@ -1,7 +1,9 @@
 // @ts-nocheck
 const fs = require("fs");
+const os = require("os");
 const path = require("path");
 const {
+  buildOpenClawAuthProfilesWriteCommand,
   buildOpenClawConfigMergeScript,
   buildOpenClawConfigMergeCommand,
   buildMcpServersConfig,
@@ -78,6 +80,54 @@ describe("OpenClaw bootstrap helpers", () => {
     expect(cmd).toContain("hash -r 2>/dev/null || true");
     expect(cmd).toContain('export OPENCLAW_CLI_PATH="$OPENCLAW_BIN"');
     expect(cmd).toContain('export OPENCLAW_TSX_BIN="$OPENCLAW_TSX_BIN"');
+  });
+
+  it("imports API-key auth profiles into OpenClaw's per-agent store", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nora-openclaw-auth-"));
+    try {
+      const fakeOpenClaw = path.join(tmpDir, "openclaw");
+      const argsLog = path.join(tmpDir, "args.log");
+      const stdinLog = path.join(tmpDir, "stdin.log");
+      fs.writeFileSync(
+        fakeOpenClaw,
+        '#!/bin/sh\nprintf \'%s\\n\' "$*" >> "$OPENCLAW_ARGS_LOG"\ncat >> "$OPENCLAW_STDIN_LOG"\n',
+        { mode: 0o755 },
+      );
+
+      const command = buildOpenClawAuthProfilesWriteCommand(
+        {
+          version: 1,
+          profiles: {
+            "openai:default": { type: "api_key", provider: "openai", key: "sk-openai" },
+            "microsoft-foundry:default": {
+              type: "api_key",
+              provider: "microsoft-foundry",
+              key: "ms-key",
+            },
+          },
+        },
+        { authPath: path.join(tmpDir, "auth-profiles.json") },
+      );
+      const result = require("child_process").spawnSync("/bin/sh", ["-c", command], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          OPENCLAW_CLI_PATH: fakeOpenClaw,
+          OPENCLAW_ARGS_LOG: argsLog,
+          OPENCLAW_STDIN_LOG: stdinLog,
+        },
+      });
+
+      expect(result.status).toBe(0);
+      expect(fs.readFileSync(argsLog, "utf8")).toContain(
+        "models auth --agent main paste-api-key --provider openai --profile-id openai:default",
+      );
+      expect(fs.readFileSync(argsLog, "utf8")).not.toContain("microsoft-foundry");
+      expect(fs.readFileSync(stdinLog, "utf8")).toBe("sk-openai\n");
+      expect(fs.existsSync(path.join(tmpDir, "auth-profiles.json"))).toBe(true);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 
   it("disables Bonjour in managed runtime environments by default", () => {
@@ -320,6 +370,8 @@ describe("Provisioner backends", () => {
       "mkdir -p /var/log /root/.openclaw/workspace /root/.openclaw/agents/main/agent",
     );
     expect(startupScript.content).toContain("__NORA_MERGE_OPENCLAW_CONFIG__");
+    expect(startupScript.content).toContain("__NORA_OPENCLAW_AUTH_SQLITE_IMPORT__");
+    expect(startupScript.content).toContain("paste-api-key");
     expect(startupScript.content).toContain(
       '"$OPENCLAW_TSX_BIN" /opt/openclaw-runtime/lib/agent.ts >> /var/log/openclaw-agent.log 2>&1 &',
     );

--- a/backend-api/__tests__/provisioning.test.ts
+++ b/backend-api/__tests__/provisioning.test.ts
@@ -317,6 +317,8 @@ describe("provisioning runtime/gateway contracts", () => {
     const container = deployment.spec.template.spec.containers[0];
 
     expect(configMap.data["bootstrap.sh"]).toContain("openclaw@latest");
+    expect(configMap.data["bootstrap.sh"]).toContain("__NORA_OPENCLAW_AUTH_SQLITE_IMPORT__");
+    expect(configMap.data["bootstrap.sh"]).toContain("paste-api-key");
     expect(container.command).toEqual(["/bin/sh", "-c"]);
     expect(container.args).toEqual([". /opt/nora-bootstrap/bootstrap.sh"]);
     expect(container.volumeMounts).toEqual(

--- a/backend-api/authSync.ts
+++ b/backend-api/authSync.ts
@@ -1,7 +1,8 @@
 // @ts-nocheck
-// Syncs auth-profiles.json to running agents via the runtime sidecar.
-// After writing, restarts the backend so the OpenClaw gateway process
-// re-reads the file on startup (it does not hot-reload from disk).
+// Syncs OpenClaw auth to running agents via the runtime sidecar.
+// Writes the legacy auth-profiles.json file, imports API-key profiles into
+// OpenClaw's per-agent SQLite auth store, then restarts the backend so the
+// gateway process re-reads auth on startup (it does not hot-reload from disk).
 // Called whenever LLM provider keys or LLM-relevant integrations change.
 
 const db = require("./db");
@@ -13,6 +14,7 @@ const { waitForAgentReadiness } = require("./healthChecks");
 const { resolveAgentRuntimeFamily } = require("./agentRuntimeFields");
 const { shellSingleQuote } = require("../agent-runtime/lib/containerCommand");
 const {
+  buildOpenClawAuthProfilesWriteCommand,
   buildOpenClawConfigMergeCommand,
   buildOpenClawCustomProviders,
   mapNoraProviderIdToOpenClaw,
@@ -272,12 +274,7 @@ async function buildHermesManagedEnvForAgent(userId, agentId) {
 }
 
 function buildAuthProfilesWriteCommand(authProfiles) {
-  const authJsonB64 = Buffer.from(JSON.stringify(authProfiles)).toString("base64");
-  return (
-    `mkdir -p /root/.openclaw/agents/main/agent && ` +
-    `printf '%s' '${authJsonB64}' | base64 -d > /root/.openclaw/agents/main/agent/auth-profiles.json && ` +
-    `chmod 0600 /root/.openclaw/agents/main/agent/auth-profiles.json`
-  );
+  return buildOpenClawAuthProfilesWriteCommand(authProfiles);
 }
 
 function buildDefaultModelCommand(defaultProvider = null) {
@@ -526,7 +523,7 @@ async function restartAgentAndRefreshAddress(agent) {
 }
 
 /**
- * Sync auth-profiles.json to all running agents of a user.
+ * Sync OpenClaw auth to all running agents of a user.
  * If agentId is provided, syncs only that agent.
  *
  * Returns an array of { agentId, status, error? } results.
@@ -705,7 +702,7 @@ async function syncAuthToUserAgents(userId, agentId = null, options = {}) {
         await runRuntimeCommand(agent, modelCommand, { timeout: 60000 });
       }
 
-      console.log(`[authSync] Synced auth-profiles.json to agent ${agent.id} (backend restarted)`);
+      console.log(`[authSync] Synced OpenClaw auth to agent ${agent.id} (backend restarted)`);
       results.push({ agentId: agent.id, status: "synced" });
     } catch (e) {
       console.warn(`[authSync] Failed for agent ${agent.id}:`, e.message);

--- a/e2e/specs/platform-journey.spec.ts
+++ b/e2e/specs/platform-journey.spec.ts
@@ -329,8 +329,11 @@ test.describe("Complete platform journey", () => {
     await listingRow.getByRole("button", { name: /approve/i }).click();
     await expect(listingRow).toContainText(/published/i);
 
-    await waitForAdminAuditEvent(request, admin.token, (event) =>
-      String(event.message || "").includes(publishedListing.name),
+    const publishedAuditMessage = `Agent Hub listing "${publishedListing.name}" marked published`;
+    await waitForAdminAuditEvent(
+      request,
+      admin.token,
+      (event) => String(event.message || "") === publishedAuditMessage,
     );
 
     await page.goto("/admin/audit", { waitUntil: "domcontentloaded" });
@@ -338,11 +341,7 @@ test.describe("Complete platform journey", () => {
     await page
       .getByPlaceholder(/message, source, actor, owner, request, or error/i)
       .fill(publishedListing.name);
-    await expect(
-      page.getByText(`Agent Hub listing "${publishedListing.name}" marked published`, {
-        exact: true,
-      }),
-    ).toBeVisible();
+    await expect(page.getByText(publishedAuditMessage, { exact: true })).toBeVisible();
 
     await page.goto("/admin/settings", { waitUntil: "domcontentloaded" });
     await expect(page.getByRole("heading", { name: /^platform settings$/i })).toBeVisible();

--- a/workers/provisioner/backends/docker.ts
+++ b/workers/provisioner/backends/docker.ts
@@ -3,6 +3,7 @@ const ProvisionerBackend = require("./interface");
 const crypto = require("crypto");
 const path = require("path");
 const {
+  buildOpenClawAuthImportFromFileCommand,
   buildOpenClawInstallCommand,
   buildOpenClawConfigMergeScript,
   buildMcpServersConfig,
@@ -254,6 +255,7 @@ class DockerBackend extends ProvisionerBackend {
       "if [ ! -f /root/.openclaw/agents/main/agent/auth-profiles.json ]; then",
       '  "$OPENCLAW_TSX_BIN" /opt/openclaw-runtime/lib/build-auth.js',
       "fi",
+      buildOpenClawAuthImportFromFileCommand({ requireCli: true }),
       `exec "$OPENCLAW_BIN" gateway --port ${OPENCLAW_GATEWAY_PORT}`,
       "",
     ].join("\n");

--- a/workers/provisioner/backends/k8s.ts
+++ b/workers/provisioner/backends/k8s.ts
@@ -3,6 +3,7 @@ const k8s = require("@kubernetes/client-node");
 const crypto = require("crypto");
 const ProvisionerBackend = require("./interface");
 const {
+  buildOpenClawAuthImportFromFileCommand,
   buildOpenClawInstallCommand,
   buildRuntimeBootstrapCommand,
   buildTemplatePayloadBootstrapCommand,
@@ -380,6 +381,7 @@ function buildOpenClawRuntimeAuthBootstrapCommand() {
     "fs.mkdirSync('/root/.openclaw', { recursive: true });",
     "fs.writeFileSync(configPath, JSON.stringify(config, null, 2));",
     "__NORA_OPENCLAW_AUTH_BOOTSTRAP__",
+    buildOpenClawAuthImportFromFileCommand({ requireCli: true }),
     "",
   ].join("\n");
 }

--- a/workers/provisioner/backends/nemoclaw.ts
+++ b/workers/provisioner/backends/nemoclaw.ts
@@ -8,6 +8,7 @@ const ProvisionerBackend = require("./interface");
 const crypto = require("crypto");
 const path = require("path");
 const {
+  buildOpenClawAuthImportFromFileCommand,
   buildOpenClawInstallCommand,
   buildTemplatePayloadBootstrapCommand,
   buildRuntimeBootstrapFiles,
@@ -180,6 +181,7 @@ class NemoClawBackend extends ProvisionerBackend {
       "touch /var/log/openclaw-agent.log",
       '"$OPENCLAW_TSX_BIN" /opt/openclaw-runtime/lib/agent.ts >> /var/log/openclaw-agent.log 2>&1 &',
       '"$OPENCLAW_TSX_BIN" /opt/openclaw-runtime/lib/build-auth.js',
+      buildOpenClawAuthImportFromFileCommand({ requireCli: true }),
       `exec "$OPENCLAW_BIN" gateway --port ${OPENCLAW_GATEWAY_PORT} --password ${gatewayToken}`,
       "",
     ].join("\n");

--- a/workers/provisioner/backends/proxmox.ts
+++ b/workers/provisioner/backends/proxmox.ts
@@ -7,6 +7,7 @@ const { PassThrough } = require("stream");
 const { URL } = require("url");
 const ProvisionerBackend = require("./interface");
 const {
+  buildOpenClawAuthImportFromFileCommand,
   buildOpenClawInstallCommand,
   buildOpenClawConfigMergeScript,
   buildOpenClawCustomProviders,
@@ -527,6 +528,7 @@ class ProxmoxBackend extends ProvisionerBackend {
       "touch /var/log/openclaw-agent.log",
       '"$OPENCLAW_TSX_BIN" /opt/openclaw-runtime/lib/agent.ts >> /var/log/openclaw-agent.log 2>&1 &',
       'if [ ! -f /root/.openclaw/agents/main/agent/auth-profiles.json ]; then "$OPENCLAW_TSX_BIN" /opt/openclaw-runtime/lib/build-auth.js; fi',
+      buildOpenClawAuthImportFromFileCommand({ requireCli: true }),
       `exec "$OPENCLAW_CLI_PATH" gateway --port ${OPENCLAW_GATEWAY_PORT}`,
       "",
     ].join("\n");

--- a/workers/provisioner/worker.ts
+++ b/workers/provisioner/worker.ts
@@ -47,6 +47,7 @@ const {
   NORA_SYNC_INTEGRATIONS_DIR,
 } = require("../../agent-runtime/lib/integrationTools");
 const {
+  buildOpenClawAuthProfilesWriteCommand,
   buildOpenClawConfigMergeCommand,
   buildOpenClawCustomProviders,
   mapNoraProviderIdToOpenClaw,
@@ -279,12 +280,7 @@ function buildAuthProfiles(providerKeys = {}) {
 }
 
 function buildAuthProfilesWriteCommand(authProfiles) {
-  const authJsonB64 = Buffer.from(JSON.stringify(authProfiles)).toString("base64");
-  return (
-    `mkdir -p /root/.openclaw/agents/main/agent && ` +
-    `printf '%s' '${authJsonB64}' | base64 -d > /root/.openclaw/agents/main/agent/auth-profiles.json && ` +
-    `chmod 0600 /root/.openclaw/agents/main/agent/auth-profiles.json`
-  );
+  return buildOpenClawAuthProfilesWriteCommand(authProfiles);
 }
 
 function buildDefaultModelCommand(defaultProvider = null) {


### PR DESCRIPTION
## Summary
- write OpenClaw auth profiles to the legacy JSON file and import API-key profiles into the per-agent SQLite auth store
- wire the import into live auth sync plus Docker, Kubernetes, NemoClaw, and Proxmox startup paths
- tighten the Agent Hub audit E2E wait to avoid matching the earlier shared event before the published event exists

## Tests
- npm test -- --runInBand __tests__/authSync.test.ts __tests__/dockerBootstrap.test.ts __tests__/provisioning.test.ts
- /root/.codex/skills/nora-ci-checks/scripts/run-nora-ci-checks.sh --repo /home/projects/nora --no-install

Note: local pre-push passes; GitHub CodeQL still needs verification after push.