### PR TITLE
chore: clear prettier/eslint drift so changed-files CI stays green

### DIFF
--- a/admin-dashboard/components/LogViewer.tsx
+++ b/admin-dashboard/components/LogViewer.tsx
@@ -1,12 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { Download, Terminal, Trash2, WifiOff } from "lucide-react";
 
-export default function LogViewer({
-  agentId,
-  historyRef,
-  maxLines = 1500,
-  className = "",
-}) {
+export default function LogViewer({ agentId, historyRef, maxLines = 1500, className = "" }) {
   const [logs, setLogs] = useState(() => historyRef?.current || []);
   const [connected, setConnected] = useState(false);
   const endRef = useRef(null);
@@ -133,9 +128,7 @@ export default function LogViewer({
       </div>
 
       <div className="h-[420px] overflow-y-auto p-4 font-mono text-xs leading-relaxed">
-        {logs.length === 0 ? (
-          <p className="italic text-slate-600">Waiting for logs...</p>
-        ) : null}
+        {logs.length === 0 ? <p className="italic text-slate-600">Waiting for logs...</p> : null}
 
         <div className="space-y-1.5">
           {logs.map((entry, index) => (
@@ -144,9 +137,7 @@ export default function LogViewer({
               className="flex gap-2 rounded-lg px-2 py-1 hover:bg-white/[0.03]"
             >
               <span className="shrink-0 text-slate-600">
-                {entry.timestamp
-                  ? new Date(entry.timestamp).toLocaleTimeString()
-                  : "--:--:--"}
+                {entry.timestamp ? new Date(entry.timestamp).toLocaleTimeString() : "--:--:--"}
               </span>
               {entry.level ? (
                 <span
@@ -160,8 +151,8 @@ export default function LogViewer({
                   entry.type === "system"
                     ? "text-cyan-300"
                     : entry.type === "error"
-                    ? "text-red-300"
-                    : "text-slate-200"
+                      ? "text-red-300"
+                      : "text-slate-200"
                 }
               >
                 {entry.message}

--- a/admin-dashboard/pages/fleet/[id].tsx
+++ b/admin-dashboard/pages/fleet/[id].tsx
@@ -59,9 +59,7 @@ function ActionButton({
 function InfoRow({ label, value }) {
   return (
     <div className="rounded-[1.25rem] bg-slate-50 px-4 py-4">
-      <p className="text-[11px] font-black uppercase tracking-[0.18em] text-slate-400">
-        {label}
-      </p>
+      <p className="text-[11px] font-black uppercase tracking-[0.18em] text-slate-400">{label}</p>
       <p className="mt-2 text-sm font-semibold text-slate-950">{value}</p>
     </div>
   );
@@ -134,8 +132,7 @@ export default function FleetAgentDetailPage() {
 
   useEffect(() => {
     if (!id || loading) return undefined;
-    const isTransient =
-      agent && (agent.status === "queued" || agent.status === "deploying");
+    const isTransient = agent && (agent.status === "queued" || agent.status === "deploying");
     const intervalId = setInterval(loadAgent, isTransient ? 5000 : 15000);
     return () => clearInterval(intervalId);
   }, [agent, id, loadAgent, loading]);
@@ -145,9 +142,7 @@ export default function FleetAgentDetailPage() {
 
     if (
       action === "delete" &&
-      !window.confirm(
-        `Delete ${agent.name}? This permanently removes the agent and its runtime.`
-      )
+      !window.confirm(`Delete ${agent.name}? This permanently removes the agent and its runtime.`)
     ) {
       return;
     }
@@ -156,12 +151,12 @@ export default function FleetAgentDetailPage() {
       action === "start"
         ? `/api/admin/agents/${id}/start`
         : action === "stop"
-        ? `/api/admin/agents/${id}/stop`
-        : action === "restart"
-        ? `/api/admin/agents/${id}/restart`
-        : action === "redeploy"
-        ? `/api/admin/agents/${id}/redeploy`
-        : `/api/admin/agents/${id}`;
+          ? `/api/admin/agents/${id}/stop`
+          : action === "restart"
+            ? `/api/admin/agents/${id}/restart`
+            : action === "redeploy"
+              ? `/api/admin/agents/${id}/redeploy`
+              : `/api/admin/agents/${id}`;
 
     const method = action === "delete" ? "DELETE" : "POST";
 
@@ -217,9 +212,7 @@ export default function FleetAgentDetailPage() {
   }
 
   const current = stats?.current || {};
-  const historySamples = Array.isArray(history?.samples)
-    ? history.samples.slice(-8).reverse()
-    : [];
+  const historySamples = Array.isArray(history?.samples) ? history.samples.slice(-8).reverse() : [];
 
   return (
     <AdminLayout>
@@ -338,27 +331,19 @@ export default function FleetAgentDetailPage() {
 
         <div className="grid gap-6 xl:grid-cols-[0.95fr,1.05fr]">
           <section className="rounded-[2rem] border border-slate-200 bg-white p-5 shadow-sm sm:p-6">
-            <h2 className="text-lg font-black tracking-tight text-slate-950">
-              Runtime metadata
-            </h2>
+            <h2 className="text-lg font-black tracking-tight text-slate-950">Runtime metadata</h2>
             <p className="mt-1 text-sm font-medium text-slate-500">
               Last-known ownership and runtime placement details.
             </p>
 
             <div className="mt-6 grid gap-4 sm:grid-cols-2">
               <InfoRow label="Owner" value={agent.ownerEmail || "Unknown"} />
-              <InfoRow
-                label="Created"
-                value={formatDateTime(agent.created_at)}
-              />
+              <InfoRow label="Created" value={formatDateTime(agent.created_at)} />
               <InfoRow
                 label="Backend / Node"
                 value={`${agent.backend_type || "docker"} · ${agent.node || "node n/a"}`}
               />
-              <InfoRow
-                label="Container"
-                value={agent.container_id || "No active container"}
-              />
+              <InfoRow label="Container" value={agent.container_id || "No active container"} />
               <InfoRow
                 label="Runtime Host"
                 value={
@@ -428,7 +413,8 @@ export default function FleetAgentDetailPage() {
                           {formatMemoryMb(sample.memory_usage_mb)}
                         </td>
                         <td className="px-2 py-4 text-sm font-semibold text-slate-900">
-                          {formatRateMb(sample.network_rx_rate_mbps)} / {formatRateMb(sample.network_tx_rate_mbps)}
+                          {formatRateMb(sample.network_rx_rate_mbps)} /{" "}
+                          {formatRateMb(sample.network_tx_rate_mbps)}
                         </td>
                         <td className="px-2 py-4 text-sm font-semibold text-slate-900">
                           {sample.pids ?? "—"}
@@ -444,9 +430,7 @@ export default function FleetAgentDetailPage() {
 
         <section className="rounded-[2rem] border border-slate-200 bg-white p-5 shadow-sm sm:p-6">
           <div className="mb-5 flex flex-col gap-1">
-            <h2 className="text-lg font-black tracking-tight text-slate-950">
-              Live runtime logs
-            </h2>
+            <h2 className="text-lg font-black tracking-tight text-slate-950">Live runtime logs</h2>
             <p className="text-sm font-medium text-slate-500">
               Direct websocket log stream for admin diagnosis.
             </p>

--- a/admin-dashboard/pages/fleet/index.tsx
+++ b/admin-dashboard/pages/fleet/index.tsx
@@ -1,12 +1,6 @@
 import Link from "next/link";
 import { useCallback, useDeferredValue, useEffect, useState } from "react";
-import {
-  ArrowRight,
-  Loader2,
-  RefreshCw,
-  Search,
-  Server,
-} from "lucide-react";
+import { ArrowRight, Loader2, RefreshCw, Search, Server } from "lucide-react";
 import AdminLayout from "../../components/AdminLayout";
 import MetricCard from "../../components/MetricCard";
 import StatusBadge from "../../components/StatusBadge";
@@ -79,8 +73,8 @@ export default function FleetPage() {
               Global agent fleet
             </h1>
             <p className="mt-2 max-w-2xl text-sm font-medium leading-relaxed text-slate-500">
-              Inspect every agent across all users, filter by status, and drill
-              into admin-only lifecycle controls and runtime diagnostics.
+              Inspect every agent across all users, filter by status, and drill into admin-only
+              lifecycle controls and runtime diagnostics.
             </p>
           </div>
 
@@ -113,9 +107,7 @@ export default function FleetPage() {
           />
           <MetricCard
             label="Queued / Deploying"
-            value={formatCount(
-              (statusCounts.queued || 0) + (statusCounts.deploying || 0)
-            )}
+            value={formatCount((statusCounts.queued || 0) + (statusCounts.deploying || 0))}
             icon={ArrowRight}
             tone="purple"
             caption="Work still in flight"
@@ -194,17 +186,13 @@ export default function FleetPage() {
                 </thead>
                 <tbody>
                   {filteredAgents.map((agent) => (
-                    <tr
-                      key={agent.id}
-                      className="border-b border-slate-100 last:border-b-0"
-                    >
+                    <tr key={agent.id} className="border-b border-slate-100 last:border-b-0">
                       <td className="px-2 py-4">
                         <div>
-                          <p className="text-sm font-semibold text-slate-950">
-                            {agent.name}
-                          </p>
+                          <p className="text-sm font-semibold text-slate-950">{agent.name}</p>
                           <p className="mt-1 text-xs text-slate-500">
-                            {formatShortId(agent.id)} · {agent.container_name || "no container name"}
+                            {formatShortId(agent.id)} ·{" "}
+                            {agent.container_name || "no container name"}
                           </p>
                         </div>
                       </td>

--- a/admin-dashboard/pages/queue.tsx
+++ b/admin-dashboard/pages/queue.tsx
@@ -132,8 +132,8 @@ export default function QueuePage() {
               Deployment queue and DLQ
             </h1>
             <p className="mt-2 max-w-2xl text-sm font-medium leading-relaxed text-slate-500">
-              Inspect queue pressure, review failed jobs, and retry dead-lettered
-              deployments without leaving the admin surface.
+              Inspect queue pressure, review failed jobs, and retry dead-lettered deployments
+              without leaving the admin surface.
             </p>
           </div>
 
@@ -219,9 +219,7 @@ export default function QueuePage() {
           <section className="rounded-[2rem] border border-slate-200 bg-white p-5 shadow-sm sm:p-6">
             <div className="flex items-center justify-between gap-4">
               <div>
-                <h2 className="text-lg font-black tracking-tight text-slate-950">
-                  Job detail
-                </h2>
+                <h2 className="text-lg font-black tracking-tight text-slate-950">Job detail</h2>
                 <p className="mt-1 text-sm font-medium text-slate-500">
                   Inspect payloads and retry failed work from the DLQ.
                 </p>
@@ -245,9 +243,7 @@ export default function QueuePage() {
             {!selectedJob ? (
               <div className="mt-6 flex h-56 flex-col items-center justify-center rounded-[1.5rem] border border-dashed border-slate-200 bg-slate-50 text-center text-slate-400">
                 <AlertTriangle size={34} className="mb-3 opacity-60" />
-                <p className="text-sm font-semibold">
-                  Select a DLQ job to inspect it.
-                </p>
+                <p className="text-sm font-semibold">Select a DLQ job to inspect it.</p>
               </div>
             ) : (
               <div className="mt-6 space-y-5">

--- a/backend-api/__tests__/agentFiles.test.ts
+++ b/backend-api/__tests__/agentFiles.test.ts
@@ -5,12 +5,7 @@ jest.mock("../authSync", () => ({
   runContainerCommand: (...args) => mockRunContainerCommand(...args),
 }));
 
-const {
-  createDirectory,
-  listFiles,
-  rootsForAgent,
-  writeFile,
-} = require("../agentFiles");
+const { createDirectory, listFiles, rootsForAgent, writeFile } = require("../agentFiles");
 
 describe("agentFiles", () => {
   beforeEach(() => {
@@ -29,7 +24,7 @@ describe("agentFiles", () => {
           access: "rw",
           kind: "file",
         }),
-      ])
+      ]),
     );
   });
 
@@ -45,7 +40,7 @@ describe("agentFiles", () => {
           access: "ro",
           kind: "directory",
         }),
-      ])
+      ]),
     );
   });
 
@@ -61,7 +56,7 @@ describe("agentFiles", () => {
         id: "openclaw-config",
         access: "rw",
         kind: "file",
-      })
+      }),
     );
     expect(result.entries).toEqual([
       expect.objectContaining({
@@ -82,8 +77,8 @@ describe("agentFiles", () => {
         { runtime_family: "openclaw" },
         "openclaw-config",
         "openclaw.json",
-        Buffer.from('{"runtime":"ok"}').toString("base64")
-      )
+        Buffer.from('{"runtime":"ok"}').toString("base64"),
+      ),
     ).resolves.toEqual({ success: true });
 
     expect(mockRunContainerCommand).toHaveBeenCalledTimes(1);
@@ -95,8 +90,8 @@ describe("agentFiles", () => {
         { runtime_family: "openclaw" },
         "openclaw-config",
         "workspace/notes.txt",
-        Buffer.from("nope").toString("base64")
-      )
+        Buffer.from("nope").toString("base64"),
+      ),
     ).rejects.toMatchObject({
       statusCode: 403,
       message: "Only openclaw.json can be edited from this filesystem root",
@@ -107,7 +102,7 @@ describe("agentFiles", () => {
 
   it("rejects directory mutations for the dedicated config root", async () => {
     await expect(
-      createDirectory({ runtime_family: "openclaw" }, "openclaw-config", "backup")
+      createDirectory({ runtime_family: "openclaw" }, "openclaw-config", "backup"),
     ).rejects.toMatchObject({
       statusCode: 403,
       message:

--- a/backend-api/__tests__/bootstrapAdmin.test.ts
+++ b/backend-api/__tests__/bootstrapAdmin.test.ts
@@ -10,7 +10,9 @@ describe("bootstrap admin policy", () => {
   });
 
   it("rejects short bootstrap passwords", () => {
-    expect(getBootstrapAdminSeedConfig({ adminEmail: "admin@example.com", adminPassword: "shortpass" })).toMatchObject({
+    expect(
+      getBootstrapAdminSeedConfig({ adminEmail: "admin@example.com", adminPassword: "shortpass" }),
+    ).toMatchObject({
       shouldSeed: false,
       reason: "password_too_short",
       email: "admin@example.com",
@@ -18,7 +20,9 @@ describe("bootstrap admin policy", () => {
   });
 
   it("rejects the legacy default bootstrap password", () => {
-    expect(getBootstrapAdminSeedConfig({ adminEmail: "admin@example.com", adminPassword: "admin123" })).toMatchObject({
+    expect(
+      getBootstrapAdminSeedConfig({ adminEmail: "admin@example.com", adminPassword: "admin123" }),
+    ).toMatchObject({
       shouldSeed: false,
       reason: "default_password_forbidden",
       email: "admin@example.com",
@@ -26,7 +30,12 @@ describe("bootstrap admin policy", () => {
   });
 
   it("accepts explicit secure bootstrap credentials and trims the email", () => {
-    expect(getBootstrapAdminSeedConfig({ adminEmail: "  admin@example.com ", adminPassword: "supersecure12" })).toEqual({
+    expect(
+      getBootstrapAdminSeedConfig({
+        adminEmail: "  admin@example.com ",
+        adminPassword: "supersecure12",
+      }),
+    ).toEqual({
       shouldSeed: true,
       email: "admin@example.com",
       password: "supersecure12",

--- a/backend-api/__tests__/channels.test.ts
+++ b/backend-api/__tests__/channels.test.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 const mockDb = { query: jest.fn() };
 const mockEncrypt = jest.fn((value) => `enc(${value})`);
-const mockDecrypt = jest.fn((value) => value.startsWith("enc(") ? value.slice(4, -1) : value);
+const mockDecrypt = jest.fn((value) => (value.startsWith("enc(") ? value.slice(4, -1) : value));
 const mockEnsureEncryptionConfigured = jest.fn();
 
 jest.mock("../db", () => mockDb);
@@ -26,14 +26,16 @@ describe("channel secret redaction", () => {
 
   it("redacts password and secret-like fields when creating a channel", async () => {
     mockDb.query.mockResolvedValueOnce({
-      rows: [{
-        id: "ch-1",
-        agent_id: "agent-1",
-        type: "telegram",
-        name: "Ops Telegram",
-        config: { bot_token: "123:secret", chat_id: "42" },
-        enabled: true,
-      }],
+      rows: [
+        {
+          id: "ch-1",
+          agent_id: "agent-1",
+          type: "telegram",
+          name: "Ops Telegram",
+          config: { bot_token: "123:secret", chat_id: "42" },
+          enabled: true,
+        },
+      ],
     });
 
     const result = await channels.createChannel("agent-1", "telegram", "Ops Telegram", {
@@ -49,18 +51,20 @@ describe("channel secret redaction", () => {
 
   it("redacts webhook and token fields when listing channels", async () => {
     mockDb.query.mockResolvedValueOnce({
-      rows: [{
-        id: "ch-2",
-        agent_id: "agent-1",
-        type: "whatsapp",
-        name: "Ops WhatsApp",
-        config: {
-          phone_number_id: "pn_123",
-          access_token: "wa-secret",
-          verify_token: "verify-me",
+      rows: [
+        {
+          id: "ch-2",
+          agent_id: "agent-1",
+          type: "whatsapp",
+          name: "Ops WhatsApp",
+          config: {
+            phone_number_id: "pn_123",
+            access_token: "wa-secret",
+            verify_token: "verify-me",
+          },
+          enabled: true,
         },
-        enabled: true,
-      }],
+      ],
     });
 
     const result = await channels.listChannels("agent-1");
@@ -76,32 +80,36 @@ describe("channel secret redaction", () => {
   it("redacts webhook URLs and password fields when updating a channel", async () => {
     mockDb.query
       .mockResolvedValueOnce({
-        rows: [{
-          id: "ch-3",
-          agent_id: "agent-1",
-          type: "slack",
-          name: "Ops Slack",
-          config: {
-            webhook_url: "enc(https://hooks.slack.test/secret)",
-            bot_token: "enc(xoxb-secret)",
-            channel: "#ops",
+        rows: [
+          {
+            id: "ch-3",
+            agent_id: "agent-1",
+            type: "slack",
+            name: "Ops Slack",
+            config: {
+              webhook_url: "enc(https://hooks.slack.test/secret)",
+              bot_token: "enc(xoxb-secret)",
+              channel: "#ops",
+            },
+            enabled: true,
           },
-          enabled: true,
-        }],
+        ],
       })
       .mockResolvedValueOnce({
-        rows: [{
-          id: "ch-3",
-          agent_id: "agent-1",
-          type: "slack",
-          name: "Ops Slack",
-          config: {
-            webhook_url: "enc(https://hooks.slack.test/secret)",
-            bot_token: "enc(xoxb-secret)",
-            channel: "#ops",
+        rows: [
+          {
+            id: "ch-3",
+            agent_id: "agent-1",
+            type: "slack",
+            name: "Ops Slack",
+            config: {
+              webhook_url: "enc(https://hooks.slack.test/secret)",
+              bot_token: "enc(xoxb-secret)",
+              channel: "#ops",
+            },
+            enabled: true,
           },
-          enabled: true,
-        }],
+        ],
       });
 
     const result = await channels.updateChannel("ch-3", "agent-1", {
@@ -122,30 +130,34 @@ describe("channel secret redaction", () => {
   it("preserves existing secret values when the update payload keeps them redacted", async () => {
     mockDb.query
       .mockResolvedValueOnce({
-        rows: [{
-          id: "ch-4",
-          agent_id: "agent-1",
-          type: "telegram",
-          name: "Ops Telegram",
-          config: {
-            bot_token: "enc(123:secret)",
-            chat_id: "42",
+        rows: [
+          {
+            id: "ch-4",
+            agent_id: "agent-1",
+            type: "telegram",
+            name: "Ops Telegram",
+            config: {
+              bot_token: "enc(123:secret)",
+              chat_id: "42",
+            },
+            enabled: true,
           },
-          enabled: true,
-        }],
+        ],
       })
       .mockResolvedValueOnce({
-        rows: [{
-          id: "ch-4",
-          agent_id: "agent-1",
-          type: "telegram",
-          name: "Ops Telegram",
-          config: {
-            bot_token: "enc(123:secret)",
-            chat_id: "99",
+        rows: [
+          {
+            id: "ch-4",
+            agent_id: "agent-1",
+            type: "telegram",
+            name: "Ops Telegram",
+            config: {
+              bot_token: "enc(123:secret)",
+              chat_id: "99",
+            },
+            enabled: true,
           },
-          enabled: true,
-        }],
+        ],
       });
 
     const result = await channels.updateChannel("ch-4", "agent-1", {

--- a/backend-api/__tests__/channelsEncryption.test.ts
+++ b/backend-api/__tests__/channelsEncryption.test.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 const mockDb = { query: jest.fn() };
 const mockEncrypt = jest.fn((value) => `enc(${value})`);
-const mockDecrypt = jest.fn((value) => value.startsWith("enc(") ? value.slice(4, -1) : value);
+const mockDecrypt = jest.fn((value) => (value.startsWith("enc(") ? value.slice(4, -1) : value));
 const mockEnsureEncryptionConfigured = jest.fn();
 const mockSend = jest.fn().mockResolvedValue({ delivered: true });
 
@@ -27,7 +27,11 @@ jest.mock("../channels/adapters", () => ({
     ],
     send: mockSend,
     verify: jest.fn().mockResolvedValue({ valid: true }),
-    formatInbound: jest.fn((payload) => ({ content: payload.text || "ok", sender: "tester", metadata: {} })),
+    formatInbound: jest.fn((payload) => ({
+      content: payload.text || "ok",
+      sender: "tester",
+      metadata: {},
+    })),
   })),
   listAdapterTypes: jest.fn(() => []),
 }));
@@ -45,14 +49,16 @@ describe("channel config encryption", () => {
 
   it("encrypts sensitive config keys before storing a channel", async () => {
     mockDb.query.mockResolvedValueOnce({
-      rows: [{
-        id: "ch-1",
-        agent_id: "agent-1",
-        type: "telegram",
-        name: "Ops Telegram",
-        config: { bot_token: "enc(secret-token)", chat_id: "42" },
-        enabled: true,
-      }],
+      rows: [
+        {
+          id: "ch-1",
+          agent_id: "agent-1",
+          type: "telegram",
+          name: "Ops Telegram",
+          config: { bot_token: "enc(secret-token)", chat_id: "42" },
+          enabled: true,
+        },
+      ],
     });
 
     const result = await channels.createChannel("agent-1", "telegram", "Ops Telegram", {
@@ -72,13 +78,15 @@ describe("channel config encryption", () => {
   it("decrypts stored secrets before adapter send", async () => {
     mockDb.query
       .mockResolvedValueOnce({
-        rows: [{
-          id: "ch-2",
-          agent_id: "agent-1",
-          type: "telegram",
-          enabled: true,
-          config: { bot_token: "enc(secret-token)", chat_id: "42" },
-        }],
+        rows: [
+          {
+            id: "ch-2",
+            agent_id: "agent-1",
+            type: "telegram",
+            enabled: true,
+            config: { bot_token: "enc(secret-token)", chat_id: "42" },
+          },
+        ],
       })
       .mockResolvedValueOnce({ rows: [] });
 
@@ -90,29 +98,37 @@ describe("channel config encryption", () => {
         config: { bot_token: "secret-token", chat_id: "42" },
       }),
       "hello",
-      { to: "42" }
+      { to: "42" },
     );
   });
 
   it("encrypts secret-like non-password keys such as verify_token on update", async () => {
     mockDb.query
       .mockResolvedValueOnce({
-        rows: [{
-          id: "ch-3",
-          agent_id: "agent-1",
-          type: "whatsapp",
-          enabled: true,
-          config: { phone_number_id: "pn_123" },
-        }],
+        rows: [
+          {
+            id: "ch-3",
+            agent_id: "agent-1",
+            type: "whatsapp",
+            enabled: true,
+            config: { phone_number_id: "pn_123" },
+          },
+        ],
       })
       .mockResolvedValueOnce({
-        rows: [{
-          id: "ch-3",
-          agent_id: "agent-1",
-          type: "whatsapp",
-          enabled: true,
-          config: { phone_number_id: "pn_123", access_token: "enc(wa-secret)", verify_token: "enc(verify-me)" },
-        }],
+        rows: [
+          {
+            id: "ch-3",
+            agent_id: "agent-1",
+            type: "whatsapp",
+            enabled: true,
+            config: {
+              phone_number_id: "pn_123",
+              access_token: "enc(wa-secret)",
+              verify_token: "enc(verify-me)",
+            },
+          },
+        ],
       });
 
     const result = await channels.updateChannel("ch-3", "agent-1", {

--- a/backend-api/__tests__/ensureAdminUser.test.ts
+++ b/backend-api/__tests__/ensureAdminUser.test.ts
@@ -21,7 +21,9 @@ describe("ensureFirstRegisteredUserIsAdmin", () => {
 
     await expect(ensureFirstRegisteredUserIsAdmin()).resolves.toEqual(promotedUser);
     expect(mockDb.query).toHaveBeenCalledWith(expect.stringContaining("WHERE NOT EXISTS"));
-    expect(mockDb.query).toHaveBeenCalledWith(expect.stringContaining("ORDER BY created_at ASC, id ASC"));
+    expect(mockDb.query).toHaveBeenCalledWith(
+      expect.stringContaining("ORDER BY created_at ASC, id ASC"),
+    );
   });
 
   it("returns null when an admin already exists or there are no users", async () => {

--- a/backend-api/agentFiles.ts
+++ b/backend-api/agentFiles.ts
@@ -6,7 +6,9 @@ const { shellSingleQuote } = require("../agent-runtime/lib/containerCommand");
 const MAX_INLINE_FILE_BYTES = 5 * 1024 * 1024;
 
 function normalizeRelativePath(rawValue, { allowEmpty = true } = {}) {
-  const raw = String(rawValue || "").replace(/\\/g, "/").trim();
+  const raw = String(rawValue || "")
+    .replace(/\\/g, "/")
+    .trim();
   if (!raw) return allowEmpty ? "" : null;
 
   const normalized = path.posix.normalize(raw).replace(/^\/+/, "");
@@ -16,7 +18,11 @@ function normalizeRelativePath(rawValue, { allowEmpty = true } = {}) {
 }
 
 function rootsForAgent(agent = {}) {
-  if (String(agent.runtime_family || "").trim().toLowerCase() === "hermes") {
+  if (
+    String(agent.runtime_family || "")
+      .trim()
+      .toLowerCase() === "hermes"
+  ) {
     return [
       {
         id: "workspace",
@@ -68,7 +74,8 @@ function rootsForAgent(agent = {}) {
       path: "/root/.openclaw",
       access: "ro",
       kind: "directory",
-      description: "Read-only OpenClaw runtime home, including agent files, sessions, and support state.",
+      description:
+        "Read-only OpenClaw runtime home, including agent files, sessions, and support state.",
     },
   ];
 }
@@ -129,7 +136,7 @@ function assertWritableTarget(root, relativePath = "", operation = "write") {
   if (!isFileRoot(root)) return;
   if (operation !== "write") {
     const error = new Error(
-      "This filesystem root only supports editing and downloading the OpenClaw config file"
+      "This filesystem root only supports editing and downloading the OpenClaw config file",
     );
     error.statusCode = 403;
     throw error;
@@ -260,10 +267,9 @@ async function listFiles(agent, rootId, relativePath = "") {
     const type = segments[index + 1];
     const size = Number.parseInt(segments[index + 2], 10) || 0;
     const mtime = Number.parseFloat(segments[index + 3]);
-    const entryPath = normalizeRelativePath(
-      relativePath ? `${relativePath}/${name}` : name,
-      { allowEmpty: false }
-    );
+    const entryPath = normalizeRelativePath(relativePath ? `${relativePath}/${name}` : name, {
+      allowEmpty: false,
+    });
 
     if (!entryPath) continue;
 
@@ -449,10 +455,10 @@ async function downloadPath(agent, rootId, relativePath = "") {
     'if [ -d "$target_real" ]; then',
     '  printf "directory\\0"',
     '  tar -C "$target_real" -czf - . | base64 | tr -d "\\n"',
-    'else',
+    "else",
     '  printf "file\\0"',
     '  base64 "$target_real" | tr -d "\\n"',
-    'fi',
+    "fi",
   ].join("\n");
 
   const { output } = await runFileCommand(agent, command, { timeout: 120000 });
@@ -466,10 +472,8 @@ async function downloadPath(agent, rootId, relativePath = "") {
 
   return {
     kind,
-    filename:
-      kind === "directory" ? `${name || root.id}.tar.gz` : name || `${root.id}.bin`,
-    contentType:
-      kind === "directory" ? "application/gzip" : "application/octet-stream",
+    filename: kind === "directory" ? `${name || root.id}.tar.gz` : name || `${root.id}.bin`,
+    contentType: kind === "directory" ? "application/gzip" : "application/octet-stream",
     contentBase64,
   };
 }

--- a/backend-api/agentSecretOverrides.ts
+++ b/backend-api/agentSecretOverrides.ts
@@ -30,7 +30,7 @@ async function listAgentSecretOverrides(agentId, { decryptValues = false } = {})
        FROM agent_secret_overrides
       WHERE agent_id = $1
       ORDER BY env_key ASC`,
-    [agentId]
+    [agentId],
   );
 
   return result.rows.reduce((acc, row) => {
@@ -60,7 +60,7 @@ async function replaceAgentSecretOverrides(agentId, rawEntries = {}) {
     await db.query(
       `INSERT INTO agent_secret_overrides(agent_id, env_key, env_value)
        VALUES($1, $2, $3)`,
-      [agentId, envKey, encrypt(envValue)]
+      [agentId, envKey, encrypt(envValue)],
     );
   }
 

--- a/backend-api/auditSource.ts
+++ b/backend-api/auditSource.ts
@@ -33,12 +33,7 @@ function readRequestIp(req) {
     return forwardedFor.split(",")[0].trim();
   }
 
-  return (
-    req.ip ||
-    req.socket?.remoteAddress ||
-    req.connection?.remoteAddress ||
-    null
-  );
+  return req.ip || req.socket?.remoteAddress || req.connection?.remoteAddress || null;
 }
 
 function normalizeSourceAccount(account = {}) {
@@ -91,14 +86,11 @@ function buildSourceMetadata(req, source = {}) {
             email: req.user.email || null,
             role: req.user.role || null,
           }
-        : null)
+        : null),
   );
   const resolvedKind = kind || (account ? "account" : req ? "request" : "system");
   const resolvedService =
-    service ||
-    process.env.AUDIT_SOURCE_SERVICE ||
-    process.env.SERVICE_NAME ||
-    "backend-api";
+    service || process.env.AUDIT_SOURCE_SERVICE || process.env.SERVICE_NAME || "backend-api";
 
   return compactObject({
     kind: resolvedKind,
@@ -108,11 +100,7 @@ function buildSourceMetadata(req, source = {}) {
     area: area || null,
     method: method || req?.method || null,
     route: route || req?.originalUrl || req?.path || null,
-    origin:
-      origin ||
-      readRequestHeader(req, "origin") ||
-      readRequestHeader(req, "referer") ||
-      null,
+    origin: origin || readRequestHeader(req, "origin") || readRequestHeader(req, "referer") || null,
     ip: ip || readRequestIp(req) || null,
     userAgent: userAgent || readRequestHeader(req, "user-agent") || null,
     account,

--- a/backend-api/backends/telemetry.ts
+++ b/backend-api/backends/telemetry.ts
@@ -24,10 +24,7 @@ const PROXMOX_DEFAULT_CAPABILITIES = Object.freeze({
 });
 
 function toFiniteNumber(value) {
-  const parsed =
-    typeof value === "string" && value.trim() !== ""
-      ? Number(value)
-      : value;
+  const parsed = typeof value === "string" && value.trim() !== "" ? Number(value) : value;
   return Number.isFinite(parsed) ? parsed : null;
 }
 
@@ -113,9 +110,7 @@ function buildUnavailableTelemetry({
 }
 
 function uptimeFromContainerInfo(info) {
-  const startedAt = info?.State?.StartedAt
-    ? new Date(info.State.StartedAt).getTime()
-    : 0;
+  const startedAt = info?.State?.StartedAt ? new Date(info.State.StartedAt).getTime() : 0;
   if (!info?.State?.Running || !startedAt) return 0;
   return Math.max(0, Math.floor((Date.now() - startedAt) / 1000));
 }
@@ -149,12 +144,9 @@ function dockerCpuPercent(stats) {
     (stats?.cpu_stats?.cpu_usage?.total_usage || 0) -
     (stats?.precpu_stats?.cpu_usage?.total_usage || 0);
   const systemDelta =
-    (stats?.cpu_stats?.system_cpu_usage || 0) -
-    (stats?.precpu_stats?.system_cpu_usage || 0);
+    (stats?.cpu_stats?.system_cpu_usage || 0) - (stats?.precpu_stats?.system_cpu_usage || 0);
   const cpuCount =
-    stats?.cpu_stats?.online_cpus ||
-    stats?.cpu_stats?.cpu_usage?.percpu_usage?.length ||
-    1;
+    stats?.cpu_stats?.online_cpus || stats?.cpu_stats?.cpu_usage?.percpu_usage?.length || 1;
 
   if (systemDelta <= 0) return 0;
   return roundMetric((cpuDelta / systemDelta) * cpuCount * 100);
@@ -178,8 +170,7 @@ function buildDockerTelemetry({ stats, info, backendType = "docker" }) {
       cpu_percent: dockerCpuPercent(stats),
       memory_usage_mb: bytesToMegabytes(memActual, 0),
       memory_limit_mb: bytesToMegabytes(memLimit, 0),
-      memory_percent:
-        memLimit > 0 ? roundMetric((memActual / memLimit) * 100) : 0,
+      memory_percent: memLimit > 0 ? roundMetric((memActual / memLimit) * 100) : 0,
       network_rx_mb: bytesToMegabytes(network.received),
       network_tx_mb: bytesToMegabytes(network.transmitted),
       disk_read_mb: bytesToMegabytes(disk.read),

--- a/backend-api/channels/adapters.ts
+++ b/backend-api/channels/adapters.ts
@@ -165,7 +165,8 @@ const email = {
   },
 
   async verify(config) {
-    if (!config.smtp_host || !config.smtp_user) return { valid: false, error: "SMTP host and user required" };
+    if (!config.smtp_host || !config.smtp_user)
+      return { valid: false, error: "SMTP host and user required" };
     return { valid: true };
   },
 
@@ -187,7 +188,13 @@ const webhook = {
 
   configFields: [
     { key: "url", label: "Webhook URL", type: "url", required: true },
-    { key: "method", label: "HTTP Method", type: "select", options: ["POST", "PUT"], required: false },
+    {
+      key: "method",
+      label: "HTTP Method",
+      type: "select",
+      options: ["POST", "PUT"],
+      required: false,
+    },
     { key: "headers", label: "Custom Headers (JSON)", type: "textarea", required: false },
     { key: "secret", label: "Signing Secret", type: "password", required: false },
   ],
@@ -201,7 +208,9 @@ const webhook = {
     if (channel.config.headers) {
       try {
         headers = { ...headers, ...filterWebhookHeaders(JSON.parse(channel.config.headers)) };
-      } catch { /* ignore parse errors */ }
+      } catch {
+        /* ignore parse errors */
+      }
     }
     const res = await fetch(url, {
       method,
@@ -439,7 +448,12 @@ const line = {
   icon: "message-square",
 
   configFields: [
-    { key: "channel_access_token", label: "Channel Access Token", type: "password", required: true },
+    {
+      key: "channel_access_token",
+      label: "Channel Access Token",
+      type: "password",
+      required: true,
+    },
     { key: "channel_secret", label: "Channel Secret", type: "password", required: false },
     { key: "user_id", label: "Default User/Group ID", type: "text", required: false },
   ],
@@ -468,7 +482,8 @@ const line = {
   },
 
   async verify(config) {
-    if (!config.channel_access_token) return { valid: false, error: "Channel Access Token required" };
+    if (!config.channel_access_token)
+      return { valid: false, error: "Channel Access Token required" };
     return { valid: true };
   },
 

--- a/backend-api/crypto.ts
+++ b/backend-api/crypto.ts
@@ -11,8 +11,8 @@ const ENCRYPTION_KEY = /^[0-9a-fA-F]{64}$/.test(RAW_KEY) ? RAW_KEY : null;
 if (!ENCRYPTION_KEY) {
   console.error(
     "SECURITY WARNING: ENCRYPTION_KEY is not set or invalid. " +
-    "Sensitive credential writes are blocked until encryption at rest is configured. " +
-    "Set a 64-char hex key in .env to enable secure storage."
+      "Sensitive credential writes are blocked until encryption at rest is configured. " +
+      "Set a 64-char hex key in .env to enable secure storage.",
   );
 }
 
@@ -22,7 +22,9 @@ function isEncryptionConfigured() {
 
 function ensureEncryptionConfigured(context = "Sensitive credential storage") {
   if (ENCRYPTION_KEY) return;
-  const err = new Error(`${context} requires ENCRYPTION_KEY to be configured with a valid 64-char hex key`);
+  const err = new Error(
+    `${context} requires ENCRYPTION_KEY to be configured with a valid 64-char hex key`,
+  );
   err.statusCode = 503;
   throw err;
 }
@@ -74,8 +76,16 @@ function decrypt(data) {
     return decrypted;
   } catch (err) {
     console.error("Decryption failed (key mismatch or corrupted data):", err.message);
-    throw new DecryptionError("Failed to decrypt stored credential — encryption key may have rotated or data is corrupted");
+    throw new DecryptionError(
+      "Failed to decrypt stored credential — encryption key may have rotated or data is corrupted",
+    );
   }
 }
 
-module.exports = { encrypt, decrypt, isEncryptionConfigured, ensureEncryptionConfigured, DecryptionError };
+module.exports = {
+  encrypt,
+  decrypt,
+  isEncryptionConfigured,
+  ensureEncryptionConfigured,
+  DecryptionError,
+};

--- a/backend-api/db.ts
+++ b/backend-api/db.ts
@@ -1,12 +1,12 @@
 // @ts-nocheck
-const {Pool} = require('pg')
+const { Pool } = require("pg");
 
 const pool = new Pool({
-  user: process.env.DB_USER || 'nora',
-  password: process.env.DB_PASSWORD || 'nora',
-  host: process.env.DB_HOST || 'postgres',
-  database: process.env.DB_NAME || 'nora',
-  port: parseInt(process.env.DB_PORT || '5432'),
-})
+  user: process.env.DB_USER || "nora",
+  password: process.env.DB_PASSWORD || "nora",
+  host: process.env.DB_HOST || "postgres",
+  database: process.env.DB_NAME || "nora",
+  port: parseInt(process.env.DB_PORT || "5432"),
+});
 
-module.exports = pool
+module.exports = pool;

--- a/backend-api/ensureAdminUser.ts
+++ b/backend-api/ensureAdminUser.ts
@@ -17,7 +17,7 @@ async function ensureFirstRegisteredUserIsAdmin(queryable = db) {
      UPDATE users
      SET role = 'admin'
      WHERE id = (SELECT id FROM first_user)
-     RETURNING id, email, role, created_at`
+     RETURNING id, email, role, created_at`,
   );
 
   return result.rows[0] || null;

--- a/backend-api/healthChecks.ts
+++ b/backend-api/healthChecks.ts
@@ -53,15 +53,18 @@ async function waitForHttpReady(url, options = {}) {
   };
 }
 
-async function waitForAgentReadiness({
-  host,
-  runtimeHost = null,
-  runtimePort = AGENT_RUNTIME_PORT,
-  gatewayHostPort = null,
-  gatewayHost = null,
-  gatewayPort = OPENCLAW_GATEWAY_PORT,
-  checkGateway = true,
-} = {}, options = {}) {
+async function waitForAgentReadiness(
+  {
+    host,
+    runtimeHost = null,
+    runtimePort = AGENT_RUNTIME_PORT,
+    gatewayHostPort = null,
+    gatewayHost = null,
+    gatewayPort = OPENCLAW_GATEWAY_PORT,
+    checkGateway = true,
+  } = {},
+  options = {},
+) {
   const resolvedRuntimeHost = runtimeHost || host;
   const resolvedRuntimePort = runtimePort || AGENT_RUNTIME_PORT;
 
@@ -73,26 +76,23 @@ async function waitForAgentReadiness({
       timeoutMs: 5000,
       acceptStatuses: [200],
       ...options.runtime,
-    }
+    },
   );
 
   let gateway = null;
   if (checkGateway) {
     const resolvedGatewayHost = gatewayHostPort
-      ? (gatewayHost || process.env.GATEWAY_HOST || "host.docker.internal")
-      : (gatewayHost || host);
+      ? gatewayHost || process.env.GATEWAY_HOST || "host.docker.internal"
+      : gatewayHost || host;
     const resolvedGatewayPort = gatewayHostPort || gatewayPort || OPENCLAW_GATEWAY_PORT;
 
-    gateway = await waitForHttpReady(
-      gatewayUrl(resolvedGatewayHost, resolvedGatewayPort, "/"),
-      {
-        attempts: 15,
-        intervalMs: 10000,
-        timeoutMs: 5000,
-        acceptStatuses: [200, 401, 403],
-        ...options.gateway,
-      }
-    );
+    gateway = await waitForHttpReady(gatewayUrl(resolvedGatewayHost, resolvedGatewayPort, "/"), {
+      attempts: 15,
+      intervalMs: 10000,
+      timeoutMs: 5000,
+      acceptStatuses: [200, 401, 403],
+      ...options.gateway,
+    });
     gateway = {
       ...gateway,
       host: resolvedGatewayHost,

--- a/backend-api/middleware/requestMetrics.ts
+++ b/backend-api/middleware/requestMetrics.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
-const { recordApiMetric } = require('../metrics');
-const safeRecordApiMetric = typeof recordApiMetric === 'function' ? recordApiMetric : () => {};
+const { recordApiMetric } = require("../metrics");
+const safeRecordApiMetric = typeof recordApiMetric === "function" ? recordApiMetric : () => {};
 
 /**
  * Middleware that records request latency and status for API performance tracking.
@@ -8,9 +8,9 @@ const safeRecordApiMetric = typeof recordApiMetric === 'function' ? recordApiMet
  */
 function requestMetrics(req, res, next) {
   const start = process.hrtime.bigint();
-  res.on('finish', () => {
+  res.on("finish", () => {
     // Skip health checks and static assets
-    if (req.originalUrl === '/health') return;
+    if (req.originalUrl === "/health") return;
 
     const durationMs = Number(process.hrtime.bigint() - start) / 1e6;
     safeRecordApiMetric({

--- a/backend-api/oauthProviders.ts
+++ b/backend-api/oauthProviders.ts
@@ -31,14 +31,20 @@ async function fetchJson(url, options, providerLabel) {
     throw new Error(
       detail
         ? `${providerLabel} token verification failed: ${detail}`
-        : `${providerLabel} token verification failed (${res.status})`
+        : `${providerLabel} token verification failed (${res.status})`,
     );
   }
 
   return data || {};
 }
 
-function assertRequestedIdentityMatches({ requestedEmail, requestedProviderId, actualEmail, actualProviderId, providerLabel }) {
+function assertRequestedIdentityMatches({
+  requestedEmail,
+  requestedProviderId,
+  actualEmail,
+  actualProviderId,
+  providerLabel,
+}) {
   if (requestedEmail && normalizeEmail(requestedEmail) !== normalizeEmail(actualEmail)) {
     throw new Error(`${providerLabel} token email did not match the requested account`);
   }
@@ -75,7 +81,7 @@ async function verifyGoogleIdentity({ accessToken, idToken, email, providerId })
     const data = await fetchJson(
       GOOGLE_OIDC_USERINFO_URL,
       { headers: { Authorization: `Bearer ${accessToken}` } },
-      "Google"
+      "Google",
     );
 
     if (!data.sub) throw new Error("Google token verification failed: missing subject");
@@ -116,8 +122,8 @@ async function verifyGitHubIdentity({ accessToken, email, providerId }) {
   const user = await fetchJson(GITHUB_USER_URL, { headers }, "GitHub");
   const emails = await fetchJson(GITHUB_EMAILS_URL, { headers }, "GitHub");
   const primaryVerified = Array.isArray(emails)
-    ? emails.find((entry) => entry.primary && entry.verified && entry.email)
-      || emails.find((entry) => entry.verified && entry.email)
+    ? emails.find((entry) => entry.primary && entry.verified && entry.email) ||
+      emails.find((entry) => entry.verified && entry.email)
     : null;
   const verifiedEmail = primaryVerified?.email || null;
 

--- a/backend-api/promiseTimeout.ts
+++ b/backend-api/promiseTimeout.ts
@@ -36,9 +36,7 @@ function runWithCancellableTimeout(factory, timeoutMs, message) {
       reject(error);
     }, timeoutMs);
   });
-  const work = Promise.resolve().then(() =>
-    factory({ signal: controller.signal, controller }),
-  );
+  const work = Promise.resolve().then(() => factory({ signal: controller.signal, controller }));
   return Promise.race([work, timeout]).finally(() => clearTimeout(timer));
 }
 

--- a/backend-api/routes/agentFiles.ts
+++ b/backend-api/routes/agentFiles.ts
@@ -14,10 +14,7 @@ const {
   rootsForAgent,
   writeFile,
 } = require("../agentFiles");
-const {
-  buildMigrationManifestFromAgent,
-  packMigrationBundle,
-} = require("../agentMigrations");
+const { buildMigrationManifestFromAgent, packMigrationBundle } = require("../agentMigrations");
 const { asyncHandler } = require("../middleware/errorHandler");
 const { createMutationFailureAuditMiddleware } = require("../auditLog");
 
@@ -29,7 +26,7 @@ async function loadOwnedAgent(req, res) {
     `SELECT *
        FROM agents
       WHERE id = $1 AND user_id = $2`,
-    [req.params.id, req.user.id]
+    [req.params.id, req.user.id],
   );
   const agent = result.rows[0];
   if (!agent) {
@@ -64,10 +61,10 @@ router.get(
     res.setHeader("Content-Type", "application/gzip");
     res.setHeader(
       "Content-Disposition",
-      `attachment; filename="${filenameSeed || "nora-agent"}.nora-migration.tgz"`
+      `attachment; filename="${filenameSeed || "nora-agent"}.nora-migration.tgz"`,
     );
     res.send(bundle);
-  })
+  }),
 );
 
 router.get(
@@ -76,7 +73,7 @@ router.get(
     const agent = await loadOwnedAgent(req, res);
     if (!agent) return;
     res.json({ roots: rootsForAgent(agent) });
-  })
+  }),
 );
 
 router.get(
@@ -88,10 +85,10 @@ router.get(
     const payload = await listFiles(
       agent,
       req.query.root,
-      typeof req.query.path === "string" ? req.query.path : ""
+      typeof req.query.path === "string" ? req.query.path : "",
     );
     res.json(payload);
-  })
+  }),
 );
 
 router.get(
@@ -103,10 +100,10 @@ router.get(
     const payload = await readFile(
       agent,
       req.query.root,
-      typeof req.query.path === "string" ? req.query.path : ""
+      typeof req.query.path === "string" ? req.query.path : "",
     );
     res.json(payload);
-  })
+  }),
 );
 
 router.get(
@@ -118,15 +115,12 @@ router.get(
     const payload = await downloadPath(
       agent,
       req.query.root,
-      typeof req.query.path === "string" ? req.query.path : ""
+      typeof req.query.path === "string" ? req.query.path : "",
     );
     res.setHeader("Content-Type", payload.contentType);
-    res.setHeader(
-      "Content-Disposition",
-      `attachment; filename="${payload.filename}"`
-    );
+    res.setHeader("Content-Disposition", `attachment; filename="${payload.filename}"`);
     res.send(Buffer.from(payload.contentBase64, "base64"));
-  })
+  }),
 );
 
 router.put(
@@ -140,10 +134,10 @@ router.put(
       req.body?.root,
       req.body?.path,
       req.body?.contentBase64 || "",
-      Number.isInteger(req.body?.mode) ? req.body.mode : 0o644
+      Number.isInteger(req.body?.mode) ? req.body.mode : 0o644,
     );
     res.json(result);
-  })
+  }),
 );
 
 router.post(
@@ -160,20 +154,18 @@ router.post(
 
     const baseDirectory = normalizeRelativePath(
       typeof req.query.path === "string" ? req.query.path : "",
-      { allowEmpty: true }
+      { allowEmpty: true },
     );
-    const relativePath = baseDirectory
-      ? path.posix.join(baseDirectory, filename)
-      : filename;
+    const relativePath = baseDirectory ? path.posix.join(baseDirectory, filename) : filename;
 
     const result = await writeFile(
       agent,
       req.query.root,
       relativePath,
-      Buffer.from(req.body || Buffer.alloc(0)).toString("base64")
+      Buffer.from(req.body || Buffer.alloc(0)).toString("base64"),
     );
     res.json(result);
-  })
+  }),
 );
 
 router.post(
@@ -184,7 +176,7 @@ router.post(
 
     const result = await createDirectory(agent, req.body?.root, req.body?.path);
     res.json(result);
-  })
+  }),
 );
 
 router.post(
@@ -193,14 +185,9 @@ router.post(
     const agent = await loadOwnedAgent(req, res);
     if (!agent) return;
 
-    const result = await movePath(
-      agent,
-      req.body?.root,
-      req.body?.fromPath,
-      req.body?.toPath
-    );
+    const result = await movePath(agent, req.body?.root, req.body?.fromPath, req.body?.toPath);
     res.json(result);
-  })
+  }),
 );
 
 router.delete(
@@ -211,7 +198,7 @@ router.delete(
 
     const result = await deletePath(agent, req.body?.root, req.body?.path);
     res.json(result);
-  })
+  }),
 );
 
 module.exports = router;

--- a/backend-api/routes/agentMigrations.ts
+++ b/backend-api/routes/agentMigrations.ts
@@ -28,7 +28,7 @@ router.post(
     });
 
     res.json({ draft: draft.preview });
-  })
+  }),
 );
 
 router.post(
@@ -43,7 +43,7 @@ router.post(
     });
 
     res.json({ draft: draft.preview });
-  })
+  }),
 );
 
 router.get(
@@ -55,7 +55,7 @@ router.get(
     }
 
     res.json({ draft: draft.preview });
-  })
+  }),
 );
 
 router.delete(
@@ -73,7 +73,7 @@ router.delete(
 
     const deleted = await deleteOwnedMigrationDraft(req.params.id, req.user.id);
     res.json({ success: deleted });
-  })
+  }),
 );
 
 module.exports = router;

--- a/backend-api/scheduler.ts
+++ b/backend-api/scheduler.ts
@@ -22,7 +22,7 @@ async function selectNode(options = {}) {
 
   // Query current agent distribution across nodes
   const result = await db.query(
-    "SELECT node, COUNT(*)::int AS agent_count FROM agents WHERE status NOT IN ('error', 'deleted') GROUP BY node"
+    "SELECT node, COUNT(*)::int AS agent_count FROM agents WHERE status NOT IN ('error', 'deleted') GROUP BY node",
   );
   const counts = {};
   result.rows.forEach((r) => {

--- a/backend-api/snapshots.ts
+++ b/backend-api/snapshots.ts
@@ -10,9 +10,7 @@ function stringifyConfig(config = {}) {
 function normalizeSnapshotOptions(options = {}) {
   return {
     kind:
-      typeof options.kind === "string" && options.kind.trim()
-        ? options.kind.trim()
-        : "snapshot",
+      typeof options.kind === "string" && options.kind.trim() ? options.kind.trim() : "snapshot",
     templateKey:
       typeof options.templateKey === "string" && options.templateKey.trim()
         ? options.templateKey.trim()
@@ -21,13 +19,7 @@ function normalizeSnapshotOptions(options = {}) {
   };
 }
 
-async function createSnapshot(
-  agentId,
-  name,
-  description,
-  config = {},
-  options = {}
-) {
+async function createSnapshot(agentId, name, description, config = {}, options = {}) {
   const normalized = normalizeSnapshotOptions(options);
   const result = await db.query(
     `INSERT INTO snapshots(agent_id, name, description, config, kind, template_key, built_in)
@@ -41,7 +33,7 @@ async function createSnapshot(
       normalized.kind,
       normalized.templateKey,
       normalized.builtIn,
-    ]
+    ],
   );
   return result.rows[0];
 }
@@ -60,7 +52,7 @@ async function getSnapshotByTemplateKey(templateKey) {
   if (!templateKey) return null;
   const result = await db.query(
     "SELECT * FROM snapshots WHERE template_key = $1 ORDER BY created_at ASC LIMIT 1",
-    [templateKey]
+    [templateKey],
   );
   return result.rows[0] || null;
 }
@@ -96,7 +88,7 @@ async function upsertSnapshot({
           normalized.kind,
           normalized.builtIn,
           existing.id,
-        ]
+        ],
       );
       return result.rows[0];
     }
@@ -107,23 +99,14 @@ async function upsertSnapshot({
 
 async function updateSnapshot(
   id,
-  {
-    agentId,
-    name,
-    description,
-    config,
-    kind,
-    templateKey,
-    builtIn,
-  } = {}
+  { agentId, name, description, config, kind, templateKey, builtIn } = {},
 ) {
   const existing = await getSnapshot(id);
   if (!existing) return null;
 
   const normalized = normalizeSnapshotOptions({
     kind: kind ?? existing.kind,
-    templateKey:
-      templateKey !== undefined ? templateKey : existing.template_key,
+    templateKey: templateKey !== undefined ? templateKey : existing.template_key,
     builtIn: builtIn ?? existing.built_in,
   });
 
@@ -147,7 +130,7 @@ async function updateSnapshot(
       normalized.templateKey,
       normalized.builtIn,
       id,
-    ]
+    ],
   );
 
   return result.rows[0] || null;

--- a/cli/src/client.js
+++ b/cli/src/client.js
@@ -20,9 +20,7 @@ function requireConfig() {
     );
   }
   if (!config.token) {
-    throw new Error(
-      "No API token found. Run `nora login --token nora_...` or set NORA_TOKEN.",
-    );
+    throw new Error("No API token found. Run `nora login --token nora_...` or set NORA_TOKEN.");
   }
   return config;
 }
@@ -59,9 +57,7 @@ async function request(method, path, { body, query } = {}) {
       (typeof parsed === "string" && parsed) ||
       `Request failed (${response.status})`;
     const code =
-      parsed && typeof parsed === "object" && typeof parsed.code === "string"
-        ? parsed.code
-        : null;
+      parsed && typeof parsed === "object" && typeof parsed.code === "string" ? parsed.code : null;
     throw new ApiError(response.status, message, code);
   }
   return parsed;

--- a/cli/src/commands/monitoring.js
+++ b/cli/src/commands/monitoring.js
@@ -23,7 +23,6 @@ async function tail(args, flags) {
   const intervalMs = Math.max(1000, Number(flags.interval || 5000));
   console.log(`Tailing events every ${intervalMs}ms (Ctrl+C to stop)…`);
   let lastSeen = null;
-  // eslint-disable-next-line no-constant-condition
   while (true) {
     try {
       const data = await api.get("/api/monitoring/events", { query: { limit: 50 } });

--- a/frontend-dashboard/components/ConfirmDialog.tsx
+++ b/frontend-dashboard/components/ConfirmDialog.tsx
@@ -16,9 +16,14 @@ export default function ConfirmDialog({ open, title, message, confirmLabel, onCo
           </div>
           <div className="flex-1">
             <h3 className="text-lg font-bold text-slate-900">{title || "Confirm Action"}</h3>
-            <p className="text-sm text-slate-500 mt-1 leading-relaxed">{message || "Are you sure?"}</p>
+            <p className="text-sm text-slate-500 mt-1 leading-relaxed">
+              {message || "Are you sure?"}
+            </p>
           </div>
-          <button onClick={onCancel} className="text-slate-400 hover:text-slate-600 transition-colors">
+          <button
+            onClick={onCancel}
+            className="text-slate-400 hover:text-slate-600 transition-colors"
+          >
             <X size={18} />
           </button>
         </div>

--- a/frontend-dashboard/components/LogViewer.tsx
+++ b/frontend-dashboard/components/LogViewer.tsx
@@ -83,11 +83,13 @@ export default function LogViewer({
   }, [visible]);
 
   const exportLogs = useCallback(() => {
-    const text = logs.map(log => {
-      const ts = log.timestamp ? `[${log.timestamp}]` : "";
-      const level = log.level ? ` ${log.level}` : "";
-      return `${ts}${level} ${log.message || ""}`;
-    }).join("\n");
+    const text = logs
+      .map((log) => {
+        const ts = log.timestamp ? `[${log.timestamp}]` : "";
+        const level = log.level ? ` ${log.level}` : "";
+        return `${ts}${level} ${log.message || ""}`;
+      })
+      .join("\n");
 
     const blob = new Blob([text], { type: "text/plain" });
     const url = URL.createObjectURL(blob);
@@ -106,12 +108,17 @@ export default function LogViewer({
   };
 
   return (
-    <div className="bg-slate-950 border border-slate-800 rounded-2xl overflow-hidden" style={{ height: "100%" }}>
+    <div
+      className="bg-slate-950 border border-slate-800 rounded-2xl overflow-hidden"
+      style={{ height: "100%" }}
+    >
       {/* Toolbar */}
       <div className="flex items-center justify-between px-4 py-3 border-b border-slate-800 bg-slate-900/50">
         <div className="flex items-center gap-2">
           <Terminal size={14} className="text-slate-500" />
-          <span className="text-xs font-bold text-slate-400 uppercase tracking-widest">Live Logs</span>
+          <span className="text-xs font-bold text-slate-400 uppercase tracking-widest">
+            Live Logs
+          </span>
           <span className="text-[10px] text-slate-600">{logs.length} entries</span>
         </div>
         <div className="flex items-center gap-3">
@@ -148,10 +155,11 @@ export default function LogViewer({
       </div>
 
       {/* Log output */}
-      <div className="overflow-y-auto p-4 font-mono text-xs leading-relaxed space-y-0.5 scrollbar-thin scrollbar-thumb-slate-800" style={{ height: "calc(100% - 45px)" }}>
-        {logs.length === 0 && (
-          <p className="text-slate-600 italic">Waiting for logs...</p>
-        )}
+      <div
+        className="overflow-y-auto p-4 font-mono text-xs leading-relaxed space-y-0.5 scrollbar-thin scrollbar-thumb-slate-800"
+        style={{ height: "calc(100% - 45px)" }}
+      >
+        {logs.length === 0 && <p className="text-slate-600 italic">Waiting for logs...</p>}
         {logs.map((log, i) => (
           <div key={i} className="flex gap-2 hover:bg-white/[0.02] px-1 -mx-1 rounded">
             {log.timestamp && (
@@ -160,7 +168,9 @@ export default function LogViewer({
               </span>
             )}
             {log.level && (
-              <span className={`font-bold shrink-0 w-12 ${levelColors[log.level] || "text-slate-400"}`}>
+              <span
+                className={`font-bold shrink-0 w-12 ${levelColors[log.level] || "text-slate-400"}`}
+              >
                 {log.level}
               </span>
             )}
@@ -169,8 +179,8 @@ export default function LogViewer({
                 log.type === "system"
                   ? "text-cyan-400"
                   : log.type === "error"
-                  ? "text-red-400"
-                  : "text-slate-300"
+                    ? "text-red-400"
+                    : "text-slate-300"
               }
             >
               {log.message}

--- a/frontend-dashboard/components/RuntimePathFields.tsx
+++ b/frontend-dashboard/components/RuntimePathFields.tsx
@@ -44,46 +44,42 @@ export default function RuntimePathFields({
 }: RuntimePathFieldsProps) {
   const activeRuntimeFamily = useMemo(
     () => runtimeFamilyFromConfig(backendConfig, runtimeFamily),
-    [backendConfig, runtimeFamily]
+    [backendConfig, runtimeFamily],
   );
   const visibleRuntimeFamilies = useMemo(
     () => visibleRuntimeFamiliesFromConfig(backendConfig, viewerRole),
-    [backendConfig, viewerRole]
+    [backendConfig, viewerRole],
   );
   const visibleExecutionTargets = useMemo(
     () =>
       visibleExecutionTargetsFromConfig(
         backendConfig,
         viewerRole,
-        activeRuntimeFamily?.id || runtimeFamily
+        activeRuntimeFamily?.id || runtimeFamily,
       ),
-    [backendConfig, viewerRole, activeRuntimeFamily?.id, runtimeFamily]
+    [backendConfig, viewerRole, activeRuntimeFamily?.id, runtimeFamily],
   );
   const activeExecutionTarget = useMemo(
     () =>
       activeExecutionTargetFromConfig(
         backendConfig,
         activeRuntimeFamily?.id || runtimeFamily,
-        executionTarget
+        executionTarget,
       ),
-    [backendConfig, activeRuntimeFamily?.id, runtimeFamily, executionTarget]
+    [backendConfig, activeRuntimeFamily?.id, runtimeFamily, executionTarget],
   );
   const visibleSandboxOptions = useMemo(
     () => visibleSandboxOptionsFromTarget(activeExecutionTarget, viewerRole),
-    [activeExecutionTarget, viewerRole]
+    [activeExecutionTarget, viewerRole],
   );
   const activeSandboxOption = useMemo(
     () => activeSandboxOptionFromTarget(activeExecutionTarget, sandboxProfile),
-    [activeExecutionTarget, sandboxProfile]
+    [activeExecutionTarget, sandboxProfile],
   );
 
   useEffect(() => {
     if (!backendConfig || typeof onRuntimeFamilyChange !== "function") return;
-    const nextRuntimeFamily = pickRuntimeFamilySelection(
-      backendConfig,
-      viewerRole,
-      runtimeFamily
-    );
+    const nextRuntimeFamily = pickRuntimeFamilySelection(backendConfig, viewerRole, runtimeFamily);
     if (nextRuntimeFamily && nextRuntimeFamily !== runtimeFamily) {
       onRuntimeFamilyChange(nextRuntimeFamily);
     }
@@ -95,7 +91,7 @@ export default function RuntimePathFields({
       backendConfig,
       viewerRole,
       executionTarget,
-      activeRuntimeFamily?.id || runtimeFamily
+      activeRuntimeFamily?.id || runtimeFamily,
     );
     if (nextExecutionTarget && nextExecutionTarget !== executionTarget) {
       onExecutionTargetChange(nextExecutionTarget);
@@ -110,26 +106,18 @@ export default function RuntimePathFields({
   ]);
 
   useEffect(() => {
-    if (
-      !activeExecutionTarget ||
-      typeof onSandboxProfileChange !== "function"
-    ) {
+    if (!activeExecutionTarget || typeof onSandboxProfileChange !== "function") {
       return;
     }
     const nextSandboxProfile = pickSandboxProfileSelection(
       activeExecutionTarget,
       viewerRole,
-      sandboxProfile
+      sandboxProfile,
     );
     if (nextSandboxProfile && nextSandboxProfile !== sandboxProfile) {
       onSandboxProfileChange(nextSandboxProfile);
     }
-  }, [
-    activeExecutionTarget,
-    onSandboxProfileChange,
-    sandboxProfile,
-    viewerRole,
-  ]);
+  }, [activeExecutionTarget, onSandboxProfileChange, sandboxProfile, viewerRole]);
 
   if (!backendConfig) {
     return (
@@ -193,11 +181,7 @@ export default function RuntimePathFields({
           className="w-full rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-60"
         >
           {visibleExecutionTargets.map((target) => (
-            <option
-              key={target.id}
-              value={target.id}
-              disabled={!target.available}
-            >
+            <option key={target.id} value={target.id} disabled={!target.available}>
               {optionLabel(target)}
             </option>
           ))}
@@ -229,11 +213,7 @@ export default function RuntimePathFields({
           className="w-full rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-60"
         >
           {visibleSandboxOptions.map((profile) => (
-            <option
-              key={profile.id}
-              value={profile.id}
-              disabled={!profile.available}
-            >
+            <option key={profile.id} value={profile.id} disabled={!profile.available}>
               {optionLabel(profile)}
             </option>
           ))}
@@ -248,9 +228,7 @@ export default function RuntimePathFields({
           </p>
         )}
         {activeSandboxOption?.issue && !activeSandboxOption.available ? (
-          <p className="mt-2 text-xs leading-relaxed text-amber-600">
-            {activeSandboxOption.issue}
-          </p>
+          <p className="mt-2 text-xs leading-relaxed text-amber-600">{activeSandboxOption.issue}</p>
         ) : null}
       </div>
     </div>

--- a/frontend-dashboard/components/agents/MessageTimeline.tsx
+++ b/frontend-dashboard/components/agents/MessageTimeline.tsx
@@ -1,10 +1,6 @@
 export default function MessageTimeline({ messages }) {
   if (!messages || messages.length === 0) {
-    return (
-      <div className="text-center py-8 text-slate-400 text-sm">
-        No messages yet.
-      </div>
-    );
+    return <div className="text-center py-8 text-slate-400 text-sm">No messages yet.</div>;
   }
 
   return (
@@ -12,10 +8,7 @@ export default function MessageTimeline({ messages }) {
       {messages.map((msg) => {
         const isOutbound = msg.direction === "outbound";
         return (
-          <div
-            key={msg.id}
-            className={`flex ${isOutbound ? "justify-end" : "justify-start"}`}
-          >
+          <div key={msg.id} className={`flex ${isOutbound ? "justify-end" : "justify-start"}`}>
             <div
               className={`max-w-[75%] rounded-xl px-4 py-2.5 ${
                 isOutbound
@@ -25,9 +18,7 @@ export default function MessageTimeline({ messages }) {
             >
               <p className="text-xs leading-relaxed">{msg.content}</p>
               <div
-                className={`text-[10px] mt-1 ${
-                  isOutbound ? "text-blue-200" : "text-slate-400"
-                }`}
+                className={`text-[10px] mt-1 ${isOutbound ? "text-blue-200" : "text-slate-400"}`}
               >
                 {new Date(msg.created_at).toLocaleTimeString()} ·{" "}
                 <span className="font-bold">{msg.direction}</span>

--- a/frontend-dashboard/components/agents/MetricsAreaChart.tsx
+++ b/frontend-dashboard/components/agents/MetricsAreaChart.tsx
@@ -24,12 +24,10 @@ function resolveDomain(data, keys, explicitDomain) {
   const dataMin = Math.min(...values);
   const dataMax = Math.max(...values);
 
-  let min = Array.isArray(explicitDomain) && explicitDomain[0] !== "auto"
-    ? explicitDomain[0]
-    : dataMin;
-  let max = Array.isArray(explicitDomain) && explicitDomain[1] !== "auto"
-    ? explicitDomain[1]
-    : dataMax;
+  let min =
+    Array.isArray(explicitDomain) && explicitDomain[0] !== "auto" ? explicitDomain[0] : dataMin;
+  let max =
+    Array.isArray(explicitDomain) && explicitDomain[1] !== "auto" ? explicitDomain[1] : dataMax;
 
   if (min === max) {
     if (max === 0) {
@@ -57,11 +55,7 @@ export default function MetricsAreaChart({
 }) {
   const gradientId = buildGradientId(dataKey);
   const secondGradientId = secondDataKey ? buildGradientId(secondDataKey) : null;
-  const yDomain = resolveDomain(
-    data,
-    secondDataKey ? [dataKey, secondDataKey] : [dataKey],
-    domain
-  );
+  const yDomain = resolveDomain(data, secondDataKey ? [dataKey, secondDataKey] : [dataKey], domain);
 
   return (
     <ResponsiveContainer width="100%" height="100%">

--- a/frontend-dashboard/components/agents/NemoClawTab.tsx
+++ b/frontend-dashboard/components/agents/NemoClawTab.tsx
@@ -1,7 +1,18 @@
 import { useState, useEffect, useCallback } from "react";
 import {
-  ShieldCheck, Globe, Brain, RefreshCw, Loader2, Plus, Trash2,
-  CheckCircle2, XCircle, Clock, AlertTriangle, Shield, Wifi,
+  ShieldCheck,
+  Globe,
+  Brain,
+  RefreshCw,
+  Loader2,
+  Plus,
+  Trash2,
+  CheckCircle2,
+  XCircle,
+  Clock,
+  AlertTriangle,
+  Shield,
+  Wifi,
 } from "lucide-react";
 import { fetchWithAuth } from "../../lib/api";
 
@@ -43,9 +54,12 @@ function ApprovalRow({ approval, onDecide }) {
       <div className="flex items-center gap-3 min-w-0">
         <AlertTriangle size={14} className="text-yellow-500 shrink-0" />
         <div className="min-w-0">
-          <p className="text-sm font-bold text-slate-800 truncate">{approval.endpoint || "Unknown endpoint"}</p>
+          <p className="text-sm font-bold text-slate-800 truncate">
+            {approval.endpoint || "Unknown endpoint"}
+          </p>
           <p className="text-[10px] text-slate-400">
-            Requested {approval.requestedAt ? new Date(approval.requestedAt).toLocaleString() : "recently"}
+            Requested{" "}
+            {approval.requestedAt ? new Date(approval.requestedAt).toLocaleString() : "recently"}
           </p>
         </div>
       </div>
@@ -80,7 +94,10 @@ export default function NemoClawTab({ agentId, agentStatus }) {
   const [newName, setNewName] = useState("");
 
   const fetchAll = useCallback(async () => {
-    if (agentStatus !== "running") { setLoading(false); return; }
+    if (agentStatus !== "running") {
+      setLoading(false);
+      return;
+    }
     try {
       const [sRes, pRes, aRes] = await Promise.all([
         fetchWithAuth(`/api/agents/${agentId}/nemoclaw/status`),
@@ -99,7 +116,9 @@ export default function NemoClawTab({ agentId, agentStatus }) {
     setLoading(false);
   }, [agentId, agentStatus]);
 
-  useEffect(() => { fetchAll(); }, [fetchAll]);
+  useEffect(() => {
+    fetchAll();
+  }, [fetchAll]);
 
   // Poll approvals while running
   useEffect(() => {
@@ -107,8 +126,13 @@ export default function NemoClawTab({ agentId, agentStatus }) {
     const iv = setInterval(async () => {
       try {
         const r = await fetchWithAuth(`/api/agents/${agentId}/nemoclaw/approvals`);
-        if (r.ok) { const d = await r.json(); setApprovals(d.approvals || []); }
-      } catch { /* ignore */ }
+        if (r.ok) {
+          const d = await r.json();
+          setApprovals(d.approvals || []);
+        }
+      } catch {
+        /* ignore */
+      }
     }, 10000);
     return () => clearInterval(iv);
   }, [agentId, agentStatus]);
@@ -169,7 +193,8 @@ export default function NemoClawTab({ agentId, agentStatus }) {
       <div className="bg-slate-50 border border-slate-200 rounded-2xl p-12 flex flex-col items-center justify-center gap-3">
         <ShieldCheck size={32} className="text-slate-300" />
         <p className="text-sm text-slate-500 font-medium">
-          NemoClaw controls available when agent is <span className="text-green-500 font-bold">running</span>
+          NemoClaw controls available when agent is{" "}
+          <span className="text-green-500 font-bold">running</span>
         </p>
       </div>
     );
@@ -194,15 +219,34 @@ export default function NemoClawTab({ agentId, agentStatus }) {
           <div>
             <p className="text-sm font-bold text-slate-800">NemoClaw Secure Sandbox</p>
             <div className="flex items-center gap-3 mt-0.5 text-[10px] text-slate-500 font-medium">
-              {status?.model && <span className="flex items-center gap-1"><Brain size={10} /> {status.model.replace("nvidia/", "")}</span>}
-              {status?.inferenceConfigured && <span className="flex items-center gap-1 text-green-600"><Wifi size={10} /> Inference connected</span>}
-              {status?.policyActive && <span className="flex items-center gap-1 text-green-600"><Shield size={10} /> Policy active</span>}
-              {status?.uptime != null && <span className="flex items-center gap-1"><Clock size={10} /> {Math.floor(status.uptime / 60)}m uptime</span>}
+              {status?.model && (
+                <span className="flex items-center gap-1">
+                  <Brain size={10} /> {status.model.replace("nvidia/", "")}
+                </span>
+              )}
+              {status?.inferenceConfigured && (
+                <span className="flex items-center gap-1 text-green-600">
+                  <Wifi size={10} /> Inference connected
+                </span>
+              )}
+              {status?.policyActive && (
+                <span className="flex items-center gap-1 text-green-600">
+                  <Shield size={10} /> Policy active
+                </span>
+              )}
+              {status?.uptime != null && (
+                <span className="flex items-center gap-1">
+                  <Clock size={10} /> {Math.floor(status.uptime / 60)}m uptime
+                </span>
+              )}
             </div>
           </div>
         </div>
         <button
-          onClick={() => { setLoading(true); fetchAll(); }}
+          onClick={() => {
+            setLoading(true);
+            fetchAll();
+          }}
           className="text-green-600 hover:text-green-800 transition-colors"
         >
           <RefreshCw size={16} />
@@ -241,13 +285,17 @@ export default function NemoClawTab({ agentId, agentStatus }) {
             ))}
           </div>
         ) : (
-          <p className="text-xs text-slate-400 italic">No network policy rules. All egress is blocked by default.</p>
+          <p className="text-xs text-slate-400 italic">
+            No network policy rules. All egress is blocked by default.
+          </p>
         )}
 
         {/* Add rule */}
         <div className="flex items-end gap-2 pt-2 border-t border-slate-100">
           <div className="flex-1">
-            <label className="text-[10px] text-slate-400 font-bold uppercase tracking-widest">Rule Name</label>
+            <label className="text-[10px] text-slate-400 font-bold uppercase tracking-widest">
+              Rule Name
+            </label>
             <input
               className="w-full mt-1 px-3 py-2 bg-slate-50 border border-slate-200 rounded-lg text-xs font-medium outline-none focus:ring-1 focus:ring-green-500/30"
               placeholder="e.g. my_api"
@@ -256,7 +304,9 @@ export default function NemoClawTab({ agentId, agentStatus }) {
             />
           </div>
           <div className="flex-[2]">
-            <label className="text-[10px] text-slate-400 font-bold uppercase tracking-widest">Endpoint</label>
+            <label className="text-[10px] text-slate-400 font-bold uppercase tracking-widest">
+              Endpoint
+            </label>
             <input
               className="w-full mt-1 px-3 py-2 bg-slate-50 border border-slate-200 rounded-lg text-xs font-medium outline-none focus:ring-1 focus:ring-green-500/30"
               placeholder="e.g. api.example.com:443"
@@ -277,15 +327,41 @@ export default function NemoClawTab({ agentId, agentStatus }) {
       {/* Security Summary */}
       <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
         {[
-          { label: "Capabilities", value: "Dropped", icon: ShieldCheck, color: "text-green-600", bg: "bg-green-50 border-green-100" },
-          { label: "Network", value: "Deny-default", icon: Shield, color: "text-green-600", bg: "bg-green-50 border-green-100" },
-          { label: "Filesystem", value: "Restricted", icon: ShieldCheck, color: "text-green-600", bg: "bg-green-50 border-green-100" },
-          { label: "Bridge", value: "Disabled", icon: Shield, color: "text-green-600", bg: "bg-green-50 border-green-100" },
+          {
+            label: "Capabilities",
+            value: "Dropped",
+            icon: ShieldCheck,
+            color: "text-green-600",
+            bg: "bg-green-50 border-green-100",
+          },
+          {
+            label: "Network",
+            value: "Deny-default",
+            icon: Shield,
+            color: "text-green-600",
+            bg: "bg-green-50 border-green-100",
+          },
+          {
+            label: "Filesystem",
+            value: "Restricted",
+            icon: ShieldCheck,
+            color: "text-green-600",
+            bg: "bg-green-50 border-green-100",
+          },
+          {
+            label: "Bridge",
+            value: "Disabled",
+            icon: Shield,
+            color: "text-green-600",
+            bg: "bg-green-50 border-green-100",
+          },
         ].map((item) => (
           <div key={item.label} className={`${item.bg} border rounded-2xl p-4`}>
             <div className="flex items-center gap-1.5 mb-1">
               <item.icon size={12} className={item.color} />
-              <span className="text-[10px] text-slate-400 font-black uppercase tracking-widest">{item.label}</span>
+              <span className="text-[10px] text-slate-400 font-black uppercase tracking-widest">
+                {item.label}
+              </span>
             </div>
             <p className="text-sm font-bold text-slate-900">{item.value}</p>
           </div>

--- a/frontend-dashboard/components/agents/hermes/ChannelsPanel.tsx
+++ b/frontend-dashboard/components/agents/hermes/ChannelsPanel.tsx
@@ -28,11 +28,7 @@ function formatTimestamp(value) {
 function homeChannelLabel(homeChannel) {
   if (!homeChannel || typeof homeChannel !== "object") return null;
   return (
-    homeChannel.name ||
-    homeChannel.display_name ||
-    homeChannel.id ||
-    homeChannel.channel_id ||
-    null
+    homeChannel.name || homeChannel.display_name || homeChannel.id || homeChannel.channel_id || null
   );
 }
 
@@ -132,7 +128,7 @@ export default function HermesChannelsPanel({ agentId }) {
     return new Set(
       channels
         .filter((channel) => channel?.configured && !channel?.readOnly)
-        .map((channel) => channel.type)
+        .map((channel) => channel.type),
     );
   }, [channels]);
 
@@ -141,8 +137,7 @@ export default function HermesChannelsPanel({ agentId }) {
   }, [availableTypes, configuredTypes]);
 
   const activeDefinition =
-    availableTypes.find((type) => type.type === selectedType || type.id === selectedType) ||
-    null;
+    availableTypes.find((type) => type.type === selectedType || type.id === selectedType) || null;
 
   function closeEditor() {
     setShowEditor(false);
@@ -157,9 +152,7 @@ export default function HermesChannelsPanel({ agentId }) {
     setEditorMode("create");
     setSelectedType(nextType);
     setFormValues(
-      initialValuesForDefinition(
-        availableTypes.find((type) => type.type === nextType) || null
-      )
+      initialValuesForDefinition(availableTypes.find((type) => type.type === nextType) || null),
     );
     setShowEditor(true);
   }
@@ -193,7 +186,7 @@ export default function HermesChannelsPanel({ agentId }) {
         body: JSON.stringify(
           editorMode === "create"
             ? { type: selectedType, config: formValues }
-            : { config: formValues }
+            : { config: formValues },
         ),
       });
       const data = await res.json().catch(() => ({}));
@@ -214,9 +207,7 @@ export default function HermesChannelsPanel({ agentId }) {
         await loadChannels();
       }
 
-      toast.success(
-        editorMode === "create" ? "Channel saved to Hermes" : "Channel updated"
-      );
+      toast.success(editorMode === "create" ? "Channel saved to Hermes" : "Channel updated");
       closeEditor();
     } catch (nextError) {
       const message = nextError.message || "Failed to save Hermes channel";
@@ -232,10 +223,9 @@ export default function HermesChannelsPanel({ agentId }) {
     setError("");
 
     try {
-      const res = await fetchWithAuth(
-        `/api/agents/${agentId}/hermes-ui/channels/${channel.type}`,
-        { method: "DELETE" }
-      );
+      const res = await fetchWithAuth(`/api/agents/${agentId}/hermes-ui/channels/${channel.type}`, {
+        method: "DELETE",
+      });
       const data = await res.json().catch(() => ({}));
       if (!res.ok) {
         throw new Error(data.error || "Failed to delete Hermes channel");
@@ -243,9 +233,7 @@ export default function HermesChannelsPanel({ agentId }) {
 
       setPayload({
         channels: Array.isArray(data?.channels) ? data.channels : [],
-        availableTypes: Array.isArray(data?.availableTypes)
-          ? data.availableTypes
-          : availableTypes,
+        availableTypes: Array.isArray(data?.availableTypes) ? data.availableTypes : availableTypes,
         gateway: data?.gateway || null,
         directoryUpdatedAt: data?.directoryUpdatedAt || null,
       });
@@ -266,7 +254,7 @@ export default function HermesChannelsPanel({ agentId }) {
     try {
       const res = await fetchWithAuth(
         `/api/agents/${agentId}/hermes-ui/channels/${channel.type}/test`,
-        { method: "POST" }
+        { method: "POST" },
       );
       const data = await res.json().catch(() => ({}));
       if (!res.ok) {
@@ -308,7 +296,9 @@ export default function HermesChannelsPanel({ agentId }) {
             </p>
             <p className="mt-1 text-xs text-slate-500">
               Gateway snapshot updated{" "}
-              {formatTimestamp(payload.directoryUpdatedAt || payload.gateway?.updatedAt) || "recently"}.
+              {formatTimestamp(payload.directoryUpdatedAt || payload.gateway?.updatedAt) ||
+                "recently"}
+              .
             </p>
           </div>
           <div className="flex items-center gap-2">
@@ -408,10 +398,11 @@ export default function HermesChannelsPanel({ agentId }) {
                             </span>
                             <span
                               className={`rounded-full px-2.5 py-1 text-[10px] font-bold ${channelTone(
-                                channel
+                                channel,
                               )}`}
                             >
-                              {channel.status?.state || (channel.configured ? "configured" : "idle")}
+                              {channel.status?.state ||
+                                (channel.configured ? "configured" : "idle")}
                             </span>
                             {channel.readOnly ? (
                               <span className="rounded-full bg-slate-100 px-2.5 py-1 text-[10px] font-bold text-slate-500">
@@ -522,7 +513,8 @@ export default function HermesChannelsPanel({ agentId }) {
                   {editorMode === "create" ? "Add Hermes Channel" : "Edit Hermes Channel"}
                 </p>
                 <p className="mt-1 text-[11px] text-slate-500">
-                  Hermes stores these settings in its runtime configuration and may restart after save.
+                  Hermes stores these settings in its runtime configuration and may restart after
+                  save.
                 </p>
               </div>
               <button
@@ -546,8 +538,8 @@ export default function HermesChannelsPanel({ agentId }) {
                       setSelectedType(nextType);
                       setFormValues(
                         initialValuesForDefinition(
-                          availableTypes.find((type) => type.type === nextType) || null
-                        )
+                          availableTypes.find((type) => type.type === nextType) || null,
+                        ),
                       );
                     }}
                     className="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500/30"

--- a/frontend-dashboard/components/agents/hermes/OfficialDashboardPanel.tsx
+++ b/frontend-dashboard/components/agents/hermes/OfficialDashboardPanel.tsx
@@ -1,11 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import {
-  AlertTriangle,
-  LayoutDashboard,
-  Loader2,
-  Maximize2,
-  RefreshCw,
-} from "lucide-react";
+import { AlertTriangle, LayoutDashboard, Loader2, Maximize2, RefreshCw } from "lucide-react";
 
 const DASHBOARD_BOOT_MESSAGE =
   "Fresh Hermes deployments can take a couple of minutes while the official dashboard boots.";
@@ -25,8 +19,7 @@ export default function OfficialDashboardPanel({
     typeof dashboardInfo?.ready === "boolean"
       ? dashboardInfo.ready
       : Boolean(runtimeInfo?.health?.ok);
-  const dashboardError =
-    dashboardInfo?.error || runtimeError || DASHBOARD_BOOT_MESSAGE;
+  const dashboardError = dashboardInfo?.error || runtimeError || DASHBOARD_BOOT_MESSAGE;
 
   useEffect(() => {
     setIframeLoaded(false);
@@ -80,9 +73,7 @@ export default function OfficialDashboardPanel({
     return (
       <div className="rounded-2xl border border-amber-200 bg-amber-50 p-8 flex flex-col items-center gap-3">
         <AlertTriangle size={32} className="text-amber-500" />
-        <p className="text-sm font-bold text-slate-700">
-          Official Hermes dashboard unavailable
-        </p>
+        <p className="text-sm font-bold text-slate-700">Official Hermes dashboard unavailable</p>
         <p className="text-xs text-slate-500">{runtimeError}</p>
         <button
           onClick={handleRefresh}
@@ -95,22 +86,16 @@ export default function OfficialDashboardPanel({
   }
 
   return (
-    <div
-      className="flex flex-col"
-      style={{ height: "calc(100vh - 260px)", minHeight: "500px" }}
-    >
+    <div className="flex flex-col" style={{ height: "calc(100vh - 260px)", minHeight: "500px" }}>
       <div className="flex items-center justify-between px-4 py-2 bg-slate-900 rounded-t-xl border border-slate-700 shrink-0">
         <div className="flex items-center gap-3 min-w-0">
           <div
             className={`w-2 h-2 rounded-full ${
-              dashboardReady && iframeLoaded
-                ? "bg-green-500"
-                : "bg-amber-500 animate-pulse"
+              dashboardReady && iframeLoaded ? "bg-green-500" : "bg-amber-500 animate-pulse"
             }`}
           />
           <span className="text-xs font-mono text-slate-400 truncate">
-            {dashboardInfo?.url || "Hermes dashboard"} &middot; Port{" "}
-            {dashboardInfo?.port || "9119"}
+            {dashboardInfo?.url || "Hermes dashboard"} &middot; Port {dashboardInfo?.port || "9119"}
           </span>
         </div>
         <div className="flex items-center gap-2 shrink-0">

--- a/frontend-dashboard/components/agents/hermes/StatusPanel.tsx
+++ b/frontend-dashboard/components/agents/hermes/StatusPanel.tsx
@@ -11,11 +11,7 @@ import {
 } from "lucide-react";
 import { fetchWithAuth } from "../../../lib/api";
 import { useToast } from "../../Toast";
-import {
-  formatModelLabel,
-  getProviderMeta,
-  ProviderLogo,
-} from "../providerLogos";
+import { formatModelLabel, getProviderMeta, ProviderLogo } from "../providerLogos";
 
 function formatTimestamp(value) {
   if (!value) return "Not reported";
@@ -28,9 +24,7 @@ function formatTimestamp(value) {
 }
 
 function renderStateTone(ready) {
-  return ready
-    ? "bg-emerald-50 text-emerald-700"
-    : "bg-amber-50 text-amber-700";
+  return ready ? "bg-emerald-50 text-emerald-700" : "bg-amber-50 text-amber-700";
 }
 
 function formatProviderLabel(providerId, providerName, baseUrl = "") {
@@ -49,9 +43,7 @@ function buildChoiceKey(providerId, modelId) {
 function buildModelChoices(savedProviders, availableProviders) {
   const providerRows = Array.isArray(savedProviders) ? savedProviders : [];
   const catalogs = Array.isArray(availableProviders) ? availableProviders : [];
-  const catalogById = new Map(
-    catalogs.map((provider) => [provider.id, provider])
-  );
+  const catalogById = new Map(catalogs.map((provider) => [provider.id, provider]));
   const groups = [];
   const options = [];
   const unavailableProviders = [];
@@ -67,10 +59,9 @@ function buildModelChoices(savedProviders, availableProviders) {
 
   for (const [providerId, rows] of rowsByProvider.entries()) {
     const providerCatalog = catalogById.get(providerId) || null;
-    const providerName =
-      providerCatalog?.name || getProviderMeta(providerId, providerId).name;
+    const providerName = providerCatalog?.name || getProviderMeta(providerId, providerId).name;
     const normalizedRows = [...rows].sort(
-      (left, right) => Number(Boolean(right?.is_default)) - Number(Boolean(left?.is_default))
+      (left, right) => Number(Boolean(right?.is_default)) - Number(Boolean(left?.is_default)),
     );
     const anchorRow = normalizedRows[0] || null;
     const seenModels = new Set();
@@ -133,23 +124,15 @@ function resolveDefaultChoiceKey(savedProviders, options) {
   const exactMatch = options.find(
     (option) =>
       option.providerId === defaultRow.provider &&
-      option.modelId === String(defaultRow.model || "").trim()
+      option.modelId === String(defaultRow.model || "").trim(),
   );
   if (exactMatch) return exactMatch.key;
 
-  const providerMatch = options.find(
-    (option) => option.providerId === defaultRow.provider
-  );
+  const providerMatch = options.find((option) => option.providerId === defaultRow.provider);
   return providerMatch?.key || options[0]?.key || "";
 }
 
-export default function HermesStatusPanel({
-  agentId,
-  runtimeInfo,
-  loading,
-  error,
-  onRefresh,
-}) {
+export default function HermesStatusPanel({ agentId, runtimeInfo, loading, error, onRefresh }) {
   const [providers, setProviders] = useState(null);
   const [availableProviders, setAvailableProviders] = useState([]);
   const [selectedChoiceKey, setSelectedChoiceKey] = useState("");
@@ -213,16 +196,10 @@ export default function HermesStatusPanel({
       return;
     }
 
-    const preferredChoiceKey = resolveDefaultChoiceKey(
-      providers,
-      nextChoices.options
-    );
+    const preferredChoiceKey = resolveDefaultChoiceKey(providers, nextChoices.options);
 
     setSelectedChoiceKey((current) => {
-      if (
-        current &&
-        nextChoices.options.some((option) => option.key === current)
-      ) {
+      if (current && nextChoices.options.some((option) => option.key === current)) {
         return current;
       }
       return preferredChoiceKey;
@@ -242,18 +219,17 @@ export default function HermesStatusPanel({
       ? providers.find((provider) => provider?.is_default) || providers[0]
       : null;
   const selectedChoice =
-    modelChoices.options.find((option) => option.key === selectedChoiceKey) ||
-    null;
+    modelChoices.options.find((option) => option.key === selectedChoiceKey) || null;
   const currentProviderLabel = savedDefaultProvider
     ? formatProviderLabel(
         savedDefaultProvider.provider,
         savedDefaultProvider.provider,
-        runtimeInfo?.configuredBaseUrl || ""
+        runtimeInfo?.configuredBaseUrl || "",
       )
     : formatProviderLabel(
         runtimeInfo?.configuredProvider,
         runtimeInfo?.configuredProvider,
-        runtimeInfo?.configuredBaseUrl || ""
+        runtimeInfo?.configuredBaseUrl || "",
       );
   const currentModelLabel =
     runtimeInfo?.configuredModel ||
@@ -351,16 +327,13 @@ export default function HermesStatusPanel({
 
     setChangingModel(true);
     try {
-      const updateResponse = await fetchWithAuth(
-        `/api/llm-providers/${selectedChoice.rowId}`,
-        {
-          method: "PUT",
-          body: JSON.stringify({
-            model: selectedChoice.modelId,
-            is_default: true,
-          }),
-        }
-      );
+      const updateResponse = await fetchWithAuth(`/api/llm-providers/${selectedChoice.rowId}`, {
+        method: "PUT",
+        body: JSON.stringify({
+          model: selectedChoice.modelId,
+          is_default: true,
+        }),
+      });
       const updateData = await updateResponse.json().catch(() => ({}));
       if (!updateResponse.ok) {
         throw new Error(updateData.error || "Failed to save provider selection");
@@ -385,8 +358,8 @@ export default function HermesStatusPanel({
       await loadProviderChoices();
       toast.success(
         `Hermes now uses ${selectedChoice.providerName} / ${formatModelLabel(
-          selectedChoice.modelId
-        )}`
+          selectedChoice.modelId,
+        )}`,
       );
       window.setTimeout(() => {
         onRefresh?.();
@@ -412,9 +385,7 @@ export default function HermesStatusPanel({
         <div className="flex items-start gap-3">
           <AlertTriangle size={16} className="mt-0.5 shrink-0 text-amber-600" />
           <div>
-            <p className="text-sm font-bold text-amber-800">
-              Hermes runtime details unavailable
-            </p>
+            <p className="text-sm font-bold text-amber-800">Hermes runtime details unavailable</p>
             <p className="mt-1 text-xs text-amber-700">
               {error || "The Hermes runtime has not reported status yet."}
             </p>
@@ -448,7 +419,7 @@ export default function HermesStatusPanel({
         <div className="flex flex-wrap items-center gap-2">
           <span
             className={`inline-flex items-center gap-2 rounded-full px-3 py-1.5 text-xs font-bold ${renderStateTone(
-              runtimeReady
+              runtimeReady,
             )}`}
           >
             <span
@@ -463,11 +434,7 @@ export default function HermesStatusPanel({
             disabled={syncingKeys}
             className="inline-flex items-center gap-1.5 rounded-xl border border-emerald-200 bg-emerald-50 px-3 py-2 text-xs font-bold text-emerald-700 transition-colors hover:bg-emerald-100 disabled:cursor-not-allowed disabled:opacity-50"
           >
-            {syncingKeys ? (
-              <Loader2 size={12} className="animate-spin" />
-            ) : (
-              <Key size={12} />
-            )}
+            {syncingKeys ? <Loader2 size={12} className="animate-spin" /> : <Key size={12} />}
             Sync LLM
           </button>
           <button
@@ -494,12 +461,8 @@ export default function HermesStatusPanel({
         <div className="flex items-start gap-3 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
           <AlertTriangle size={16} className="mt-0.5 shrink-0 text-slate-500" />
           <div>
-            <p className="text-sm font-bold text-slate-800">
-              Gateway snapshot unavailable
-            </p>
-            <p className="mt-1 text-xs text-slate-600">
-              {runtimeInfo.gatewayError}
-            </p>
+            <p className="text-sm font-bold text-slate-800">Gateway snapshot unavailable</p>
+            <p className="mt-1 text-xs text-slate-600">{runtimeInfo.gatewayError}</p>
           </div>
         </div>
       ) : null}
@@ -508,12 +471,8 @@ export default function HermesStatusPanel({
         <div className="flex items-start gap-3 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
           <AlertTriangle size={16} className="mt-0.5 shrink-0 text-slate-500" />
           <div>
-            <p className="text-sm font-bold text-slate-800">
-              Model metadata warning
-            </p>
-            <p className="mt-1 text-xs text-slate-600">
-              {runtimeInfo.modelsError}
-            </p>
+            <p className="text-sm font-bold text-slate-800">Model metadata warning</p>
+            <p className="mt-1 text-xs text-slate-600">{runtimeInfo.modelsError}</p>
           </div>
         </div>
       ) : null}
@@ -575,8 +534,7 @@ export default function HermesStatusPanel({
                 <p className="mt-1 text-xs text-slate-600">
                   {runtimeReady
                     ? "Hermes reported a healthy runtime response."
-                    : runtimeInfo?.health?.error ||
-                      "Hermes has not completed startup yet."}
+                    : runtimeInfo?.health?.error || "Hermes has not completed startup yet."}
                 </p>
               </div>
             </div>
@@ -602,9 +560,7 @@ export default function HermesStatusPanel({
                 <p className="text-[10px] font-black uppercase tracking-[0.2em] text-slate-400">
                   Current Selection
                 </p>
-                <p className="mt-1 text-sm font-bold text-slate-900">
-                  {currentProviderLabel}
-                </p>
+                <p className="mt-1 text-sm font-bold text-slate-900">{currentProviderLabel}</p>
                 <p className="mt-1 break-all text-xs font-mono text-slate-600">
                   {currentModelLabel}
                 </p>
@@ -708,8 +664,7 @@ export default function HermesStatusPanel({
                 </div>
               ) : (
                 <p className="mt-3 text-xs text-slate-500">
-                  No models reported yet. Hermes may still be starting or waiting for upstream
-                  auth.
+                  No models reported yet. Hermes may still be starting or waiting for upstream auth.
                 </p>
               )}
             </div>
@@ -783,9 +738,7 @@ export default function HermesStatusPanel({
                         </span>
                       </div>
                       {state?.error_message ? (
-                        <p className="mt-1 text-xs text-rose-600">
-                          {state.error_message}
-                        </p>
+                        <p className="mt-1 text-xs text-rose-600">{state.error_message}</p>
                       ) : null}
                     </div>
                   ))}

--- a/frontend-dashboard/components/agents/openclaw/OpenClawUIPanel.tsx
+++ b/frontend-dashboard/components/agents/openclaw/OpenClawUIPanel.tsx
@@ -7,7 +7,9 @@ const GATEWAY_BOOT_MESSAGE =
   "Fresh OpenClaw deployments can take a couple of minutes while the official dashboard installs and starts.";
 
 function normalizeEmbedPath(path = "") {
-  return String(path || "").trim().replace(/^\/+/, "");
+  return String(path || "")
+    .trim()
+    .replace(/^\/+/, "");
 }
 
 type OpenClawUIPanelProps = {

--- a/frontend-dashboard/components/agents/openclaw/SessionsPanel.tsx
+++ b/frontend-dashboard/components/agents/openclaw/SessionsPanel.tsx
@@ -51,9 +51,12 @@ export default function SessionsPanel({ agentId }) {
 
   async function handleDelete(sessionKey) {
     try {
-      const res = await fetchWithAuth(`/api/agents/${agentId}/gateway/sessions/${encodeURIComponent(sessionKey)}`, {
-        method: "DELETE",
-      });
+      const res = await fetchWithAuth(
+        `/api/agents/${agentId}/gateway/sessions/${encodeURIComponent(sessionKey)}`,
+        {
+          method: "DELETE",
+        },
+      );
       if (res.ok) {
         setSessions((prev) => prev.filter((s) => (s.key || s.id) !== sessionKey));
         if ((selectedSession?.key || selectedSession?.id) === sessionKey) setSelectedSession(null);
@@ -66,7 +69,9 @@ export default function SessionsPanel({ agentId }) {
   async function handleViewSession(session) {
     const key = session.key || session.id;
     try {
-      const res = await fetchWithAuth(`/api/agents/${agentId}/gateway/sessions/${encodeURIComponent(key)}`);
+      const res = await fetchWithAuth(
+        `/api/agents/${agentId}/gateway/sessions/${encodeURIComponent(key)}`,
+      );
       if (res.ok) {
         const data = await res.json();
         setSelectedSession({ ...data, key });
@@ -130,42 +135,45 @@ export default function SessionsPanel({ agentId }) {
           {sessions.map((session) => {
             const sessionKey = session.key || session.id || session.sessionId;
             return (
-            <div
-              key={sessionKey}
-              className="bg-white border border-slate-200 rounded-xl px-4 py-3 flex items-center justify-between hover:border-blue-200 transition-colors cursor-pointer"
-              onClick={() => handleViewSession(session)}
-            >
-              <div className="flex items-center gap-3">
-                <MessageSquare size={14} className="text-slate-400" />
-                <div>
-                  <p className="text-sm font-bold text-slate-700">
-                    {session.name || session.label || sessionKey?.slice(0, 24)}
-                  </p>
-                  <p className="text-[10px] text-slate-400 font-mono">{sessionKey}</p>
-                  {(session.created_at || session.createdAt || session.ts) && (
-                    <p className="text-[10px] text-slate-400">
-                      {new Date(session.created_at || session.createdAt || session.ts).toLocaleString()}
+              <div
+                key={sessionKey}
+                className="bg-white border border-slate-200 rounded-xl px-4 py-3 flex items-center justify-between hover:border-blue-200 transition-colors cursor-pointer"
+                onClick={() => handleViewSession(session)}
+              >
+                <div className="flex items-center gap-3">
+                  <MessageSquare size={14} className="text-slate-400" />
+                  <div>
+                    <p className="text-sm font-bold text-slate-700">
+                      {session.name || session.label || sessionKey?.slice(0, 24)}
                     </p>
+                    <p className="text-[10px] text-slate-400 font-mono">{sessionKey}</p>
+                    {(session.created_at || session.createdAt || session.ts) && (
+                      <p className="text-[10px] text-slate-400">
+                        {new Date(
+                          session.created_at || session.createdAt || session.ts,
+                        ).toLocaleString()}
+                      </p>
+                    )}
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  {(session.message_count ?? session.messageCount ?? session.turns) !==
+                    undefined && (
+                    <span className="text-[10px] text-slate-400">
+                      {session.message_count ?? session.messageCount ?? session.turns} msgs
+                    </span>
                   )}
+                  <button
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleDelete(sessionKey);
+                    }}
+                    className="text-slate-300 hover:text-red-500 transition-colors p-1"
+                  >
+                    <Trash2 size={12} />
+                  </button>
                 </div>
               </div>
-              <div className="flex items-center gap-2">
-                {(session.message_count ?? session.messageCount ?? session.turns) !== undefined && (
-                  <span className="text-[10px] text-slate-400">
-                    {session.message_count ?? session.messageCount ?? session.turns} msgs
-                  </span>
-                )}
-                <button
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    handleDelete(sessionKey);
-                  }}
-                  className="text-slate-300 hover:text-red-500 transition-colors p-1"
-                >
-                  <Trash2 size={12} />
-                </button>
-              </div>
-            </div>
             );
           })}
         </div>
@@ -176,7 +184,8 @@ export default function SessionsPanel({ agentId }) {
         <div className="bg-slate-50 border border-slate-200 rounded-xl p-4 space-y-3">
           <div className="flex items-center justify-between">
             <h4 className="text-xs font-bold text-slate-600">
-              Session: {selectedSession.name || selectedSession.label || selectedSession.key?.slice(0, 24)}
+              Session:{" "}
+              {selectedSession.name || selectedSession.label || selectedSession.key?.slice(0, 24)}
             </h4>
             <button
               onClick={() => setSelectedSession(null)}
@@ -188,13 +197,20 @@ export default function SessionsPanel({ agentId }) {
           {selectedSession.messages?.length > 0 ? (
             <div className="space-y-2 max-h-64 overflow-y-auto">
               {selectedSession.messages.map((msg, i) => (
-                <div key={i} className={`text-xs p-2 rounded-lg ${
-                  msg.role === "user" ? "bg-blue-50 text-blue-800" :
-                  msg.role === "assistant" ? "bg-slate-100 text-slate-700" :
-                  "bg-amber-50 text-amber-700"
-                }`}>
+                <div
+                  key={i}
+                  className={`text-xs p-2 rounded-lg ${
+                    msg.role === "user"
+                      ? "bg-blue-50 text-blue-800"
+                      : msg.role === "assistant"
+                        ? "bg-slate-100 text-slate-700"
+                        : "bg-amber-50 text-amber-700"
+                  }`}
+                >
                   <span className="font-bold capitalize">{msg.role}: </span>
-                  <span className="whitespace-pre-wrap">{typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content)}</span>
+                  <span className="whitespace-pre-wrap">
+                    {typeof msg.content === "string" ? msg.content : JSON.stringify(msg.content)}
+                  </span>
                 </div>
               ))}
             </div>

--- a/frontend-dashboard/components/agents/openclaw/StatusPanel.tsx
+++ b/frontend-dashboard/components/agents/openclaw/StatusPanel.tsx
@@ -1,6 +1,16 @@
 import { useState, useEffect } from "react";
 import { fetchWithAuth } from "../../../lib/api";
-import { Radio, RefreshCw, CheckCircle, XCircle, Loader2, Key, ChevronDown, Settings, Plus } from "lucide-react";
+import {
+  Radio,
+  RefreshCw,
+  CheckCircle,
+  XCircle,
+  Loader2,
+  Key,
+  ChevronDown,
+  Settings,
+  Plus,
+} from "lucide-react";
 import { useToast } from "../../Toast";
 
 export default function StatusPanel({ agentId }) {
@@ -83,7 +93,7 @@ export default function StatusPanel({ agentId }) {
     setShowModelPicker(false);
     try {
       // Set as default and sync
-      const provider = providers?.find(p => p.provider === providerId);
+      const provider = providers?.find((p) => p.provider === providerId);
       if (provider) {
         await fetchWithAuth(`/api/llm-providers/${provider.id}`, {
           method: "PUT",
@@ -108,10 +118,12 @@ export default function StatusPanel({ agentId }) {
   }
 
   // Build a flat list of all available models from configured providers
-  const configuredProviderIds = new Set((providers || []).map(p => p.provider));
+  const configuredProviderIds = new Set((providers || []).map((p) => p.provider));
   const modelOptions = availableProviders
-    .filter(p => configuredProviderIds.has(p.id))
-    .flatMap(p => (p.models || []).map(m => ({ provider: p.id, providerName: p.name, model: m })));
+    .filter((p) => configuredProviderIds.has(p.id))
+    .flatMap((p) =>
+      (p.models || []).map((m) => ({ provider: p.id, providerName: p.name, model: m })),
+    );
 
   const hasProviders = providers && providers.length > 0;
 
@@ -181,101 +193,119 @@ export default function StatusPanel({ agentId }) {
             </p>
           </div>
         </div>
-      ) : status ? (() => {
-        const h = status.health || {};
-        const s = status.status || {};
-        const version = s.runtimeVersion || h.server?.version || "";
-        const sessionCount = s.sessions?.count ?? h.sessions?.count ?? h.agents?.[0]?.sessions?.count;
-        const defaultAgent = h.defaultAgentId || s.heartbeat?.defaultAgentId || "main";
-        const heartbeatEvery = s.heartbeat?.agents?.[0]?.every || h.heartbeatSeconds ? `${h.heartbeatSeconds}s` : null;
-        const currentModel = s.sessions?.defaults?.model || h.agents?.[0]?.model || "";
+      ) : status ? (
+        (() => {
+          const h = status.health || {};
+          const s = status.status || {};
+          const version = s.runtimeVersion || h.server?.version || "";
+          const sessionCount =
+            s.sessions?.count ?? h.sessions?.count ?? h.agents?.[0]?.sessions?.count;
+          const defaultAgent = h.defaultAgentId || s.heartbeat?.defaultAgentId || "main";
+          const heartbeatEvery =
+            s.heartbeat?.agents?.[0]?.every || h.heartbeatSeconds ? `${h.heartbeatSeconds}s` : null;
+          const currentModel = s.sessions?.defaults?.model || h.agents?.[0]?.model || "";
 
-        return (
-          <div className="bg-white border border-slate-200 rounded-xl divide-y divide-slate-100">
-            <div className="flex items-center justify-between px-4 py-3">
-              <span className="text-xs text-slate-500 font-medium">Status</span>
-              <span className={`flex items-center gap-1.5 text-xs font-bold ${h.ok ? "text-green-600" : "text-yellow-600"}`}>
-                {h.ok ? <CheckCircle size={12} /> : <XCircle size={12} />}
-                {h.ok ? "Online" : "Degraded"}
-              </span>
-            </div>
-            {version && (
+          return (
+            <div className="bg-white border border-slate-200 rounded-xl divide-y divide-slate-100">
               <div className="flex items-center justify-between px-4 py-3">
-                <span className="text-xs text-slate-500 font-medium">Version</span>
-                <span className="text-xs font-mono text-slate-700">{version}</span>
-              </div>
-            )}
-            <div className="flex items-center justify-between px-4 py-3">
-              <span className="text-xs text-slate-500 font-medium">Default Agent</span>
-              <span className="text-xs font-mono text-slate-700">{defaultAgent}</span>
-            </div>
-            {sessionCount !== undefined && (
-              <div className="flex items-center justify-between px-4 py-3">
-                <span className="text-xs text-slate-500 font-medium">Sessions</span>
-                <span className="text-xs font-bold text-slate-700">{sessionCount}</span>
-              </div>
-            )}
-            {heartbeatEvery && (
-              <div className="flex items-center justify-between px-4 py-3">
-                <span className="text-xs text-slate-500 font-medium">Heartbeat</span>
-                <span className="text-xs font-mono text-slate-700">{heartbeatEvery}</span>
-              </div>
-            )}
-
-            {/* Default Model — with inline picker */}
-            <div className="flex items-center justify-between px-4 py-3 relative">
-              <span className="text-xs text-slate-500 font-medium">Default Model</span>
-              {currentModel ? (
-                <div className="flex items-center gap-1.5">
-                  <span className="text-xs font-mono text-slate-700">{currentModel}</span>
-                  {modelOptions.length > 0 && (
-                    <button
-                      onClick={() => setShowModelPicker(!showModelPicker)}
-                      disabled={changingModel}
-                      className="text-blue-500 hover:text-blue-700 transition-colors"
-                    >
-                      {changingModel ? <Loader2 size={11} className="animate-spin" /> : <ChevronDown size={11} />}
-                    </button>
-                  )}
-                </div>
-              ) : (
-                <button
-                  onClick={() => modelOptions.length > 0 ? setShowModelPicker(!showModelPicker) : null}
-                  className="text-xs text-blue-600 hover:text-blue-800 font-bold flex items-center gap-1 transition-colors"
+                <span className="text-xs text-slate-500 font-medium">Status</span>
+                <span
+                  className={`flex items-center gap-1.5 text-xs font-bold ${h.ok ? "text-green-600" : "text-yellow-600"}`}
                 >
-                  {modelOptions.length > 0 ? (
-                    <>Select model <ChevronDown size={10} /></>
-                  ) : (
-                    <a href="/settings" className="flex items-center gap-1">
-                      <Settings size={10} /> Add LLM provider first
-                    </a>
-                  )}
-                </button>
-              )}
-
-              {/* Model dropdown */}
-              {showModelPicker && modelOptions.length > 0 && (
-                <div className="absolute right-0 top-full mt-1 z-50 bg-white border border-slate-200 rounded-xl shadow-lg py-1 min-w-[240px] max-h-64 overflow-y-auto">
-                  {modelOptions.map((opt) => (
-                    <button
-                      key={`${opt.provider}/${opt.model}`}
-                      onClick={() => handleChangeModel(opt.provider, opt.model)}
-                      className={`w-full text-left px-3 py-2 text-xs hover:bg-blue-50 transition-colors flex items-center justify-between gap-2 ${
-                        currentModel === `${opt.provider}/${opt.model}` ? "bg-blue-50 text-blue-700 font-bold" : "text-slate-700"
-                      }`}
-                    >
-                      <span className="font-mono">{opt.provider}/{opt.model}</span>
-                      {currentModel === `${opt.provider}/${opt.model}` && (
-                        <CheckCircle size={10} className="text-blue-500 shrink-0" />
-                      )}
-                    </button>
-                  ))}
+                  {h.ok ? <CheckCircle size={12} /> : <XCircle size={12} />}
+                  {h.ok ? "Online" : "Degraded"}
+                </span>
+              </div>
+              {version && (
+                <div className="flex items-center justify-between px-4 py-3">
+                  <span className="text-xs text-slate-500 font-medium">Version</span>
+                  <span className="text-xs font-mono text-slate-700">{version}</span>
                 </div>
               )}
+              <div className="flex items-center justify-between px-4 py-3">
+                <span className="text-xs text-slate-500 font-medium">Default Agent</span>
+                <span className="text-xs font-mono text-slate-700">{defaultAgent}</span>
+              </div>
+              {sessionCount !== undefined && (
+                <div className="flex items-center justify-between px-4 py-3">
+                  <span className="text-xs text-slate-500 font-medium">Sessions</span>
+                  <span className="text-xs font-bold text-slate-700">{sessionCount}</span>
+                </div>
+              )}
+              {heartbeatEvery && (
+                <div className="flex items-center justify-between px-4 py-3">
+                  <span className="text-xs text-slate-500 font-medium">Heartbeat</span>
+                  <span className="text-xs font-mono text-slate-700">{heartbeatEvery}</span>
+                </div>
+              )}
+
+              {/* Default Model — with inline picker */}
+              <div className="flex items-center justify-between px-4 py-3 relative">
+                <span className="text-xs text-slate-500 font-medium">Default Model</span>
+                {currentModel ? (
+                  <div className="flex items-center gap-1.5">
+                    <span className="text-xs font-mono text-slate-700">{currentModel}</span>
+                    {modelOptions.length > 0 && (
+                      <button
+                        onClick={() => setShowModelPicker(!showModelPicker)}
+                        disabled={changingModel}
+                        className="text-blue-500 hover:text-blue-700 transition-colors"
+                      >
+                        {changingModel ? (
+                          <Loader2 size={11} className="animate-spin" />
+                        ) : (
+                          <ChevronDown size={11} />
+                        )}
+                      </button>
+                    )}
+                  </div>
+                ) : (
+                  <button
+                    onClick={() =>
+                      modelOptions.length > 0 ? setShowModelPicker(!showModelPicker) : null
+                    }
+                    className="text-xs text-blue-600 hover:text-blue-800 font-bold flex items-center gap-1 transition-colors"
+                  >
+                    {modelOptions.length > 0 ? (
+                      <>
+                        Select model <ChevronDown size={10} />
+                      </>
+                    ) : (
+                      <a href="/settings" className="flex items-center gap-1">
+                        <Settings size={10} /> Add LLM provider first
+                      </a>
+                    )}
+                  </button>
+                )}
+
+                {/* Model dropdown */}
+                {showModelPicker && modelOptions.length > 0 && (
+                  <div className="absolute right-0 top-full mt-1 z-50 bg-white border border-slate-200 rounded-xl shadow-lg py-1 min-w-[240px] max-h-64 overflow-y-auto">
+                    {modelOptions.map((opt) => (
+                      <button
+                        key={`${opt.provider}/${opt.model}`}
+                        onClick={() => handleChangeModel(opt.provider, opt.model)}
+                        className={`w-full text-left px-3 py-2 text-xs hover:bg-blue-50 transition-colors flex items-center justify-between gap-2 ${
+                          currentModel === `${opt.provider}/${opt.model}`
+                            ? "bg-blue-50 text-blue-700 font-bold"
+                            : "text-slate-700"
+                        }`}
+                      >
+                        <span className="font-mono">
+                          {opt.provider}/{opt.model}
+                        </span>
+                        {currentModel === `${opt.provider}/${opt.model}` && (
+                          <CheckCircle size={10} className="text-blue-500 shrink-0" />
+                        )}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
             </div>
-          </div>
-        );
-      })() : null}
+          );
+        })()
+      ) : null}
     </div>
   );
 }

--- a/frontend-dashboard/components/agents/openclaw/ToolsPanel.tsx
+++ b/frontend-dashboard/components/agents/openclaw/ToolsPanel.tsx
@@ -130,7 +130,9 @@ export default function ToolsPanel({ agentId }) {
                     {/* Parameters schema */}
                     {params && (
                       <div>
-                        <p className="text-[10px] font-bold text-slate-500 mb-1">Parameters Schema</p>
+                        <p className="text-[10px] font-bold text-slate-500 mb-1">
+                          Parameters Schema
+                        </p>
                         <pre className="bg-slate-50 border border-slate-200 rounded-lg p-2 text-[10px] text-slate-600 font-mono overflow-x-auto max-h-40">
                           {JSON.stringify(params, null, 2)}
                         </pre>
@@ -174,8 +176,8 @@ export default function ToolsPanel({ agentId }) {
                       {noraMeta?.executionState === "runtime_skill"
                         ? "This tool is connected through Nora and is executable inside the agent via the generated nora-integrations skill and local nora-integration-tool command."
                         : noraMeta?.executionState === "manifest_only"
-                        ? "This tool comes from the Nora integration manifest. It advertises provider capability and schema, but the current runtime does not execute it yet."
-                        : "Tools are invoked automatically by the AI model during chat conversations."}
+                          ? "This tool comes from the Nora integration manifest. It advertises provider capability and schema, but the current runtime does not execute it yet."
+                          : "Tools are invoked automatically by the AI model during chat conversations."}
                     </p>
                   </div>
                 )}

--- a/workers/provisioner/backends/telemetry.ts
+++ b/workers/provisioner/backends/telemetry.ts
@@ -24,10 +24,7 @@ const PROXMOX_DEFAULT_CAPABILITIES = Object.freeze({
 });
 
 function toFiniteNumber(value) {
-  const parsed =
-    typeof value === "string" && value.trim() !== ""
-      ? Number(value)
-      : value;
+  const parsed = typeof value === "string" && value.trim() !== "" ? Number(value) : value;
   return Number.isFinite(parsed) ? parsed : null;
 }
 
@@ -113,9 +110,7 @@ function buildUnavailableTelemetry({
 }
 
 function uptimeFromContainerInfo(info) {
-  const startedAt = info?.State?.StartedAt
-    ? new Date(info.State.StartedAt).getTime()
-    : 0;
+  const startedAt = info?.State?.StartedAt ? new Date(info.State.StartedAt).getTime() : 0;
   if (!info?.State?.Running || !startedAt) return 0;
   return Math.max(0, Math.floor((Date.now() - startedAt) / 1000));
 }
@@ -149,12 +144,9 @@ function dockerCpuPercent(stats) {
     (stats?.cpu_stats?.cpu_usage?.total_usage || 0) -
     (stats?.precpu_stats?.cpu_usage?.total_usage || 0);
   const systemDelta =
-    (stats?.cpu_stats?.system_cpu_usage || 0) -
-    (stats?.precpu_stats?.system_cpu_usage || 0);
+    (stats?.cpu_stats?.system_cpu_usage || 0) - (stats?.precpu_stats?.system_cpu_usage || 0);
   const cpuCount =
-    stats?.cpu_stats?.online_cpus ||
-    stats?.cpu_stats?.cpu_usage?.percpu_usage?.length ||
-    1;
+    stats?.cpu_stats?.online_cpus || stats?.cpu_stats?.cpu_usage?.percpu_usage?.length || 1;
 
   if (systemDelta <= 0) return 0;
   return roundMetric((cpuDelta / systemDelta) * cpuCount * 100);
@@ -178,8 +170,7 @@ function buildDockerTelemetry({ stats, info, backendType = "docker" }) {
       cpu_percent: dockerCpuPercent(stats),
       memory_usage_mb: bytesToMegabytes(memActual, 0),
       memory_limit_mb: bytesToMegabytes(memLimit, 0),
-      memory_percent:
-        memLimit > 0 ? roundMetric((memActual / memLimit) * 100) : 0,
+      memory_percent: memLimit > 0 ? roundMetric((memActual / memLimit) * 100) : 0,
       network_rx_mb: bytesToMegabytes(network.received),
       network_tx_mb: bytesToMegabytes(network.transmitted),
       disk_read_mb: bytesToMegabytes(disk.read),

--- a/workers/provisioner/crypto.ts
+++ b/workers/provisioner/crypto.ts
@@ -11,8 +11,8 @@ const ENCRYPTION_KEY = /^[0-9a-fA-F]{64}$/.test(RAW_KEY) ? RAW_KEY : null;
 if (!ENCRYPTION_KEY) {
   console.error(
     "SECURITY WARNING: ENCRYPTION_KEY is not set or invalid. " +
-    "Sensitive data (API keys, tokens) will be stored in PLAINTEXT. " +
-    "Set a 64-char hex key in .env to enable encryption at rest."
+      "Sensitive data (API keys, tokens) will be stored in PLAINTEXT. " +
+      "Set a 64-char hex key in .env to enable encryption at rest.",
   );
 }
 
@@ -61,7 +61,9 @@ function decrypt(data) {
     return decrypted;
   } catch (err) {
     console.error("Decryption failed (key mismatch or corrupted data):", err.message);
-    throw new DecryptionError("Failed to decrypt stored credential — encryption key may have rotated or data is corrupted");
+    throw new DecryptionError(
+      "Failed to decrypt stored credential — encryption key may have rotated or data is corrupted",
+    );
   }
 }
 

--- a/workers/provisioner/healthChecks.ts
+++ b/workers/provisioner/healthChecks.ts
@@ -53,31 +53,37 @@ async function waitForHttpReady(url, options = {}) {
   };
 }
 
-async function waitForAgentReadiness({
-  host,
-  runtimeHost = null,
-  runtimePort = AGENT_RUNTIME_PORT,
-  gatewayHostPort = null,
-  gatewayHost = null,
-  gatewayPort = OPENCLAW_GATEWAY_PORT,
-  checkGateway = true,
-} = {}, options = {}) {
+async function waitForAgentReadiness(
+  {
+    host,
+    runtimeHost = null,
+    runtimePort = AGENT_RUNTIME_PORT,
+    gatewayHostPort = null,
+    gatewayHost = null,
+    gatewayPort = OPENCLAW_GATEWAY_PORT,
+    checkGateway = true,
+  } = {},
+  options = {},
+) {
   const resolvedRuntimeHost = runtimeHost || host;
   const resolvedRuntimePort = runtimePort || AGENT_RUNTIME_PORT;
 
-  const runtime = await waitForHttpReady(gatewayUrl(resolvedRuntimeHost, resolvedRuntimePort, "/health"), {
-    attempts: 12,
-    intervalMs: 5000,
-    timeoutMs: 5000,
-    acceptStatuses: [200],
-    ...options.runtime,
-  });
+  const runtime = await waitForHttpReady(
+    gatewayUrl(resolvedRuntimeHost, resolvedRuntimePort, "/health"),
+    {
+      attempts: 12,
+      intervalMs: 5000,
+      timeoutMs: 5000,
+      acceptStatuses: [200],
+      ...options.runtime,
+    },
+  );
 
   let gateway = null;
   if (checkGateway) {
     const resolvedGatewayHost = gatewayHostPort
-      ? (gatewayHost || process.env.GATEWAY_HOST || "host.docker.internal")
-      : (gatewayHost || host);
+      ? gatewayHost || process.env.GATEWAY_HOST || "host.docker.internal"
+      : gatewayHost || host;
     const resolvedGatewayPort = gatewayHostPort || gatewayPort || OPENCLAW_GATEWAY_PORT;
 
     gateway = await waitForHttpReady(gatewayUrl(resolvedGatewayHost, resolvedGatewayPort, "/"), {


### PR DESCRIPTION
## Why

A full-repo sweep (mirroring `ci-quality` locally) found latent lint/format drift that CI can't see: the quality workflow only checks **files changed in a PR**, so files last formatted before the current root prettier toolchain/config (`printWidth: 100`, prettier 3.8.3 locked) fail the check the moment any future PR touches them — red CI with noise unrelated to that PR.

## What

- `npx prettier --write` on the 42 drifted files (backend-api, frontend-dashboard, admin-dashboard, workers/provisioner, cli). Pure formatting: line joins/wraps to the 100-col width and trailing commas — verified formatting-only via whitespace-insensitive diff review.
- Removed a stale `eslint-disable-next-line no-constant-condition` in `cli/src/commands/monitoring.js` (unused directive; fails `--max-warnings=0`).

Three touched files are in the shared backend/worker mount zone (`workers/provisioner/backends/telemetry.ts`, `crypto.ts`, `healthChecks.ts`) — formatting-only, no behavioral change.

## Verification

- eslint full sweep across all 7 lint packages: clean at `--max-warnings=0`
- prettier `--check` over the full CI file set: clean
- typecheck: backend-api, workers/provisioner, frontend-dashboard, admin-dashboard all pass
- backend-api Jest: 150 suites / 1290 tests pass; cli `node --test` passes