### PR TITLE
fix(provisioner): retry occupied Docker ports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -244,6 +244,13 @@ ENABLED_SANDBOX_PROFILES=standard
 # cluster, put one file in this directory and register one Admin row.
 NORA_KUBECONFIGS_DIR=./.secrets/kubeconfigs
 
+# Docker and remote-Docker agents reserve published gateway ports from this
+# range. Values must stay within 19000-19999, which is the default gateway-proxy
+# security envelope. Local Docker also skips ports already published by running
+# containers and retries bounded bind conflicts from non-Docker listeners.
+DOCKER_AGENT_PORT_RANGE_MIN=19000
+DOCKER_AGENT_PORT_RANGE_MAX=19999
+
 # Gateway proxy SSRF guard overrides. Defaults allow OpenClaw's internal
 # gateway port, Docker-published 19000-19999, and Kubernetes NodePort 30000-32767.
 NORA_GATEWAY_PROXY_ALLOWED_PORTS=

--- a/backend-api/__tests__/dockerPublishedPorts.test.ts
+++ b/backend-api/__tests__/dockerPublishedPorts.test.ts
@@ -1,0 +1,132 @@
+// @ts-nocheck
+const {
+  collectOccupiedDockerPublishedPorts,
+  createWithDockerPortRetry,
+  getOccupiedDockerPublishedPorts,
+  isDockerPortBindConflict,
+} = require("../../workers/provisioner/backends/dockerPublishedPorts");
+
+describe("Docker published-port inspection", () => {
+  it("collects running host ports while ignoring the agent being redeployed", () => {
+    const occupied = collectOccupiedDockerPublishedPorts(
+      [
+        {
+          Labels: { "openclaw.agent.id": "other-agent" },
+          Ports: [
+            { PublicPort: 19000, PrivatePort: 18789, Type: "tcp" },
+            { PublicPort: 8080, PrivatePort: 80, Type: "tcp" },
+          ],
+        },
+        {
+          Labels: { "openclaw.agent.id": "redeploy-agent" },
+          Ports: [{ PublicPort: 19001, PrivatePort: 18789, Type: "tcp" }],
+        },
+        { Ports: [{ PublicPort: undefined, PrivatePort: 5432, Type: "tcp" }] },
+      ],
+      { agentId: "redeploy-agent" },
+    );
+
+    expect([...occupied]).toEqual([19000, 8080]);
+  });
+
+  it("asks Docker only for running containers", async () => {
+    const listContainers = jest
+      .fn()
+      .mockResolvedValue([{ Ports: [{ PublicPort: 19000, PrivatePort: 18789, Type: "tcp" }] }]);
+
+    const occupied = await getOccupiedDockerPublishedPorts({ docker: { listContainers } });
+
+    expect(listContainers).toHaveBeenCalledWith({ all: false });
+    expect([...occupied]).toEqual([19000]);
+  });
+
+  it("falls back to bind retries when Docker inspection fails", async () => {
+    const warning = jest.spyOn(console, "warn").mockImplementation(() => {});
+    const occupied = await getOccupiedDockerPublishedPorts({
+      docker: { listContainers: jest.fn().mockRejectedValue(new Error("daemon unavailable")) },
+    });
+
+    expect([...occupied]).toEqual([]);
+    expect(warning).toHaveBeenCalledWith(expect.stringContaining("relying on bind retry"));
+    warning.mockRestore();
+  });
+});
+
+describe("Docker published-port bind retry", () => {
+  it.each([
+    "Bind for 127.0.0.1:19000 failed: port is already allocated",
+    "failed to bind host port for 0.0.0.0:19000: address already in use",
+  ])("recognizes Docker bind conflicts: %s", (message) => {
+    expect(isDockerPortBindConflict(new Error(message))).toBe(true);
+  });
+
+  it("persists a replacement and retries create with the new port", async () => {
+    const attempts = [];
+    const create = jest.fn().mockImplementation(async (port) => {
+      attempts.push(port);
+      if (attempts.length === 1) {
+        throw new Error("Bind for 127.0.0.1:19000 failed: port is already allocated");
+      }
+      return { gatewayHostPort: String(port) };
+    });
+    const reallocate = jest.fn().mockResolvedValue(19002);
+
+    const result = await createWithDockerPortRetry({
+      create,
+      initialPort: 19000,
+      getOccupiedPorts: async () => new Set([19001]),
+      reallocate,
+    });
+
+    expect(attempts).toEqual([19000, 19002]);
+    expect(reallocate).toHaveBeenCalledWith({
+      previousPort: 19000,
+      unavailablePorts: [19000, 19001],
+    });
+    expect(result.gatewayHostPort).toBe("19002");
+  });
+
+  it("remembers rejected ports across retries", async () => {
+    const create = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("port is already allocated"))
+      .mockRejectedValueOnce(new Error("address already in use"))
+      .mockResolvedValue({ ok: true });
+    const reallocate = jest.fn().mockResolvedValueOnce(19001).mockResolvedValueOnce(19002);
+
+    await createWithDockerPortRetry({
+      create,
+      initialPort: 19000,
+      getOccupiedPorts: async () => new Set(),
+      reallocate,
+    });
+
+    expect(reallocate.mock.calls[1][0].unavailablePorts).toEqual([19000, 19001]);
+  });
+
+  it("does not retry non-bind failures", async () => {
+    const create = jest.fn().mockRejectedValue(new Error("image pull denied"));
+    const reallocate = jest.fn();
+
+    await expect(
+      createWithDockerPortRetry({ create, initialPort: 19000, reallocate }),
+    ).rejects.toThrow(/image pull denied/);
+    expect(reallocate).not.toHaveBeenCalled();
+  });
+
+  it("stops after the bounded retry limit", async () => {
+    const create = jest.fn().mockRejectedValue(new Error("port is already allocated"));
+    const reallocate = jest.fn().mockResolvedValueOnce(19001).mockResolvedValueOnce(19002);
+
+    await expect(
+      createWithDockerPortRetry({
+        create,
+        initialPort: 19000,
+        reallocate,
+        maxRetries: 2,
+      }),
+    ).rejects.toThrow(/port is already allocated/);
+    expect(create).toHaveBeenCalledTimes(3);
+    expect(reallocate).toHaveBeenCalledTimes(2);
+  });
+});

