### PR TITLE
fix(mcp): start npm bin through symlinks

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -18,7 +18,7 @@
   "mcpServers": {
     "nora": {
       "command": "npx",
-      "args": ["-y", "@noraai/mcp-server@0.1.2"]
+      "args": ["-y", "@noraai/mcp-server@0.1.3"]
     }
   }
 }

--- a/mcp-server/manifest.json
+++ b/mcp-server/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "nora",
   "display_name": "Nora",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Operate your self-hosted Nora agent fleet from Claude Desktop.",
   "long_description": "Connect Claude Desktop to a Nora control plane you operate. Deploy and control OpenClaw or Hermes agents, inspect fleet health, and read metrics, events, and cost through Nora's workspace-scoped API.",
   "author": {

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@noraai/mcp-server",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@noraai/mcp-server",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noraai/mcp-server",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "MCP server for Nora — deploy, monitor, and operate self-hosted OpenClaw and Hermes agent fleets on Docker or Kubernetes.",
   "mcpName": "io.github.solomon2773/nora",
   "license": "Apache-2.0",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.solomon2773/nora",
   "title": "Nora",
   "description": "Operate your self-hosted Nora agent fleet from MCP clients.",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "websiteUrl": "https://noradocs.solomontsao.com",
   "repository": {
     "url": "https://github.com/solomon2773/nora",
@@ -15,7 +15,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@noraai/mcp-server",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "transport": {
         "type": "stdio"
       },

--- a/mcp-server/src/client.js
+++ b/mcp-server/src/client.js
@@ -38,7 +38,7 @@ export function createApi({ baseUrl, apiKey, fetchImpl } = {}) {
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${resolved.apiKey}`,
-        "User-Agent": "nora-mcp-server/0.1.0",
+        "User-Agent": "nora-mcp-server/0.1.3",
       },
       body: body !== undefined ? JSON.stringify(body) : undefined,
     });

--- a/mcp-server/src/index.js
+++ b/mcp-server/src/index.js
@@ -4,14 +4,15 @@
 // Stdio transport: stdout belongs to the protocol. Anything human-facing goes
 // to stderr; never console.log in this process.
 
-import { pathToFileURL } from "node:url";
+import fs from "node:fs";
+import { fileURLToPath } from "node:url";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { createApi } from "./client.js";
 import { registerAgentTools } from "./tools/agents.js";
 import { registerMonitoringTools } from "./tools/monitoring.js";
 
-export const SERVER_INFO = { name: "nora", version: "0.1.2" };
+export const SERVER_INFO = { name: "nora", version: "0.1.3" };
 
 export function createServer({ api, env = process.env } = {}) {
   const server = new McpServer(SERVER_INFO, {
@@ -38,8 +39,21 @@ export async function main() {
   console.error("Nora MCP server ready (stdio)");
 }
 
-const isDirectRun = process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
-if (isDirectRun) {
+function isDirectRun() {
+  const entrypointPath = process.argv[1];
+  const modulePath = fileURLToPath(import.meta.url);
+  if (!entrypointPath || !fs.existsSync(entrypointPath) || !fs.existsSync(modulePath)) {
+    return false;
+  }
+
+  try {
+    return fs.realpathSync(entrypointPath) === fs.realpathSync(modulePath);
+  } catch {
+    return false;
+  }
+}
+
+if (isDirectRun()) {
   main().catch((error) => {
     console.error(error);
     process.exit(1);

--- a/mcp-server/test/entrypoint.test.js
+++ b/mcp-server/test/entrypoint.test.js
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { chmod, copyFile, cp, mkdir, mkdtemp, rm, symlink } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const packageRoot = fileURLToPath(new URL("../", import.meta.url));
+
+test(
+  "starts through an npm-style symlinked bin",
+  {
+    timeout: 10_000,
+    skip:
+      process.platform === "win32"
+        ? "npm uses command shims instead of symlinks on Windows"
+        : false,
+  },
+  async (t) => {
+    const installRoot = await mkdtemp(path.join(tmpdir(), "nora-mcp-entrypoint-"));
+    t.after(() => rm(installRoot, { recursive: true, force: true }));
+
+    const binDirectory = path.join(installRoot, "node_modules", ".bin");
+    const binPath = path.join(binDirectory, "nora-mcp");
+    const installedPackage = path.join(installRoot, "node_modules", "@noraai", "mcp-server");
+    const entrypointPath = path.join(installedPackage, "src", "index.js");
+    await mkdir(installedPackage, { recursive: true });
+    await cp(path.join(packageRoot, "src"), path.join(installedPackage, "src"), {
+      recursive: true,
+    });
+    await copyFile(
+      path.join(packageRoot, "package.json"),
+      path.join(installedPackage, "package.json"),
+    );
+    await symlink(
+      path.join(packageRoot, "node_modules"),
+      path.join(installedPackage, "node_modules"),
+      "dir",
+    );
+    await chmod(entrypointPath, 0o755);
+    await mkdir(binDirectory, { recursive: true });
+    await symlink(path.relative(binDirectory, entrypointPath), binPath);
+
+    const transport = new StdioClientTransport({
+      command: binPath,
+      env: {
+        ...process.env,
+        NORA_API_URL: "https://nora.invalid",
+        NORA_API_KEY: "nora_test",
+      },
+    });
+    const client = new Client({ name: "entrypoint-regression", version: "0.0.0" });
+    t.after(() => client.close());
+
+    await client.connect(transport);
+    assert.equal(client.getServerVersion()?.version, "0.1.3");
+
+    const result = await client.listTools();
+
+    assert.ok(result.tools.some((tool) => tool.name === "list_agents"));
+  },
+);

--- a/mcp-server/test/tools.test.js
+++ b/mcp-server/test/tools.test.js
@@ -135,6 +135,7 @@ test("the HTTP client sends bearer auth and parses JSON for a valid path", async
   const fetchImpl = async (url, opts) => {
     seen.url = url.toString();
     seen.auth = opts.headers.Authorization;
+    seen.userAgent = opts.headers["User-Agent"];
     return { ok: true, status: 200, text: async () => JSON.stringify({ id: AID }) };
   };
   const api = createApi({ baseUrl: "https://nora.example.com", apiKey: "nora_test", fetchImpl });
@@ -142,6 +143,7 @@ test("the HTTP client sends bearer auth and parses JSON for a valid path", async
   assert.deepEqual(body, { id: AID });
   assert.equal(seen.url, `https://nora.example.com/api/agents/${AID}`);
   assert.equal(seen.auth, "Bearer nora_test");
+  assert.equal(seen.userAgent, "nora-mcp-server/0.1.3");
 });
 
 test("per-agent observability tools use the /api/agents/:id paths", async () => {


### PR DESCRIPTION
## Summary

- resolve npm and npx bin symlinks before deciding whether the MCP entrypoint is running directly
- add a real stdio initialize and list-tools regression test through an npm-style executable symlink
- release the corrected package metadata as @noraai/mcp-server 0.1.3 and update the Gemini extension pin

## Why

The published 0.1.2 package compared the npm-created symlink path directly with import.meta.url. That comparison failed, main() never started, and MCP clients reported Connection closed.

## Verification

- npm test: 12 passed
- npm run typecheck
- ESLint and Prettier checks on every changed file
- npm pack, clean install, and MCP handshake through node_modules/.bin/nora-mcp
- MCPB 2.1.2 validate, pack, unpack, initialize, and declared/runtime tool inventory match
- Gemini CLI 0.50.0 extension validation
- full Nora local CI suite, including Docker builds and Playwright E2E: 16 passed, 65 real-credential tests skipped by design

CodeQL must still be verified on GitHub.