### PR TITLE
fix(auth): verify session upgrade tokens

### DIFF
--- a/backend-api/__tests__/auth.test.ts
+++ b/backend-api/__tests__/auth.test.ts
@@ -118,6 +118,8 @@ jest.mock("../metrics", () => ({
   recordApiMetric: jest.fn(),
 }));
 
+const apiKeys = require("../apiKeys");
+const mockVerifyApiKey = jest.spyOn(apiKeys, "verifyApiKey");
 const app = require("../server");
 
 function jsonResponse(body, ok = true, status = ok ? 200 : 400) {
@@ -136,6 +138,19 @@ function signupRequest(ip = null) {
     .set("X-Forwarded-For", ip || `203.0.113.${signupIpCounter}`);
 }
 
+function mockValidNoraApiKey() {
+  mockVerifyApiKey.mockResolvedValueOnce({
+    user: {
+      id: "api-key-user",
+      email: "api-key-user@example.com",
+      role: "user",
+      name: "API Key User",
+    },
+    key: { id: "key-1", scopes: ["agents:read"] },
+    workspace: { id: "workspace-1", name: "Test Workspace" },
+  });
+}
+
 beforeEach(() => {
   mockDb.query.mockReset();
   mockDb.connect.mockReset();
@@ -149,6 +164,11 @@ beforeEach(() => {
   delete process.env.SIGNUP_TURNSTILE_SECRET;
   delete process.env.SIGNUP_RECAPTCHA_SECRET;
   global.fetch = jest.fn();
+  mockVerifyApiKey.mockReset();
+});
+
+afterAll(() => {
+  mockVerifyApiKey.mockRestore();
 });
 
 describe("POST /auth/signup", () => {
@@ -430,6 +450,173 @@ describe("POST /auth/login", () => {
   });
 });
 
+describe("POST /auth/session-upgrade", () => {
+  it("sets an HttpOnly cookie for a valid HS256 bearer JWT", async () => {
+    const token = jwt.sign({ id: "user-1", email: "user@example.com", role: "user" }, JWT_SECRET, {
+      algorithm: "HS256",
+      expiresIn: "1h",
+    });
+
+    const res = await request(app)
+      .post("/auth/session-upgrade")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true });
+    const setCookie = res.headers["set-cookie"] || [];
+    const authCookie = setCookie.find((cookie) => cookie.startsWith("nora_auth="));
+    expect(authCookie).toBeDefined();
+    expect(authCookie).toMatch(/HttpOnly/i);
+    expect(authCookie).toMatch(/SameSite=Lax/i);
+    expect(decodeURIComponent(authCookie.match(/nora_auth=([^;]+)/)?.[1])).toBe(token);
+  });
+
+  it("rejects correctly signed JWTs that do not match the historical session contract", async () => {
+    const tokens = [
+      jwt.sign({ id: "user-1", arbitrary: true }, JWT_SECRET, {
+        algorithm: "HS256",
+        expiresIn: "1h",
+      }),
+      jwt.sign({ id: "user-1", agentId: "agent-1", scope: "gateway-embed" }, JWT_SECRET, {
+        algorithm: "HS256",
+        expiresIn: "15m",
+      }),
+      jwt.sign({ id: "user-1", role: "user" }, JWT_SECRET, {
+        algorithm: "HS256",
+        expiresIn: "1h",
+      }),
+      jwt.sign({ id: "user-1", email: "user@example.com", role: "owner" }, JWT_SECRET, {
+        algorithm: "HS256",
+        expiresIn: "1h",
+      }),
+      jwt.sign(
+        { id: "user-1", email: "user@example.com", role: "user", unexpected: true },
+        JWT_SECRET,
+        { algorithm: "HS256", expiresIn: "1h" },
+      ),
+      jwt.sign({ id: "user-1", email: "user@example.com", role: "user" }, JWT_SECRET, {
+        algorithm: "HS256",
+        noTimestamp: true,
+      }),
+    ];
+
+    for (const token of tokens) {
+      const res = await request(app)
+        .post("/auth/session-upgrade")
+        .set("Authorization", `Bearer ${token}`);
+
+      expect(res.status).toBe(401);
+      expect(res.headers["set-cookie"]).toBeUndefined();
+    }
+  });
+
+  it("rejects a forged bearer JWT even when a valid auth cookie is present", async () => {
+    const cookieToken = jwt.sign(
+      { id: "user-1", email: "user@example.com", role: "user" },
+      JWT_SECRET,
+      { algorithm: "HS256", expiresIn: "1h" },
+    );
+    const forgedBearer = jwt.sign(
+      { id: "attacker", email: "attacker@example.com", role: "admin" },
+      "wrong-secret",
+      { algorithm: "HS256", expiresIn: "1h" },
+    );
+
+    const res = await request(app)
+      .post("/auth/session-upgrade")
+      .set("Cookie", `nora_auth=${cookieToken}`)
+      .set("Authorization", `Bearer ${forgedBearer}`);
+
+    expect(res.status).toBe(401);
+    expect(res.headers["set-cookie"]).toBeUndefined();
+  });
+
+  it("rejects a Nora API key even when a valid auth cookie is present", async () => {
+    const cookieToken = jwt.sign(
+      { id: "user-1", email: "user@example.com", role: "user" },
+      JWT_SECRET,
+      { algorithm: "HS256", expiresIn: "1h" },
+    );
+
+    const res = await request(app)
+      .post("/auth/session-upgrade")
+      .set("Cookie", `nora_auth=${cookieToken}`)
+      .set("Authorization", "Bearer nora_test_api_key");
+
+    expect(res.status).toBe(401);
+    expect(res.headers["set-cookie"]).toBeUndefined();
+  });
+
+  it("rejects expired bearer JWTs without setting a cookie", async () => {
+    const expiredToken = jwt.sign(
+      { id: "user-1", email: "user@example.com", role: "user" },
+      JWT_SECRET,
+      { algorithm: "HS256", expiresIn: -1 },
+    );
+
+    const res = await request(app)
+      .post("/auth/session-upgrade")
+      .set("Authorization", `Bearer ${expiredToken}`);
+
+    expect(res.status).toBe(401);
+    expect(res.headers["set-cookie"]).toBeUndefined();
+  });
+
+  it("rejects JWTs signed with a non-HS256 algorithm", async () => {
+    const token = jwt.sign({ id: "user-1", email: "user@example.com", role: "user" }, JWT_SECRET, {
+      algorithm: "HS384",
+      expiresIn: "1h",
+    });
+
+    const res = await request(app)
+      .post("/auth/session-upgrade")
+      .set("Authorization", `Bearer ${token}`);
+
+    expect(res.status).toBe(401);
+    expect(res.headers["set-cookie"]).toBeUndefined();
+  });
+
+  it("rejects signed JWTs without a non-empty string user id", async () => {
+    const tokens = [
+      jwt.sign("not-a-session", JWT_SECRET, { algorithm: "HS256" }),
+      jwt.sign({ email: "user@example.com", role: "user" }, JWT_SECRET, {
+        algorithm: "HS256",
+        expiresIn: "1h",
+      }),
+      jwt.sign({ id: "   ", email: "user@example.com", role: "user" }, JWT_SECRET, {
+        algorithm: "HS256",
+        expiresIn: "1h",
+      }),
+    ];
+
+    for (const token of tokens) {
+      const res = await request(app)
+        .post("/auth/session-upgrade")
+        .set("Authorization", `Bearer ${token}`);
+
+      expect(res.status).toBe(401);
+      expect(res.headers["set-cookie"]).toBeUndefined();
+    }
+  });
+
+  it("rejects missing and malformed bearer headers without setting a cookie", async () => {
+    const token = jwt.sign({ id: "user-1", email: "user@example.com", role: "user" }, JWT_SECRET, {
+      algorithm: "HS256",
+      expiresIn: "1h",
+    });
+    const headers = [null, `Basic ${token}`, "Bearer", `Bearer ${token} trailing`];
+
+    for (const authorization of headers) {
+      let pendingRequest = request(app).post("/auth/session-upgrade");
+      if (authorization) pendingRequest = pendingRequest.set("Authorization", authorization);
+      const res = await pendingRequest;
+
+      expect(res.status).toBe(400);
+      expect(res.headers["set-cookie"]).toBeUndefined();
+    }
+  });
+});
+
 describe("Cookie-based authentication", () => {
   it("authenticates protected routes via the nora_auth cookie", async () => {
     const token = jwt.sign({ id: "user-1", role: "user" }, JWT_SECRET, { expiresIn: "1h" });
@@ -472,6 +659,42 @@ describe("Cookie-based authentication", () => {
 });
 
 describe("Protected auth routes", () => {
+  it("rejects API-key authentication on profile mutation before any DB access", async () => {
+    mockValidNoraApiKey();
+
+    const res = await request(app)
+      .patch("/auth/profile")
+      .set("Authorization", "Bearer nora_valid_profile_key")
+      .send({ name: "Changed Name" });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({ code: "session_required" });
+    expect(mockDb.query).not.toHaveBeenCalled();
+  });
+
+  it("rejects API-key authentication on password mutation before any DB access", async () => {
+    mockValidNoraApiKey();
+
+    const res = await request(app)
+      .patch("/auth/password")
+      .set("Authorization", "Bearer nora_valid_password_key")
+      .send({ currentPassword: "currentpassword123", newPassword: "newpassword123" });
+
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({ code: "session_required" });
+    expect(mockDb.query).not.toHaveBeenCalled();
+  });
+
+  it("rejects API-key authentication on the current-user endpoint before any DB access", async () => {
+    mockValidNoraApiKey();
+
+    const res = await request(app).get("/auth/me").set("Authorization", "Bearer nora_valid_me_key");
+
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({ code: "session_required" });
+    expect(mockDb.query).not.toHaveBeenCalled();
+  });
+
   it("rejects password changes that do not meet the signup password policy", async () => {
     const token = jwt.sign({ id: "user-1", role: "user" }, JWT_SECRET, { expiresIn: "1h" });
 

--- a/backend-api/routes/auth.ts
+++ b/backend-api/routes/auth.ts
@@ -4,7 +4,7 @@ const bcrypt = require("bcryptjs");
 const jwt = require("jsonwebtoken");
 const rateLimit = require("express-rate-limit");
 const db = require("../db");
-const { authenticateToken } = require("../middleware/auth");
+const { authenticateToken, requireSession } = require("../middleware/auth");
 const { setAuthCookie, clearAuthCookie } = require("../authCookie");
 const { normalizeEmail, normalizeProvider, verifyOAuthIdentity } = require("../oauthProviders");
 const {
@@ -172,6 +172,29 @@ function validatePassword(pw) {
   if (pw.length < 8) return "Password must be at least 8 characters";
   if (pw.length > 128) return "Password too long";
   return null;
+}
+
+const LEGACY_SESSION_CLAIMS = new Set(["id", "email", "role", "iat", "exp"]);
+
+function isLegacySessionPayload(payload) {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) return false;
+
+  // Backend-issued browser sessions have always contained exactly these
+  // custom claims plus jsonwebtoken's iat/exp timestamps. Other JWTs share the
+  // signing secret (for example short-lived gateway embed tokens), so a valid
+  // signature alone is not enough to promote a token into the primary cookie.
+  if (Object.keys(payload).some((claim) => !LEGACY_SESSION_CLAIMS.has(claim))) return false;
+
+  return (
+    typeof payload.id === "string" &&
+    Boolean(payload.id.trim()) &&
+    typeof payload.email === "string" &&
+    !validateEmail(payload.email) &&
+    (payload.role === "user" || payload.role === "admin") &&
+    Number.isInteger(payload.iat) &&
+    Number.isInteger(payload.exp) &&
+    payload.exp > payload.iat
+  );
 }
 
 async function withUserCreationLock(work) {
@@ -410,9 +433,9 @@ router.post("/oauth-login", authLimiter, async (req, res, next) => {
   }
 });
 
-// ─── Protected routes (require authenticateToken) ─────────────────
+// ─── Protected routes (require a user session) ────────────────────
 
-router.patch("/password", authenticateToken, async (req, res, next) => {
+router.patch("/password", authenticateToken, requireSession, async (req, res, next) => {
   try {
     const { currentPassword, newPassword } = req.body;
     if (!currentPassword || !newPassword)
@@ -433,7 +456,7 @@ router.patch("/password", authenticateToken, async (req, res, next) => {
   }
 });
 
-router.get("/me", authenticateToken, async (req, res, next) => {
+router.get("/me", authenticateToken, requireSession, async (req, res, next) => {
   try {
     const [result, languageSettings] = await Promise.all([
       db.query(
@@ -463,7 +486,7 @@ router.get("/me", authenticateToken, async (req, res, next) => {
   }
 });
 
-router.patch("/profile", authenticateToken, async (req, res) => {
+router.patch("/profile", authenticateToken, requireSession, async (req, res) => {
   try {
     const body = req.body || {};
     const { name, avatar } = body;
@@ -539,10 +562,25 @@ router.patch("/profile", authenticateToken, async (req, res) => {
 //
 // Path avoids /auth/session to remain compatible with older deployments that
 // routed that path through the marketing app.
-router.post("/session-upgrade", authenticateToken, (req, res) => {
-  const authHeader = req.headers["authorization"] || "";
-  const [, token] = authHeader.split(" ");
-  if (!token) return res.status(400).json({ error: "Bearer token required" });
+router.post("/session-upgrade", (req, res) => {
+  const authHeader = req.headers["authorization"];
+  const bearerMatch = typeof authHeader === "string" ? /^Bearer ([^\s]+)$/i.exec(authHeader) : null;
+  if (!bearerMatch) return res.status(400).json({ error: "Bearer token required" });
+
+  const token = bearerMatch[1];
+  if (token.startsWith("nora_")) {
+    return res.status(401).json({ error: "Invalid or expired Bearer token" });
+  }
+
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET, { algorithms: ["HS256"] });
+    if (!isLegacySessionPayload(decoded)) {
+      return res.status(401).json({ error: "Invalid or expired Bearer token" });
+    }
+  } catch {
+    return res.status(401).json({ error: "Invalid or expired Bearer token" });
+  }
+
   setAuthCookie(res, token, req);
   res.json({ success: true });
 });


### PR DESCRIPTION
## Summary

- verify the Authorization bearer directly before upgrading it to the HttpOnly session cookie
- accept only the historical Nora browser-session claim contract and reject other-purpose signed JWTs
- reject API keys on session-only auth routes, including profile and password mutations
- add regression coverage for forged, expired, malformed, alternate-algorithm, API-key, and embed-purpose credentials

## Verification

- Nora local CI checks passed: lint, format, package typechecks, security scans, dependency/license policy, infra validation, backend and runtime tests, and Docker builds
- focused auth suite: 50/50 passed
- independent auth/API-key review suite: 70/70 passed
- git diff --check passed
- local compose-backed Playwright skipped because the existing Nora E2E stack owns port 18080; GitHub Playwright and CodeQL remain required before merge