### PR TITLE
fix(k8s): pinnable openclaw package, pod probes, honest agent status

### DIFF
--- a/backend-api/__tests__/agentStatus.test.ts
+++ b/backend-api/__tests__/agentStatus.test.ts
@@ -16,8 +16,10 @@ describe("isGatewayAvailableStatus", () => {
 });
 
 describe("reconcileAgentStatus", () => {
-  it("preserves warning when the container is still running", () => {
-    expect(reconcileAgentStatus("warning", true)).toBe("warning");
+  it("self-heals warning to running when the container is live", () => {
+    // warning is a point-in-time readiness miss; once the runtime is
+    // demonstrably live it must recover like stopped/error do.
+    expect(reconcileAgentStatus("warning", true)).toBe("running");
   });
 
   it("downgrades warning to stopped when the container is no longer running", () => {

--- a/backend-api/__tests__/agents.test.ts
+++ b/backend-api/__tests__/agents.test.ts
@@ -452,7 +452,7 @@ describe("GET /agents", () => {
 });
 
 describe("GET /agents/:id", () => {
-  it("preserves warning status when the container is still live", async () => {
+  it("self-heals warning status to running when the container is still live", async () => {
     mockDb.query.mockResolvedValueOnce({
       rows: [
         {
@@ -469,7 +469,7 @@ describe("GET /agents/:id", () => {
     const res = await auth(request(app).get("/agents/a-warning"));
 
     expect(res.status).toBe(200);
-    expect(res.body).toHaveProperty("status", "warning");
+    expect(res.body).toHaveProperty("status", "running");
   });
 
   it("reconciles warning agents to stopped when the container is no longer live", async () => {

--- a/backend-api/__tests__/dockerBootstrap.test.ts
+++ b/backend-api/__tests__/dockerBootstrap.test.ts
@@ -573,7 +573,9 @@ describe("Provisioner backends", () => {
     );
 
     expect(k8sSource).toContain("buildOpenClawInstallCommand(");
-    expect(k8sSource).toContain('["openclaw@latest"]');
+    // k8s shares the docker package spec (OPENCLAW_DOCKER_PACKAGE env) so a
+    // fleet can be pinned with one knob instead of hardcoding @latest.
+    expect(k8sSource).toContain("getStandardDockerPackageSpec()");
     expect(k8sSource).toContain('"nemoclaw@latest"');
     expect(nemoclawSource).toContain("buildOpenClawInstallCommand([");
 

--- a/backend-api/__tests__/provisioning.test.ts
+++ b/backend-api/__tests__/provisioning.test.ts
@@ -396,6 +396,17 @@ describe("provisioning runtime/gateway contracts", () => {
         expect.objectContaining({ name: "runtime", containerPort: AGENT_RUNTIME_PORT }),
       ]),
     );
+    // Pods must not report Ready before the gateway listens; cold boot gets a
+    // startup budget so liveness can't kill the npm install.
+    expect(container.startupProbe).toEqual(
+      expect.objectContaining({ tcpSocket: { port: OPENCLAW_GATEWAY_PORT } }),
+    );
+    expect(container.readinessProbe).toEqual(
+      expect.objectContaining({ tcpSocket: { port: OPENCLAW_GATEWAY_PORT } }),
+    );
+    expect(container.livenessProbe).toEqual(
+      expect.objectContaining({ tcpSocket: { port: OPENCLAW_GATEWAY_PORT } }),
+    );
     expect(service.spec.ports).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/backend-api/agentStatus.ts
+++ b/backend-api/agentStatus.ts
@@ -9,7 +9,11 @@ function reconcileAgentStatus(currentStatus, liveRunning) {
   }
 
   if (liveRunning) {
-    if (currentStatus === "warning") return "warning";
+    // warning is a point-in-time readiness miss (deploy probe timed out) —
+    // once the runtime is demonstrably live it must self-heal, same as
+    // stopped/error below. Leaving it sticky meant every slow cold boot wore
+    // a permanent false "warning" until a manual stop/start.
+    if (currentStatus === "warning") return "running";
     if (currentStatus === "stopped" || currentStatus === "error") return "running";
     return currentStatus;
   }

--- a/workers/provisioner/backends/k8s.ts
+++ b/workers/provisioner/backends/k8s.ts
@@ -15,7 +15,10 @@ const {
   AGENT_RUNTIME_PORT,
   HERMES_DASHBOARD_PORT,
 } = require("../../../agent-runtime/lib/contracts");
-const { getHermesDockerAgentImage } = require("../../../agent-runtime/lib/agentImages");
+const {
+  getHermesDockerAgentImage,
+  getStandardDockerPackageSpec,
+} = require("../../../agent-runtime/lib/agentImages");
 const { getNemoClawDefaultModel } = require("../../../agent-runtime/lib/nemoclawDefaults");
 const {
   buildContainerBootstrap,
@@ -1868,6 +1871,24 @@ class K8sBackend extends ProvisionerBackend {
                   { name: "runtime", containerPort: HERMES_RUNTIME_PORT },
                   { name: "dashboard", containerPort: HERMES_DASHBOARD_PORT },
                 ],
+                // See the OpenClaw deployment below for probe rationale; the
+                // Hermes image boots faster (prebaked), so a shorter startup
+                // budget suffices.
+                startupProbe: {
+                  tcpSocket: { port: HERMES_RUNTIME_PORT },
+                  periodSeconds: 10,
+                  failureThreshold: 30,
+                },
+                readinessProbe: {
+                  tcpSocket: { port: HERMES_RUNTIME_PORT },
+                  periodSeconds: 10,
+                  failureThreshold: 3,
+                },
+                livenessProbe: {
+                  tcpSocket: { port: HERMES_RUNTIME_PORT },
+                  periodSeconds: 30,
+                  failureThreshold: 4,
+                },
                 resources: {
                   requests: {
                     cpu: `${(vcpu || 2) * 1000}m`,
@@ -2027,8 +2048,14 @@ class K8sBackend extends ProvisionerBackend {
     const escapedPaired = pairedJson.replace(/'/g, "'\\''");
     const runtimeBootstrapCmd = buildRuntimeBootstrapCommand();
     const templateBootstrapCmd = buildTemplatePayloadBootstrapCommand(templatePayload);
+    // Same package spec as the docker backend (OPENCLAW_DOCKER_PACKAGE /
+    // NEMOCLAW_PACKAGE env) — one fleet-wide pin knob. An unpinned @latest
+    // here is a fleet-breakage lever: every fresh pod and every crash-restart
+    // npm-installs it at boot.
+    const openclawPackageSpec = getStandardDockerPackageSpec();
+    const nemoclawPackageSpec = process.env.NEMOCLAW_PACKAGE || "nemoclaw@latest";
     const ensureOpenClawCmd = buildOpenClawInstallCommand(
-      isNemoClaw ? ["openclaw@latest", "nemoclaw@latest"] : ["openclaw@latest"],
+      isNemoClaw ? [openclawPackageSpec, nemoclawPackageSpec] : [openclawPackageSpec],
     );
     const nemoPolicyCmd = isNemoClaw
       ? `mkdir -p /opt/openclaw && echo '${JSON.stringify({
@@ -2184,6 +2211,27 @@ class K8sBackend extends ProvisionerBackend {
                   { name: "gateway", containerPort: OPENCLAW_GATEWAY_PORT },
                   { name: "runtime", containerPort: AGENT_RUNTIME_PORT },
                 ],
+                // Without probes the pod is Ready the instant /bin/sh starts —
+                // long before the gateway listens — so status() reports running
+                // prematurely and a hung gateway is never restarted. Cold boot
+                // npm-installs the runtime (minutes on a fresh node); the
+                // startup probe gives it a 10-minute budget before liveness
+                // takes over.
+                startupProbe: {
+                  tcpSocket: { port: OPENCLAW_GATEWAY_PORT },
+                  periodSeconds: 10,
+                  failureThreshold: 60,
+                },
+                readinessProbe: {
+                  tcpSocket: { port: OPENCLAW_GATEWAY_PORT },
+                  periodSeconds: 10,
+                  failureThreshold: 3,
+                },
+                livenessProbe: {
+                  tcpSocket: { port: OPENCLAW_GATEWAY_PORT },
+                  periodSeconds: 30,
+                  failureThreshold: 4,
+                },
                 resources: {
                   requests: {
                     cpu: `${(vcpu || 2) * 1000}m`,

--- a/workers/provisioner/worker.ts
+++ b/workers/provisioner/worker.ts
@@ -2707,6 +2707,13 @@ worker.on("failed", async (job, err) => {
       `[DLQ] Agent "${job.data.name}" (${job.data.id}) exhausted all ${maxAttempts} retry attempts`,
     );
     try {
+      // Terminal: without this, a job that died after the container was
+      // created (e.g. the final status UPDATE failed) leaves the agent in
+      // 'deploying' forever — the background reconciler deliberately skips
+      // queued/deploying rows, so nothing else can ever move it.
+      await db.query("UPDATE agents SET status = 'error' WHERE id = $1 AND status = 'deploying'", [
+        job.data.id,
+      ]);
       await db.query("INSERT INTO events(type, message, metadata) VALUES($1, $2, $3)", [
         "agent_deploy_dlq",
         `Agent "${job.data.name}" exhausted all ${maxAttempts} retry attempts`,


### PR DESCRIPTION
Batch 3 from the 2026-07-04 stage functional audit (after #260/#261/#262/#263).

- **Pinnable boot install**: the k8s boot script now uses the shared package spec (`OPENCLAW_DOCKER_PACKAGE`, same env knob the docker backend already honors; `NEMOCLAW_PACKAGE` for the sandbox profile) instead of hardcoded `openclaw@latest`. Every fresh pod and crash-restart npm-installs at boot, so unpinned `@latest` was a fleet-wide breakage lever with no rollback path.
- **Pod probes**: startup/readiness/liveness tcpSocket probes on the gateway port (OpenClaw/NemoClaw) and runtime port (Hermes). Pods previously went Ready the instant the shell started — minutes before the gateway listened — so `status()` reported running prematurely and hung gateways were never restarted. Startup probe budgets 10 min (OpenClaw) / 5 min (Hermes) for cold boots before liveness engages; readiness also makes `availableReplicas` a truthful signal for the reconciler.
- **Status truthfulness**: `warning` self-heals to `running` when the runtime is demonstrably live (it was permanently sticky — every slow cold boot wore a false warning until a manual stop/start, while `stopped`/`error` already recovered). Deploy jobs that exhaust retries now mark the agent `error` if still `deploying` — the reconciler deliberately skips `deploying` rows, so those agents were stuck forever.

Validation: 150 suites / 1290 tests green; provisioning test asserts the three probes; agentStatus + agents-route tests updated to the self-heal semantics; source-guard test updated for the shared package spec.