### PR TITLE
feat(channels): durable OpenClaw channel config with reseed on provision

### DIFF
--- a/backend-api/__tests__/openclawChannels.test.ts
+++ b/backend-api/__tests__/openclawChannels.test.ts
@@ -1,6 +1,9 @@
 // @ts-nocheck
+process.env.ENCRYPTION_KEY = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
 const mockRpcCall = jest.fn();
 const mockRunContainerCommand = jest.fn();
+const mockDbQuery = jest.fn();
 
 jest.mock("../gatewayProxy", () => ({
   rpcCall: (...args) => mockRpcCall(...args),
@@ -8,6 +11,10 @@ jest.mock("../gatewayProxy", () => ({
 
 jest.mock("../authSync", () => ({
   runContainerCommand: (...args) => mockRunContainerCommand(...args),
+}));
+
+jest.mock("../db", () => ({
+  query: (...args) => mockDbQuery(...args),
 }));
 
 const {
@@ -193,6 +200,15 @@ describe("openclaw channel catalog compatibility", () => {
       channel: "telegram",
       restart: "requested",
     });
+    // The saved patch is also persisted (encrypted) so redeploys can reseed
+    // channel config — the runtime's openclaw.json dies with the container.
+    const persistCall = mockDbQuery.mock.calls.find(([sql]) =>
+      String(sql).includes("openclaw_channel_state"),
+    );
+    expect(persistCall).toBeTruthy();
+    expect(persistCall[1][0]).toBe("agent-openclaw-1");
+    expect(persistCall[1][1]).toBe("telegram");
+    expect(String(persistCall[1][2])).not.toContain("secret-token");
     expect(mockRpcCall).toHaveBeenCalledTimes(3);
     expect(mockRpcCall).toHaveBeenNthCalledWith(
       3,

--- a/backend-api/channels/openclaw.ts
+++ b/backend-api/channels/openclaw.ts
@@ -2,6 +2,8 @@
 const { rpcCall } = require("../gatewayProxy");
 const { resolveAgentRuntimeFamily } = require("../agentRuntimeFields");
 const { OPENCLAW_GATEWAY_PORT } = require("../../agent-runtime/lib/contracts");
+const db = require("../db");
+const { encrypt, ensureEncryptionConfigured } = require("../crypto");
 
 const REDACTED_SECRET = "[REDACTED]";
 const OPENCLAW_RUNTIME_READY_STATUSES = new Set(["running", "warning"]);
@@ -1596,6 +1598,27 @@ async function getOpenClawChannelType(agent, channelId) {
   });
 }
 
+// Best-effort by design: the runtime write above already succeeded, so a DB
+// hiccup must not fail the save — it only means this channel won't reseed on
+// the next redeploy (and the next successful save repairs that).
+async function persistOpenClawChannelState(agentId, channelId, patch) {
+  if (!agentId || !channelId || !isPlainObject(patch)) return;
+  try {
+    ensureEncryptionConfigured("OpenClaw channel config persistence");
+    await db.query(
+      `INSERT INTO openclaw_channel_state(agent_id, channel_id, config_encrypted, updated_at)
+       VALUES ($1, $2, $3, NOW())
+       ON CONFLICT (agent_id, channel_id)
+       DO UPDATE SET config_encrypted = EXCLUDED.config_encrypted, updated_at = NOW()`,
+      [agentId, channelId, encrypt(JSON.stringify(patch))],
+    );
+  } catch (error) {
+    console.warn(
+      `[channels] Could not persist OpenClaw channel state for agent ${agentId}/${channelId}: ${error.message}`,
+    );
+  }
+}
+
 async function saveOpenClawChannel(agent, channelId, input = {}, { create = false } = {}) {
   let lastError = null;
 
@@ -1617,11 +1640,14 @@ async function saveOpenClawChannel(agent, channelId, input = {}, { create = fals
         nextConfig.enabled = input.enabled;
       }
 
-      const result = await writeConfigPatch(
-        agent,
-        snapshot,
-        buildOpenClawChannelConfigPatch(channelId, nextConfig),
-      );
+      const patch = buildOpenClawChannelConfigPatch(channelId, nextConfig);
+      const result = await writeConfigPatch(agent, snapshot, patch);
+
+      // The runtime's openclaw.json is the live source of channel config, but
+      // it dies with the container on redeploy — keep a durable encrypted
+      // copy so provisioning can reseed it. QR session state (device links)
+      // cannot be captured here; those channels re-pair after a rebuild.
+      await persistOpenClawChannelState(agent.id, channelId, patch);
 
       return {
         success: true,

--- a/backend-api/db_schema.sql
+++ b/backend-api/db_schema.sql
@@ -183,6 +183,18 @@ CREATE TABLE IF NOT EXISTS hermes_runtime_state (
   updated_at TIMESTAMPTZ DEFAULT NOW()
 );
 
+-- Durable copy of OpenClaw channel config: the runtime's openclaw.json is the
+-- live source, but it dies with the container on redeploy, so each saved
+-- channel's config patch is persisted (encrypted) and reseeded on provision.
+CREATE TABLE IF NOT EXISTS openclaw_channel_state (
+  agent_id UUID REFERENCES agents(id) ON DELETE CASCADE,
+  channel_id TEXT NOT NULL,
+  config_encrypted TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  PRIMARY KEY (agent_id, channel_id)
+);
+
 CREATE TABLE IF NOT EXISTS platform_settings (
   singleton BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (singleton = TRUE),
   default_vcpu INTEGER NOT NULL DEFAULT 1,

--- a/backend-api/server.ts
+++ b/backend-api/server.ts
@@ -1642,6 +1642,14 @@ async function migrateDB() {
        created_at TIMESTAMPTZ DEFAULT NOW(),
        updated_at TIMESTAMPTZ DEFAULT NOW()
      )`,
+    `CREATE TABLE IF NOT EXISTS openclaw_channel_state (
+       agent_id UUID REFERENCES agents(id) ON DELETE CASCADE,
+       channel_id TEXT NOT NULL,
+       config_encrypted TEXT NOT NULL,
+       created_at TIMESTAMPTZ DEFAULT NOW(),
+       updated_at TIMESTAMPTZ DEFAULT NOW(),
+       PRIMARY KEY (agent_id, channel_id)
+     )`,
     `DO $$ BEGIN ALTER TABLE snapshots ADD COLUMN kind TEXT DEFAULT 'snapshot'; EXCEPTION WHEN duplicate_column THEN NULL; END $$`,
     `DO $$ BEGIN ALTER TABLE snapshots ADD COLUMN template_key TEXT; EXCEPTION WHEN duplicate_column THEN NULL; END $$`,
     `DO $$ BEGIN ALTER TABLE snapshots ADD COLUMN built_in BOOLEAN DEFAULT false; EXCEPTION WHEN duplicate_column THEN NULL; END $$`,

--- a/infra/helm/nora/files/db_schema.sql
+++ b/infra/helm/nora/files/db_schema.sql
@@ -183,6 +183,18 @@ CREATE TABLE IF NOT EXISTS hermes_runtime_state (
   updated_at TIMESTAMPTZ DEFAULT NOW()
 );
 
+-- Durable copy of OpenClaw channel config: the runtime's openclaw.json is the
+-- live source, but it dies with the container on redeploy, so each saved
+-- channel's config patch is persisted (encrypted) and reseeded on provision.
+CREATE TABLE IF NOT EXISTS openclaw_channel_state (
+  agent_id UUID REFERENCES agents(id) ON DELETE CASCADE,
+  channel_id TEXT NOT NULL,
+  config_encrypted TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  PRIMARY KEY (agent_id, channel_id)
+);
+
 CREATE TABLE IF NOT EXISTS platform_settings (
   singleton BOOLEAN PRIMARY KEY DEFAULT TRUE CHECK (singleton = TRUE),
   default_vcpu INTEGER NOT NULL DEFAULT 1,

--- a/workers/provisioner/worker.ts
+++ b/workers/provisioner/worker.ts
@@ -1293,6 +1293,70 @@ async function markDeploymentLifecycle(db, agentId, status) {
   await db.query("UPDATE deployments SET status = $2 WHERE agent_id = $1", [agentId, status]);
 }
 
+function mergePlainObjects(current, next) {
+  if (!next || typeof next !== "object" || Array.isArray(next)) return next;
+  const out =
+    current && typeof current === "object" && !Array.isArray(current) ? { ...current } : {};
+  for (const [key, value] of Object.entries(next)) {
+    out[key] = mergePlainObjects(out[key], value);
+  }
+  return out;
+}
+
+/**
+ * Reseed persisted OpenClaw channel config into a fresh runtime. Channel
+ * config lives in the runtime's openclaw.json, which dies with the container
+ * on redeploy; every channel save keeps an encrypted per-channel config patch
+ * in openclaw_channel_state. Merging them back restores token channels —
+ * QR-linked sessions (WhatsApp device links) still need a re-pair, since
+ * device state cannot be captured control-plane-side.
+ */
+async function reconcileOpenClawChannelState({
+  agentId,
+  resolvedBackend,
+  containerId,
+  provisioner,
+  host,
+  runtimeHost,
+  runtimePort,
+  gatewayToken,
+}) {
+  const rows = await db.query(
+    "SELECT channel_id, config_encrypted FROM openclaw_channel_state WHERE agent_id = $1",
+    [agentId],
+  );
+  if (rows.rows.length === 0) return { status: "skipped" };
+
+  const { decrypt } = require("./crypto");
+  let delta = {};
+  for (const row of rows.rows) {
+    try {
+      delta = mergePlainObjects(delta, JSON.parse(decrypt(row.config_encrypted)));
+    } catch (error) {
+      console.warn(
+        `[provisioner] Skipping undecryptable channel state ${row.channel_id} for agent ${agentId}: ${error.message}`,
+      );
+    }
+  }
+  if (Object.keys(delta).length === 0) return { status: "skipped" };
+
+  const agentRef = {
+    backend_type: resolvedBackend,
+    host,
+    runtime_host: runtimeHost,
+    runtime_port: runtimePort,
+    gateway_token: gatewayToken,
+  };
+  const command = buildOpenClawConfigMergeCommand(delta);
+  try {
+    await runRuntimeCommand(agentRef, command);
+  } catch (error) {
+    if (!DOCKER_EXEC_FALLBACK_BACKENDS.has(resolvedBackend)) throw error;
+    await runProvisionerExecCommand(provisioner, containerId, command);
+  }
+  return { status: "synced", channels: rows.rows.length };
+}
+
 // ── ClawHub Helpers ──────────────────────────────────────
 function createClawhubSkillJobLogger({ jobId, agentId, slug, operation }) {
   const startedAt = Date.now();
@@ -2530,6 +2594,33 @@ const worker = new Worker(
           } catch (e) {
             console.warn(
               `[provisioner] Failed to reconcile runtime LLM auth for agent ${id}:`,
+              e.message,
+            );
+          }
+        }
+
+        // Reseed persisted channel config before skills/integrations so a
+        // redeploy comes back with its Telegram/Slack/Discord channels wired.
+        if (resolvedRuntimeFields.runtime_family === "openclaw" && readiness.ok) {
+          try {
+            const channelSeed = await reconcileOpenClawChannelState({
+              agentId: id,
+              resolvedBackend,
+              containerId,
+              provisioner,
+              host,
+              runtimeHost,
+              runtimePort,
+              gatewayToken,
+            });
+            if (channelSeed.status === "synced") {
+              console.log(
+                `[provisioner] Reseeded ${channelSeed.channels} OpenClaw channel config(s) for agent ${id}`,
+              );
+            }
+          } catch (e) {
+            console.warn(
+              `[provisioner] Failed to reseed OpenClaw channel config for agent ${id}:`,
               e.message,
             );
           }


### PR DESCRIPTION
P0.1 from the 2026-07-04 stage functional audit — the biggest remaining data-loss gap.

**Problem:** OpenClaw channel credentials (Telegram/Slack/Discord tokens, enabled flags, QR-plugin enables) lived ONLY inside the runtime's `openclaw.json`. A redeploy — and, for pre-PVC agents, any pod replacement — silently lost every connected channel with no way to recover them (no control-plane copy existed, unlike Hermes' `hermes_runtime_state`).

**Fix:**
- New `openclaw_channel_state` table: `(agent_id, channel_id) → encrypted config patch`, created via the boot-time schema path + `db_schema.sql`.
- Every successful channel save persists the exact patch it wrote through the gateway (the `channels.<id>` block plus `plugins.entries` enable flags). Best-effort: the runtime write already succeeded, so a DB hiccup logs loudly instead of failing the save.
- The provisioner reseeds all persisted patches into fresh runtimes right after the post-deploy LLM auth reconcile — deep-merged into one delta, applied via the shared openclaw.json config-merge command with the usual docker-exec fallback. A redeployed agent comes back with its token channels wired.
- QR-linked sessions (WhatsApp device links) can't be captured control-plane-side: their config/enabled flags reseed, the device re-pairs after a rebuild (documented in code).

Validation: full backend suite 150 suites / 1290 tests green; the channel-save test now asserts the persisted row exists, is keyed correctly, and does not contain the plaintext token.