### PR TITLE
chore(agent-runtime): apply prettier formatting to 4 drifted files

### DIFF
--- a/agent-runtime/bin/openclaw.ts
+++ b/agent-runtime/bin/openclaw.ts
@@ -31,7 +31,10 @@ const HELP = `
 function formatBytes(bytes) {
   const units = ["B", "KB", "MB", "GB"];
   let i = 0;
-  while (bytes >= 1024 && i < units.length - 1) { bytes /= 1024; i++; }
+  while (bytes >= 1024 && i < units.length - 1) {
+    bytes /= 1024;
+    i++;
+  }
   return `${bytes.toFixed(1)} ${units[i]}`;
 }
 
@@ -82,8 +85,24 @@ const commands = {
     console.log("\x1b[36m── Health Checks ─────────────────────────\x1b[0m\n");
     const checks = [
       { name: "Node.js runtime", test: () => !!process.version },
-      { name: "File system (writable)", test: () => { require("fs").writeFileSync("/tmp/.openclaw-health", "ok"); return true; } },
-      { name: "Network (DNS)", test: () => { try { require("dns").lookupService("127.0.0.1", 80, () => {}); return true; } catch { return false; } } },
+      {
+        name: "File system (writable)",
+        test: () => {
+          require("fs").writeFileSync("/tmp/.openclaw-health", "ok");
+          return true;
+        },
+      },
+      {
+        name: "Network (DNS)",
+        test: () => {
+          try {
+            require("dns").lookupService("127.0.0.1", 80, () => {});
+            return true;
+          } catch {
+            return false;
+          }
+        },
+      },
       { name: "Memory available", test: () => os.freemem() > 50 * 1024 * 1024 },
       { name: "Agent env vars set", test: () => !!process.env.AGENT_ID },
     ];
@@ -99,7 +118,9 @@ const commands = {
         allOk = false;
       }
     }
-    console.log(`\n  ${allOk ? "\x1b[32mAll checks passed\x1b[0m" : "\x1b[33mSome checks failed\x1b[0m"}\n`);
+    console.log(
+      `\n  ${allOk ? "\x1b[32mAll checks passed\x1b[0m" : "\x1b[33mSome checks failed\x1b[0m"}\n`,
+    );
   },
 
   logs() {

--- a/agent-runtime/lib/agent.ts
+++ b/agent-runtime/lib/agent.ts
@@ -13,7 +13,9 @@ function log(level, message) {
   console.log(line);
   try {
     fs.appendFileSync(LOG_FILE, line + "\n");
-  } catch { /* ignore write errors */ }
+  } catch {
+    /* ignore write errors */
+  }
 }
 
 // Banner
@@ -33,7 +35,10 @@ const HEARTBEAT_INTERVAL = 60_000; // 1 minute
 setInterval(() => {
   const memUsed = os.totalmem() - os.freemem();
   const memPct = ((memUsed / os.totalmem()) * 100).toFixed(1);
-  log("INFO", `Heartbeat — uptime: ${Math.floor(os.uptime())}s, memory: ${memPct}%, load: ${os.loadavg()[0].toFixed(2)}`);
+  log(
+    "INFO",
+    `Heartbeat — uptime: ${Math.floor(os.uptime())}s, memory: ${memPct}%, load: ${os.loadavg()[0].toFixed(2)}`,
+  );
 }, HEARTBEAT_INTERVAL);
 
 // Graceful shutdown

--- a/agent-runtime/lib/clawhubReconciliation.js
+++ b/agent-runtime/lib/clawhubReconciliation.js
@@ -44,14 +44,18 @@ function normalizeSavedSkillEntries(entries = []) {
 
 function computeMissingSavedSkills(savedSkills = [], installedSkills = []) {
   const normalizedSaved = normalizeSavedSkillEntries(savedSkills);
-  const installedSlugs = new Set(normalizeInstalledSkillEntries(installedSkills).map((entry) => entry.slug));
+  const installedSlugs = new Set(
+    normalizeInstalledSkillEntries(installedSkills).map((entry) => entry.slug),
+  );
   return normalizedSaved.filter((entry) => !installedSlugs.has(entry.installSlug));
 }
 
 function computeOrphanedInstalledSkills(savedSkills = [], installedSkills = []) {
   const normalizedSaved = normalizeSavedSkillEntries(savedSkills);
   const savedSlugs = new Set(normalizedSaved.map((entry) => entry.installSlug));
-  return normalizeInstalledSkillEntries(installedSkills).filter((entry) => !savedSlugs.has(entry.slug));
+  return normalizeInstalledSkillEntries(installedSkills).filter(
+    (entry) => !savedSlugs.has(entry.slug),
+  );
 }
 
 function removeSavedSkillEntry(entries = [], slug, author = "") {
@@ -91,13 +95,14 @@ function mergeClawhubSkillState(savedSkills = [], installedSkills = [], pendingJ
       author: saved.author,
       pagePath: saved.pagePath,
       installedAt: saved.installedAt || null,
-      status: pending?.operation === "delete"
-        ? "pending_delete"
-        : pending?.operation === "install"
-          ? "pending_install"
-          : installed
-            ? "healthy"
-            : "missing_runtime",
+      status:
+        pending?.operation === "delete"
+          ? "pending_delete"
+          : pending?.operation === "install"
+            ? "pending_install"
+            : installed
+              ? "healthy"
+              : "missing_runtime",
     });
     installedBySlug.delete(saved.installSlug);
   }

--- a/agent-runtime/lib/contracts.ts
+++ b/agent-runtime/lib/contracts.ts
@@ -3,7 +3,7 @@ const OPENCLAW_GATEWAY_PORT = 18789;
 const HERMES_DASHBOARD_PORT = 9119;
 
 function joinHttpUrl(host, port, path = "/") {
-  const normalizedPath = !path ? "" : (path.startsWith("/") ? path : `/${path}`);
+  const normalizedPath = !path ? "" : path.startsWith("/") ? path : `/${path}`;
   return `http://${host}:${port}${normalizedPath}`;
 }
 


### PR DESCRIPTION
## Why

A full-repo prettier sweep (wider than CI's format matrix) found 4 files in `agent-runtime/` that don't match the repo prettier config. `agent-runtime/` is intentionally **not** in CI's prettier/eslint matrix, so this is **not** a CI-red risk — it's a consistency fix for a shared-blast-radius zone (mounted read-only into both backend-api and worker-provisioner), where keeping formatting consistent reduces diff noise across two consumers.

## What

`prettier --write` on:
- `agent-runtime/bin/openclaw.ts`
- `agent-runtime/lib/agent.ts`
- `agent-runtime/lib/clawhubReconciliation.js`
- `agent-runtime/lib/contracts.ts`

Pure formatting — single-line blocks expanded to multi-line per the repo's `printWidth: 100` config. Verified formatting-only via whitespace-insensitive diff review.

## Verification

- prettier `--check` on the 4 files: clean
- `agent-runtime` typecheck: pass
- `agent-runtime` vitest: 10 tests pass