### PR TITLE
fix: gateway DNS re-resolve, credential auto-test, LB diagnostics, honest pricing dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -189,7 +189,7 @@ COST_PER_1K_TOKENS=0.002
 # Optional per-model token rates. Keys may be model ids or provider/model ids.
 # Split rates are used when Nora records input/output token metadata; per_1k
 # is used when only total tokens are available.
-COST_MODEL_RATES_JSON={"openai/gpt-5.4":{"input_per_1k":0.002,"output_per_1k":0.008},"claude-sonnet-4-5":{"input_per_1k":0.003,"output_per_1k":0.015}}
+COST_MODEL_RATES_JSON={"openai/gpt-5.5":{"input_per_1k":0.002,"output_per_1k":0.008},"claude-sonnet-4-5":{"input_per_1k":0.003,"output_per_1k":0.015},"gemini-3.1-pro-preview":{"input_per_1k":0.00125,"output_per_1k":0.01}}
 
 # ── OpenTelemetry GenAI export (optional; off by default) ────
 # Export per-exchange chat spans + token/cost/resource metrics under the OTel

--- a/backend-api/__tests__/provisioning.test.ts
+++ b/backend-api/__tests__/provisioning.test.ts
@@ -1418,7 +1418,7 @@ describe("provisioning runtime/gateway contracts", () => {
         env: { OPENAI_API_KEY: "test-key" },
       }),
     ).rejects.toThrow(
-      "Timed out waiting for K8s LoadBalancer address for nora-oclaw-pending-loadbalancer-qa-999",
+      "Timed out waiting for a LoadBalancer address for nora-oclaw-pending-loadbalancer-qa-999",
     );
   });
 

