### PR TITLE
fix(runtime): OpenClaw ≥2026.6 auth for custom providers (Foundry)

### DIFF
--- a/agent-runtime/lib/runtimeBootstrap.ts
+++ b/agent-runtime/lib/runtimeBootstrap.ts
@@ -524,11 +524,18 @@ function buildOpenClawModelForProvider(noraProviderId, modelId) {
   return rawModelId.includes("/") ? rawModelId : `${openclawProvider}/${rawModelId}`;
 }
 
-const OPENCLAW_SQLITE_AUTH_SKIP_PROVIDERS = Object.freeze([
-  "microsoft-foundry",
-  FOUNDRY_OPENCLAW_PROVIDER_ID,
-  "demo",
-  DEMO_OPENCLAW_PROVIDER_ID,
+// OpenClaw ≥2026.6 resolves embedded-agent auth exclusively from the
+// per-agent SQLite store — the inline `apiKey` on a custom provider in
+// openclaw.json is not consulted for agent turns. Custom-provider profiles
+// therefore MUST be imported too, translated to the OpenClaw provider id
+// they are registered under (skipping them leaves the store empty and every
+// turn fails with missing-provider-auth). Their import is best-effort: the
+// registration may legitimately be absent (e.g. Foundry key without a base
+// URL), and a failed paste must not abort the builtin-provider imports.
+const OPENCLAW_SQLITE_AUTH_PROVIDER_ALIASES = NORA_TO_OPENCLAW_PROVIDER_ID;
+const OPENCLAW_SQLITE_AUTH_BEST_EFFORT_PROVIDERS = Object.freeze([
+  ...Object.keys(NORA_TO_OPENCLAW_PROVIDER_ID),
+  ...Object.values(NORA_TO_OPENCLAW_PROVIDER_ID),
 ]);
 
 function buildOpenClawAuthImportFromFileCommand(options = {}) {
@@ -549,14 +556,19 @@ function buildOpenClawAuthImportFromFileCommand(options = {}) {
     "const { spawnSync } = require('child_process');",
     `const authPath = ${JSON.stringify(authPath)};`,
     `const agentId = ${JSON.stringify(agentId)};`,
-    `const skipProviders = new Set(${JSON.stringify(OPENCLAW_SQLITE_AUTH_SKIP_PROVIDERS)});`,
+    `const providerAliases = ${JSON.stringify(OPENCLAW_SQLITE_AUTH_PROVIDER_ALIASES)};`,
+    `const bestEffortProviders = new Set(${JSON.stringify(OPENCLAW_SQLITE_AUTH_BEST_EFFORT_PROVIDERS)});`,
     "let auth = {};",
     "try { auth = JSON.parse(fs.readFileSync(authPath, 'utf8')); } catch { process.exit(0); }",
     "const profiles = auth && auth.profiles && typeof auth.profiles === 'object' ? auth.profiles : {};",
     "for (const [profileId, profile] of Object.entries(profiles)) {",
     "  if (!profile || profile.type !== 'api_key' || !profile.key) continue;",
-    "  const provider = String(profile.provider || '').trim();",
-    "  if (!provider || skipProviders.has(provider)) continue;",
+    "  const rawProvider = String(profile.provider || '').trim();",
+    "  if (!rawProvider) continue;",
+    "  const provider = providerAliases[rawProvider] || rawProvider;",
+    "  const importProfileId = provider === rawProvider",
+    "    ? String(profileId)",
+    "    : String(profileId).replace(`${rawProvider}:`, `${provider}:`);",
     "  const result = spawnSync(process.env.OPENCLAW_BIN, [",
     "    'models',",
     "    'auth',",
@@ -566,7 +578,7 @@ function buildOpenClawAuthImportFromFileCommand(options = {}) {
     "    '--provider',",
     "    provider,",
     "    '--profile-id',",
-    "    String(profileId),",
+    "    importProfileId,",
     "  ], {",
     "    input: `${String(profile.key)}\\n`,",
     "    encoding: 'utf8',",
@@ -576,6 +588,10 @@ function buildOpenClawAuthImportFromFileCommand(options = {}) {
     "  if (result.status !== 0) {",
     "    if (result.stderr) process.stderr.write(result.stderr);",
     "    if (result.stdout) process.stderr.write(result.stdout);",
+    "    if (bestEffortProviders.has(provider)) {",
+    "      process.stderr.write(`auth import skipped for ${provider} (custom provider not registered?)\\n`);",
+    "      continue;",
+    "    }",
     "    process.exit(result.status || 1);",
     "  }",
     "}",
@@ -647,6 +663,21 @@ function buildOpenClawConfigMergeScript(gatewayConfig) {
 // merge semantics as the boot-time script so both paths agree.
 function buildOpenClawConfigMergeCommand(configDelta) {
   return buildOpenClawConfigMergeScript(configDelta).join("\n");
+}
+
+// Default-model apply for sync flows. Deliberately NOT `openclaw models set`:
+// OpenClaw ≥2026.6 canonicalizes the model ref against its builtin catalog,
+// rewriting `azure-openai-responses/<deployment>` to `openai/<deployment>` —
+// a provider the agent holds no credentials for. Writing the value straight
+// into openclaw.json (the same shape the boot scripts use) keeps the
+// custom-provider prefix intact; the gateway re-reads it on restart or via
+// its config watcher.
+function buildOpenClawDefaultModelCommand(fullModel) {
+  const model = String(fullModel || "").trim();
+  if (!model) return null;
+  return buildOpenClawConfigMergeCommand({
+    agents: { defaults: { model: { primary: model }, models: { [model]: {} } } },
+  });
 }
 
 // buildMcpServersConfig lives in its own dependency-free module so it can be
@@ -768,6 +799,7 @@ module.exports = {
   buildIntegrationToolWrapperScript,
   buildOpenClawConfigMergeScript,
   buildOpenClawConfigMergeCommand,
+  buildOpenClawDefaultModelCommand,
   buildOpenClawAuthImportFromFileCommand,
   buildOpenClawAuthProfilesWriteCommand,
   buildMcpServersConfig,

--- a/backend-api/__tests__/authSync.test.ts
+++ b/backend-api/__tests__/authSync.test.ts
@@ -84,9 +84,7 @@ describe("auth sync", () => {
     mockRestart.mockReset().mockResolvedValue(undefined);
     mockIsKubernetesAgent
       .mockReset()
-      .mockImplementation(
-        (agent) => String(agent?.backend_type || "").toLowerCase() === "k8s",
-      );
+      .mockImplementation((agent) => String(agent?.backend_type || "").toLowerCase() === "k8s");
     mockUpdateEnv.mockReset().mockResolvedValue(undefined);
     mockGetProviderKeys.mockReset().mockResolvedValue({
       OPENAI_API_KEY: "sk-live-test",
@@ -199,13 +197,10 @@ describe("auth sync", () => {
     );
     // Kubernetes restarts are rollouts: the replacement pod re-seeds auth
     // from the Deployment env, so the sync must patch it too.
-    expect(mockUpdateEnv).toHaveBeenCalledWith(
-      expect.objectContaining({ id: "agent-k8s-1" }),
-      {
-        OPENAI_API_KEY: "sk-live-test",
-        NORA_DEFAULT_OPENCLAW_MODEL: "openai/gpt-5.5",
-      },
-    );
+    expect(mockUpdateEnv).toHaveBeenCalledWith(expect.objectContaining({ id: "agent-k8s-1" }), {
+      OPENAI_API_KEY: "sk-live-test",
+      NORA_DEFAULT_OPENCLAW_MODEL: "openai/gpt-5.5",
+    });
     expect(results).toEqual([{ agentId: "agent-k8s-1", status: "synced" }]);
   });
 

--- a/backend-api/__tests__/authSync.test.ts
+++ b/backend-api/__tests__/authSync.test.ts
@@ -5,6 +5,8 @@ const { PassThrough } = require("stream");
 const mockDb = { query: jest.fn() };
 const mockRestart = jest.fn();
 const mockExec = jest.fn();
+const mockIsKubernetesAgent = jest.fn();
+const mockUpdateEnv = jest.fn();
 const mockGetProviderKeys = jest.fn();
 const mockBuildAuthProfiles = jest.fn();
 const mockGetIntegrationEnvVars = jest.fn();
@@ -15,6 +17,8 @@ jest.mock("../db", () => mockDb);
 jest.mock("../containerManager", () => ({
   exec: mockExec,
   restart: mockRestart,
+  isKubernetesAgent: mockIsKubernetesAgent,
+  updateEnv: mockUpdateEnv,
 }));
 jest.mock("../llmProviders", () => ({
   PROVIDERS: [
@@ -78,6 +82,12 @@ describe("auth sync", () => {
     mockDb.query.mockReset();
     mockExec.mockReset().mockResolvedValue(execResult());
     mockRestart.mockReset().mockResolvedValue(undefined);
+    mockIsKubernetesAgent
+      .mockReset()
+      .mockImplementation(
+        (agent) => String(agent?.backend_type || "").toLowerCase() === "k8s",
+      );
+    mockUpdateEnv.mockReset().mockResolvedValue(undefined);
     mockGetProviderKeys.mockReset().mockResolvedValue({
       OPENAI_API_KEY: "sk-live-test",
     });
@@ -117,8 +127,13 @@ describe("auth sync", () => {
       model: "openai/gpt-5.5-1",
     });
 
-    expect(command).toContain('"models" "set" "azure-openai-responses/gpt-5.5-1"');
-    expect(command).not.toContain('"models" "set" "openai/gpt-5.5-1"');
+    // Written via config merge, NOT `openclaw models set`: the CLI
+    // canonicalizes the ref back to `openai/<deployment>`, a provider the
+    // agent has no credentials for.
+    expect(command).toContain("__NORA_MERGE_OPENCLAW_CONFIG__");
+    expect(command).toContain('"primary": "azure-openai-responses/gpt-5.5-1"');
+    expect(command).not.toContain('"openai/gpt-5.5-1"');
+    expect(command).not.toContain('"models" "set"');
   });
 
   it("syncs auth through the runtime endpoint and restarts supported non-docker agents", async () => {
@@ -180,7 +195,16 @@ describe("auth sync", () => {
       }),
     );
     expect(JSON.parse(global.fetch.mock.calls[1][1].body).command).toContain(
-      'models" "set" "openai/gpt-5.5',
+      '"primary": "openai/gpt-5.5"',
+    );
+    // Kubernetes restarts are rollouts: the replacement pod re-seeds auth
+    // from the Deployment env, so the sync must patch it too.
+    expect(mockUpdateEnv).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "agent-k8s-1" }),
+      {
+        OPENAI_API_KEY: "sk-live-test",
+        NORA_DEFAULT_OPENCLAW_MODEL: "openai/gpt-5.5",
+      },
     );
     expect(results).toEqual([{ agentId: "agent-k8s-1", status: "synced" }]);
   });

--- a/backend-api/__tests__/dockerBootstrap.test.ts
+++ b/backend-api/__tests__/dockerBootstrap.test.ts
@@ -124,9 +124,61 @@ describe("OpenClaw bootstrap helpers", () => {
       expect(fs.readFileSync(argsLog, "utf8")).toContain(
         "models auth --agent main paste-api-key --provider openai --profile-id openai:default",
       );
+      // Custom providers are imported under their OpenClaw id — the embedded
+      // agent resolves auth from the per-agent SQLite store only, so skipping
+      // Foundry here left agents failing with missing-provider-auth.
+      expect(fs.readFileSync(argsLog, "utf8")).toContain(
+        "models auth --agent main paste-api-key --provider azure-openai-responses --profile-id azure-openai-responses:default",
+      );
       expect(fs.readFileSync(argsLog, "utf8")).not.toContain("microsoft-foundry");
-      expect(fs.readFileSync(stdinLog, "utf8")).toBe("sk-openai\n");
+      expect(fs.readFileSync(stdinLog, "utf8")).toBe("sk-openai\nms-key\n");
       expect(fs.existsSync(path.join(tmpDir, "auth-profiles.json"))).toBe(true);
+    } finally {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it("keeps builtin-provider imports when a custom-provider paste fails", () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "nora-openclaw-auth-"));
+    try {
+      const fakeOpenClaw = path.join(tmpDir, "openclaw");
+      const argsLog = path.join(tmpDir, "args.log");
+      // Fail only the azure-openai-responses paste (provider not registered),
+      // as happens when a Foundry key is saved without a base URL.
+      fs.writeFileSync(
+        fakeOpenClaw,
+        '#!/bin/sh\nprintf \'%s\\n\' "$*" >> "$OPENCLAW_ARGS_LOG"\ncat > /dev/null\ncase "$*" in *azure-openai-responses*) exit 1 ;; esac\n',
+        { mode: 0o755 },
+      );
+
+      const command = buildOpenClawAuthProfilesWriteCommand(
+        {
+          version: 1,
+          profiles: {
+            "microsoft-foundry:default": {
+              type: "api_key",
+              provider: "microsoft-foundry",
+              key: "ms-key",
+            },
+            "openai:default": { type: "api_key", provider: "openai", key: "sk-openai" },
+          },
+        },
+        { authPath: path.join(tmpDir, "auth-profiles.json") },
+      );
+      const result = require("child_process").spawnSync("/bin/sh", ["-c", command], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          OPENCLAW_CLI_PATH: fakeOpenClaw,
+          OPENCLAW_ARGS_LOG: argsLog,
+        },
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toContain("auth import skipped for azure-openai-responses");
+      expect(fs.readFileSync(argsLog, "utf8")).toContain(
+        "models auth --agent main paste-api-key --provider openai --profile-id openai:default",
+      );
     } finally {
       fs.rmSync(tmpDir, { recursive: true, force: true });
     }

--- a/backend-api/authSync.ts
+++ b/backend-api/authSync.ts
@@ -683,11 +683,7 @@ async function syncAuthToUserAgents(userId, agentId = null, options = {}) {
         containerManager.isKubernetesAgent(agent) &&
         typeof containerManager.updateEnv === "function"
       ) {
-        const managedEnv = await buildOpenClawManagedEnvForAgent(
-          userId,
-          agent.id,
-          defaultProvider,
-        );
+        const managedEnv = await buildOpenClawManagedEnvForAgent(userId, agent.id, defaultProvider);
         if (Object.keys(managedEnv).length > 0) {
           await containerManager.updateEnv(agent, managedEnv);
         }

--- a/backend-api/authSync.ts
+++ b/backend-api/authSync.ts
@@ -17,6 +17,7 @@ const {
   buildOpenClawAuthProfilesWriteCommand,
   buildOpenClawConfigMergeCommand,
   buildOpenClawCustomProviders,
+  buildOpenClawDefaultModelCommand,
   buildOpenClawModelForProvider,
 } = require("../agent-runtime/lib/runtimeBootstrap");
 const { buildHermesRuntimeBootstrapEnv } = require("../agent-runtime/lib/hermesRuntimeBootstrap");
@@ -207,13 +208,7 @@ function hasMeaningfulHermesModelConfig(modelConfig = {}) {
  * that overlap with LLM auth env vars (e.g., HF_TOKEN, OPENAI_API_KEY).
  * Explicit LLM provider keys always take precedence over integration tokens.
  */
-async function buildAuthProfilesForAgent(userId, agentId) {
-  const llmKeys = await llmProviders.getProviderKeys(userId);
-  const overrides =
-    typeof llmProviders.getProviderEndpoints === "function"
-      ? await llmProviders.getProviderEndpoints(userId)
-      : { byEnvVar: {}, byProvider: {}, apiVersionByEnvVar: {}, apiVersionByProvider: {} };
-
+async function getIntegrationLlmEnvVars(agentId) {
   try {
     const { getIntegrationEnvVars } = require("./integrations");
     const integrationEnvVars = await getIntegrationEnvVars(agentId);
@@ -223,19 +218,71 @@ async function buildAuthProfilesForAgent(userId, agentId) {
         integrationLlmKeys[envVar] = value;
       }
     }
-    // LLM provider keys win over integration-sourced tokens for the same env var
-    return llmProviders.buildAuthProfiles(
-      { ...integrationLlmKeys, ...llmKeys },
-      overrides.byProvider || {},
-      overrides.apiVersionByProvider || {},
-    );
+    return integrationLlmKeys;
   } catch {
-    return llmProviders.buildAuthProfiles(
-      llmKeys,
-      overrides.byProvider || {},
-      overrides.apiVersionByProvider || {},
-    );
+    return {};
   }
+}
+
+async function buildAuthProfilesForAgent(userId, agentId) {
+  const llmKeys = await llmProviders.getProviderKeys(userId);
+  const overrides =
+    typeof llmProviders.getProviderEndpoints === "function"
+      ? await llmProviders.getProviderEndpoints(userId)
+      : { byEnvVar: {}, byProvider: {}, apiVersionByEnvVar: {}, apiVersionByProvider: {} };
+
+  const integrationLlmKeys = await getIntegrationLlmEnvVars(agentId);
+  // LLM provider keys win over integration-sourced tokens for the same env var
+  return llmProviders.buildAuthProfiles(
+    { ...integrationLlmKeys, ...llmKeys },
+    overrides.byProvider || {},
+    overrides.apiVersionByProvider || {},
+  );
+}
+
+/**
+ * Env vars the OpenClaw boot script needs to rebuild auth from scratch.
+ * On Kubernetes a restart is a rollout: the replacement pod gets a fresh
+ * filesystem and re-seeds auth-profiles.json + the SQLite auth store from
+ * the pod env alone, so exec-written files never survive it. Keys saved
+ * after provisioning must therefore be patched onto the Deployment env.
+ */
+async function buildOpenClawManagedEnvForAgent(userId, agentId, defaultProvider = null) {
+  const llmKeys = await llmProviders.getProviderKeys(userId);
+  const overrides =
+    typeof llmProviders.getProviderEndpoints === "function"
+      ? await llmProviders.getProviderEndpoints(userId)
+      : { byEnvVar: {}, apiVersionByEnvVar: {}, deploymentByEnvVar: {} };
+  const baseUrlEnvVars =
+    typeof llmProviders.buildBaseUrlEnvVars === "function"
+      ? llmProviders.buildBaseUrlEnvVars(overrides.byEnvVar || {})
+      : {};
+  const apiVersionEnvVars =
+    typeof llmProviders.buildApiVersionEnvVars === "function"
+      ? llmProviders.buildApiVersionEnvVars(overrides.apiVersionByEnvVar || {})
+      : {};
+  const deploymentEnvVars =
+    typeof llmProviders.buildDeploymentEnvVars === "function"
+      ? llmProviders.buildDeploymentEnvVars(overrides.deploymentByEnvVar || {})
+      : {};
+  const integrationLlmKeys = await getIntegrationLlmEnvVars(agentId);
+  const fullModel = buildDefaultOpenClawModel(defaultProvider);
+
+  return Object.fromEntries(
+    Object.entries(
+      buildCustomProviderEnv(
+        {
+          ...integrationLlmKeys,
+          ...llmKeys,
+          ...baseUrlEnvVars,
+          ...apiVersionEnvVars,
+          ...deploymentEnvVars,
+          ...(fullModel ? { NORA_DEFAULT_OPENCLAW_MODEL: fullModel } : {}),
+        },
+        defaultProvider,
+      ),
+    ).filter(([key, value]) => key && value != null && String(value) !== ""),
+  );
 }
 
 async function buildHermesManagedEnvForAgent(userId, agentId) {
@@ -281,14 +328,7 @@ function buildDefaultModelCommand(defaultProvider = null) {
   const fullModel = buildDefaultOpenClawModel(defaultProvider);
   if (!fullModel) return null;
 
-  return (
-    'OPENCLAW_BIN="${OPENCLAW_CLI_PATH:-/usr/local/bin/openclaw}"; ' +
-    'if [ ! -x "$OPENCLAW_BIN" ]; then OPENCLAW_BIN="$(command -v openclaw 2>/dev/null || true)"; fi; ' +
-    '[ -n "$OPENCLAW_BIN" ] && [ -x "$OPENCLAW_BIN" ] || exit 127; ' +
-    `exec "$OPENCLAW_BIN" ${["models", "set", fullModel]
-      .map((arg) => JSON.stringify(String(arg)))
-      .join(" ")}`
-  );
+  return buildOpenClawDefaultModelCommand(fullModel);
 }
 
 function buildDefaultOpenClawModel(defaultProvider = null) {
@@ -633,6 +673,26 @@ async function syncAuthToUserAgents(userId, agentId = null, options = {}) {
         results.push({ agentId: agent.id, status: "skipped" });
         continue;
       }
+
+      // Kubernetes: patch the Deployment env before any exec writes. The
+      // exec-written files below only fix the CURRENT pod; the rollout the
+      // restart triggers replaces it with a pod that re-seeds auth from env,
+      // and the same applies to evictions and node scale events later on.
+      if (
+        typeof containerManager.isKubernetesAgent === "function" &&
+        containerManager.isKubernetesAgent(agent) &&
+        typeof containerManager.updateEnv === "function"
+      ) {
+        const managedEnv = await buildOpenClawManagedEnvForAgent(
+          userId,
+          agent.id,
+          defaultProvider,
+        );
+        if (Object.keys(managedEnv).length > 0) {
+          await containerManager.updateEnv(agent, managedEnv);
+        }
+      }
+
       await writeAuthToContainer(agent, authProfiles);
 
       // Merge custom-provider registrations (Foundry → azure-openai-responses)
@@ -715,6 +775,7 @@ module.exports = {
   buildAuthProfilesForAgent,
   buildAuthProfilesWriteCommand,
   buildDefaultModelCommand,
+  buildOpenClawManagedEnvForAgent,
   buildHermesModelConfig,
   buildHermesEnvWriteCommand,
   buildHermesManagedEnvForAgent,

--- a/backend-api/authSync.ts
+++ b/backend-api/authSync.ts
@@ -202,12 +202,6 @@ function hasMeaningfulHermesModelConfig(modelConfig = {}) {
   );
 }
 
-/**
- * Build auth-profiles.json content for a specific agent.
- * Merges per-user LLM provider keys with per-agent integration tokens
- * that overlap with LLM auth env vars (e.g., HF_TOKEN, OPENAI_API_KEY).
- * Explicit LLM provider keys always take precedence over integration tokens.
- */
 async function getIntegrationLlmEnvVars(agentId) {
   try {
     const { getIntegrationEnvVars } = require("./integrations");
@@ -224,6 +218,12 @@ async function getIntegrationLlmEnvVars(agentId) {
   }
 }
 
+/**
+ * Build auth-profiles.json content for a specific agent.
+ * Merges per-user LLM provider keys with per-agent integration tokens
+ * that overlap with LLM auth env vars (e.g., HF_TOKEN, OPENAI_API_KEY).
+ * Explicit LLM provider keys always take precedence over integration tokens.
+ */
 async function buildAuthProfilesForAgent(userId, agentId) {
   const llmKeys = await llmProviders.getProviderKeys(userId);
   const overrides =

--- a/workers/provisioner/worker.ts
+++ b/workers/provisioner/worker.ts
@@ -54,6 +54,7 @@ const {
   buildOpenClawAuthProfilesWriteCommand,
   buildOpenClawConfigMergeCommand,
   buildOpenClawCustomProviders,
+  buildOpenClawDefaultModelCommand,
   buildOpenClawModelForProvider,
 } = require("../../agent-runtime/lib/runtimeBootstrap");
 const {
@@ -316,14 +317,7 @@ function buildDefaultModelCommand(defaultProvider = null) {
   const fullModel = buildDefaultOpenClawModel(defaultProvider);
   if (!fullModel) return null;
 
-  return (
-    'OPENCLAW_BIN="${OPENCLAW_CLI_PATH:-/usr/local/bin/openclaw}"; ' +
-    'if [ ! -x "$OPENCLAW_BIN" ]; then OPENCLAW_BIN="$(command -v openclaw 2>/dev/null || true)"; fi; ' +
-    '[ -n "$OPENCLAW_BIN" ] && [ -x "$OPENCLAW_BIN" ] || exit 127; ' +
-    `exec "$OPENCLAW_BIN" ${["models", "set", fullModel]
-      .map((arg) => JSON.stringify(String(arg)))
-      .join(" ")}`
-  );
+  return buildOpenClawDefaultModelCommand(fullModel);
 }
 
 function buildDefaultOpenClawModel(defaultProvider = null) {


### PR DESCRIPTION
## Problem

Foundry-backed OpenClaw agents fail every turn with:

> ⚠️ Agent failed before reply: No API key found for provider "openai". Auth store: /root/.openclaw/agents/main/agent/openclaw-agent.sqlite … | missing-provider-auth

Root causes (verified live against a stage AKS agent on OpenClaw 2026.6.10):

1. **OpenClaw ≥2026.6 resolves embedded-agent auth exclusively from the per-agent SQLite auth store.** The inline `apiKey` on the `azure-openai-responses` custom provider in `openclaw.json` is no longer consulted for agent turns. Nora's SQLite import deliberately skipped Foundry/demo profiles (`OPENCLAW_SQLITE_AUTH_SKIP_PROVIDERS`), so those agents ended up with an **empty auth store** and failed with `missing-provider-auth` (the error names the API family "openai", which is misleading).
2. **`openclaw models set azure-openai-responses/<deployment>` canonicalizes the ref to `openai/<deployment>`** and persists that as `agents.defaults.model.primary` — a provider the agent holds no credentials for. Nora's auth sync used `models set`, so every key save silently re-broke the default model.
3. **On Kubernetes, `restart` is a rollout**: the replacement pod re-seeds auth exclusively from the pod env, so the sync's exec-written auth files never survive a pod replacement. Keys saved after provisioning evaporated on the next rollout/eviction.

## Fix

- `agent-runtime/lib/runtimeBootstrap.ts`: import custom-provider profiles into the SQLite store under their OpenClaw ids (`microsoft-foundry` → `azure-openai-responses`, `demo` → `nora-demo`) instead of skipping them; best-effort so an unregistered provider can't abort builtin imports. New `buildOpenClawDefaultModelCommand` applies the default model via a direct `openclaw.json` config merge (same shape as the boot scripts), never `models set`.
- `backend-api/authSync.ts` + `workers/provisioner/worker.ts`: use the merge-based default-model command. On Kubernetes, `syncAuthToUserAgents` now also patches LLM env vars + `NORA_DEFAULT_OPENCLAW_MODEL` onto the Deployment (`containerManager.updateEnv`) before exec writes, so replacement pods boot with current keys.

## Validation

- `openclaw models auth --agent main paste-api-key --provider azure-openai-responses` on the failing stage pod immediately unblocked agent turns (no gateway restart needed — SQLite is read per request).
- Ran the fixed `syncAuthToUserAgents` against stage: both AKS Foundry agents got their SQLite store seeded and `defaults.model.primary` corrected from `openai/gpt-5.5-1` to `azure-openai-responses/gpt-5.5-1`; live `openclaw agent` turns reply normally on both.
- `cd backend-api && npm test`: 150 suites / 1287 tests green, including new coverage: Foundry profiles imported under `azure-openai-responses`, best-effort custom paste failure keeps builtin imports, k8s sync calls `updateEnv`, default-model command asserts merge (not `models set`).