### PR TITLE
Normalize Foundry OpenClaw model prefixes

### DIFF
--- a/agent-runtime/lib/runtimeBootstrap.ts
+++ b/agent-runtime/lib/runtimeBootstrap.ts
@@ -352,12 +352,21 @@ const FOUNDRY_DEFAULT_MODELS = [
 // saved provider's model/config). Fall back to the canonical "gpt-5.5" when
 // unset so existing single-deployment setups keep working.
 const FOUNDRY_FALLBACK_DEPLOYMENT = "gpt-5.5";
+const FOUNDRY_MODEL_PROVIDER_PREFIXES = Object.freeze([
+  FOUNDRY_OPENCLAW_PROVIDER_ID,
+  "microsoft-foundry",
+  "openai",
+  "openai-responses",
+]);
 
 function normalizeFoundryDeployment(value) {
   let deployment = String(value || "").trim();
-  const providerPrefix = `${FOUNDRY_OPENCLAW_PROVIDER_ID}/`;
-  if (deployment.startsWith(providerPrefix)) {
-    deployment = deployment.slice(providerPrefix.length).trim();
+  for (const providerId of FOUNDRY_MODEL_PROVIDER_PREFIXES) {
+    const providerPrefix = `${providerId}/`;
+    if (deployment.startsWith(providerPrefix)) {
+      deployment = deployment.slice(providerPrefix.length).trim();
+      break;
+    }
   }
   return deployment && !deployment.includes("/") ? deployment : "";
 }
@@ -499,6 +508,20 @@ const NORA_TO_OPENCLAW_PROVIDER_ID = Object.freeze({
 function mapNoraProviderIdToOpenClaw(noraProviderId) {
   if (!noraProviderId) return noraProviderId;
   return NORA_TO_OPENCLAW_PROVIDER_ID[noraProviderId] || noraProviderId;
+}
+
+function buildOpenClawModelForProvider(noraProviderId, modelId) {
+  const providerId = String(noraProviderId || "").trim();
+  const rawModelId = String(modelId || "").trim();
+  if (!providerId || !rawModelId) return null;
+
+  if (providerId === "microsoft-foundry") {
+    const deployment = normalizeFoundryDeployment(rawModelId);
+    return deployment ? `${FOUNDRY_OPENCLAW_PROVIDER_ID}/${deployment}` : null;
+  }
+
+  const openclawProvider = mapNoraProviderIdToOpenClaw(providerId);
+  return rawModelId.includes("/") ? rawModelId : `${openclawProvider}/${rawModelId}`;
 }
 
 const OPENCLAW_SQLITE_AUTH_SKIP_PROVIDERS = Object.freeze([
@@ -750,6 +773,7 @@ module.exports = {
   buildMcpServersConfig,
   buildOpenClawCustomProviders,
   mapNoraProviderIdToOpenClaw,
+  buildOpenClawModelForProvider,
   FOUNDRY_OPENCLAW_PROVIDER_ID,
   DEMO_OPENCLAW_PROVIDER_ID,
   DEMO_OPENCLAW_MODEL_ID,

--- a/backend-api/__tests__/authSync.test.ts
+++ b/backend-api/__tests__/authSync.test.ts
@@ -35,6 +35,7 @@ jest.mock("../healthChecks", () => ({
 }));
 
 const {
+  buildDefaultModelCommand,
   buildHermesEnvWriteCommand,
   runContainerCommand,
   syncAuthToUserAgents,
@@ -108,6 +109,16 @@ describe("auth sync", () => {
     consoleLogSpy.mockRestore();
     consoleWarnSpy.mockRestore();
     delete global.fetch;
+  });
+
+  it("sets Microsoft Foundry defaults through azure-openai-responses even when the saved model has an OpenAI prefix", () => {
+    const command = buildDefaultModelCommand({
+      provider: "microsoft-foundry",
+      model: "openai/gpt-5.5-1",
+    });
+
+    expect(command).toContain('"models" "set" "azure-openai-responses/gpt-5.5-1"');
+    expect(command).not.toContain('"models" "set" "openai/gpt-5.5-1"');
   });
 
   it("syncs auth through the runtime endpoint and restarts supported non-docker agents", async () => {

--- a/backend-api/__tests__/dockerBootstrap.test.ts
+++ b/backend-api/__tests__/dockerBootstrap.test.ts
@@ -12,7 +12,9 @@ const {
   buildRuntimeBootstrapCommand,
   buildTemplatePayloadBootstrapFiles,
   mapNoraProviderIdToOpenClaw,
+  buildOpenClawModelForProvider,
   FOUNDRY_OPENCLAW_PROVIDER_ID,
+  resolveFoundryDeployment,
 } = require("../../workers/provisioner/runtimeBootstrap");
 const DockerBackend = require("../../workers/provisioner/backends/docker");
 const tar = require(
@@ -304,6 +306,41 @@ describe("OpenClaw bootstrap helpers", () => {
       expect(mapNoraProviderIdToOpenClaw(undefined)).toBe(undefined);
       expect(mapNoraProviderIdToOpenClaw(null)).toBe(null);
       expect(mapNoraProviderIdToOpenClaw("")).toBe("");
+    });
+  });
+
+  describe("buildOpenClawModelForProvider", () => {
+    it("rewrites prefixed Foundry deployment strings to OpenClaw's Azure provider id", () => {
+      expect(buildOpenClawModelForProvider("microsoft-foundry", "gpt-5.5-1")).toBe(
+        "azure-openai-responses/gpt-5.5-1",
+      );
+      expect(buildOpenClawModelForProvider("microsoft-foundry", "openai/gpt-5.5-1")).toBe(
+        "azure-openai-responses/gpt-5.5-1",
+      );
+      expect(
+        buildOpenClawModelForProvider("microsoft-foundry", "microsoft-foundry/gpt-5.5-1"),
+      ).toBe("azure-openai-responses/gpt-5.5-1");
+      expect(
+        buildOpenClawModelForProvider("microsoft-foundry", "azure-openai-responses/gpt-5.5-1"),
+      ).toBe("azure-openai-responses/gpt-5.5-1");
+    });
+
+    it("preserves normal prefixed models for non-Foundry providers", () => {
+      expect(buildOpenClawModelForProvider("openai", "openai/gpt-5.5-1")).toBe("openai/gpt-5.5-1");
+      expect(buildOpenClawModelForProvider("anthropic", "claude-sonnet-4-5")).toBe(
+        "anthropic/claude-sonnet-4-5",
+      );
+    });
+  });
+
+  describe("resolveFoundryDeployment", () => {
+    it("accepts legacy OpenAI-prefixed Foundry model values as deployment names", () => {
+      expect(resolveFoundryDeployment({ MICROSOFT_FOUNDRY_DEPLOYMENT: "openai/gpt-5.5-1" })).toBe(
+        "gpt-5.5-1",
+      );
+      expect(resolveFoundryDeployment({ NORA_DEFAULT_OPENCLAW_MODEL: "openai/gpt-5.5-1" })).toBe(
+        "gpt-5.5-1",
+      );
     });
   });
 

--- a/backend-api/authSync.ts
+++ b/backend-api/authSync.ts
@@ -17,7 +17,7 @@ const {
   buildOpenClawAuthProfilesWriteCommand,
   buildOpenClawConfigMergeCommand,
   buildOpenClawCustomProviders,
-  mapNoraProviderIdToOpenClaw,
+  buildOpenClawModelForProvider,
 } = require("../agent-runtime/lib/runtimeBootstrap");
 const { buildHermesRuntimeBootstrapEnv } = require("../agent-runtime/lib/hermesRuntimeBootstrap");
 const { NEMOCLAW_DEFAULT_MODEL } = require("../agent-runtime/lib/nemoclawDefaults");
@@ -46,7 +46,7 @@ const PROVIDER_MODEL_DEFAULTS = {
   zai: "glm-5",
   minimax: "MiniMax-M2.7",
   // Bare deployment name — buildDefaultModelCommand prefixes it with the
-  // OpenClaw provider id (azure-openai-responses) via mapNoraProviderIdToOpenClaw.
+  // OpenClaw provider id (azure-openai-responses) via buildOpenClawModelForProvider.
   "microsoft-foundry": "gpt-5.5-1",
 };
 
@@ -297,9 +297,7 @@ function buildDefaultOpenClawModel(defaultProvider = null) {
   const modelId = defaultProvider.model || PROVIDER_MODEL_DEFAULTS[defaultProvider.provider];
   if (!modelId) return null;
 
-  // Translate Nora provider id → OpenClaw provider id (Foundry → azure-openai-responses).
-  const openclawProvider = mapNoraProviderIdToOpenClaw(defaultProvider.provider);
-  return modelId.includes("/") ? modelId : `${openclawProvider}/${modelId}`;
+  return buildOpenClawModelForProvider(defaultProvider.provider, modelId);
 }
 
 function buildCustomProviderEnv(baseEnv = {}, defaultProvider = null) {

--- a/workers/provisioner/worker.ts
+++ b/workers/provisioner/worker.ts
@@ -50,7 +50,7 @@ const {
   buildOpenClawAuthProfilesWriteCommand,
   buildOpenClawConfigMergeCommand,
   buildOpenClawCustomProviders,
-  mapNoraProviderIdToOpenClaw,
+  buildOpenClawModelForProvider,
 } = require("../../agent-runtime/lib/runtimeBootstrap");
 const {
   buildHermesRuntimeBootstrapEnv,
@@ -183,7 +183,7 @@ const PROVIDER_ENV_ENDPOINT_MAP = Object.freeze({
 
 const PROVIDER_MODEL_DEFAULTS = Object.freeze({
   // Bare model id — prefixed with the OpenClaw provider id (nora-demo) via
-  // mapNoraProviderIdToOpenClaw, same as microsoft-foundry below.
+  // buildOpenClawModelForProvider, same as microsoft-foundry below.
   demo: "nora-demo-1",
   anthropic: "claude-sonnet-4-5",
   openai: "gpt-5.5",
@@ -200,7 +200,7 @@ const PROVIDER_MODEL_DEFAULTS = Object.freeze({
   zai: "glm-5",
   minimax: "MiniMax-M2.7",
   // Bare deployment name — buildDefaultModelCommand prefixes it with the
-  // OpenClaw provider id (azure-openai-responses) via mapNoraProviderIdToOpenClaw.
+  // OpenClaw provider id (azure-openai-responses) via buildOpenClawModelForProvider.
   "microsoft-foundry": "gpt-5.5-1",
 });
 
@@ -303,9 +303,7 @@ function buildDefaultOpenClawModel(defaultProvider = null) {
   const modelId = defaultProvider.model || PROVIDER_MODEL_DEFAULTS[defaultProvider.provider];
   if (!modelId) return null;
 
-  // Translate Nora provider id → OpenClaw provider id (Foundry → azure-openai-responses).
-  const openclawProvider = mapNoraProviderIdToOpenClaw(defaultProvider.provider);
-  return modelId.includes("/") ? modelId : `${openclawProvider}/${modelId}`;
+  return buildOpenClawModelForProvider(defaultProvider.provider, modelId);
 }
 
 function normalizeProviderConfig(config) {


### PR DESCRIPTION
## Summary
- normalize Microsoft Foundry saved model values to OpenClaw's azure-openai-responses provider id even when older values are stored as openai/<deployment>
- reuse the shared normalization in backend auth sync and provisioner post-deploy reconciliation
- add regression coverage for Foundry model command generation and runtime bootstrap helpers

## Verification
- npm test -- --runInBand __tests__/authSync.test.ts __tests__/dockerBootstrap.test.ts __tests__/provisioning.test.ts
- /root/.codex/skills/nora-ci-checks/scripts/run-nora-ci-checks.sh --repo /home/projects/nora --no-install

Note: local npm audit still reports the existing js-yaml moderate advisories in backend-api/workers; the Nora CI script completed successfully and reported them without failing.