### PR TITLE
fix(integrations): credential trust — surface dead OAuth tokens, durable env, retryable webhooks

### DIFF
--- a/backend-api/__tests__/authSync.test.ts
+++ b/backend-api/__tests__/authSync.test.ts
@@ -158,6 +158,9 @@ describe("auth sync", () => {
     global.fetch
       .mockResolvedValueOnce(jsonResponse({ exitCode: 0, stdout: "", stderr: "" }))
       .mockResolvedValueOnce(jsonResponse({ exitCode: 0, stdout: "", stderr: "" }));
+    // Non-LLM integration tokens must reach the Deployment env too — they
+    // otherwise live only in the pod's openclaw.json and die with the pod.
+    mockGetIntegrationEnvVars.mockResolvedValue({ GITHUB_TOKEN: "gh-tok" });
 
     const results = await syncAuthToUserAgents("user-1");
 
@@ -198,6 +201,7 @@ describe("auth sync", () => {
     // Kubernetes restarts are rollouts: the replacement pod re-seeds auth
     // from the Deployment env, so the sync must patch it too.
     expect(mockUpdateEnv).toHaveBeenCalledWith(expect.objectContaining({ id: "agent-k8s-1" }), {
+      GITHUB_TOKEN: "gh-tok",
       OPENAI_API_KEY: "sk-live-test",
       NORA_DEFAULT_OPENCLAW_MODEL: "openai/gpt-5.5",
     });

--- a/backend-api/authSync.ts
+++ b/backend-api/authSync.ts
@@ -246,6 +246,9 @@ async function buildAuthProfilesForAgent(userId, agentId) {
  * filesystem and re-seeds auth-profiles.json + the SQLite auth store from
  * the pod env alone, so exec-written files never survive it. Keys saved
  * after provisioning must therefore be patched onto the Deployment env.
+ * Carries ALL integration env vars (not just LLM-overlapping ones) — a
+ * GITHUB_TOKEN/SLACK_TOKEN connected after provisioning otherwise lives
+ * only in the pod's openclaw.json and dies with the pod.
  */
 async function buildOpenClawManagedEnvForAgent(userId, agentId, defaultProvider = null) {
   const llmKeys = await llmProviders.getProviderKeys(userId);
@@ -265,14 +268,20 @@ async function buildOpenClawManagedEnvForAgent(userId, agentId, defaultProvider 
     typeof llmProviders.buildDeploymentEnvVars === "function"
       ? llmProviders.buildDeploymentEnvVars(overrides.deploymentByEnvVar || {})
       : {};
-  const integrationLlmKeys = await getIntegrationLlmEnvVars(agentId);
+  let integrationEnvVars = {};
+  try {
+    const { getIntegrationEnvVars } = require("./integrations");
+    integrationEnvVars = await getIntegrationEnvVars(agentId);
+  } catch {
+    integrationEnvVars = {};
+  }
   const fullModel = buildDefaultOpenClawModel(defaultProvider);
 
   return Object.fromEntries(
     Object.entries(
       buildCustomProviderEnv(
         {
-          ...integrationLlmKeys,
+          ...integrationEnvVars,
           ...llmKeys,
           ...baseUrlEnvVars,
           ...apiVersionEnvVars,

--- a/backend-api/channels/index.ts
+++ b/backend-api/channels/index.ts
@@ -320,6 +320,8 @@ async function handleInboundWebhook(channelId, payload, headers) {
   const runtimeUrl = runtimeUrlForAgent(agent, "/channels/receive");
   if (runtimeUrl && agent?.host !== "pending") {
     try {
+      // Bounded: a hung runtime socket must not stall the provider's webhook
+      // delivery worker.
       await fetch(runtimeUrl, {
         method: "POST",
         headers: { "Content-Type": "application/json", ...(await runtimeAuthHeaders(agent)) },
@@ -330,9 +332,19 @@ async function handleInboundWebhook(channelId, payload, headers) {
           sender: formatted.sender,
           metadata: formatted.metadata,
         }),
+        signal: AbortSignal.timeout(10000),
       });
-    } catch {
-      // Agent may not be reachable — that's okay, message is already logged
+    } catch (error) {
+      // Do NOT swallow this as a 200: providers treat 2xx as delivered and
+      // never retry, so the message would be silently lost exactly when the
+      // agent pod is restarting. Signal "try again later" instead — the
+      // inbound copy is already logged for the audit trail.
+      const failure = new Error(
+        `Agent runtime unreachable — webhook not delivered (${error?.message || "fetch failed"})`,
+      );
+      failure.statusCode = 503;
+      failure.retryable = true;
+      throw failure;
     }
   }
 

--- a/backend-api/integrations/providers/linkedin.ts
+++ b/backend-api/integrations/providers/linkedin.ts
@@ -108,6 +108,7 @@ export const linkedinProvider: Provider = {
     });
 
     let tokenData: any = null;
+    let rejection: string | null = null;
     try {
       const response = await deps.fetch(LINKEDIN_TOKEN_URL, {
         method: "POST",
@@ -116,21 +117,31 @@ export const linkedinProvider: Provider = {
       });
       tokenData = await (response as any).json().catch(() => ({}));
       if (!response.ok) {
-        const message =
+        // The endpoint answered and said no — revoked/expired grant, not a blip.
+        rejection =
           stringValue(tokenData?.error_description) ||
           stringValue(tokenData?.error) ||
           `HTTP ${response.status}`;
-        throw new Error(message);
       }
     } catch (error: any) {
+      // Transient (network/DNS) — retry on the next sync without alarming the operator.
       console.warn(
         `[integrations] Failed to refresh LinkedIn OAuth token for integration ${row.id}: ${error?.message ?? error}`,
       );
       return { row, refreshed: false };
     }
 
+    if (rejection) {
+      console.warn(
+        `[integrations] LinkedIn rejected OAuth token refresh for integration ${row.id}: ${rejection}`,
+      );
+      return { row, refreshed: false, failed: true, error: rejection };
+    }
+
     const accessToken = stringValue(tokenData.access_token);
-    if (!accessToken) return { row, refreshed: false };
+    if (!accessToken) {
+      return { row, refreshed: false, failed: true, error: "Token response had no access_token" };
+    }
 
     deps.ensureEncryptionConfigured("LinkedIn OAuth token refresh");
     const nextConfig = {

--- a/backend-api/integrations/providers/twitter.ts
+++ b/backend-api/integrations/providers/twitter.ts
@@ -153,6 +153,7 @@ export const twitterProvider: Provider = {
     }
 
     let tokenData: any = null;
+    let rejection: string | null = null;
     try {
       const response = await deps.fetch(TWITTER_OAUTH_TOKEN_URL, {
         method: "POST",
@@ -161,21 +162,31 @@ export const twitterProvider: Provider = {
       });
       tokenData = await (response as any).json().catch(() => ({}));
       if (!response.ok) {
-        const message =
+        // The endpoint answered and said no — revoked/expired grant, not a blip.
+        rejection =
           stringValue(tokenData?.error_description) ||
           stringValue(tokenData?.error) ||
           `HTTP ${response.status}`;
-        throw new Error(message);
       }
     } catch (error: any) {
+      // Transient (network/DNS) — retry on the next sync without alarming the operator.
       console.warn(
         `[integrations] Failed to refresh Twitter/X OAuth token for integration ${row.id}: ${error?.message ?? error}`,
       );
       return { row, refreshed: false };
     }
 
+    if (rejection) {
+      console.warn(
+        `[integrations] Twitter/X rejected OAuth token refresh for integration ${row.id}: ${rejection}`,
+      );
+      return { row, refreshed: false, failed: true, error: rejection };
+    }
+
     const accessToken = stringValue(tokenData.access_token);
-    if (!accessToken) return { row, refreshed: false };
+    if (!accessToken) {
+      return { row, refreshed: false, failed: true, error: "Token response had no access_token" };
+    }
 
     deps.ensureEncryptionConfigured("Twitter/X OAuth token refresh");
     const nextConfig = {

--- a/backend-api/integrations/repository/integrationsRepository.ts
+++ b/backend-api/integrations/repository/integrationsRepository.ts
@@ -54,6 +54,7 @@ export interface IntegrationsRepository {
     encryptedToken: string;
     encryptedConfigJson: string;
   }): Promise<void>;
+  updateStatus(input: { id: string; status: string }): Promise<void>;
   updateCronJobId(input: { id: string; agentId: string; cronJobId: string | null }): Promise<void>;
   findActiveEmailIntegrations(agentId: string): Promise<IntegrationRow[]>;
   findActiveIntegrationByCronJobId(input: {
@@ -178,6 +179,10 @@ export function createIntegrationsRepository(db: DbLike): IntegrationsRepository
         encryptedConfigJson,
         id,
       ]);
+    },
+
+    async updateStatus({ id, status }) {
+      await db.query("UPDATE integrations SET status = $1 WHERE id = $2", [status, id]);
     },
 
     async updateIntegration({ id, agentId, encryptedToken, encryptedConfigJson }) {

--- a/backend-api/integrations/services/integrationsService.ts
+++ b/backend-api/integrations/services/integrationsService.ts
@@ -280,6 +280,24 @@ async function refreshTwitterOAuthRowIfNeeded(row = {}) {
   };
 
   const outcome = await resolved.refreshCredentials(decryptedRow, providerDeps);
+
+  // A definitive provider rejection (revoked/expired grant) means the stored
+  // token is dead and every agent call will 401 — surface it to the operator
+  // instead of leaving the integration silently "active".
+  if (outcome?.failed) {
+    console.warn(
+      `[integrations] Marking integration ${row.id} (${provider}) needs_reconnect: ${outcome.error || "OAuth refresh failed"}`,
+    );
+    try {
+      await repo.updateStatus({ id: row.id, status: "needs_reconnect" });
+    } catch (statusError) {
+      console.warn(
+        `[integrations] Could not persist needs_reconnect for ${row.id}: ${statusError.message}`,
+      );
+    }
+    return { ...row, status: "needs_reconnect" };
+  }
+
   if (!outcome?.refreshed) return row;
 
   const newConfig = outcome.row.config || {};

--- a/backend-api/integrations/types/provider.ts
+++ b/backend-api/integrations/types/provider.ts
@@ -24,6 +24,14 @@ export interface EnvMapping {
 export interface RefreshOutcome {
   row: IntegrationRow;
   refreshed: boolean;
+  /**
+   * Set when the provider DEFINITIVELY rejected the refresh (revoked/expired
+   * grant, missing refresh material) as opposed to a transient network
+   * failure. The service flips the integration to needs_reconnect so the
+   * operator learns about it instead of the agent silently 401ing.
+   */
+  failed?: boolean;
+  error?: string;
 }
 
 export type ProviderAuthType =

--- a/backend-api/server.ts
+++ b/backend-api/server.ts
@@ -777,7 +777,9 @@ app.post("/webhooks/:channelId", async (req, res) => {
     await channels.handleInboundWebhook(req.params.channelId, req.body, req.headers);
     res.json({ received: true });
   } catch (e) {
-    res.status(400).json({ error: e.message });
+    // 503 for runtime-unreachable so providers retry delivery; 400 for
+    // malformed/unknown-channel requests they should not retry.
+    res.status(e.statusCode || 400).json({ error: e.message });
   }
 });
 


### PR DESCRIPTION
Second batch from the 2026-07-04 stage functional audit (see PR #261 for batch 1).

- **OAuth refresh failures are no longer silent.** twitter/linkedin `refreshCredentials` distinguish a definitive provider rejection (revoked/expired grant, empty token response) from transient network failures; on rejection the service persists `status = needs_reconnect` (new `repo.updateStatus`) and returns the flipped row. Transient failures keep the previous retry-next-sync behavior.
- **All integration env vars reach the k8s Deployment.** `buildOpenClawManagedEnvForAgent` previously filtered to LLM-overlapping keys only, so a `GITHUB_TOKEN`/`SLACK_TOKEN` connected after provisioning lived only in the pod's `openclaw.json` and died with the pod. LLM provider keys still win env-var collisions.
- **Inbound webhooks stop dropping messages.** Runtime-forward failure now surfaces as 503 (providers retry) instead of a 200 ack; the forward has a 10s abort so a hung runtime can't stall the provider's webhook worker. Malformed/unknown-channel requests still 400 (non-retryable).

Validation: full backend suite 150 suites / 1290 tests green; authSync k8s test now asserts integration tokens ride the Deployment env patch.