### PR TITLE
fix(api): scope monitoring ownership guard

### DIFF
--- a/backend-api/__tests__/monitoringRoutes.test.ts
+++ b/backend-api/__tests__/monitoringRoutes.test.ts
@@ -15,15 +15,10 @@ const mockMetrics = {
   getAgentSummary: jest.fn(),
   getAgentCost: jest.fn(),
 };
-const mockOwnership = {
-  findAccessibleAgent: jest.fn(),
-  requireAccessibleAgent: jest.fn(() => (req, res, next) => next()),
-};
 
 jest.mock("../db", () => mockDb);
 jest.mock("../monitoring", () => mockMonitoring);
 jest.mock("../metrics", () => mockMetrics);
-jest.mock("../middleware/ownership", () => mockOwnership);
 
 const router = require("../routes/monitoring");
 
@@ -37,7 +32,6 @@ describe("monitoring route ownership", () => {
     mockMonitoring.getRecentEvents.mockReset();
     mockMonitoring.getUserRecentEvents.mockReset();
     mockMonitoring.getUserEventsPage.mockReset();
-    mockOwnership.findAccessibleAgent.mockReset();
     currentUser = { id: "user-1", role: "user" };
 
     app = express();
@@ -47,6 +41,30 @@ describe("monitoring route ownership", () => {
       next();
     });
     app.use(router);
+  });
+
+  it("lets unrelated static agent POST routes fall through without an ownership lookup", async () => {
+    const res = await request(app).post("/agents/activate-demo").send({});
+
+    expect(res.status).toBe(404);
+    expect(mockDb.query).not.toHaveBeenCalled();
+  });
+
+  it("still applies the ownership guard to agent monitoring routes", async () => {
+    const agentId = "00000000-0000-4000-8000-000000000001";
+    mockDb.query.mockResolvedValueOnce({ rows: [{ id: agentId, user_id: "user-1" }] });
+    mockMetrics.getAgentMetrics.mockResolvedValueOnce([]);
+
+    const res = await request(app).get(`/agents/${agentId}/metrics`);
+
+    expect(res.status).toBe(200);
+    expect(mockDb.query).toHaveBeenCalledWith("SELECT * FROM agents WHERE id = $1", [agentId]);
+    expect(mockMetrics.getAgentMetrics).toHaveBeenCalledWith(
+      agentId,
+      null,
+      expect.any(String),
+      expect.any(String),
+    );
   });
 
   it("returns the current user's recent events", async () => {

--- a/backend-api/routes/monitoring.ts
+++ b/backend-api/routes/monitoring.ts
@@ -10,7 +10,10 @@ const { requireAdmin, scopeByMethod } = require("../middleware/auth");
 
 const router = express.Router();
 
-router.use("/agents/:id", requireAccessibleAgent("viewer", "id"));
+const requireAccessibleMonitoringAgent = requireAccessibleAgent("viewer", "id");
+router.get("/agents/:id/metrics", requireAccessibleMonitoringAgent);
+router.get("/agents/:id/metrics/summary", requireAccessibleMonitoringAgent);
+router.get("/agents/:id/cost", requireAccessibleMonitoringAgent);
 // Monitoring is read-only via API keys. We scope-gate the specific path
 // prefixes the router handles — applying scopeByMethod at the router root
 // would block unrelated requests because this router is mounted at "/".


### PR DESCRIPTION
## Summary

- apply the agent ownership lookup only to the three monitoring GET routes that need it
- let unrelated `/agents/*` routes continue to their owning routers without treating static path segments as agent UUIDs
- add regression coverage for `/agents/activate-demo` fallthrough and retain monitoring-route authorization coverage

## Why

The monitoring router is mounted at `/`. Its previous `router.use("/agents/:id", ...)` middleware intercepted every `/agents/*` method before the owning router could handle it. Static routes such as `POST /agents/activate-demo` therefore attempted an agent lookup using `activate-demo` as the id.

## Validation

- focused monitoring route tests
- backend OpenAPI tests
- backend typecheck, lint, and formatting
- full local Nora CI pre-push suite, including 1,350 backend tests, agent-runtime tests, Docker image builds, and compose-backed Playwright E2E

GitHub CodeQL is intentionally left to the hosted workflow.