### PR TITLE
Fix production product-version metadata

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -13,7 +13,7 @@ on:
         required: false
         default: master
       version:
-        description: Override NORA_CURRENT_VERSION for this deploy
+        description: Override with an existing Nora product tag reachable from the target commit
         required: false
         default: ""
 
@@ -82,17 +82,37 @@ jobs:
         run: |
           set -euo pipefail
           commit="$(git rev-parse HEAD)"
-          exact_tag="$(git tag --points-at HEAD | head -n 1 || true)"
+          product_version_pattern='^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+          product_tags=()
+          while IFS= read -r candidate_tag; do
+            if [[ "$candidate_tag" =~ $product_version_pattern ]]; then
+              product_tags+=("$candidate_tag")
+            fi
+          done < <(git tag --points-at HEAD)
+
+          exact_tag=""
+          if [ "${#product_tags[@]}" -gt 0 ]; then
+            exact_tag="$(printf '%s\n' "${product_tags[@]}" | sort -V | tail -n 1)"
+          fi
 
           version="${INPUT_VERSION:-}"
+          if [ -n "$version" ]; then
+            if [[ ! "$version" =~ $product_version_pattern ]]; then
+              echo "::error::Version override must be an exact Nora product tag such as v1.16.0; got '$version'."
+              exit 1
+            fi
+            version_commit="$(git rev-parse --verify --quiet "refs/tags/${version}^{commit}" || true)"
+            if [ -z "$version_commit" ]; then
+              echo "::error::Version override must name an existing Nora product tag; got '$version'."
+              exit 1
+            fi
+            if ! git merge-base --is-ancestor "$version_commit" HEAD; then
+              echo "::error::Version override '$version' is not reachable from target commit '$commit'."
+              exit 1
+            fi
+          fi
           if [ -z "$version" ] && [ -n "$exact_tag" ]; then
             version="$exact_tag"
-          fi
-          if [ -z "$version" ]; then
-            latest_tag="$(git describe --tags --abbrev=0 2>/dev/null || true)"
-            if [ -n "$latest_tag" ] && git merge-base --is-ancestor "$latest_tag" HEAD; then
-              version="$latest_tag"
-            fi
           fi
           if [ -z "$version" ]; then
             version=""

--- a/.github/workflows/scripts/validate-infra.mjs
+++ b/.github/workflows/scripts/validate-infra.mjs
@@ -1,5 +1,7 @@
-import { execFileSync } from "node:child_process";
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { parse } from "yaml";
@@ -137,6 +139,127 @@ function runCapture(command, args) {
   return execFileSync(command, args, { cwd: repoRoot, encoding: "utf8" });
 }
 
