### PR TITLE
fix(backends): durable agent state on k8s + docker, MCP on k8s, env-secret hygiene

### DIFF
--- a/agent-runtime/lib/runtimeBootstrap.ts
+++ b/agent-runtime/lib/runtimeBootstrap.ts
@@ -331,13 +331,6 @@ const FOUNDRY_DEFAULT_MODELS = [
     maxTokens: 128000,
   },
   {
-    id: "gpt-5.5",
-    name: "GPT-5.5 (Azure)",
-    reasoning: true,
-    contextWindow: 200000,
-    maxTokens: 128000,
-  },
-  {
     id: "gpt-5.2-codex",
     name: "GPT-5.2 Codex (Azure)",
     reasoning: true,

--- a/backend-api/__tests__/hermesUi.test.ts
+++ b/backend-api/__tests__/hermesUi.test.ts
@@ -3,19 +3,29 @@ process.env.ENCRYPTION_KEY = "0123456789abcdef0123456789abcdef0123456789abcdef01
 
 const mockDb = { query: jest.fn() };
 const mockRunContainerCommand = jest.fn();
+const mockBuildHermesManagedEnvForAgent = jest.fn();
+const mockWriteHermesEnvToContainer = jest.fn();
+const mockIsKubernetesAgent = jest.fn();
+const mockUpdateEnv = jest.fn();
+const mockRestart = jest.fn();
+const mockWaitForAgentReadiness = jest.fn();
 
 jest.mock("../db", () => mockDb);
 
 jest.mock("../authSync", () => ({
   runContainerCommand: mockRunContainerCommand,
+  buildHermesManagedEnvForAgent: mockBuildHermesManagedEnvForAgent,
+  writeHermesEnvToContainer: mockWriteHermesEnvToContainer,
 }));
 
 jest.mock("../containerManager", () => ({
-  restart: jest.fn(),
+  restart: mockRestart,
+  isKubernetesAgent: mockIsKubernetesAgent,
+  updateEnv: mockUpdateEnv,
 }));
 
 jest.mock("../healthChecks", () => ({
-  waitForAgentReadiness: jest.fn(),
+  waitForAgentReadiness: mockWaitForAgentReadiness,
 }));
 
 const {
@@ -24,6 +34,7 @@ const {
   readHermesRuntimeSnapshot,
   repairHermesAgentConfig,
   replacePersistedHermesState,
+  saveHermesChannel,
   snapshotToPersistedHermesState,
 } = require("../hermesUi");
 
@@ -36,7 +47,17 @@ function decodeHermesHelperScript(command) {
 describe("Hermes helper execution", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockDb.query.mockReset();
+    mockDb.query.mockReset().mockResolvedValue({ rows: [] });
+    mockIsKubernetesAgent.mockReset().mockReturnValue(false);
+    mockUpdateEnv.mockReset().mockResolvedValue(undefined);
+    mockRestart.mockReset().mockResolvedValue(undefined);
+    mockWaitForAgentReadiness.mockReset().mockResolvedValue({
+      ok: true,
+      runtime: { ok: true },
+      gateway: { ok: true },
+    });
+    mockBuildHermesManagedEnvForAgent.mockReset().mockResolvedValue({});
+    mockWriteHermesEnvToContainer.mockReset().mockResolvedValue(undefined);
     mockRunContainerCommand.mockReset().mockResolvedValue({
       output: JSON.stringify({
         runtimeStatus: {},
@@ -47,6 +68,37 @@ describe("Hermes helper execution", () => {
         modelConfig: {},
       }),
     });
+  });
+
+  it("projects Hermes channel env onto the Deployment env for kubernetes agents", async () => {
+    mockIsKubernetesAgent.mockReturnValue(true);
+    mockBuildHermesManagedEnvForAgent.mockResolvedValue({
+      TELEGRAM_BOT_TOKEN: "tok-123",
+      OPENAI_API_KEY: "sk-test",
+    });
+
+    const agent = {
+      id: "agent-hermes-k8s",
+      user_id: "user-1",
+      container_id: "nora-hermes-qa-1",
+      backend_type: "k8s",
+      host: "runtime.internal",
+      runtime_host: "runtime.internal",
+      runtime_port: 8642,
+    };
+
+    await saveHermesChannel(agent, "telegram", { TELEGRAM_BOT_TOKEN: "tok-123" });
+
+    // k8s: the exec-written /opt/data/.env would be wiped by the rollout the
+    // save triggers, so the full managed env must go through the Deployment.
+    expect(mockBuildHermesManagedEnvForAgent).toHaveBeenCalledWith("user-1", "agent-hermes-k8s");
+    expect(mockWriteHermesEnvToContainer).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "agent-hermes-k8s" }),
+      { TELEGRAM_BOT_TOKEN: "tok-123", OPENAI_API_KEY: "sk-test" },
+    );
+    const execCommands = mockRunContainerCommand.mock.calls.map((call) => String(call[1] || ""));
+    expect(execCommands.some((command) => command.includes("save_env_value"))).toBe(false);
+    expect(mockRestart).toHaveBeenCalled();
   });
 
   it("runs helper scripts from /opt/hermes inside the Hermes virtualenv", async () => {

--- a/backend-api/__tests__/provisioning.test.ts
+++ b/backend-api/__tests__/provisioning.test.ts
@@ -32,6 +32,9 @@ const mockCreateNamespacedSecret = jest.fn();
 const mockReadNamespacedSecret = jest.fn();
 const mockReplaceNamespacedSecret = jest.fn();
 const mockDeleteNamespacedSecret = jest.fn();
+const mockCreateNamespacedPersistentVolumeClaim = jest.fn();
+const mockReadNamespacedPersistentVolumeClaim = jest.fn();
+const mockDeleteNamespacedPersistentVolumeClaim = jest.fn();
 const mockGetNamespacedCustomObject = jest.fn();
 const mockLoadKubeconfigFromFile = jest.fn();
 
@@ -82,6 +85,9 @@ jest.mock(
             readNamespacedSecret: mockReadNamespacedSecret,
             replaceNamespacedSecret: mockReplaceNamespacedSecret,
             deleteNamespacedSecret: mockDeleteNamespacedSecret,
+            createNamespacedPersistentVolumeClaim: mockCreateNamespacedPersistentVolumeClaim,
+            readNamespacedPersistentVolumeClaim: mockReadNamespacedPersistentVolumeClaim,
+            deleteNamespacedPersistentVolumeClaim: mockDeleteNamespacedPersistentVolumeClaim,
           };
         }
         if (api === AppsV1Api) {
@@ -153,6 +159,13 @@ describe("provisioning runtime/gateway contracts", () => {
     });
     mockReplaceNamespacedSecret.mockReset().mockResolvedValue({});
     mockDeleteNamespacedSecret.mockReset().mockResolvedValue({});
+    mockCreateNamespacedPersistentVolumeClaim.mockReset().mockResolvedValue({});
+    // Reads only happen in _waitForDeleted; defaulting to 404 means "already
+    // deleted" so destroy paths terminate immediately.
+    mockReadNamespacedPersistentVolumeClaim
+      .mockReset()
+      .mockRejectedValue(Object.assign(new Error("not found"), { statusCode: 404 }));
+    mockDeleteNamespacedPersistentVolumeClaim.mockReset().mockResolvedValue({});
     mockGetNamespacedCustomObject.mockReset().mockResolvedValue({});
     mockLoadKubeconfigFromFile.mockReset().mockReturnValue(undefined);
     delete process.env.GATEWAY_HOST;
@@ -346,9 +359,21 @@ describe("provisioning runtime/gateway contracts", () => {
     expect(deployment.metadata.labels["nora.sandbox.profile"]).toBe("standard");
     expect(deployment.spec.template.metadata.labels["nora.sandbox.profile"]).toBe("standard");
     expect(deployment.spec.selector.matchLabels).toEqual({ "openclaw.agent.id": "123" });
+    // Recreate: required for the RWO state volume and prevents RollingUpdate
+    // surge pods sticking Pending on full clusters.
+    expect(deployment.spec.strategy).toEqual({ type: "Recreate" });
+    // Agent state must survive pod replacement — a k8s restart is a rollout.
+    expect(mockCreateNamespacedPersistentVolumeClaim).toHaveBeenCalledTimes(1);
+    const pvc = mockCreateNamespacedPersistentVolumeClaim.mock.calls[0][0].body;
+    expect(pvc.metadata.name).toBe("nora-oclaw-nora-qa-123-state");
+    expect(pvc.spec.accessModes).toEqual(["ReadWriteOnce"]);
+    // Boot must not clobber persisted state: openclaw.json is seeded only
+    // when absent.
+    expect(configMap.data["bootstrap.sh"]).toContain("[ -f ~/.openclaw/openclaw.json ] ||");
     expect(container.volumeMounts).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ name: "nora-bootstrap", mountPath: "/opt/nora-bootstrap" }),
+        expect.objectContaining({ name: "nora-agent-state", mountPath: "/root/.openclaw" }),
       ]),
     );
     expect(deployment.spec.template.spec.volumes).toEqual(
@@ -356,6 +381,12 @@ describe("provisioning runtime/gateway contracts", () => {
         expect.objectContaining({
           name: "nora-bootstrap",
           configMap: expect.objectContaining({ name: "nora-oclaw-nora-qa-123-bootstrap" }),
+        }),
+        expect.objectContaining({
+          name: "nora-agent-state",
+          persistentVolumeClaim: expect.objectContaining({
+            claimName: "nora-oclaw-nora-qa-123-state",
+          }),
         }),
       ]),
     );