--- a/backend-api/gatewayProxy.ts
+++ b/backend-api/gatewayProxy.ts
@@ -397,10 +397,16 @@ function buildConnectDevice(identity, role, scopes, nonce) {
 // ─── WS-RPC Connection Pool ─────────────────────────────────────
 
 class GatewayConnection {
-  constructor(host, token, port) {
+  constructor(host, token, port, { resolveHost = null, sourceHost = null } = {}) {
     this.host = host;
     this.token = token;
     this.port = port || GATEWAY_PORT;
+    // Re-resolution hook: `host` is a concrete IP resolved from the agent's
+    // service DNS at pool-creation time. On k8s a pod replacement changes the
+    // pod IP, so reconnects must re-resolve the ORIGINAL name or they hammer
+    // the dead IP until the circuit opens (~30s of 502s per pod swap).
+    this._resolveHost = typeof resolveHost === "function" ? resolveHost : null;
+    this._sourceHost = sourceHost || host;
     this.ws = null;
     this.connected = false;
     this.pending = new Map(); // id -> { resolve, reject, timer }
@@ -581,6 +587,23 @@ class GatewayConnection {
     await new Promise((r) => setTimeout(r, delay));
     this._reconnectAttempts++;
 
+    // The cached IP may belong to a replaced pod — refresh it from the
+    // original service name before dialing. Failure keeps the previous
+    // address; the connect below will fail and back off as before.
+    if (this._resolveHost) {
+      try {
+        const nextHost = await this._resolveHost();
+        if (nextHost && nextHost !== this.host) {
+          console.log(
+            `[gatewayProxy] Gateway ${this._sourceHost} re-resolved ${this.host} -> ${nextHost}`,
+          );
+          this.host = nextHost;
+        }
+      } catch {
+        // DNS not answering right now — retry with the old address.
+      }
+    }
+
     try {
       await this.connect();
       this._reconnectAttempts = 0;
@@ -679,7 +702,10 @@ async function getConnection(agent) {
   );
   // gateway_token is encrypted at rest; decrypt() is transparent to legacy
   // plaintext, so it is safe regardless of the token's storage form.
-  conn = new GatewayConnection(connectHost, decrypt(agent.gateway_token), addr.port);
+  conn = new GatewayConnection(connectHost, decrypt(agent.gateway_token), addr.port, {
+    resolveHost: () => resolveGatewayHostForProxy(addr.host, "agent gateway", extraAllowedHosts),
+    sourceHost: addr.host,
+  });
   pool.set(key, conn);
   try {
     await conn.connect();

--- a/backend-api/metrics.ts
+++ b/backend-api/metrics.ts
@@ -53,9 +53,23 @@ function extractTokenUsage(payload = {}, defaults = {}) {
     {};
   if (!usage || typeof usage !== "object") return null;
 
-  const inputTokens = normalizeUsageNumber(
-    firstDefined(usage.input_tokens, usage.prompt_tokens, usage.inputTokens, usage.promptTokens),
+  // Anthropic reports input_tokens as the UNCACHED remainder — the cached
+  // read/write portions arrive in separate fields and were previously
+  // dropped entirely, understating both token counts and cost for
+  // cache-heavy agents. OpenAI nests cached counts in prompt_tokens_details
+  // (already included in prompt_tokens, so not re-added here).
+  const cacheReadTokens = normalizeUsageNumber(
+    firstDefined(usage.cache_read_input_tokens, usage.cacheReadInputTokens),
   );
+  const cacheWriteTokens = normalizeUsageNumber(
+    firstDefined(usage.cache_creation_input_tokens, usage.cacheCreationInputTokens),
+  );
+  const inputTokens =
+    normalizeUsageNumber(
+      firstDefined(usage.input_tokens, usage.prompt_tokens, usage.inputTokens, usage.promptTokens),
+    ) +
+    cacheReadTokens +
+    cacheWriteTokens;
   const outputTokens = normalizeUsageNumber(
     firstDefined(
       usage.output_tokens,
@@ -64,9 +78,12 @@ function extractTokenUsage(payload = {}, defaults = {}) {
       usage.completionTokens,
     ),
   );
-  const totalTokens =
-    normalizeUsageNumber(firstDefined(usage.total_tokens, usage.totalTokens, usage.tokens)) ||
-    inputTokens + outputTokens;
+  const recordedTotal = normalizeUsageNumber(
+    firstDefined(usage.total_tokens, usage.totalTokens, usage.tokens),
+  );
+  const totalTokens = recordedTotal
+    ? recordedTotal + cacheReadTokens + cacheWriteTokens
+    : inputTokens + outputTokens;
   if (!totalTokens) return null;
 
   const model = firstDefined(
@@ -467,6 +484,10 @@ function buildTokenCostModel(row, modelRates, fallbackPer1k) {
     output_tokens: outputTokens,
     total_tokens: totalTokens,
     token_cost: roundCurrency(tokenCost),
+    // Unrounded cost for summation: cent-rounding each model first zeroes
+    // out every model that costs <$0.005 in the window, silently understating
+    // agent/workspace/fleet totals on many-small-model fleets.
+    token_cost_raw: tokenCost,
     request_count: Number.parseInt(row.request_count, 10) || 0,
     rate_source: rateSource,
     rates: appliedRates,
@@ -509,7 +530,8 @@ async function getTokenCostBreakdown(agentId, costWindow) {
   const totalTokens = models.reduce((sum, row) => sum + row.total_tokens, 0);
   const inputTokens = models.reduce((sum, row) => sum + row.input_tokens, 0);
   const outputTokens = models.reduce((sum, row) => sum + row.output_tokens, 0);
-  const tokenCost = models.reduce((sum, row) => sum + row.token_cost, 0);
+  // Sum the unrounded per-model costs; round once at the total.
+  const tokenCost = models.reduce((sum, row) => sum + (row.token_cost_raw ?? row.token_cost), 0);
 
   return {
     fallback_per_1k: fallbackPer1k,

--- a/backend-api/routes/integrations.ts
+++ b/backend-api/routes/integrations.ts
@@ -891,6 +891,18 @@ router.post("/agents/:id/integrations", async (req, res) => {
       }
     }
 
+    // Auto-verify the stored credentials so broken keys surface at save time
+    // instead of at first agent use. Non-blocking: the row is already stored
+    // and synced — the outcome rides along for the UI to display.
+    if (result?.id) {
+      try {
+        const connectivity = await integrations.testIntegration(result.id, req.params.id);
+        result = { ...result, connectivity };
+      } catch (testError) {
+        result = { ...result, connectivity: { success: false, error: testError.message } };
+      }
+    }
+
     res.json(result);
   } catch (e) {
     res.status(e.statusCode || 500).json({ error: e.message });

--- a/backend-api/routes/llmProviders.ts
+++ b/backend-api/routes/llmProviders.ts
@@ -26,7 +26,9 @@ router.post("/", async (req, res) => {
     if (!provider || (!apiKey && provider !== "demo"))
       return res.status(400).json({ error: "provider and apiKey required" });
     const result = await llmProviders.addProvider(req.user.id, provider, apiKey, model, config);
-    syncAuthToUserAgents(req.user.id).catch(() => {});
+    syncAuthToUserAgents(req.user.id).catch((error) =>
+      console.warn("[llmProviders] Post-save auth sync failed:", error.message),
+    );
     res.json(result);
   } catch (e) {
     res.status(400).json({ error: e.message });
@@ -36,7 +38,9 @@ router.post("/", async (req, res) => {
 router.put("/:id", async (req, res) => {
   try {
     const result = await llmProviders.updateProvider(req.params.id, req.user.id, req.body);
-    syncAuthToUserAgents(req.user.id).catch(() => {});
+    syncAuthToUserAgents(req.user.id).catch((error) =>
+      console.warn("[llmProviders] Post-save auth sync failed:", error.message),
+    );
     res.json(result);
   } catch (e) {
     res.status(400).json({ error: e.message });
@@ -46,7 +50,9 @@ router.put("/:id", async (req, res) => {
 router.delete("/:id", async (req, res) => {
   try {
     await llmProviders.deleteProvider(req.params.id, req.user.id);
-    syncAuthToUserAgents(req.user.id).catch(() => {});
+    syncAuthToUserAgents(req.user.id).catch((error) =>
+      console.warn("[llmProviders] Post-save auth sync failed:", error.message),
+    );
     res.json({ success: true });
   } catch (e) {
     res.status(400).json({ error: e.message });

--- a/backend-api/workspaceBudgets.ts
+++ b/backend-api/workspaceBudgets.ts
@@ -97,13 +97,26 @@ async function deleteBudget(budgetId, workspaceId) {
   return Boolean(result.rows[0]);
 }
 
+const BUDGET_PERIOD_DAYS = { daily: 1, weekly: 7, monthly: 30 };
+
 // Check current spend against budgets and return an array of bucket
 // crossings (none / soft / hard). Callers (the cost route handler, or a
 // background task) decide whether to emit events from the result.
-async function evaluateBudgetCrossings(workspaceId, currentUsd) {
+// Spend is resolved PER BUDGET PERIOD — never from whatever window the
+// viewer happened to select (that measured a daily $10 budget against
+// 30-day spend and fired false alerts on every page view).
+async function evaluateBudgetCrossings(workspaceId, _ignoredViewerWindowUsd, deps = {}) {
+  const { costResolver = require("./metrics").getWorkspaceCost } = deps;
   const budgets = await listBudgets(workspaceId);
   const crossings = [];
+  const spendByPeriod = new Map();
   for (const budget of budgets) {
+    const periodDays = BUDGET_PERIOD_DAYS[budget.period] || 30;
+    if (!spendByPeriod.has(periodDays)) {
+      const cost = await costResolver(workspaceId, { periodDays });
+      spendByPeriod.set(periodDays, Number(cost?.totalUsd ?? cost?.total_cost ?? 0));
+    }
+    const currentUsd = spendByPeriod.get(periodDays);
     const pct = budget.limitUsd > 0 ? Math.floor((currentUsd / budget.limitUsd) * 100) : 0;
     let bucket = "none";
     if (pct >= 100) bucket = "hard";

--- a/frontend-dashboard/pages/workspaces/[id]/cost.tsx
+++ b/frontend-dashboard/pages/workspaces/[id]/cost.tsx
@@ -26,8 +26,8 @@ import {
 const PERIOD_DAYS_OPTIONS = [7, 30, 90];
 const BUDGET_PERIODS: Array<"daily" | "weekly" | "monthly"> = ["daily", "weekly", "monthly"];
 
-function formatUsd(value: number): string {
-  return `$${value.toFixed(2)}`;
+function formatUsd(value?: number | null): string {
+  return `$${Number(value || 0).toFixed(2)}`;
 }
 
 function formatNumber(value?: number | null): string {

--- a/workers/provisioner/backends/k8s.ts
+++ b/workers/provisioner/backends/k8s.ts
@@ -1148,11 +1148,22 @@ class K8sBackend extends ProvisionerBackend {
 
   async _waitForLoadBalancerAddress(deployName, initialService, namespace = this.namespace) {
     const deadline = Date.now() + this.loadBalancerReadyTimeoutMs;
+    const halfway = Date.now() + this.loadBalancerReadyTimeoutMs / 2;
+    let warned = false;
     let service = this._serviceObject(initialService);
 
     while (Date.now() <= deadline) {
       const address = this._loadBalancerAddress(service);
       if (address) return address;
+
+      if (!warned && Date.now() >= halfway) {
+        warned = true;
+        console.warn(
+          `[k8s] Still waiting for a LoadBalancer address for ${deployName} — ` +
+            `each agent gets its own cloud load balancer + public IP in this exposure mode, ` +
+            `so slow allocation usually means an LB/IP quota is nearly exhausted.`,
+        );
+      }
 
       await sleep(this.loadBalancerReadyIntervalMs);
       service = this._serviceObject(
@@ -1164,8 +1175,10 @@ class K8sBackend extends ProvisionerBackend {
     }
 
     throw new Error(
-      `Timed out waiting for K8s LoadBalancer address for ${deployName} after ` +
-        `${this.loadBalancerReadyTimeoutMs}ms`,
+      `Timed out waiting for a LoadBalancer address for ${deployName} after ` +
+        `${this.loadBalancerReadyTimeoutMs}ms. This cluster's exposure mode allocates one ` +
+        `cloud load balancer + public IP PER AGENT — check the provider's LB/public-IP quota, ` +
+        `or switch the cluster's exposure mode to node-port/cluster-ip in Admin → Kubernetes.`,
     );
   }
 


### PR DESCRIPTION
Batch 4 from the stage functional audit — the three remaining named fixes plus the pricing-dashboard audit findings.

**Gateway proxy**
- Reconnects re-resolve the agent's service DNS before dialing. The pool cached a concrete pod IP, so every k8s pod replacement caused ~30s of circuit-breaker 502s while reconnects hammered the dead IP.

**Credential trust**
- Connecting/replacing an integration auto-runs the provider connectivity test; the outcome rides on the response (`connectivity: {success, error}`) so broken keys surface at save time. Non-blocking — the row is already stored/synced.
- LLM provider post-save sync failures are logged instead of swallowed.

**LoadBalancer exposure**
- The LB wait warns halfway and times out with an actionable error (per-agent LB + public IP quota reality, and how to switch exposure mode) instead of an opaque failure after 10 silent minutes. (The durable cost fix — a shared ingress instead of per-agent LBs — is flagged as follow-up architecture, not rushed here.)

**Pricing dashboard (audit findings)**
- Workspace budget alerts evaluate spend per budget period (daily/weekly/monthly), mirroring `agentBudgets` — previously a daily $10 budget was measured against the viewer's selected window (default 30d), firing false `workspace.budget_exceeded` events/webhooks on every page view and masking real overages under short windows.
- `.env.example` rates: `openai/gpt-5.4` → `openai/gpt-5.5` (stale key silently priced gpt-5.5 output at the flat 0.002 fallback — 4× undercharge) + a `gemini-3.1-pro-preview` entry.
- Per-model costs sum unrounded, rounded once at the total (cent-rounding per model zeroed out every model under $0.005/window).
- Anthropic `cache_read_input_tokens`/`cache_creation_input_tokens` are folded into usage (previously dropped entirely — cache-heavy agents under-reported). OpenAI cached counts are already inside `prompt_tokens` and are not double-added.
- Workspace cost page `formatUsd` coerces null/NaN like the fleet page.

Deferred with notes: date-picker timezone drift (needs a client-tz API field) and the cost page reload() fetch race.

Validation: 150 suites / 1290 tests green; frontend-dashboard typecheck clean; prettier clean.