+function validateDeployVersionMetadata() {
+  const workflow = fs.readFileSync(
+    path.join(repoRoot, ".github", "workflows", "deploy-production.yml"),
+    "utf8",
+  );
+  const stepMatch = workflow.match(
+    / {6}- name: Compute deployed version metadata\n {8}id: release_meta\n {8}run: \|\n([\s\S]*?)(?=\n {6}- uses:)/,
+  );
+  assert.ok(stepMatch, "deploy workflow must expose an executable release metadata step");
+  assert.doesNotMatch(workflow, /git describe --tags/);
+
+  const script = stepMatch[1].replace(/^ {10}/gm, "");
+  const fixtureRepo = fs.mkdtempSync(path.join(os.tmpdir(), "nora-release-metadata-"));
+
+  const runGit = (args) =>
+    execFileSync("git", args, {
+      cwd: fixtureRepo,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  const runMetadata = (inputVersion = "") => {
+    const outputFile = path.join(fixtureRepo, `github-output-${Date.now()}-${Math.random()}`);
+    fs.writeFileSync(outputFile, "");
+    const result = spawnSync("bash", ["-c", script], {
+      cwd: fixtureRepo,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GITHUB_OUTPUT: outputFile,
+        INPUT_VERSION: inputVersion,
+      },
+    });
+    return {
+      result,
+      output: fs.readFileSync(outputFile, "utf8"),
+    };
+  };
+
+  try {
+    fs.writeFileSync(path.join(fixtureRepo, "fixture.txt"), "release metadata fixture\n");
+    runGit(["init", "-q"]);
+    runGit(["add", "fixture.txt"]);
+    runGit([
+      "-c",
+      "user.name=Nora CI",
+      "-c",
+      "user.email=ci@example.invalid",
+      "commit",
+      "-qm",
+      "fixture",
+    ]);
+    runGit(["tag", "nora-copilot-plugin-v0.1.3"]);
+
+    const componentOnly = runMetadata();
+    assert.equal(componentOnly.result.status, 0, componentOnly.result.stderr);
+    assert.match(componentOnly.output, /^version=$/m);
+    assert.doesNotMatch(componentOnly.output, /nora-copilot-plugin/);
+    assert.match(componentOnly.output, /^commit=[0-9a-f]{40}$/m);
+
+    runGit(["tag", "v1.16.0"]);
+    const automaticProductVersion = runMetadata();
+    assert.equal(automaticProductVersion.result.status, 0, automaticProductVersion.result.stderr);
+    assert.match(automaticProductVersion.output, /^version=v1\.16\.0$/m);
+
+    fs.writeFileSync(path.join(fixtureRepo, "post-release.txt"), "post-release source checkout\n");
+    runGit(["add", "post-release.txt"]);
+    runGit([
+      "-c",
+      "user.name=Nora CI",
+      "-c",
+      "user.email=ci@example.invalid",
+      "commit",
+      "-qm",
+      "post-release source checkout",
+    ]);
+
+    const sourceCheckout = runMetadata();
+    assert.equal(sourceCheckout.result.status, 0, sourceCheckout.result.stderr);
+    assert.match(sourceCheckout.output, /^version=$/m);
+
+    const manualProductVersion = runMetadata("v1.16.0");
+    assert.equal(manualProductVersion.result.status, 0, manualProductVersion.result.stderr);
+    assert.match(manualProductVersion.output, /^version=v1\.16\.0$/m);
+
+    const componentOverride = runMetadata("nora-copilot-plugin-v0.1.3");
+    assert.notEqual(componentOverride.result.status, 0);
+    assert.match(
+      `${componentOverride.result.stderr}${componentOverride.result.stdout}`,
+      /must be an exact Nora product tag/,
+    );
+
+    const nonexistentOverride = runMetadata("v99.0.0");
+    assert.notEqual(nonexistentOverride.result.status, 0);
+    assert.match(
+      `${nonexistentOverride.result.stderr}${nonexistentOverride.result.stdout}`,
+      /must name an existing Nora product tag/,
+    );
+
+    const tree = runGit(["rev-parse", "HEAD^{tree}"]).trim();
+    const unrelatedCommit = runGit([
+      "-c",
+      "user.name=Nora CI",
+      "-c",
+      "user.email=ci@example.invalid",
+      "commit-tree",
+      tree,
+      "-m",
+      "unrelated release",
+    ]).trim();
+    runGit(["tag", "v2.0.0", unrelatedCommit]);
+    const unrelatedOverride = runMetadata("v2.0.0");
+    assert.notEqual(unrelatedOverride.result.status, 0);
+    assert.match(
+      `${unrelatedOverride.result.stderr}${unrelatedOverride.result.stdout}`,
+      /is not reachable from target commit/,
+    );
+  } finally {
+    fs.rmSync(fixtureRepo, { recursive: true, force: true });
+  }
+}
+
 function kubeconformRendered(rendered, label) {
   const renderedPath = path.join(repoRoot, `.helm-rendered-ci-${label}.yaml`);
   fs.writeFileSync(renderedPath, rendered);
@@ -219,6 +342,7 @@ function validateKubernetesManifests(manifestFiles) {
   run("kubeconform", ["-summary", ...manifestFiles.map((file) => path.relative(repoRoot, file))]);
 }
 
+validateDeployVersionMetadata();
 validateComposeFiles();
 
 const chartFiles = walk(infraDir, (fullPath) => path.basename(fullPath) === "Chart.yaml");


### PR DESCRIPTION
## Summary

- only stamp `NORA_CURRENT_VERSION` from an exact `vMAJOR.MINOR.PATCH` tag at the deployed commit
- reject malformed, missing, component, and unreachable manual version overrides
- execute the workflow metadata step against temporary Git fixtures in `ci:validate-infra`

## Why

Production currently reports the component tag `nora-copilot-plugin-v0.1.3` as the Nora product version, which makes `/api/config/platform` show a false upgrade to `v1.15.0`.

## Validation

- full local pre-push suite passed except compose-backed Playwright
- 1,367 backend tests and 10 agent-runtime tests passed
- typechecks, security scan, dependency audits, license policy, infra validation, and five Docker builds passed
- Playwright was skipped because an existing `nora-e2e` stack already owns port 18080 and was not disturbed
- independent review found no blocking issues

GitHub CI and CodeQL remain required before merge.