@@ -388,6 +419,70 @@ describe("provisioning runtime/gateway contracts", () => {
         gatewayPort: OPENCLAW_GATEWAY_PORT,
       }),
     );
+  });
+
+  it("bakes MCP servers into the kubernetes bootstrap like the docker backend", async () => {
+    const K8sBackend = require("../../workers/provisioner/backends/k8s");
+    const backend = new K8sBackend(k8sProfile());
+
+    await backend.create({
+      id: "321",
+      name: "MCP QA",
+      vcpu: 2,
+      ram_mb: 2048,
+      env: {},
+      mcpServers: [
+        { name: "notion", npmPackage: "@notionhq/notion-mcp-server", env: { NOTION_TOKEN: "t" } },
+      ],
+    });
+
+    const configMap = mockCreateNamespacedConfigMap.mock.calls[0][0].body;
+    const script = configMap.data["bootstrap.sh"];
+    expect(script).toContain('"notion"');
+    expect(script).toContain("@notionhq/notion-mcp-server");
+    expect(script).toContain("config.mcpServers = mcpServers");
+  });
+
+  it("routes sensitive updateEnv values into the env Secret instead of plaintext pod spec", async () => {
+    const K8sBackend = require("../../workers/provisioner/backends/k8s");
+    const backend = new K8sBackend(k8sProfile());
+
+    mockReadNamespacedDeployment.mockResolvedValue({
+      metadata: { name: "nora-oclaw-nora-qa-123" },
+      spec: {
+        template: {
+          spec: {
+            containers: [{ name: "agent", env: [{ name: "OPENAI_API_KEY", value: "old" }] }],
+          },
+        },
+      },
+    });
+    mockReadNamespacedSecret.mockResolvedValue({
+      metadata: { name: "nora-oclaw-nora-qa-123-env", resourceVersion: "secret-rv" },
+      type: "Opaque",
+      data: { EXISTING_TOKEN: "b2xk" },
+    });
+
+    await backend.updateEnv("nora-oclaw-nora-qa-123", {
+      OPENAI_API_KEY: "sk-new",
+      PLAIN_SETTING: "value",
+    });
+
+    // Sensitive value merged into the Secret without dropping existing keys.
+    const replacedSecret = mockReplaceNamespacedSecret.mock.calls[0][0].body;
+    expect(replacedSecret.stringData).toEqual({ OPENAI_API_KEY: "sk-new" });
+    expect(replacedSecret.data).toEqual({ EXISTING_TOKEN: "b2xk" });
+
+    // Deployment env references the Secret; only non-sensitive values inline.
+    const patch = mockPatchNamespacedDeployment.mock.calls[0][0].body;
+    const envOps = patch.filter((op) => op.path.includes("/env"));
+    const sensitiveOp = envOps.find((op) => op.value?.name === "OPENAI_API_KEY");
+    expect(sensitiveOp.value.valueFrom).toEqual({
+      secretKeyRef: { name: "nora-oclaw-nora-qa-123-env", key: "OPENAI_API_KEY" },
+    });
+    expect(sensitiveOp.value.value).toBeUndefined();
+    const plainOp = envOps.find((op) => op.value?.name === "PLAIN_SETTING");
+    expect(plainOp.value).toEqual({ name: "PLAIN_SETTING", value: "value" });
   });
 
   it("returns node-port endpoints for docker-hosted kind verification", async () => {
@@ -1326,10 +1421,12 @@ describe("provisioning runtime/gateway contracts", () => {
     mockDeleteNamespacedService.mockImplementation(deleteIfLegacyNamespace);
     mockDeleteNamespacedConfigMap.mockImplementation(deleteIfLegacyNamespace);
     mockDeleteNamespacedSecret.mockImplementation(deleteIfLegacyNamespace);
+    mockDeleteNamespacedPersistentVolumeClaim.mockImplementation(deleteIfLegacyNamespace);
     mockReadNamespacedDeployment.mockRejectedValue(notFound);
     mockReadNamespacedService.mockRejectedValue(notFound);
     mockReadNamespacedConfigMap.mockRejectedValue(notFound);
     mockReadNamespacedSecret.mockRejectedValue(notFound);
+    mockReadNamespacedPersistentVolumeClaim.mockRejectedValue(notFound);
 
     const K8sBackend = require("../../workers/provisioner/backends/k8s");
     const backend = new K8sBackend(

--- a/backend-api/authSync.ts
+++ b/backend-api/authSync.ts
@@ -300,12 +300,24 @@ async function buildHermesManagedEnvForAgent(userId, agentId) {
       ? llmProviders.buildApiVersionEnvVars(overrides.apiVersionByEnvVar || {})
       : {};
 
+  // The managed .env block is replaced wholesale on every write, so persisted
+  // channel env must ride along or an LLM key save silently drops every
+  // configured Hermes channel.
+  let channelEnvVars = {};
+  try {
+    const { buildHermesChannelEnvForAgent } = require("./hermesUi");
+    channelEnvVars = await buildHermesChannelEnvForAgent(agentId);
+  } catch {
+    channelEnvVars = {};
+  }
+
   try {
     const { getIntegrationEnvVars } = require("./integrations");
     const integrationEnvVars = await getIntegrationEnvVars(agentId);
     return Object.fromEntries(
       Object.entries({
         ...integrationEnvVars,
+        ...channelEnvVars,
         ...llmKeys,
         ...baseUrlEnvVars,
         ...apiVersionEnvVars,
@@ -313,9 +325,12 @@ async function buildHermesManagedEnvForAgent(userId, agentId) {
     );
   } catch {
     return Object.fromEntries(
-      Object.entries({ ...llmKeys, ...baseUrlEnvVars, ...apiVersionEnvVars }).filter(
-        ([key, value]) => key && value != null && String(value) !== "",
-      ),
+      Object.entries({
+        ...channelEnvVars,
+        ...llmKeys,
+        ...baseUrlEnvVars,
+        ...apiVersionEnvVars,
+      }).filter(([key, value]) => key && value != null && String(value) !== ""),
     );
   }
 }

--- a/backend-api/channels/index.ts
+++ b/backend-api/channels/index.ts
@@ -229,6 +229,12 @@ async function sendMessage(channelId, content, metadata = {}) {
   const adapter = getAdapter(channel.type);
   const result = await adapter.send(channel, content, metadata);
 
+  // Some adapters (email) report failures via `delivered: false` instead of
+  // throwing — surface those instead of logging a phantom outbound message.
+  if (result && result.delivered === false) {
+    throw new Error(result.error || `Message delivery failed for ${channel.type} channel`);
+  }
+
   // Log the outbound message
   await db.query(
     "INSERT INTO channel_messages(channel_id, direction, content, metadata) VALUES($1, 'outbound', $2, $3)",
@@ -269,7 +275,15 @@ async function testChannel(channelId, agentId) {
 
   // Then try sending a test message
   try {
-    await adapter.send(channel, `🦞 OpenClaw test message — ${new Date().toISOString()}`);
+    const sendResult = await adapter.send(
+      channel,
+      `🦞 OpenClaw test message — ${new Date().toISOString()}`,
+    );
+    // Non-throwing adapters (email) report failure via `delivered: false` —
+    // a test must not show green over a failed delivery.
+    if (sendResult && sendResult.delivered === false) {
+      return { success: false, error: sendResult.error || "Test message delivery failed" };
+    }
     return { success: true, message: "Test message sent successfully" };
   } catch (e) {
     return { success: false, error: e.message };

--- a/backend-api/hermesUi.ts
+++ b/backend-api/hermesUi.ts
@@ -1021,7 +1021,51 @@ async function restartHermesRuntime(agent) {
   }
 }
 
+/**
+ * Env vars for every channel persisted in hermes_runtime_state for an agent.
+ * Callers persist DB state first, then project this into the runtime.
+ */
+async function buildHermesChannelEnvForAgent(agentId) {
+  const state = await getPersistedHermesState(agentId);
+  const channels = normalizeHermesChannelStateList(state?.channels || []);
+  const env = {};
+  for (const entry of channels) {
+    const definition = definitionForChannelType(entry.type);
+    if (!definition) continue;
+    const normalized = normalizeHermesChannelInput(definition, entry.config || {}, {});
+    for (const [key, value] of Object.entries(normalized || {})) {
+      const text = value == null ? "" : String(value).trim();
+      if (text) env[key] = text;
+    }
+  }
+  return env;
+}
+
+// Kubernetes: exec-written /opt/data/.env does not survive the rollout the
+// save flow triggers right after, so channel env must be projected onto the
+// Deployment env (the postStart bootstrap rebuilds the managed .env block
+// from it on every pod start). The managed block is replaced wholesale, so
+// the FULL env set (LLM keys + all persisted channels) is recomputed from
+// the DB rather than just the channel being edited.
+async function syncHermesManagedEnvToKubernetes(agent) {
+  const { buildHermesManagedEnvForAgent, writeHermesEnvToContainer } = require("./authSync");
+  const envVars = await buildHermesManagedEnvForAgent(agent.user_id, agent.id);
+  await writeHermesEnvToContainer(agent, envVars);
+}
+
+function isKubernetesHermesAgent(agent) {
+  return (
+    typeof containerManager.isKubernetesAgent === "function" &&
+    containerManager.isKubernetesAgent(agent)
+  );
+}
+
 async function persistHermesChannelConfig(agent, definition, config) {
+  if (isKubernetesHermesAgent(agent)) {
+    await syncHermesManagedEnvToKubernetes(agent);
+    return;
+  }
+
   const payloadJson = JSON.stringify(config || {});
   const script = `
 import json
@@ -1042,6 +1086,13 @@ print(json.dumps({"ok": True}))
 }
 
 async function removeHermesChannelConfig(agent, definition) {
+  if (isKubernetesHermesAgent(agent)) {
+    // DB state was deleted by the caller; rebuilding the managed env from the
+    // DB drops the removed channel's keys from the managed block.
+    await syncHermesManagedEnvToKubernetes(agent);
+    return;
+  }
+
   const script = `
 import json
 
@@ -1218,6 +1269,7 @@ module.exports = {
   HERMES_CHANNEL_DEFINITIONS,
   HERMES_CHANNEL_TYPES,
   applyPersistedHermesState,
+  buildHermesChannelEnvForAgent,
   buildHermesPythonCommand,
   definitionForChannelType,
   getPersistedHermesState,

--- a/backend-api/llmProviders.ts
+++ b/backend-api/llmProviders.ts
@@ -27,7 +27,8 @@ const PROVIDERS = [
     id: "groq",
     name: "Groq",
     envVar: "GROQ_API_KEY",
-    models: ["llama-3.3-70b-versatile", "mixtral-8x7b-32768"],
+    // mixtral-8x7b-32768 was decommissioned by Groq — do not resurface it.
+    models: ["llama-3.3-70b-versatile"],
   },
   { id: "mistral", name: "Mistral", envVar: "MISTRAL_API_KEY", models: ["mistral-large-latest"] },
   {
@@ -52,7 +53,16 @@ const PROVIDERS = [
   },
   { id: "moonshot", name: "Moonshot AI", envVar: "MOONSHOT_API_KEY", models: ["kimi-k2.5"] },
   { id: "zai", name: "Z.AI", envVar: "ZAI_API_KEY", models: ["glm-5"] },
-  { id: "ollama", name: "Ollama", envVar: "OLLAMA_API_KEY", models: [] },
+  {
+    // Ollama endpoints are per-host (the operator's own server) — without a
+    // base URL the agent container has nothing to connect to.
+    id: "ollama",
+    name: "Ollama",
+    envVar: "OLLAMA_API_KEY",
+    requiresBaseUrl: true,
+    baseUrlPlaceholder: "http://<ollama-host>:11434/v1",
+    models: [],
+  },
   { id: "minimax", name: "MiniMax", envVar: "MINIMAX_API_KEY", models: ["MiniMax-M2.7"] },
   { id: "github-copilot", name: "GitHub Copilot", envVar: "COPILOT_GITHUB_TOKEN", models: [] },
   { id: "huggingface", name: "Hugging Face (Inference)", envVar: "HF_TOKEN", models: [] },
@@ -87,7 +97,6 @@ const PROVIDERS = [
     apiVersionPlaceholder: "2024-10-21",
     models: [
       "gpt-5.5-1",
-      "gpt5.5-1",
       "gpt-5.5",
       "gpt-5.5-mini",
       "o3",

--- a/workers/provisioner/backends/docker.ts
+++ b/workers/provisioner/backends/docker.ts
@@ -681,10 +681,17 @@ class DockerBackend extends ProvisionerBackend {
         .slice(0, 63) || `agent-${id}`;
 
     const volumeName = `nora_agent_state_${id}`;
-    try {
-      await this.docker.createVolume({ Name: volumeName });
-    } catch (e) {
-      if (!String(e.message).includes("already exists")) throw e;
+    // The agent's real state root. Without this, /root/.openclaw lives on the
+    // container writable layer and is lost whenever the container is
+    // recreated (image update, redeploy) — the /mnt volume only covers the
+    // integration-tool state dir.
+    const homeVolumeName = `nora_agent_home_${id}`;
+    for (const volume of [volumeName, homeVolumeName]) {
+      try {
+        await this.docker.createVolume({ Name: volume });
+      } catch (e) {
+        if (!String(e.message).includes("already exists")) throw e;
+      }
     }
 
     try {
@@ -712,7 +719,7 @@ class DockerBackend extends ProvisionerBackend {
           },
           // DNS servers for internet access from within the container
           Dns: ["8.8.8.8", "8.8.4.4", "1.1.1.1"],
-          Binds: [`${volumeName}:/mnt/nora-agent-state`],
+          Binds: [`${volumeName}:/mnt/nora-agent-state`, `${homeVolumeName}:/root/.openclaw`],
         },
         NetworkingConfig: composeNetwork
           ? {
@@ -775,10 +782,12 @@ class DockerBackend extends ProvisionerBackend {
           // Best effort cleanup only.
         }
       }
-      try {
-        await this.docker.getVolume(volumeName).remove({ force: true });
-      } catch {
-        // Best effort cleanup only.
+      for (const volume of [volumeName, homeVolumeName]) {
+        try {
+          await this.docker.getVolume(volume).remove({ force: true });
+        } catch {
+          // Best effort cleanup only.
+        }
       }
       throw error;
     }
@@ -805,11 +814,15 @@ class DockerBackend extends ProvisionerBackend {
     console.log(`[docker] Container ${containerId} removed`);
 
     if (agentId) {
-      try {
-        await this.docker.getVolume(`nora_agent_state_${agentId}`).remove({ force: true });
-        console.log(`[docker] Volume nora_agent_state_${agentId} removed`);
-      } catch (e) {
-        console.warn(`[docker] Could not remove volume for agent ${agentId}: ${e.message}`);
+      for (const volume of [`nora_agent_state_${agentId}`, `nora_agent_home_${agentId}`]) {
+        try {
+          await this.docker.getVolume(volume).remove({ force: true });
+          console.log(`[docker] Volume ${volume} removed`);
+        } catch (e) {
+          console.warn(
+            `[docker] Could not remove volume ${volume} for agent ${agentId}: ${e.message}`,
+          );
+        }
       }
     }
   }

--- a/workers/provisioner/backends/k8s.ts
+++ b/workers/provisioner/backends/k8s.ts
@@ -3,6 +3,7 @@ const k8s = require("@kubernetes/client-node");
 const crypto = require("crypto");
 const ProvisionerBackend = require("./interface");
 const {
+  buildMcpServersConfig,
   buildOpenClawAuthImportFromFileCommand,
   buildOpenClawInstallCommand,
   buildRuntimeBootstrapCommand,
@@ -72,6 +73,9 @@ const SENSITIVE_ENV_PATTERNS = Object.freeze([
   /^PGPASSWORD$/i,
   /^API_SERVER_KEY$/i,
   /^OPENCLAW_GATEWAY_TOKEN$/i,
+  // Hermes bootstrap blobs carry decrypted provider keys / channel tokens.
+  /^NORA_HERMES_MANAGED_ENV_B64$/i,
+  /^NORA_HERMES_MODEL_CONFIG_B64$/i,
 ]);
 
 function parseK8sCpuCores(value) {
@@ -231,7 +235,7 @@ function buildHermesPostStartCommand() {
   ].join("\n");
 }
 
-function buildOpenClawRuntimeAuthBootstrapCommand() {
+function buildOpenClawRuntimeAuthBootstrapCommand({ mcpServers = null } = {}) {
   const providerMap = {
     ANTHROPIC_API_KEY: "anthropic",
     OPENAI_API_KEY: "openai",
@@ -295,16 +299,6 @@ function buildOpenClawRuntimeAuthBootstrapCommand() {
       compat: { supportsStore: false, supportsReasoningEffort: true },
     },
     {
-      id: "gpt-5.5",
-      name: "GPT-5.5 (Azure)",
-      reasoning: true,
-      input: ["text", "image"],
-      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-      contextWindow: 200000,
-      maxTokens: 128000,
-      compat: { supportsStore: false, supportsReasoningEffort: true },
-    },
-    {
       id: "gpt-5.2-codex",
       name: "GPT-5.2 Codex (Azure)",
       reasoning: true,
@@ -334,6 +328,7 @@ function buildOpenClawRuntimeAuthBootstrapCommand() {
     `const staticEndpointMap = ${JSON.stringify(staticEndpointMap)};`,
     `const apiVersionEnvMap = ${JSON.stringify(apiVersionEnvMap)};`,
     `const foundryModels = ${JSON.stringify(foundryModels)};`,
+    `const mcpServers = ${JSON.stringify(mcpServers && typeof mcpServers === "object" ? mcpServers : null)};`,
     "const authPath = '/root/.openclaw/agents/main/agent/auth-profiles.json';",
     "const configPath = '/root/.openclaw/openclaw.json';",
     "const auth = { version: 1, profiles: {}, order: {}, lastGood: {} };",
@@ -389,6 +384,16 @@ function buildOpenClawRuntimeAuthBootstrapCommand() {
     "  config.agents.defaults.model = { primary: defaultModel };",
     "  config.agents.defaults.models = config.agents.defaults.models && typeof config.agents.defaults.models === 'object' ? config.agents.defaults.models : {};",
     "  config.agents.defaults.models[defaultModel] = config.agents.defaults.models[defaultModel] || {};",
+    "}",
+    // Nora owns the mcpServers block: replace it wholesale with the
+    // provision-time value (same semantics as the docker backend, which bakes
+    // it into the create-time openclaw.json; changes flow via redeploy).
+    "if (mcpServers) {",
+    "  if (Object.keys(mcpServers).length > 0) {",
+    "    config.mcpServers = mcpServers;",
+    "  } else {",
+    "    delete config.mcpServers;",
+    "  }",
     "}",
     "fs.mkdirSync('/root/.openclaw', { recursive: true });",
     "fs.writeFileSync(configPath, JSON.stringify(config, null, 2));",
@@ -1205,6 +1210,82 @@ class K8sBackend extends ProvisionerBackend {
     };
   }
 
+  _stateVolumeClaimName(deployName) {
+    return `${deployName}-state`;
+  }
+
+  _stateVolume(claimName) {
+    return {
+      name: "nora-agent-state",
+      persistentVolumeClaim: { claimName },
+    };
+  }
+
+  _stateVolumeMount(mountPath) {
+    return {
+      name: "nora-agent-state",
+      mountPath,
+    };
+  }
+
+  // Agent state (OpenClaw config/auth/sessions/workspace, Hermes /opt/data)
+  // must survive pod replacement — a k8s restart is a rollout and the
+  // container writable layer is reset on every kubelet restart. RWO is
+  // sufficient because agent Deployments run a single replica with
+  // strategy Recreate (old pod terminates before the new one mounts).
+  async _upsertStateVolumeClaim(deployName, { sizeGi, labels = {}, namespace } = {}) {
+    const name = this._stateVolumeClaimName(deployName);
+    const storage = `${Math.max(1, Math.round(Number(sizeGi) || 10))}Gi`;
+    const body = {
+      apiVersion: "v1",
+      kind: "PersistentVolumeClaim",
+      metadata: {
+        name,
+        namespace,
+        labels: {
+          "nora.agent.id": this._agentIdFromDeployName(deployName),
+          "nora.agent.state": "true",
+          "nora.execution.target": this.executionTargetLabelValue,
+          "nora.kubernetes.cluster": this.clusterId,
+          ...labels,
+        },
+      },
+      spec: {
+        accessModes: ["ReadWriteOnce"],
+        resources: { requests: { storage } },
+      },
+    };
+
+    try {
+      await this.coreApi.createNamespacedPersistentVolumeClaim({ namespace, body });
+    } catch (error) {
+      // PVC specs are immutable once bound (apart from expansion); reuse the
+      // existing claim as-is so retried creates don't fail.
+      if (!this._isAlreadyExistsError(error)) throw error;
+    }
+
+    return name;
+  }
+
+  async _deleteStateVolumeClaimIfExists(deployName, namespace) {
+    const name = this._stateVolumeClaimName(deployName);
+    try {
+      await this.coreApi.deleteNamespacedPersistentVolumeClaim({
+        name,
+        namespace,
+        propagationPolicy: "Foreground",
+      });
+    } catch (error) {
+      if (this._isNotFoundError(error)) return false;
+      throw error;
+    }
+
+    await this._waitForDeleted("PersistentVolumeClaim", name, namespace, () =>
+      this.coreApi.readNamespacedPersistentVolumeClaim({ name, namespace }),
+    );
+    return true;
+  }
+
   async _upsertBootstrapConfigMap(deployName, script, labels = {}, namespace = this.namespace) {
     const name = this._bootstrapConfigMapName(deployName);
     const body = {
@@ -1588,6 +1669,35 @@ class K8sBackend extends ProvisionerBackend {
     return true;
   }
 
+  // Merge new keys into the env Secret without dropping existing ones.
+  // Used by updateEnv so rotated sensitive values stay in the Secret instead
+  // of being downgraded to plaintext pod-spec env.
+  async _mergeEnvSecretData(deployName, stringData = {}, namespace = this.namespace) {
+    const name = this._envSecretName(deployName);
+    let current = null;
+    try {
+      current = this._serviceObject(await this.coreApi.readNamespacedSecret({ name, namespace }));
+    } catch (error) {
+      if (!this._isNotFoundError(error)) throw error;
+    }
+
+    if (!current) {
+      return this._upsertEnvSecret(deployName, stringData, {}, namespace);
+    }
+
+    // stringData overlays data on write, so existing keys survive untouched.
+    const body = {
+      apiVersion: "v1",
+      kind: "Secret",
+      metadata: current.metadata,
+      type: current.type || "Opaque",
+      data: current.data || {},
+      stringData,
+    };
+    await this.coreApi.replaceNamespacedSecret({ name, namespace, body });
+    return name;
+  }
+
   async _deleteEnvSecretIfExists(deployName, namespace) {
     const name = this._envSecretName(deployName);
     try {
@@ -1631,7 +1741,7 @@ class K8sBackend extends ProvisionerBackend {
   }
 
   async _createHermes(config, deployName) {
-    const { id, name, image, vcpu, ram_mb, env } = config;
+    const { id, name, image, vcpu, ram_mb, disk_gb, env } = config;
     const namespace = this._namespaceForRuntimeFamily("hermes");
     const imgName = image || getHermesDockerAgentImage();
     const apiServerKey = config.gatewayToken || crypto.randomBytes(32).toString("hex");
@@ -1690,6 +1800,16 @@ class K8sBackend extends ProvisionerBackend {
       );
     }
 
+    const stateClaimName = await this._upsertStateVolumeClaim(deployName, {
+      sizeGi: disk_gb,
+      labels: {
+        "nora.agent.id": String(id),
+        "nora.deployment.name": deployName,
+        "nora.runtime.family": "hermes",
+      },
+      namespace,
+    });
+
     const deployment = {
       apiVersion: "apps/v1",
       kind: "Deployment",
@@ -1707,6 +1827,12 @@ class K8sBackend extends ProvisionerBackend {
       },
       spec: {
         replicas: 1,
+        // Recreate is required for the RWO state volume and lets restarts
+        // complete on capacity-constrained clusters: RollingUpdate's surge pod
+        // needs a second full Guaranteed-QoS reservation, which sticks Pending
+        // forever on a full cluster while the old pod keeps serving stale
+        // config.
+        strategy: { type: "Recreate" },
         selector: {
           matchLabels: { "nora.agent.id": String(id) },
         },
@@ -1737,7 +1863,7 @@ class K8sBackend extends ProvisionerBackend {
                     },
                   },
                 },
-                volumeMounts: [this._bootstrapVolumeMount()],
+                volumeMounts: [this._bootstrapVolumeMount(), this._stateVolumeMount(HERMES_HOME)],
                 ports: [
                   { name: "runtime", containerPort: HERMES_RUNTIME_PORT },
                   { name: "dashboard", containerPort: HERMES_DASHBOARD_PORT },
@@ -1754,7 +1880,10 @@ class K8sBackend extends ProvisionerBackend {
                 },
               },
             ],
-            volumes: [this._bootstrapVolume(bootstrapConfigMapName)],
+            volumes: [
+              this._bootstrapVolume(bootstrapConfigMapName),
+              this._stateVolume(stateClaimName),
+            ],
           },
         },
       },
@@ -1780,7 +1909,7 @@ class K8sBackend extends ProvisionerBackend {
   }
 
   async create(config) {
-    const { id, name, image, vcpu, ram_mb, env, templatePayload, sandboxProfile } = config;
+    const { id, name, image, vcpu, ram_mb, disk_gb, env, templatePayload, sandboxProfile } = config;
     const runtimeFamily = String(config.runtimeFamily || "openclaw")
       .trim()
       .toLowerCase();
@@ -1936,15 +2065,23 @@ class K8sBackend extends ProvisionerBackend {
           },
         }).replace(/'/g, "'\\''")}' > /opt/openclaw/policy.yaml && `
       : "";
+    const mcpServersConfig =
+      Array.isArray(config.mcpServers) && config.mcpServers.length > 0
+        ? buildMcpServersConfig(config.mcpServers)
+        : {};
+    // openclaw.json is seeded only when absent: the pod's state volume outlives
+    // pod replacement, and an unconditional write would wipe channel config,
+    // provider registrations, and default-model changes accumulated since
+    // provisioning. The auth bootstrap below MERGES into the existing file.
     const gatewayScript =
       "set -eu\n" +
       ensureOpenClawCmd +
       "mkdir -p ~/.openclaw/devices && " +
-      `echo '{"gateway":{"port":${OPENCLAW_GATEWAY_PORT},"bind":"lan","mode":"local"}}' > ~/.openclaw/openclaw.json && ` +
+      `[ -f ~/.openclaw/openclaw.json ] || echo '{"gateway":{"port":${OPENCLAW_GATEWAY_PORT},"bind":"lan","mode":"local"}}' > ~/.openclaw/openclaw.json && ` +
       `echo '${escapedPaired}' > ~/.openclaw/devices/paired.json && ` +
       `echo '{}' > ~/.openclaw/devices/pending.json && ` +
       nemoPolicyCmd +
-      buildOpenClawRuntimeAuthBootstrapCommand() +
+      buildOpenClawRuntimeAuthBootstrapCommand({ mcpServers: mcpServersConfig }) +
       templateBootstrapCmd +
       runtimeBootstrapCmd +
       '"$OPENCLAW_BIN" gateway --port ' +
@@ -1968,6 +2105,19 @@ class K8sBackend extends ProvisionerBackend {
     );
     const gatewayLaunch = this._bootstrapLaunch(gatewayBootstrap);
 
+    // NemoClaw runs with HOME=/sandbox, so its OpenClaw state root lives there.
+    const stateMountPath = isNemoClaw ? "/sandbox" : "/root/.openclaw";
+    const stateClaimName = await this._upsertStateVolumeClaim(deployName, {
+      sizeGi: disk_gb,
+      labels: {
+        "nora.agent.id": String(id),
+        "nora.deployment.name": deployName,
+        "nora.runtime.family": "openclaw",
+        "nora.sandbox.profile": isNemoClaw ? "nemoclaw" : "standard",
+      },
+      namespace,
+    });
+
     const deployment = {
       apiVersion: "apps/v1",
       kind: "Deployment",
@@ -1988,6 +2138,10 @@ class K8sBackend extends ProvisionerBackend {
       },
       spec: {
         replicas: 1,
+        // See the Hermes deployment above: Recreate is required for the RWO
+        // state volume and prevents stuck RollingUpdate surge pods on full
+        // clusters.
+        strategy: { type: "Recreate" },
         selector: {
           matchLabels: { "openclaw.agent.id": String(id) },
         },
@@ -2022,7 +2176,10 @@ class K8sBackend extends ProvisionerBackend {
                 args: gatewayLaunch.args,
                 workingDir: isNemoClaw ? "/sandbox" : undefined,
                 env: envVars,
-                volumeMounts: [this._bootstrapVolumeMount()],
+                volumeMounts: [
+                  this._bootstrapVolumeMount(),
+                  this._stateVolumeMount(stateMountPath),
+                ],
                 ports: [
                   { name: "gateway", containerPort: OPENCLAW_GATEWAY_PORT },
                   { name: "runtime", containerPort: AGENT_RUNTIME_PORT },
@@ -2039,7 +2196,10 @@ class K8sBackend extends ProvisionerBackend {
                 },
               },
             ],
-            volumes: [this._bootstrapVolume(bootstrapConfigMapName)],
+            volumes: [
+              this._bootstrapVolume(bootstrapConfigMapName),
+              this._stateVolume(stateClaimName),
+            ],
           },
         },
       },
@@ -2080,8 +2240,16 @@ class K8sBackend extends ProvisionerBackend {
       const deletedService = await this._deleteServiceIfExists(deployName, namespace);
       const deletedConfigMap = await this._deleteBootstrapConfigMapIfExists(deployName, namespace);
       const deletedSecret = await this._deleteEnvSecretIfExists(deployName, namespace);
+      // Deployment deletion above is Foreground, so no pod holds the claim by
+      // the time this runs.
+      const deletedStateClaim = await this._deleteStateVolumeClaimIfExists(deployName, namespace);
       deletedAny =
-        deletedAny || deletedDeployment || deletedService || deletedConfigMap || deletedSecret;
+        deletedAny ||
+        deletedDeployment ||
+        deletedService ||
+        deletedConfigMap ||
+        deletedSecret ||
+        deletedStateClaim;
     }
 
     console.log(
@@ -2438,14 +2606,34 @@ class K8sBackend extends ProvisionerBackend {
       patch.push({ op: "add", path: envPath, value: [] });
     }
 
+    // Sensitive values go into the env Secret and are referenced via
+    // secretKeyRef — replacing an existing secretKeyRef entry with a literal
+    // value would put the decrypted key into the pod spec (readable by
+    // anyone with `get deployment`) and let the Secret drift.
+    const secretName = this._envSecretName(deployName);
+    const sensitiveData = {};
     for (const [name, value] of entries) {
-      const nextEntry = { name: String(name), value: String(value ?? "") };
-      const existingIndex = envIndexByName.get(name);
+      const key = String(name);
+      const stringValue = String(value ?? "");
+      let nextEntry;
+      if (isSensitiveEnvName(key)) {
+        sensitiveData[key] = stringValue;
+        nextEntry = { name: key, valueFrom: { secretKeyRef: { name: secretName, key } } };
+      } else {
+        nextEntry = { name: key, value: stringValue };
+      }
+      const existingIndex = envIndexByName.get(key);
       if (Number.isInteger(existingIndex)) {
         patch.push({ op: "replace", path: `${envPath}/${existingIndex}`, value: nextEntry });
       } else {
         patch.push({ op: "add", path: `${envPath}/-`, value: nextEntry });
       }
+    }
+
+    // Update the Secret before the Deployment so secretKeyRef entries resolve
+    // as soon as the rollout (or the caller's explicit restart) starts pods.
+    if (Object.keys(sensitiveData).length > 0) {
+      await this._mergeEnvSecretData(deployName, sensitiveData, namespace);
     }
 
     await this.appsApi.patchNamespacedDeployment({


### PR DESCRIPTION
## Context

Follow-ups from today's stage functional audit (four-track code audit + live AKS/docker sweep). The systemic root cause: agent state lives only inside the agent container, and Kubernetes resets the container filesystem on every restart (a k8s restart is a rollout) — so channel logins, sessions, workspace files, and any post-provision config silently evaporated on pod replacement, while RollingUpdate surge pods stuck Pending forever on CPU-full clusters (the "Current 2 · Available 1" state) with the old pod serving stale config.

## Changes

**Kubernetes adapter**
- `strategy: Recreate` + per-agent PVC mounted at the state root (`/root/.openclaw` OpenClaw, `/sandbox` NemoClaw, `/opt/data` Hermes); PVC sized from `disk_gb`, deleted in `destroy`. Boot script seeds `openclaw.json` only when absent so persisted channel/provider config survives reboots (the auth bootstrap merges into it).
- MCP servers wired in: provision-time entries are baked into the boot script and replace the openclaw.json `mcpServers` block each boot (docker parity). Previously the adapter dropped the parameter entirely — MCP was silently non-functional on k8s.
- `updateEnv` secret hygiene: sensitive values merge into the per-agent env Secret and are referenced via `secretKeyRef` instead of being written as plaintext pod-spec env (which also let the Secret drift). Hermes `NORA_HERMES_*_B64` bootstrap blobs are now classified sensitive.

**Hermes channels on k8s**
- Channel save/remove now project the FULL managed env (LLM keys + all persisted channels from `hermes_runtime_state`) onto the Deployment via `updateEnv`, instead of exec-writing `/opt/data/.env` which the save's own rollout immediately wiped — Hermes channels were effectively unconfigurable on k8s. `authSync.buildHermesManagedEnvForAgent` folds channel env in, so LLM key saves no longer clobber channels (the managed .env block is replaced wholesale).

**Docker adapter**
- New per-agent named volume `nora_agent_home_<id>` at `/root/.openclaw`. The existing volume was mounted at `/mnt/nora-agent-state`, which only covers the integration-tool state dir — real agent state died with container recreation. Both volumes removed on destroy.

**Catalog + channels quick wins**
- Foundry: remove `gpt5.5-1` typo and duplicate `gpt-5.5` metadata entries (llmProviders + runtimeBootstrap + k8s mirror). Groq: drop decommissioned `mixtral-8x7b-32768`. Ollama: `requiresBaseUrl` so the wizard collects the host URL (unusable without it).
- `testChannel`/`sendMessage` honor adapters that report `delivered:false` (email) instead of showing green over failed deliveries / logging phantom outbound messages.

## Validation

- backend-api: 150 suites / 1290 tests green, including new coverage: k8s create asserts Recreate + PVC + conditional openclaw.json seed; MCP entries land in the bootstrap; `updateEnv` merges sensitive values into the Secret (existing keys preserved) and patches `secretKeyRef` entries; Hermes k8s channel save projects the managed env and skips the exec write.
- agent-runtime vitest: 10/10.
- Existing agents are unaffected until their next redeploy (PVC/strategy apply to newly created Deployments); `updateEnv`/Hermes-channel behavior improves immediately.