### PR TITLE
chore(mcp): improve registry discovery metadata

### DIFF
--- a/mcp-server/manifest.json
+++ b/mcp-server/manifest.json
@@ -3,7 +3,7 @@
   "manifest_version": "0.4",
   "name": "nora",
   "display_name": "Nora",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Operate your self-hosted Nora agent fleet from Claude Desktop.",
   "long_description": "Connect Claude Desktop to a Nora control plane you operate. Deploy and control OpenClaw or Hermes agents, inspect fleet health, and read metrics, events, and cost through Nora's workspace-scoped API.",
   "author": {

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@noraai/mcp-server",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@noraai/mcp-server",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@noraai/mcp-server",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "MCP server for Nora — deploy, monitor, and operate self-hosted OpenClaw and Hermes agent fleets on Docker or Kubernetes.",
   "mcpName": "io.github.solomon2773/nora",
   "license": "Apache-2.0",

--- a/mcp-server/server.json
+++ b/mcp-server/server.json
@@ -2,8 +2,8 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.solomon2773/nora",
   "title": "Nora",
-  "description": "Operate your self-hosted Nora agent fleet from MCP clients.",
-  "version": "0.1.3",
+  "description": "Operate self-hosted OpenClaw and Hermes agent fleets on Docker or Kubernetes from MCP clients.",
+  "version": "0.1.4",
   "websiteUrl": "https://noradocs.solomontsao.com",
   "repository": {
     "url": "https://github.com/solomon2773/nora",
@@ -15,7 +15,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@noraai/mcp-server",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "transport": {
         "type": "stdio"
       },

--- a/mcp-server/src/client.js
+++ b/mcp-server/src/client.js
@@ -38,7 +38,7 @@ export function createApi({ baseUrl, apiKey, fetchImpl } = {}) {
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${resolved.apiKey}`,
-        "User-Agent": "nora-mcp-server/0.1.3",
+        "User-Agent": "nora-mcp-server/0.1.4",
       },
       body: body !== undefined ? JSON.stringify(body) : undefined,
     });

--- a/mcp-server/src/index.js
+++ b/mcp-server/src/index.js
@@ -12,7 +12,7 @@ import { createApi } from "./client.js";
 import { registerAgentTools } from "./tools/agents.js";
 import { registerMonitoringTools } from "./tools/monitoring.js";
 
-export const SERVER_INFO = { name: "nora", version: "0.1.3" };
+export const SERVER_INFO = { name: "nora", version: "0.1.4" };
 
 export function createServer({ api, env = process.env } = {}) {
   const server = new McpServer(SERVER_INFO, {

--- a/mcp-server/test/entrypoint.test.js
+++ b/mcp-server/test/entrypoint.test.js
@@ -55,7 +55,7 @@ test(
     t.after(() => client.close());
 
     await client.connect(transport);
-    assert.equal(client.getServerVersion()?.version, "0.1.3");
+    assert.equal(client.getServerVersion()?.version, "0.1.4");
 
     const result = await client.listTools();
 

--- a/mcp-server/test/tools.test.js
+++ b/mcp-server/test/tools.test.js
@@ -143,7 +143,7 @@ test("the HTTP client sends bearer auth and parses JSON for a valid path", async
   assert.deepEqual(body, { id: AID });
   assert.equal(seen.url, `https://nora.example.com/api/agents/${AID}`);
   assert.equal(seen.auth, "Bearer nora_test");
-  assert.equal(seen.userAgent, "nora-mcp-server/0.1.3");
+  assert.equal(seen.userAgent, "nora-mcp-server/0.1.4");
 });
 
 test("per-agent observability tools use the /api/agents/:id paths", async () => {


### PR DESCRIPTION
## Summary

- publish `@noraai/mcp-server` metadata as patch version `0.1.4`
- describe Nora with the OpenClaw, Hermes, Docker, and Kubernetes terms that MCP Registry users actually search
- keep runtime, MCPB, npm, and official Registry versions synchronized

## Why

The active official MCP Registry entry does not appear for searches such as `openclaw`, `hermes`, `docker`, `kubernetes`, or `fleet` because its description only says “Nora agent fleet.” Registry versions are immutable, so a patch version is required to improve discovery.

## Validation

- `npm test` — 12/12 passed
- `npm run typecheck` — passed
- focused Prettier — passed
- `npm pack --dry-run` — correct 0.1.4 tarball contents
- MCPB 2.1.2 validate + pack — passed
- extracted MCPB initialize/list-tools — version 0.1.4, 15 default-safe tools
- packed npm tarball initialize/list-tools — version 0.1.4, 15 default-safe tools
- `mcp-publisher 1.7.9 validate server.json` — passed against the live Registry
- Nora local CI — passed with Docker builds and Playwright intentionally skipped to avoid disturbing the existing shared E2E stack; GitHub CI/CodeQL remain the merge gate
