### PR TITLE
docs(claude-plugin): fix community install command

### DIFF
--- a/mcp-server/claude-plugin/README.md
+++ b/mcp-server/claude-plugin/README.md
@@ -36,7 +36,7 @@ same Nora CLI configuration at runtime. You may instead set `NORA_API_URL` and
 After the plugin is listed in Claude's community directory:
 
 ```text
-/plugin install nora@claude-plugins-community
+/plugin install nora@claude-community
 ```
 
 Restart Claude Code after installation, then ask Claude to list your Nora


### PR DESCRIPTION
## Summary

- update the Claude community install command to `nora@claude-community`
- align the plugin README with Anthropic's primary community marketplace identifier

## Checks

- `/home/projects/nora/node_modules/.bin/prettier --check mcp-server/claude-plugin/README.md`
- `git diff --check`