### PR TITLE
feat(mcp): add read-only GitHub Copilot CLI plugin

### DIFF
--- a/mcp-server/copilot-plugin/.mcp.json
+++ b/mcp-server/copilot-plugin/.mcp.json
@@ -1,0 +1,24 @@
+{
+  "mcpServers": {
+    "nora": {
+      "type": "local",
+      "command": "npx",
+      "args": ["-y", "@noraai/mcp-server@0.1.3"],
+      "env": {
+        "NORA_MCP_ALLOW_DESTRUCTIVE": "false"
+      },
+      "tools": [
+        "list_agents",
+        "get_agent",
+        "get_agent_stats",
+        "get_agent_versions",
+        "get_platform_metrics",
+        "get_fleet_status",
+        "list_monitoring_events",
+        "get_agent_metrics",
+        "get_agent_metrics_summary",
+        "get_agent_cost"
+      ]
+    }
+  }
+}

--- a/mcp-server/copilot-plugin/README.md
+++ b/mcp-server/copilot-plugin/README.md
@@ -1,0 +1,79 @@
+# Nora for GitHub Copilot CLI
+
+This plugin connects GitHub Copilot CLI to a Nora control plane through the published `@noraai/mcp-server` package. Its MCP configuration is deliberately read-only: Copilot can inspect agents, fleet health, metrics, monitoring events, and cost, but it cannot deploy, start, stop, restart, redeploy, or delete agents.
+
+## Prerequisites
+
+- GitHub Copilot CLI with plugin support
+- Node.js 24 or newer (required by the Nora CLI used for login)
+- Access to a Nora deployment
+
+## Configure Nora credentials
+
+In Nora, open **Workspace → API Keys** and create a dedicated key with only these scopes:
+
+- `agents:read`
+- `monitoring:read`
+
+Install the Nora CLI and save the deployment URL and key locally:
+
+```bash
+npm install -g @noraai/cli
+nora login --host https://nora.example.com --token nora_xxxxxxxx
+```
+
+`nora login` stores the credentials in `~/.nora/config.json` with mode `0600`. The plugin does not contain or copy the key; the local MCP process reads the same Nora CLI configuration at runtime.
+
+## Install the plugin
+
+Install directly from the Nora repository:
+
+```bash
+copilot plugin install solomon2773/nora:mcp-server/copilot-plugin
+```
+
+For development from a Nora checkout:
+
+```bash
+copilot plugin install ./mcp-server/copilot-plugin
+```
+
+Confirm the plugin and MCP server are available:
+
+```bash
+copilot plugin list
+copilot mcp get nora
+```
+
+## Available tools
+
+The plugin exposes only the following tools:
+
+| Tool                        | Required scope    |
+| --------------------------- | ----------------- |
+| `list_agents`               | `agents:read`     |
+| `get_agent`                 | `agents:read`     |
+| `get_agent_stats`           | `agents:read`     |
+| `get_agent_versions`        | `agents:read`     |
+| `get_platform_metrics`      | `monitoring:read` |
+| `get_fleet_status`          | `monitoring:read` |
+| `list_monitoring_events`    | `monitoring:read` |
+| `get_agent_metrics`         | `monitoring:read` |
+| `get_agent_metrics_summary` | `monitoring:read` |
+| `get_agent_cost`            | `monitoring:read` |
+
+The configuration pins `@noraai/mcp-server@0.1.3`, sets `NORA_MCP_ALLOW_DESTRUCTIVE=false`, and applies an explicit Copilot MCP tool allowlist. The scoped Nora key provides an additional server-side permission boundary.
+
+## Updating
+
+Update the installed plugin after this directory changes:
+
+```bash
+copilot plugin update nora
+```
+
+If the MCP package version changes, update `plugin.json`, `.mcp.json`, this README, and the parent `mcp-server/AGENTS.md` together, then repeat the local install and tool-discovery checks.
+
+## Privacy
+
+The MCP server runs locally. It sends authenticated requests directly to the Nora deployment configured by `nora login` and does not persist tool inputs or API responses. Never commit or paste a Nora API key into plugin files, issues, logs, or screenshots.

--- a/mcp-server/copilot-plugin/plugin.json
+++ b/mcp-server/copilot-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "name": "nora",
+  "description": "Inspect Nora agent fleets, health, metrics, events, and cost from GitHub Copilot CLI through a least-privilege, read-only MCP configuration.",
+  "version": "0.1.3",
+  "author": {
+    "name": "Solomon Tsao",
+    "url": "https://github.com/solomon2773"
+  },
+  "homepage": "https://github.com/solomon2773/nora",
+  "repository": "https://github.com/solomon2773/nora",
+  "license": "Apache-2.0",
+  "keywords": ["nora", "mcp", "agent-ops", "monitoring", "self-hosted"],
+  "category": "development",
+  "tags": ["mcp", "observability", "agents", "read-only"],
+  "mcpServers": ".mcp.json"
+}


### PR DESCRIPTION
## Summary

- Add a direct-install GitHub Copilot CLI plugin for the published `@noraai/mcp-server@0.1.3` package.
- Restrict Copilot to ten inventory, health, metrics, events, and cost tools through an explicit MCP allowlist.
- Keep `delete_agent` unregistered with `NORA_MCP_ALLOW_DESTRUCTIVE=false` and document a dedicated Nora key limited to `agents:read` and `monitoring:read`.
- Reuse credentials from `~/.nora/config.json` so no host or token is embedded in plugin metadata.

## Validation

- Full local pre-push matrix: `/root/.codex/skills/nora-ci-checks/scripts/run-nora-ci-checks.sh --repo /tmp/nora-glama-registry-1783816000 --no-install`
  - Typechecks, secret scan, production audits, license policy, and infra validation passed.
  - Backend: 150 suites / 1,290 tests passed.
  - Agent runtime: 3 files / 10 tests passed.
  - Five production Docker image builds passed.
  - Playwright: 16 CI tests passed; 65 real-credential tests skipped as expected.
- MCP package tests: 12/12 passed.
- Copilot CLI 1.0.70 local install and MCP configuration inspection passed.
- Published package initialize/list-tools handshake found 15 runtime tools; the plugin allowlist contains exactly ten read-only tools.
- Prettier, strict JSON parsing, secret scan, and `git diff --check` passed.

## Release And Docs Checklist

- [x] Updated the relevant local `AGENTS.md` guidance; repository policy keeps those files private-only, so they are not part of the public diff.
- [x] Public architecture docs do not need an update because this adds distribution metadata only and does not change runtime architecture, deployment topology, or API data flow.