### PR TITLE
feat(mcp): add Claude Code plugin

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -9,6 +9,15 @@ claude mcp add nora \
   -- npx -y @noraai/mcp-server
 ```
 
+The repository also ships a Claude Code plugin manifest under
+[`claude-plugin/`](./claude-plugin). Validate and load it from a Nora checkout
+with:
+
+```bash
+claude plugin validate ./mcp-server/claude-plugin --strict
+claude --plugin-dir ./mcp-server/claude-plugin
+```
+
 Or in any MCP client's JSON config:
 
 ```json

--- a/mcp-server/claude-plugin/.claude-plugin/plugin.json
+++ b/mcp-server/claude-plugin/.claude-plugin/plugin.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "nora",
+  "displayName": "Nora Agent Ops",
+  "version": "0.1.3",
+  "description": "Inspect and operate self-hosted OpenClaw and Hermes agent fleets from Claude Code through Nora's MCP server.",
+  "author": {
+    "name": "Solomon Tsao",
+    "url": "https://github.com/solomon2773"
+  },
+  "homepage": "https://github.com/solomon2773/nora",
+  "repository": "https://github.com/solomon2773/nora",
+  "license": "Apache-2.0",
+  "keywords": ["nora", "mcp", "agent-ops", "openclaw", "hermes", "self-hosted"],
+  "mcpServers": "./.mcp.json"
+}

--- a/mcp-server/claude-plugin/.mcp.json
+++ b/mcp-server/claude-plugin/.mcp.json
@@ -1,0 +1,11 @@
+{
+  "mcpServers": {
+    "nora": {
+      "command": "npx",
+      "args": ["-y", "@noraai/mcp-server@0.1.3"],
+      "env": {
+        "NORA_MCP_ALLOW_DESTRUCTIVE": "false"
+      }
+    }
+  }
+}

--- a/mcp-server/claude-plugin/README.md
+++ b/mcp-server/claude-plugin/README.md
@@ -1,0 +1,65 @@
+# Nora for Claude Code
+
+This plugin connects Claude Code to a Nora control plane through the published
+`@noraai/mcp-server` package. It can inspect agents, fleet health, metrics,
+monitoring events, and cost. Lifecycle tools are available only when the Nora
+API key has `agents:write`; permanent deletion remains disabled.
+
+## Prerequisites
+
+- Claude Code 2.1.143 or newer
+- Node.js 24 or newer (required by the Nora CLI used for login)
+- Access to a Nora deployment
+
+## Configure Nora credentials
+
+For a read-only setup, open **Workspace → API Keys** in Nora and create a
+dedicated key with only these scopes:
+
+- `agents:read`
+- `monitoring:read`
+
+Install the Nora CLI and save the deployment URL and key locally:
+
+```bash
+npm install -g @noraai/cli
+nora login --host https://nora.example.com --token nora_xxxxxxxx
+```
+
+`nora login` stores the credentials in `~/.nora/config.json` with mode `0600`.
+The plugin does not contain or copy the key; its local MCP process reads the
+same Nora CLI configuration at runtime. You may instead set `NORA_API_URL` and
+`NORA_API_KEY` in the environment that starts Claude Code.
+
+## Install from the community directory
+
+After the plugin is listed in Claude's community directory:
+
+```text
+/plugin install nora@claude-plugins-community
+```
+
+Restart Claude Code after installation, then ask Claude to list your Nora
+agents or inspect fleet health.
+
+## Validate from a Nora checkout
+
+```bash
+claude plugin validate ./mcp-server/claude-plugin --strict
+claude --plugin-dir ./mcp-server/claude-plugin
+```
+
+## Permissions and safety
+
+The Nora API enforces workspace membership and API-key scopes server-side.
+Use `agents:read` plus `monitoring:read` unless you intentionally want Claude
+to perform lifecycle actions, in which case add `agents:write` to the dedicated
+key. The plugin sets `NORA_MCP_ALLOW_DESTRUCTIVE=false`, so `delete_agent` is
+not registered even with a write-capable key.
+
+## Privacy
+
+The MCP server runs locally and sends authenticated requests directly to the
+Nora deployment you configure. It does not persist tool inputs or API
+responses. Never commit or paste a Nora API key into plugin files, issues,
+logs, or screenshots.


### PR DESCRIPTION
## Summary

- add a native Claude Code plugin manifest for the published Nora MCP server
- default permanent deletion off and document least-privilege read-only API-key scopes
- document local validation and future installation through the Claude community directory
- link the plugin from the MCP package README

## Validation

- `claude plugin validate ./mcp-server/claude-plugin --strict`
- Claude Code 2.1.207 loads `nora@inline` and connects `plugin:nora:nora`
- public `@noraai/mcp-server@0.1.3` initialize/list-tools handshake
- MCP package: 12 tests, typecheck, audit, and formatting
- full local Nora CI pre-push suite, including package checks, security and license gates, five Docker image builds, and compose-backed Playwright E2E

GitHub CodeQL is intentionally left to the hosted workflow.