--- a/backend-api/__tests__/portAllocations.test.ts
+++ b/backend-api/__tests__/portAllocations.test.ts
@@ -4,8 +4,10 @@ jest.mock("../db", () => mockDb);
 
 const {
   allocateGatewayPort,
+  reallocateGatewayPort,
   releaseGatewayPort,
   getGatewayPortAllocation,
+  resolveGatewayPortRange,
   LOCAL_HOST_KEY,
   GATEWAY_PORT_PURPOSE,
   DASHBOARD_PORT_PURPOSE,
@@ -13,19 +15,33 @@ const {
 
 // Route db.query on SQL shape. `insert` is an array of responses consumed in
 // order (so we can simulate a unique-violation race then success).
-function fakeDb({ existing = [], insertResponses = [] } = {}) {
+function fakeDb({
+  existing = [],
+  existingResponses = [],
+  insertResponses = [],
+  updateResponses = [],
+} = {}) {
   const calls = [];
+  let existingIdx = 0;
   let insertIdx = 0;
+  let updateIdx = 0;
   mockDb.query.mockImplementation(async (sql, params) => {
     calls.push({ sql, params });
     if (sql.includes("SELECT host_key, port FROM gateway_port_allocations")) {
       return { rows: existing };
     }
     if (sql.includes("SELECT port FROM gateway_port_allocations WHERE agent_id")) {
-      return { rows: existing };
+      const next = existingResponses[existingIdx++] ?? { rows: existing };
+      if (next instanceof Error) throw next;
+      return next;
     }
     if (sql.includes("INSERT INTO gateway_port_allocations")) {
       const next = insertResponses[insertIdx++] ?? { rows: [] };
+      if (next instanceof Error) throw next;
+      return next;
+    }
+    if (sql.includes("UPDATE gateway_port_allocations")) {
+      const next = updateResponses[updateIdx++] ?? { rows: [] };
       if (next instanceof Error) throw next;
       return next;
     }
@@ -38,6 +54,11 @@ function fakeDb({ existing = [], insertResponses = [] } = {}) {
 }
 
 beforeEach(() => mockDb.query.mockReset());
+
+afterEach(() => {
+  delete process.env.DOCKER_AGENT_PORT_RANGE_MIN;
+  delete process.env.DOCKER_AGENT_PORT_RANGE_MAX;
+});
 
 describe("allocateGatewayPort", () => {
   it("reuses the agent's existing allocation (idempotent across redeploys)", async () => {
@@ -54,6 +75,49 @@ describe("allocateGatewayPort", () => {
     expect(port).toBe(19000);
     const insert = calls.find((c) => c.sql.includes("INSERT INTO gateway_port_allocations"));
     expect(insert.sql).toContain("generate_series($3::integer, $4::integer)");
+  });
+
+  it("skips Docker ports that are already occupied outside the allocation table", async () => {
+    const { calls } = fakeDb({
+      existing: [],
+      insertResponses: [{ rows: [{ port: 19001 }] }],
+    });
+    const port = await allocateGatewayPort({
+      hostKey: "local",
+      agentId: "occupied-first",
+      unavailablePorts: new Set([19000]),
+    });
+
+    expect(port).toBe(19001);
+    const insert = calls.find((c) => c.sql.includes("INSERT INTO gateway_port_allocations"));
+    expect(insert.sql).toContain("candidate.port = ANY($6::integer[])");
+    expect(insert.params[5]).toEqual([19000]);
+  });
+
+  it("persists a replacement when an existing reservation is occupied", async () => {
+    const { calls } = fakeDb({
+      existing: [{ port: 19000 }],
+      updateResponses: [{ rows: [{ port: 19001 }] }],
+    });
+
+    const port = await allocateGatewayPort({
+      hostKey: "local",
+      agentId: "occupied-existing",
+      unavailablePorts: [19000],
+    });
+
+    expect(port).toBe(19001);
+    const update = calls.find((c) => c.sql.includes("UPDATE gateway_port_allocations"));
+    expect(update).toBeDefined();
+    expect(update.params).toEqual([
+      "local",
+      "occupied-existing",
+      GATEWAY_PORT_PURPOSE,
+      19000,
+      19999,
+      [19000],
+      19000,
+    ]);
   });
 
   it("retries on a UNIQUE-violation race and succeeds", async () => {
@@ -81,6 +145,42 @@ describe("allocateGatewayPort", () => {
   it("requires an agentId", async () => {
     fakeDb();
     await expect(allocateGatewayPort({ hostKey: "local" })).rejects.toThrow(/agentId/i);
+  });
+
+  it("uses an environment-configured subrange inside the gateway security envelope", async () => {
+    process.env.DOCKER_AGENT_PORT_RANGE_MIN = "19500";
+    process.env.DOCKER_AGENT_PORT_RANGE_MAX = "19510";
+    const { calls } = fakeDb({
+      existing: [],
+      insertResponses: [{ rows: [{ port: 19500 }] }],
+    });
+
+    await allocateGatewayPort({ hostKey: "local", agentId: "configured-range" });
+
+    const insert = calls.find((c) => c.sql.includes("INSERT INTO gateway_port_allocations"));
+    expect(insert.params.slice(2, 4)).toEqual([19500, 19510]);
+  });
+
+  it("rejects configured ranges outside the gateway proxy security envelope", () => {
+    expect(() =>
+      resolveGatewayPortRange({
+        env: {
+          DOCKER_AGENT_PORT_RANGE_MIN: "18999",
+          DOCKER_AGENT_PORT_RANGE_MAX: "20000",
+        },
+      }),
+    ).toThrow(/19000-19999/);
+  });
+
+  it("rejects a configured minimum above the maximum", () => {
+    expect(() =>
+      resolveGatewayPortRange({
+        env: {
+          DOCKER_AGENT_PORT_RANGE_MIN: "19510",
+          DOCKER_AGENT_PORT_RANGE_MAX: "19500",
+        },
+      }),
+    ).toThrow(/cannot exceed/);
   });
 
   it("defaults the purpose to the gateway slot", async () => {
@@ -125,6 +225,41 @@ describe("allocateGatewayPort", () => {
     });
     expect(port).toBe(19500);
     expect(calls.some((c) => c.sql.includes("INSERT INTO gateway_port_allocations"))).toBe(false);
+  });
+});
+
+describe("reallocateGatewayPort", () => {
+  it("allocates a fresh row if the expected reservation disappeared", async () => {
+    const { calls } = fakeDb({
+      existing: [],
+      insertResponses: [{ rows: [{ port: 19001 }] }],
+    });
+
+    const port = await reallocateGatewayPort({
+      hostKey: "local",
+      agentId: "missing-row",
+      previousPort: 19000,
+    });
+
+    expect(port).toBe(19001);
+    const insert = calls.find((c) => c.sql.includes("INSERT INTO gateway_port_allocations"));
+    expect(insert.params[5]).toEqual([19000]);
+  });
+
+  it("accepts a concurrent same-agent replacement after its compare-and-swap loses", async () => {
+    fakeDb({
+      existingResponses: [{ rows: [{ port: 19000 }] }, { rows: [{ port: 19001 }] }],
+      updateResponses: [{ rows: [] }],
+    });
+
+    const port = await reallocateGatewayPort({
+      hostKey: "local",
+      agentId: "concurrent-row",
+      previousPort: 19000,
+      unavailablePorts: [19000],
+    });
+
+    expect(port).toBe(19001);
   });
 });
 

--- a/backend-api/__tests__/provisioning.test.ts
+++ b/backend-api/__tests__/provisioning.test.ts
@@ -1671,6 +1671,7 @@ describe("docker gateway port allocation (BYOC Phase B)", () => {
         },
       }),
     };
+    const removeVolume = jest.fn().mockResolvedValue({});
     backend.docker = {
       getImage: jest.fn().mockReturnValue({ inspect: jest.fn().mockResolvedValue({}) }),
       getContainer: jest
@@ -1679,16 +1680,25 @@ describe("docker gateway port allocation (BYOC Phase B)", () => {
       createVolume: jest.fn().mockResolvedValue({}),
       createContainer: jest.fn().mockResolvedValue(createdContainer),
       getNetwork: jest.fn().mockReturnValue({ connect: jest.fn().mockResolvedValue({}) }),
-      getVolume: jest.fn().mockReturnValue({ remove: jest.fn().mockResolvedValue({}) }),
+      getVolume: jest.fn().mockReturnValue({ remove: removeVolume }),
     };
+    backend._testCreatedContainer = createdContainer;
+    backend._testRemoveVolume = removeVolume;
     return backend;
   }
 
   it("publishes the worker-allocated host port", async () => {
     const backend = mockDockerBackend();
-    await backend.create({ id: "999", name: "Port QA", gatewayHostPort: 19500, env: {} });
+    await backend.create({
+      id: "999",
+      name: "Port QA",
+      gatewayHostPort: 19500,
+      runtimeHostPort: 19501,
+      env: {},
+    });
     const config = backend.docker.createContainer.mock.calls[0][0];
     expect(config.HostConfig.PortBindings["18789/tcp"]).toEqual([{ HostPort: "19500" }]);
+    expect(config.HostConfig.PortBindings["9090/tcp"]).toEqual([{ HostPort: "19501" }]);
   });
 
   it("falls back to the deterministic hash when no port is allocated", async () => {
@@ -1697,5 +1707,19 @@ describe("docker gateway port allocation (BYOC Phase B)", () => {
     await backend.create({ id: "999", name: "Port QA", env: {} });
     const config = backend.docker.createContainer.mock.calls[0][0];
     expect(config.HostConfig.PortBindings["18789/tcp"]).toEqual([{ HostPort: "19999" }]);
+  });
+
+  it("preserves durable volumes when a bind conflict will be retried", async () => {
+    const backend = mockDockerBackend();
+    backend._testCreatedContainer.start.mockRejectedValueOnce(
+      new Error("Bind for 127.0.0.1:19500 failed: port is already allocated"),
+    );
+
+    await expect(
+      backend.create({ id: "999", name: "Port QA", gatewayHostPort: 19500, env: {} }),
+    ).rejects.toThrow(/port is already allocated/);
+
+    expect(backend._testCreatedContainer.remove).toHaveBeenCalledWith({ force: true });
+    expect(backend._testRemoveVolume).not.toHaveBeenCalled();
   });
 });

--- a/backend-api/portAllocations.ts
+++ b/backend-api/portAllocations.ts
@@ -41,6 +41,54 @@ function normalizePurpose(value) {
   return purpose || GATEWAY_PORT_PURPOSE;
 }
 
+function resolveGatewayPortRange({ rangeMin, rangeMax, env = process.env } = {}) {
+  const parseBoundary = (value, fallback, label) => {
+    if (value == null || String(value).trim() === "") return fallback;
+    const parsed = Number(value);
+    if (!Number.isInteger(parsed) || parsed < DEFAULT_RANGE_MIN || parsed > DEFAULT_RANGE_MAX) {
+      throw new Error(
+        `${label} must be an integer within ${DEFAULT_RANGE_MIN}-${DEFAULT_RANGE_MAX}.`,
+      );
+    }
+    return parsed;
+  };
+
+  const resolvedMin = parseBoundary(
+    rangeMin ?? env.DOCKER_AGENT_PORT_RANGE_MIN,
+    DEFAULT_RANGE_MIN,
+    "DOCKER_AGENT_PORT_RANGE_MIN",
+  );
+  const resolvedMax = parseBoundary(
+    rangeMax ?? env.DOCKER_AGENT_PORT_RANGE_MAX,
+    DEFAULT_RANGE_MAX,
+    "DOCKER_AGENT_PORT_RANGE_MAX",
+  );
+  if (resolvedMin > resolvedMax) {
+    throw new Error("DOCKER_AGENT_PORT_RANGE_MIN cannot exceed DOCKER_AGENT_PORT_RANGE_MAX.");
+  }
+
+  return { rangeMin: resolvedMin, rangeMax: resolvedMax };
+}
+
+function normalizeUnavailablePorts(value) {
+  const entries = Array.isArray(value) ? value : value instanceof Set ? [...value] : [];
+  return [
+    ...new Set(
+      entries
+        .map((entry) => Number(entry))
+        .filter((port) => Number.isInteger(port) && port >= 1 && port <= 65535),
+    ),
+  ].sort((a, b) => a - b);
+}
+
+function noFreePortError(hostKey, rangeMin, rangeMax) {
+  const error = new Error(
+    `No free gateway port available on ${hostKey} (range ${rangeMin}-${rangeMax}).`,
+  );
+  error.statusCode = 503;
+  return error;
+}
+
 async function getGatewayPortAllocation(agentId) {
   if (!agentId) return null;
   try {
@@ -62,12 +110,15 @@ async function allocateGatewayPort({
   hostKey,
   agentId,
   purpose = GATEWAY_PORT_PURPOSE,
-  rangeMin = DEFAULT_RANGE_MIN,
-  rangeMax = DEFAULT_RANGE_MAX,
+  rangeMin,
+  rangeMax,
+  unavailablePorts = [],
 } = {}) {
   if (!agentId) throw new Error("agentId is required to allocate a gateway port");
   const key = normalizeHostKey(hostKey);
   const slot = normalizePurpose(purpose);
+  const resolvedRange = resolveGatewayPortRange({ rangeMin, rangeMax });
+  const blockedPorts = normalizeUnavailablePorts(unavailablePorts);
 
   // Idempotent per (agent, host, purpose): a redeploy keeps the same port, and a
   // second purpose on the same host gets its own row rather than reusing the first.
@@ -75,7 +126,19 @@ async function allocateGatewayPort({
     "SELECT port FROM gateway_port_allocations WHERE agent_id = $1 AND host_key = $2 AND purpose = $3",
     [agentId, key, slot],
   );
-  if (existing.rows[0]) return existing.rows[0].port;
+  if (existing.rows[0]) {
+    const existingPort = Number(existing.rows[0].port);
+    if (!blockedPorts.includes(existingPort)) return existing.rows[0].port;
+    return reallocateGatewayPort({
+      hostKey: key,
+      agentId,
+      purpose: slot,
+      previousPort: existingPort,
+      rangeMin: resolvedRange.rangeMin,
+      rangeMax: resolvedRange.rangeMax,
+      unavailablePorts: blockedPorts,
+    });
+  }
 
   for (let attempt = 0; attempt < MAX_RACE_RETRIES; attempt++) {
     try {
@@ -87,22 +150,19 @@ async function allocateGatewayPort({
         `INSERT INTO gateway_port_allocations (host_key, agent_id, port, purpose)
          SELECT $1, $2, candidate.port, $5
            FROM generate_series($3::integer, $4::integer) AS candidate(port)
-          WHERE NOT EXISTS (
+          WHERE NOT (candidate.port = ANY($6::integer[]))
+            AND NOT EXISTS (
             SELECT 1 FROM gateway_port_allocations existing
              WHERE existing.host_key = $1 AND existing.port = candidate.port
           )
           ORDER BY candidate.port
-          LIMIT 1
+         LIMIT 1
          RETURNING port`,
-        [key, agentId, rangeMin, rangeMax, slot],
+        [key, agentId, resolvedRange.rangeMin, resolvedRange.rangeMax, slot, blockedPorts],
       );
       if (result.rows[0]) return result.rows[0].port;
       // No row inserted → every port in the range is taken on this host.
-      const error = new Error(
-        `No free gateway port available on ${key} (range ${rangeMin}-${rangeMax}).`,
-      );
-      error.statusCode = 503;
-      throw error;
+      throw noFreePortError(key, resolvedRange.rangeMin, resolvedRange.rangeMax);
     } catch (error) {
       if (error?.code === "23505") continue; // unique_violation — lost the race, retry
       throw error;
@@ -110,6 +170,104 @@ async function allocateGatewayPort({
   }
 
   const error = new Error(`Could not allocate a gateway port on ${key} after retries.`);
+  error.statusCode = 503;
+  throw error;
+}
+
+// Move an existing reservation to another free port while preserving the same
+// allocation row. Used only after the local Docker host reports that the
+// reserved port is occupied outside Nora's allocation table. The UPDATE and
+// host-wide UNIQUE constraint keep the persisted reservation synchronized with
+// the port handed to the next adapter.create() attempt.
+async function reallocateGatewayPort({
+  hostKey,
+  agentId,
+  purpose = GATEWAY_PORT_PURPOSE,
+  previousPort,
+  rangeMin,
+  rangeMax,
+  unavailablePorts = [],
+} = {}) {
+  if (!agentId) throw new Error("agentId is required to reallocate a gateway port");
+  const key = normalizeHostKey(hostKey);
+  const slot = normalizePurpose(purpose);
+  const resolvedRange = resolveGatewayPortRange({ rangeMin, rangeMax });
+  const blockedPorts = normalizeUnavailablePorts([
+    ...normalizeUnavailablePorts(unavailablePorts),
+    previousPort,
+  ]);
+
+  const existing = await db.query(
+    "SELECT port FROM gateway_port_allocations WHERE agent_id = $1 AND host_key = $2 AND purpose = $3",
+    [agentId, key, slot],
+  );
+  if (!existing.rows[0]) {
+    return allocateGatewayPort({
+      hostKey: key,
+      agentId,
+      purpose: slot,
+      rangeMin: resolvedRange.rangeMin,
+      rangeMax: resolvedRange.rangeMax,
+      unavailablePorts: blockedPorts,
+    });
+  }
+
+  const currentPort = Number(existing.rows[0].port);
+  if (!blockedPorts.includes(currentPort)) return existing.rows[0].port;
+
+  for (let attempt = 0; attempt < MAX_RACE_RETRIES; attempt++) {
+    try {
+      const result = await db.query(
+        `WITH candidate AS (
+           SELECT candidate.port
+             FROM generate_series($4::integer, $5::integer) AS candidate(port)
+            WHERE NOT (candidate.port = ANY($6::integer[]))
+              AND NOT EXISTS (
+                SELECT 1 FROM gateway_port_allocations occupied
+                 WHERE occupied.host_key = $1 AND occupied.port = candidate.port
+              )
+            ORDER BY candidate.port
+            LIMIT 1
+         )
+         UPDATE gateway_port_allocations allocation
+            SET port = candidate.port
+           FROM candidate
+          WHERE allocation.host_key = $1
+            AND allocation.agent_id = $2
+            AND allocation.purpose = $3
+            AND allocation.port = $7
+         RETURNING allocation.port`,
+        [
+          key,
+          agentId,
+          slot,
+          resolvedRange.rangeMin,
+          resolvedRange.rangeMax,
+          blockedPorts,
+          currentPort,
+        ],
+      );
+      if (result.rows[0]) return result.rows[0].port;
+
+      // Another same-agent caller may have moved the row after our SELECT but
+      // before this compare-and-swap UPDATE. Treat its valid replacement as
+      // success instead of misreporting the whole range as exhausted.
+      const refreshed = await db.query(
+        "SELECT port FROM gateway_port_allocations WHERE agent_id = $1 AND host_key = $2 AND purpose = $3",
+        [agentId, key, slot],
+      );
+      const refreshedPort = Number(refreshed.rows[0]?.port);
+      if (Number.isInteger(refreshedPort) && !blockedPorts.includes(refreshedPort)) {
+        return refreshed.rows[0].port;
+      }
+      throw noFreePortError(key, resolvedRange.rangeMin, resolvedRange.rangeMax);
+    } catch (error) {
+      if (error?.code === "23505") continue;
+      throw error;
+    }
+  }
+
+  const error = new Error(`Could not reallocate a gateway port on ${key} after retries.`);
   error.statusCode = 503;
   throw error;
 }
@@ -133,6 +291,8 @@ module.exports = {
   RUNTIME_PORT_PURPOSE,
   DASHBOARD_PORT_PURPOSE,
   allocateGatewayPort,
+  reallocateGatewayPort,
   releaseGatewayPort,
   getGatewayPortAllocation,
+  resolveGatewayPortRange,
 };

--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -210,6 +210,15 @@ For more than one cluster, put multiple kubeconfig files under `NORA_KUBECONFIGS
 
 Admin-registered encrypted kubeconfigs require `ENCRYPTION_KEY` because Nora stores pasted kubeconfig content encrypted at rest.
 
+## Docker agent published ports
+
+Docker and remote-Docker agents reserve their published gateway ports in PostgreSQL. The configurable subrange must remain inside `19000-19999`, which is already allowed by the gateway proxy's default SSRF guard. Local Docker deployments skip ports published by running containers and retry a bounded number of bind conflicts, including conflicts caused by non-Docker listeners.
+
+| Variable                      | Required | Default | Description                                                                                    |
+| ----------------------------- | -------- | ------- | ---------------------------------------------------------------------------------------------- |
+| `DOCKER_AGENT_PORT_RANGE_MIN` | No       | `19000` | Lowest published gateway port. Must be between `19000` and `19999`.                            |
+| `DOCKER_AGENT_PORT_RANGE_MAX` | No       | `19999` | Highest published gateway port. Must be between `19000` and `19999` and not below the minimum. |
+
 ## Gateway proxy SSRF guard
 
 Defaults allow OpenClaw's internal gateway port, Docker-published 19000-19999, and Kubernetes NodePort 30000-32767. Override only if you publish gateways on non-default ports or hosts.

--- a/docs/configuration/provisioner-backends/docker.mdx
+++ b/docs/configuration/provisioner-backends/docker.mdx
@@ -16,6 +16,8 @@ ENABLED_SANDBOX_PROFILES=standard
 
 No backend-specific credentials are required. The default `docker-compose.yml` mounts the host Docker socket into `backend-api`, `worker-provisioner`, and `worker-backup` so lifecycle operations can create, stop, restart, inspect, and delete agent containers.
 
+Nora reserves each agent's published gateway port in PostgreSQL. Local deployments also inspect ports published by running Docker containers and retry bounded bind conflicts, so an unrelated workload already using the first port in the configured `19000-19999` range does not leave an agent stuck on every queue retry. See [Environment variables](/configuration/environment-variables#docker-agent-published-ports) to narrow the allocation range.
+
 ## Resource limits
 
 Self-hosted resource ceilings apply to Docker-backed deployments:

--- a/workers/provisioner/backends/docker.ts
+++ b/workers/provisioner/backends/docker.ts
@@ -29,6 +29,7 @@ const {
   DOCKER_CAPABILITIES,
   uptimeFromContainerInfo,
 } = require("./telemetry");
+const { isDockerPortBindConflict } = require("./dockerPublishedPorts");
 
 const pendingImageBuilds = new Map();
 
@@ -582,7 +583,6 @@ class DockerBackend extends ProvisionerBackend {
       allocatedRuntimePortNumber <= 65535
         ? allocatedRuntimePortNumber
         : null;
-
     const allowedOrigins = new Set([
       "http://localhost:8080",
       "http://127.0.0.1:8080",
@@ -715,7 +715,11 @@ class DockerBackend extends ProvisionerBackend {
           // Use a deterministic port based on agent ID to survive container restarts.
           PortBindings: {
             "18789/tcp": [{ HostPort: String(hostPort) }],
-            ...(runtimeHostPort ? { "9090/tcp": [{ HostPort: String(runtimeHostPort) }] } : {}),
+            ...(runtimeHostPort
+              ? {
+                  "9090/tcp": [{ HostPort: String(runtimeHostPort) }],
+                }
+              : {}),
           },
           // DNS servers for internet access from within the container
           Dns: ["8.8.8.8", "8.8.4.4", "1.1.1.1"],
@@ -782,11 +786,17 @@ class DockerBackend extends ProvisionerBackend {
           // Best effort cleanup only.
         }
       }
-      for (const volume of [volumeName, homeVolumeName]) {
-        try {
-          await this.docker.getVolume(volume).remove({ force: true });
-        } catch {
-          // Best effort cleanup only.
+      // A bind conflict is recoverable locally: the worker can persist a
+      // replacement reservation and retry create(). Keep named volumes on every
+      // bind conflict, including remote Docker failures, so a port collision
+      // never erases durable agent state while the operator resolves it.
+      if (!isDockerPortBindConflict(error)) {
+        for (const volume of [volumeName, homeVolumeName]) {
+          try {
+            await this.docker.getVolume(volume).remove({ force: true });
+          } catch {
+            // Best effort cleanup only.
+          }
         }
       }
       throw error;

--- a/workers/provisioner/backends/dockerPublishedPorts.ts
+++ b/workers/provisioner/backends/dockerPublishedPorts.ts
@@ -1,0 +1,114 @@
+// @ts-nocheck
+
+const DEFAULT_DOCKER_PORT_BIND_RETRIES = 3;
+
+function normalizePort(value) {
+  const port = Number(value);
+  return Number.isInteger(port) && port >= 1 && port <= 65535 ? port : null;
+}
+
+function collectOccupiedDockerPublishedPorts(containers = [], { agentId } = {}) {
+  const ignoredAgentId = agentId == null ? "" : String(agentId);
+  const occupied = new Set();
+
+  for (const container of Array.isArray(containers) ? containers : []) {
+    if (
+      ignoredAgentId &&
+      String(container?.Labels?.["openclaw.agent.id"] || "") === ignoredAgentId
+    ) {
+      continue;
+    }
+    for (const binding of Array.isArray(container?.Ports) ? container.Ports : []) {
+      const port = normalizePort(binding?.PublicPort);
+      if (port) occupied.add(port);
+    }
+  }
+
+  return occupied;
+}
+
+// Docker's running-container summary is the cheapest host-aware view available
+// to the provisioner container. It catches ports held by other Docker workloads;
+// non-Docker listeners and races are handled by the bounded start retry below.
+async function getOccupiedDockerPublishedPorts(provisioner, { agentId } = {}) {
+  if (!provisioner?.docker || typeof provisioner.docker.listContainers !== "function") {
+    return new Set();
+  }
+
+  try {
+    const containers = await provisioner.docker.listContainers({ all: false });
+    return collectOccupiedDockerPublishedPorts(containers, { agentId });
+  } catch (error) {
+    console.warn(
+      `[provisioner] Could not inspect Docker published ports; relying on bind retry: ${error.message}`,
+    );
+    return new Set();
+  }
+}
+
+function isDockerPortBindConflict(error) {
+  const text = [error?.message, error?.reason, error?.json?.message, error?.cause?.message]
+    .filter(Boolean)
+    .join(" ");
+  return /port is already allocated|address already in use|failed to bind host port|bind for .* failed/i.test(
+    text,
+  );
+}
+
+async function createWithDockerPortRetry({
+  create,
+  initialPort,
+  reallocate,
+  getOccupiedPorts,
+  maxRetries = DEFAULT_DOCKER_PORT_BIND_RETRIES,
+  onRetry,
+} = {}) {
+  if (typeof create !== "function") throw new Error("create callback is required");
+  if (typeof reallocate !== "function") throw new Error("reallocate callback is required");
+
+  const retryLimit = Math.max(0, Math.min(10, Number.parseInt(maxRetries, 10) || 0));
+  const rejectedPorts = new Set();
+  let currentPort = normalizePort(initialPort);
+
+  for (let retry = 0; ; retry++) {
+    try {
+      return await create(currentPort);
+    } catch (error) {
+      if (!isDockerPortBindConflict(error) || retry >= retryLimit) throw error;
+
+      if (currentPort) rejectedPorts.add(currentPort);
+      const occupied =
+        typeof getOccupiedPorts === "function" ? await getOccupiedPorts() : new Set();
+      for (const port of occupied instanceof Set ? occupied : occupied || []) {
+        const normalized = normalizePort(port);
+        if (normalized) rejectedPorts.add(normalized);
+      }
+
+      const nextPort = normalizePort(
+        await reallocate({
+          previousPort: currentPort,
+          unavailablePorts: [...rejectedPorts],
+        }),
+      );
+      if (!nextPort) throw new Error("Docker port retry did not receive a valid replacement port");
+
+      if (typeof onRetry === "function") {
+        onRetry({
+          retry: retry + 1,
+          previousPort: currentPort,
+          nextPort,
+          error,
+        });
+      }
+      currentPort = nextPort;
+    }
+  }
+}
+
+module.exports = {
+  DEFAULT_DOCKER_PORT_BIND_RETRIES,
+  collectOccupiedDockerPublishedPorts,
+  getOccupiedDockerPublishedPorts,
+  isDockerPortBindConflict,
+  createWithDockerPortRetry,
+};

--- a/workers/provisioner/worker.ts
+++ b/workers/provisioner/worker.ts
@@ -32,10 +32,15 @@ const {
 const { getRemoteHostProfile } = require("../../backend-api/remoteHosts");
 const {
   allocateGatewayPort,
+  reallocateGatewayPort,
   LOCAL_HOST_KEY,
   DASHBOARD_PORT_PURPOSE,
   RUNTIME_PORT_PURPOSE,
 } = require("../../backend-api/portAllocations");
+const {
+  createWithDockerPortRetry,
+  getOccupiedDockerPublishedPorts,
+} = require("./backends/dockerPublishedPorts");
 const {
   buildIntegrationSyncEntry,
   decryptSensitiveConfig,
@@ -2233,90 +2238,116 @@ const worker = new Worker(
         let allocatedGatewayPort;
         let allocatedRuntimePort;
         let allocatedDashboardPort;
-        {
-          const deployTarget = resolvedRuntimeFields.deploy_target;
-          const allocationHostKey =
-            deployTarget === "remote-docker"
-              ? String(resolvedRuntimeFields.execution_target_id || "")
-                  .trim()
-                  .toLowerCase() || null
-              : deployTarget === "docker"
-                ? LOCAL_HOST_KEY
-                : null;
-          if (allocationHostKey) {
-            allocatedGatewayPort = await allocateGatewayPort({
+        const deployTarget = resolvedRuntimeFields.deploy_target;
+        const allocationHostKey =
+          deployTarget === "remote-docker"
+            ? String(resolvedRuntimeFields.execution_target_id || "")
+                .trim()
+                .toLowerCase() || null
+            : deployTarget === "docker"
+              ? LOCAL_HOST_KEY
+              : null;
+        const usesLocalDockerPublishedPort =
+          deployTarget === "docker" && resolvedRuntimeFields.runtime_family === "openclaw";
+        if (allocationHostKey) {
+          const unavailableGatewayPorts = usesLocalDockerPublishedPort
+            ? await getOccupiedDockerPublishedPorts(provisioner, { agentId: id })
+            : new Set();
+          allocatedGatewayPort = await allocateGatewayPort({
+            hostKey: allocationHostKey,
+            agentId: id,
+            unavailablePorts: unavailableGatewayPorts,
+          });
+          // Remote Hermes needs a SECOND published host port for its dashboard
+          // UI (9119), distinct from the runtime API port (8642 = the 'gateway'
+          // slot used for the readiness probe). Local Hermes reaches the
+          // dashboard on the compose network (no host publish), and OpenClaw has
+          // no separate dashboard, so neither allocates this slot.
+          if (
+            deployTarget === "remote-docker" &&
+            resolvedRuntimeFields.runtime_family === "hermes"
+          ) {
+            allocatedDashboardPort = await allocateGatewayPort({
               hostKey: allocationHostKey,
               agentId: id,
+              purpose: DASHBOARD_PORT_PURPOSE,
             });
-            // Remote Hermes needs a SECOND published host port for its dashboard
-            // UI (9119), distinct from the runtime API port (8642 = the 'gateway'
-            // slot used for the readiness probe). Local Hermes reaches the
-            // dashboard on the compose network (no host publish), and OpenClaw has
-            // no separate dashboard, so neither allocates this slot.
-            if (
-              deployTarget === "remote-docker" &&
-              resolvedRuntimeFields.runtime_family === "hermes"
-            ) {
-              allocatedDashboardPort = await allocateGatewayPort({
-                hostKey: allocationHostKey,
-                agentId: id,
-                purpose: DASHBOARD_PORT_PURPOSE,
-              });
-            }
-            if (
-              deployTarget === "remote-docker" &&
-              resolvedRuntimeFields.runtime_family === "openclaw"
-            ) {
-              allocatedRuntimePort = await allocateGatewayPort({
-                hostKey: allocationHostKey,
-                agentId: id,
-                purpose: RUNTIME_PORT_PURPOSE,
-              });
-            }
+          }
+          if (
+            deployTarget === "remote-docker" &&
+            resolvedRuntimeFields.runtime_family === "openclaw"
+          ) {
+            allocatedRuntimePort = await allocateGatewayPort({
+              hostKey: allocationHostKey,
+              agentId: id,
+              purpose: RUNTIME_PORT_PURPOSE,
+            });
           }
         }
-        const createPromise = provisioner.create({
-          id,
-          name,
-          image: resolvedImage,
-          vcpu,
-          ram_mb,
-          disk_gb,
-          container_name,
-          gatewayHostPort: allocatedGatewayPort,
-          runtimeHostPort: allocatedRuntimePort,
-          dashboardHostPort: allocatedDashboardPort,
-          gatewayToken: agentRow.gateway_token || undefined,
-          templatePayload,
-          mcpServers: mcpServerEntries,
-          runtimeFamily: resolvedRuntimeFields.runtime_family,
-          deployTarget: resolvedRuntimeFields.deploy_target,
-          executionTargetId: resolvedRuntimeFields.execution_target_id,
-          sandboxProfile: resolvedRuntimeFields.sandbox_profile,
-          abortSignal: abortController.signal,
-          env: {
-            AGENT_ID: String(id),
-            AGENT_NAME: name || "",
-            NORA_INTEGRATIONS_CONFIG:
-              resolvedRuntimeFields.runtime_family === "hermes"
-                ? HERMES_INTEGRATIONS_CONFIG_FILE
-                : NORA_SYNC_INTEGRATIONS_CATALOG_FILE,
-            NORA_INTEGRATIONS_DIR:
-              resolvedRuntimeFields.runtime_family === "hermes"
-                ? HERMES_INTEGRATIONS_DIR
-                : NORA_SYNC_INTEGRATIONS_DIR,
-            ...(resolvedRuntimeFields.sandbox_profile === "nemoclaw" && model
-              ? { NEMOCLAW_MODEL: model }
-              : {}),
-            ...(defaultOpenClawModel && resolvedRuntimeFields.runtime_family === "openclaw"
-              ? { NORA_DEFAULT_OPENCLAW_MODEL: defaultOpenClawModel }
-              : {}),
-            ...hermesRuntimeBootstrapEnv,
-            ...agentSecretEnvVars,
-            ...integrationEnvVars,
-            ...llmEnvVars,
-          },
-        });
+        const createOnce = (gatewayHostPort) =>
+          provisioner.create({
+            id,
+            name,
+            image: resolvedImage,
+            vcpu,
+            ram_mb,
+            disk_gb,
+            container_name,
+            gatewayHostPort,
+            runtimeHostPort: allocatedRuntimePort,
+            dashboardHostPort: allocatedDashboardPort,
+            gatewayToken: agentRow.gateway_token || undefined,
+            templatePayload,
+            mcpServers: mcpServerEntries,
+            runtimeFamily: resolvedRuntimeFields.runtime_family,
+            deployTarget: resolvedRuntimeFields.deploy_target,
+            executionTargetId: resolvedRuntimeFields.execution_target_id,
+            sandboxProfile: resolvedRuntimeFields.sandbox_profile,
+            abortSignal: abortController.signal,
+            env: {
+              AGENT_ID: String(id),
+              AGENT_NAME: name || "",
+              NORA_INTEGRATIONS_CONFIG:
+                resolvedRuntimeFields.runtime_family === "hermes"
+                  ? HERMES_INTEGRATIONS_CONFIG_FILE
+                  : NORA_SYNC_INTEGRATIONS_CATALOG_FILE,
+              NORA_INTEGRATIONS_DIR:
+                resolvedRuntimeFields.runtime_family === "hermes"
+                  ? HERMES_INTEGRATIONS_DIR
+                  : NORA_SYNC_INTEGRATIONS_DIR,
+              ...(resolvedRuntimeFields.sandbox_profile === "nemoclaw" && model
+                ? { NEMOCLAW_MODEL: model }
+                : {}),
+              ...(defaultOpenClawModel && resolvedRuntimeFields.runtime_family === "openclaw"
+                ? { NORA_DEFAULT_OPENCLAW_MODEL: defaultOpenClawModel }
+                : {}),
+              ...hermesRuntimeBootstrapEnv,
+              ...agentSecretEnvVars,
+              ...integrationEnvVars,
+              ...llmEnvVars,
+            },
+          });
+        const createPromise = usesLocalDockerPublishedPort
+          ? createWithDockerPortRetry({
+              create: createOnce,
+              initialPort: allocatedGatewayPort,
+              getOccupiedPorts: () => getOccupiedDockerPublishedPorts(provisioner, { agentId: id }),
+              reallocate: async ({ previousPort, unavailablePorts }) => {
+                allocatedGatewayPort = await reallocateGatewayPort({
+                  hostKey: allocationHostKey,
+                  agentId: id,
+                  previousPort,
+                  unavailablePorts,
+                });
+                return allocatedGatewayPort;
+              },
+              onRetry: ({ retry, previousPort, nextPort }) => {
+                console.warn(
+                  `[provisioner] Docker port ${previousPort} was unavailable for agent ${id}; retry ${retry} will use persisted port ${nextPort}`,
+                );
+              },
+            })
+          : createOnce(allocatedGatewayPort);
         const timeoutPromise = new Promise((_, reject) => {
           provisionTimeoutHandle = setTimeout(() => {
             const timeoutError = new Error(


### PR DESCRIPTION
## Summary

- inspect live local-Docker published ports before allocating an agent gateway port
- persist a replacement allocation when a saved port is occupied and retry bounded Docker bind failures
- preserve durable agent volumes across retries and recover cleanly from concurrent allocation updates
- document the configurable local allocation range

## Why

A stale or externally occupied published port could make an otherwise valid local Docker deployment fail immediately. This keeps deployment self-healing inside the configured range without changing remote-host exposure behavior.

## Validation

- full Nora local CI matrix passed
- focused backend/provisioner suites: 83 tests passed
- backend and provisioner typechecks passed
- Docker image builds passed
- compose Playwright E2E: 16 passed, 65 real-credential cases skipped as expected
- independent review: GO
- GitHub CodeQL still required before merge