### PR TITLE
fix: complete activation and promo readiness

### DIFF
--- a/.github/press-kit/README.md
+++ b/.github/press-kit/README.md
@@ -7,10 +7,10 @@ licensed for editorial use. Questions: open an issue on
 ## What Nora is (one line)
 
 > Nora is the self-hosted control plane for AI agents — deploy, observe, and operate
-> OpenClaw and Hermes agent runtimes on GA Docker and Kubernetes targets. NemoClaw is
-> experimental; Proxmox unprivileged LXC is experimental for OpenClaw and prepared Hermes
-> images and still requires real-hardware smoke before production. Open source, Apache-2.0,
-> no vendor lock-in.
+> OpenClaw and Hermes agent runtimes on GA Docker and Kubernetes targets. Self-hosted Remote Docker brings
+> experimental BYOC placement over pinned SSH plus a private runtime network; the OpenClaw-only NemoClaw profile and Proxmox unprivileged LXC are also
+> experimental, with Proxmox still requiring real-hardware smoke before production. Open source,
+> Apache-2.0, no vendor lock-in.
 
 ## One paragraph
 
@@ -20,8 +20,8 @@ licensed for editorial use. Questions: open an issue on
 > and a real terminal into each agent. It runs entirely self-hosted via a one-line installer
 > on Docker, scales to Kubernetes (k3s/AKS/GKE/EKS), and is fully open source under
 > Apache-2.0 — including commercial self-hosting and a built-in PaaS mode for operators
-> who want to host Nora for their own customers. The NemoClaw sandbox profile is experimental.
-> Proxmox unprivileged LXC placement is also experimental for OpenClaw and prepared Hermes
+> who want to host Nora for their own customers. Self-hosted Remote Docker BYOC placement and the OpenClaw-only NemoClaw
+> sandbox profile are experimental. Proxmox unprivileged LXC placement is also experimental for OpenClaw and prepared Hermes
 > images, uses secure API TLS plus pinned SSH, and remains gated on real-hardware smoke before
 > production; NemoClaw on Proxmox is blocked.
 
@@ -63,17 +63,20 @@ licensed for editorial use. Questions: open an issue on
 
 Source of truth: `agent-runtime/lib/backendCatalog.ts`. Lead coverage with the GA path.
 
-| Runtime family         | Docker | Kubernetes | Proxmox unprivileged LXC             |
-| ---------------------- | ------ | ---------- | ------------------------------------ |
-| **OpenClaw** (default) | GA     | GA         | Experimental                         |
-| **Hermes**             | GA     | GA         | Experimental (prepared image needed) |
+| Runtime family         | Docker | Remote Docker | Kubernetes | Proxmox unprivileged LXC             |
+| ---------------------- | ------ | ------------- | ---------- | ------------------------------------ |
+| **OpenClaw** (default) | GA     | Experimental  | GA         | Experimental                         |
+| **Hermes**             | GA     | Experimental  | GA         | Experimental (prepared image needed) |
 
 - **GA** — release-ready default path for normal onboarding.
+- **Experimental (Remote Docker)** — self-hosted-only registered BYOC host reached over SSH with a pinned host key;
+  validate the host from Nora and keep the published runtime ports on a private encrypted network.
 - **Experimental (Proxmox)** — requires secure API TLS, pinned SSH, a prepared runtime image
   where applicable, and successful real-hardware smoke before production use.
-- **Experimental** — the **NemoClaw** secure-sandbox profile (NVIDIA GPU); promising, under
-  active contract validation. Applies on top of any runtime/target when the `nemoclaw`
-  sandbox profile is selected, except Proxmox where NemoClaw remains blocked.
+- **Experimental** — the **NemoClaw** secure-sandbox profile for OpenClaw with NVIDIA-backed
+  inference; promising and under active contract validation. It is available on supported Docker,
+  Remote Docker, and Kubernetes targets. Hermes does not support NemoClaw, and NemoClaw on Proxmox
+  remains blocked.
 
 ## Brand assets
 

--- a/.github/workflows/ci-compose.yml
+++ b/.github/workflows/ci-compose.yml
@@ -110,6 +110,24 @@ jobs:
       - run: npm ci
       - run: npm test
 
+  worker-provisioner-unit-tests:
+    name: worker-provisioner unit tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: workers/provisioner
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: workers/provisioner/package-lock.json
+      - run: npm ci
+      - run: npm test
+
   worker-backup-validation:
     name: worker-backup typecheck
     runs-on: ubuntu-latest
@@ -183,6 +201,7 @@ jobs:
     needs:
       - backend-unit-tests
       - agent-runtime-unit-tests
+      - worker-provisioner-unit-tests
       - worker-backup-validation
     timeout-minutes: 30
     env:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -205,6 +205,10 @@ jobs:
             "$TARGET_COMMIT" \
             "$NORA_GITHUB_REPO"
 
+          bash infra/render-public-nginx.sh \
+            "$DEPLOY_ENV_FILE" \
+            "$DEPLOY_COMPOSE_FILES"
+
           bash scripts/materialize-compose-secrets.sh "$DEPLOY_ENV_FILE"
 
           compose_args=(--env-file "$DEPLOY_ENV_FILE")
@@ -239,6 +243,17 @@ jobs:
             fi
 
             sleep "$health_interval_seconds"
+          done
+
+          docker_probe='const http=require("http");const request=http.request({socketPath:"/var/run/docker.sock",path:"/_ping",method:"GET"},response=>{let body="";response.setEncoding("utf8");response.on("data",chunk=>body+=chunk);response.on("end",()=>process.exit(response.statusCode===200&&body.trim()==="OK"?0:1));});request.setTimeout(5000,()=>request.destroy(new Error("Docker socket timeout")));request.on("error",error=>{console.error(error.message);process.exit(1);});request.end();'
+          for service in backend-api worker-provisioner worker-backup; do
+            echo "Verifying Docker socket access from ${service}."
+            if ! docker compose "${compose_args[@]}" exec -T "$service" node -e "$docker_probe"; then
+              echo "${service} cannot access /var/run/docker.sock after deployment." >&2
+              docker compose "${compose_args[@]}" ps "$service" >&2 || true
+              docker compose "${compose_args[@]}" logs --tail=80 "$service" >&2 || true
+              exit 1
+            fi
           done
           REMOTE
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,42 @@ All notable changes to Nora are documented here. Each entry summarizes the
 corresponding [GitHub release](https://github.com/solomon2773/nora/releases),
 which carries the full notes and verification details.
 
+## [v1.16.1](https://github.com/solomon2773/nora/releases/tag/v1.16.1) — 2026-07-12
+
+Activation-reliability patch: the zero-key first proof now stays behind a final readiness
+barrier, production deploys carry the hardened edge configuration forward, and Remote Docker
+has a complete operator guide.
+
+### Added
+
+- Provisioner lifecycle regression coverage for guarded runtime metadata persistence,
+  provider-state drift, restart ordering, readiness failure, and atomic deployment finalization.
+- A Remote Docker backend guide covering registered SSH hosts, pinned host keys, runtime support,
+  workspace sharing, networking, validation, and troubleshooting.
+
+### Changed
+
+- Provisioning persists runtime endpoints while the agent remains `deploying`, reconciles any
+  in-flight provider changes, and publishes `running` / `completed` in one guarded transaction
+  only after final readiness. Unchanged demo state skips the redundant restart entirely.
+- Live OpenClaw auth sync applies auth, custom-provider, and default-model writes before one
+  restart, with readiness as the final runtime operation.
+- Production deploys refresh the host Docker socket GID, regenerate the ignored public nginx
+  config from the tracked template, verify Docker API access from every socket-using service,
+  and serve hardened browser headers plus short shared caching for the public homepage only.
+- Release metadata advances the Gemini extension manifest to `1.16.1` and the Helm chart to
+  `0.7.1` for exact-tag publication.
+
+### Fixed
+
+- The first chat after zero-key activation no longer races a post-deploy OpenClaw restart and
+  returns a transient `502` after Nora has already advertised the agent as running.
+- Built-in demo readiness failures now fail closed and retry instead of exposing an unreachable
+  runtime through the recoverable-warning path.
+- Proxmox now carries the worker-resolved per-agent MCP selection into OpenClaw bootstrap instead
+  of silently dropping it, and rejects malformed template, storage, or bridge values during
+  catalog preflight before a deployment can be queued.
+
 ## [v1.16.0](https://github.com/solomon2773/nora/releases/tag/v1.16.0) — 2026-07-12
 
 Launch-readiness release: a deterministic first-run demo, safer production defaults,

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ iwr -useb https://raw.githubusercontent.com/solomon2773/nora/master/setup.ps1 | 
 **Kubernetes (Helm):**
 
 ```bash
-helm show chart oci://ghcr.io/solomon2773/nora --version 0.7.0
+helm show chart oci://ghcr.io/solomon2773/nora --version 0.7.1
 ```
 
 The public OCI chart installs the full Nora control plane. See the [Helm instructions](https://noradocs.solomontsao.com/self-hosting#kubernetes-helm) for the required secrets and Ingress options.
@@ -142,7 +142,7 @@ For manual setup, environment variables, public-domain mode, TLS, Kubernetes, Ne
 
 - [Self-hosting guide](https://noradocs.solomontsao.com/self-hosting)
 - [Environment variables reference](https://noradocs.solomontsao.com/configuration/environment-variables)
-- [Provisioner backends](https://noradocs.solomontsao.com/configuration/provisioner-backends) (Docker and k3s/Kubernetes are GA; NemoClaw and Proxmox LXC are experimental)
+- [Provisioner backends](https://noradocs.solomontsao.com/configuration/provisioner-backends) (Docker and k3s/Kubernetes are GA; Remote Docker, NemoClaw, and Proxmox LXC are experimental)
 - [TLS and public domains](https://noradocs.solomontsao.com/configuration/tls-domains)
 - [Fronting a launch with Cloudflare](infra/cloudflare-launch.md) — edge caching, rate limiting, and spike absorption for the single-host deploy
 
@@ -171,7 +171,7 @@ Nginx
                        ├── Redis + BullMQ  (deployments, clawhub-jobs, backups, alert-deliveries)
                        ├── worker-provisioner
                        ├── worker-backup
-                       ├── deploy-target adapters  (Docker GA · k3s/k8s GA · Proxmox LXC experimental)
+                       ├── deploy-target adapters  (Docker + k3s/k8s GA · Remote Docker + Proxmox experimental)
                        └── sandbox profiles        (standard · NemoClaw experimental)
 ```
 
@@ -179,18 +179,18 @@ Full architecture write-up — system map, queue/worker boundaries, RBAC, migrat
 
 ## Tech Stack
 
-| Layer              | Technology                                                              |
-| ------------------ | ----------------------------------------------------------------------- |
-| Reverse proxy      | Nginx                                                                   |
-| Frontends          | Next.js 16, React 19, Tailwind CSS                                      |
-| Backend API        | Express.js 5, Node.js 24 LTS                                            |
-| Auth               | JWT, HttpOnly cookies, bcryptjs, provider OAuth bridge                  |
-| Database           | PostgreSQL 15                                                           |
-| Queue              | BullMQ + Redis 7                                                        |
-| Runtime families   | OpenClaw, Hermes                                                        |
-| Deployment targets | Docker and k3s/Kubernetes (GA); Proxmox unprivileged LXC (experimental) |
-| Sandbox profiles   | Standard; NemoClaw (experimental, not available on Proxmox)             |
-| Secrets at rest    | AES-256-GCM (provider keys, integrations, backups)                      |
+| Layer              | Technology                                                                                     |
+| ------------------ | ---------------------------------------------------------------------------------------------- |
+| Reverse proxy      | Nginx                                                                                          |
+| Frontends          | Next.js 16, React 19, Tailwind CSS                                                             |
+| Backend API        | Express.js 5, Node.js 24 LTS                                                                   |
+| Auth               | JWT, HttpOnly cookies, bcryptjs, provider OAuth bridge                                         |
+| Database           | PostgreSQL 15                                                                                  |
+| Queue              | BullMQ + Redis 7                                                                               |
+| Runtime families   | OpenClaw, Hermes                                                                               |
+| Deployment targets | Docker and k3s/Kubernetes (GA); Remote Docker BYOC and Proxmox unprivileged LXC (experimental) |
+| Sandbox profiles   | Standard; NemoClaw (experimental, not available on Proxmox)                                    |
+| Secrets at rest    | AES-256-GCM (provider keys, integrations, backups)                                             |
 
 ## Public REST API, CLI, and MCP
 

--- a/agent-runtime/__tests__/backendCatalog.test.ts
+++ b/agent-runtime/__tests__/backendCatalog.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from "vitest";
+import "tsx/cjs";
+
+const backendCatalog = require("../lib/backendCatalog.ts");
+
+const { getBackendStatus, getRuntimeSelectionStatus } = backendCatalog;
+
+function secureProxmoxEnv(overrides: Record<string, string> = {}) {
+  return {
+    NODE_ENV: "production",
+    ENABLED_BACKENDS: "docker,proxmox",
+    ENABLED_RUNTIME_FAMILIES: "openclaw,hermes",
+    ENABLED_SANDBOX_PROFILES: "standard",
+    PROXMOX_API_URL: "https://pve.example.com:8006/api2/json",
+    PROXMOX_TOKEN_ID: "nora@pve!provisioner",
+    PROXMOX_TOKEN_SECRET: "secret",
+    PROXMOX_NODE: "pve-a",
+    PROXMOX_TEMPLATE: "local:vztmpl/ubuntu-22.04-standard.tar.zst",
+    PROXMOX_HERMES_TEMPLATE: "local:vztmpl/nora-hermes-2026.7.tar.zst",
+    PROXMOX_ROOTFS_STORAGE: "local-lvm",
+    PROXMOX_BRIDGE: "vmbr0",
+    PROXMOX_SSH_HOST: "pve.example.com",
+    PROXMOX_SSH_USER: "nora-bootstrap",
+    PROXMOX_SSH_PASSWORD: "secret",
+    PROXMOX_SSH_HOST_FINGERPRINT: `SHA256:${"A".repeat(43)}`,
+    ...overrides,
+  };
+}
+
+describe("Proxmox catalog preflight", () => {
+  it("accepts syntactically valid templates, storage, and bridge values", () => {
+    const env = secureProxmoxEnv({
+      PROXMOX_TEMPLATE: "ceph_store:vztmpl/ubuntu-24.04+node24.tar.zst",
+      PROXMOX_HERMES_TEMPLATE: "ceph-store:vztmpl/nora-hermes_2026.7.tar.zst",
+      PROXMOX_ROOTFS_STORAGE: "ceph_store-1",
+      PROXMOX_BRIDGE: "vmbr0.42",
+    });
+
+    expect(getBackendStatus("proxmox", env)).toEqual(
+      expect.objectContaining({ configured: true, available: true, issue: null }),
+    );
+    expect(
+      getRuntimeSelectionStatus(
+        {
+          runtimeFamily: "hermes",
+          deployTarget: "proxmox",
+          sandboxProfile: "standard",
+        },
+        env,
+      ),
+    ).toEqual(expect.objectContaining({ configured: true, available: true, issue: null }));
+  });
+
+  it.each([
+    ["ISO paths", "local:iso/ubuntu.iso"],
+    ["missing storage", "vztmpl/ubuntu.tar.zst"],
+    ["option injection", "local:vztmpl/ubuntu.tar.zst,unprivileged=0"],
+    ["missing archive suffix", "local:vztmpl/not-an-archive"],
+    ["wrong archive type", "local:vztmpl/template.iso"],
+    ["embedded volume separator", "local:vztmpl/other:template.tar.zst"],
+  ])("rejects malformed OpenClaw template references (%s)", (_label, template) => {
+    const status = getBackendStatus("proxmox", secureProxmoxEnv({ PROXMOX_TEMPLATE: template }));
+
+    expect(status).toEqual(
+      expect.objectContaining({
+        configured: false,
+        available: false,
+        availableForOnboarding: false,
+        issue: "PROXMOX_TEMPLATE must use storage:vztmpl/template.tar.zst format.",
+      }),
+    );
+  });
+
+  it("rejects a malformed Hermes template without hiding the valid OpenClaw path", () => {
+    const env = secureProxmoxEnv({ PROXMOX_HERMES_TEMPLATE: "not-a-template" });
+
+    expect(getBackendStatus("proxmox", env).available).toBe(true);
+    expect(
+      getRuntimeSelectionStatus(
+        {
+          runtimeFamily: "hermes",
+          deployTarget: "proxmox",
+          sandboxProfile: "standard",
+        },
+        env,
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        configured: false,
+        available: false,
+        issue: "PROXMOX_HERMES_TEMPLATE must use storage:vztmpl/template.tar.zst format.",
+      }),
+    );
+  });
+
+  it.each([
+    ["PROXMOX_ROOTFS_STORAGE", "local-lvm,backup=1", /ROOTFS_STORAGE.*unsupported/i],
+    ["PROXMOX_ROOTFS_STORAGE", "local/lvm", /ROOTFS_STORAGE.*unsupported/i],
+    ["PROXMOX_BRIDGE", "vmbr0,firewall=0", /BRIDGE.*1-15 character/i],
+    ["PROXMOX_BRIDGE", "bridge-name-over-15", /BRIDGE.*1-15 character/i],
+  ])("rejects unsafe %s syntax", (name, value, issuePattern) => {
+    const status = getBackendStatus("proxmox", secureProxmoxEnv({ [name]: value }));
+
+    expect(status.configured).toBe(false);
+    expect(status.available).toBe(false);
+    expect(status.availableForOnboarding).toBe(false);
+    expect(status.issue).toMatch(issuePattern);
+  });
+});

--- a/agent-runtime/lib/backendCatalog.ts
+++ b/agent-runtime/lib/backendCatalog.ts
@@ -17,6 +17,14 @@ const EXTERNAL_DEPLOY_TARGET = "external";
 const KNOWN_SANDBOX_PROFILES = Object.freeze(["standard", "nemoclaw"]);
 const PROXMOX_NEMOCLAW_BLOCKER_ISSUE =
   "NemoClaw on Proxmox is not supported yet because the LXC adapter does not provide the enforced OpenShell sandbox contract.";
+const DEFAULT_PROXMOX_TEMPLATE = "local:vztmpl/ubuntu-22.04-standard_22.04-1_amd64.tar.zst";
+// Keep this in lockstep with workers/provisioner/backends/proxmox.ts. The
+// catalog must reject malformed values before a deployment reaches create().
+const PROXMOX_TEMPLATE_RE = /^[A-Za-z0-9_.-]+:vztmpl\/[A-Za-z0-9._+~-]+\.tar\.zst$/;
+const PROXMOX_RESOURCE_ID_RE = /^[A-Za-z0-9_.-]+$/;
+// Linux interface names, including Proxmox bridges, are limited to 15 bytes.
+// Restricting the character set also prevents net0 option-delimiter injection.
+const PROXMOX_BRIDGE_RE = /^[A-Za-z0-9_.-]{1,15}$/;
 
 const OPENCLAW_OPERATOR_CONTRACT = Object.freeze([
   "deploy/redeploy",
@@ -555,6 +563,19 @@ function validateProxmoxFile(filePath, label, options = {}) {
   return null;
 }
 
+function isProxmoxTemplateRef(value) {
+  return PROXMOX_TEMPLATE_RE.test(String(value || "").trim());
+}
+
+function getProxmoxTemplateIssue(value, envName) {
+  const template = String(value || "").trim();
+  if (!template) return `${envName} is required.`;
+  if (!isProxmoxTemplateRef(template)) {
+    return `${envName} must use storage:vztmpl/template.tar.zst format.`;
+  }
+  return null;
+}
+
 function getProxmoxConfigIssue(env = process.env, options = {}) {
   const rawApiUrl = String(env.PROXMOX_API_URL || "").trim();
   if (!rawApiUrl) return "Proxmox requires PROXMOX_API_URL.";
@@ -603,6 +624,23 @@ function getProxmoxConfigIssue(env = process.env, options = {}) {
   if (!/^[A-Za-z0-9_.-]+$/.test(node)) {
     return "PROXMOX_NODE contains unsupported characters.";
   }
+
+  const templateIssue = getProxmoxTemplateIssue(
+    env.PROXMOX_TEMPLATE || DEFAULT_PROXMOX_TEMPLATE,
+    "PROXMOX_TEMPLATE",
+  );
+  if (templateIssue) return templateIssue;
+
+  const rootfsStorage = String(env.PROXMOX_ROOTFS_STORAGE || "local-lvm").trim();
+  if (!PROXMOX_RESOURCE_ID_RE.test(rootfsStorage)) {
+    return "PROXMOX_ROOTFS_STORAGE contains unsupported characters.";
+  }
+
+  const bridge = String(env.PROXMOX_BRIDGE || "vmbr0").trim();
+  if (!PROXMOX_BRIDGE_RE.test(bridge)) {
+    return "PROXMOX_BRIDGE must be a 1-15 character interface name using only letters, numbers, dots, underscores, or hyphens.";
+  }
+
   const rawSshPort = String(env.PROXMOX_SSH_PORT || "22").trim();
   const sshPort = Number(rawSshPort);
   if (!/^\d+$/.test(rawSshPort) || !Number.isInteger(sshPort) || sshPort < 1 || sshPort > 65535) {
@@ -699,12 +737,13 @@ function runtimeSelectionIssue(selection = {}, env = process.env) {
   });
   if (targetIssue) return targetIssue;
 
-  if (
-    normalizedDeployTarget === "proxmox" &&
-    normalizedRuntimeFamily === "hermes" &&
-    !env.PROXMOX_HERMES_TEMPLATE
-  ) {
-    return "Hermes on Proxmox requires PROXMOX_HERMES_TEMPLATE.";
+  if (normalizedDeployTarget === "proxmox" && normalizedRuntimeFamily === "hermes") {
+    const hermesTemplate = String(env.PROXMOX_HERMES_TEMPLATE || "").trim();
+    if (!hermesTemplate) {
+      return "Hermes on Proxmox requires PROXMOX_HERMES_TEMPLATE.";
+    }
+    const hermesTemplateIssue = getProxmoxTemplateIssue(hermesTemplate, "PROXMOX_HERMES_TEMPLATE");
+    if (hermesTemplateIssue) return hermesTemplateIssue;
   }
 
   return null;

--- a/backend-api/__tests__/agentMigrationsBackend.test.ts
+++ b/backend-api/__tests__/agentMigrationsBackend.test.ts
@@ -1,0 +1,40 @@
+// @ts-nocheck
+const mockBackendFor = jest.fn();
+
+jest.mock("../containerManager", () => ({
+  backendFor: (...args) => mockBackendFor(...args),
+}));
+
+const { resolveHermesDockerContainer } = require("../agentMigrations");
+
+beforeEach(() => {
+  mockBackendFor.mockReset();
+});
+
+it("uses the selected backend Docker client for Remote Docker Hermes capture", async () => {
+  const container = { id: "remote-hermes-1" };
+  const getContainer = jest.fn().mockReturnValue(container);
+  mockBackendFor.mockResolvedValue({ docker: { getContainer } });
+  const agent = {
+    container_id: "remote-hermes-1",
+    runtime_family: "hermes",
+    deploy_target: "remote-docker",
+    execution_target_id: "remote:build-host",
+  };
+
+  await expect(resolveHermesDockerContainer(agent)).resolves.toBe(container);
+  expect(mockBackendFor).toHaveBeenCalledWith(agent);
+  expect(getContainer).toHaveBeenCalledWith("remote-hermes-1");
+});
+
+it("fails explicitly when the selected backend cannot provide a Docker archive", async () => {
+  mockBackendFor.mockResolvedValue({});
+
+  await expect(
+    resolveHermesDockerContainer({
+      container_id: "hermes-k8s-1",
+      runtime_family: "hermes",
+      deploy_target: "k8s",
+    }),
+  ).rejects.toMatchObject({ code: "MIGRATION_CAPTURE_UNSUPPORTED", statusCode: 409 });
+});

--- a/backend-api/__tests__/agents.test.ts
+++ b/backend-api/__tests__/agents.test.ts
@@ -11,6 +11,12 @@ process.env.JWT_SECRET = JWT_SECRET;
 
 const mockDbClient = { query: jest.fn(), release: jest.fn() };
 const mockDb = { query: jest.fn(), connect: jest.fn() };
+const mockActivationLockClient = {
+  connect: jest.fn(),
+  query: jest.fn(),
+  end: jest.fn(),
+};
+const mockPgClient = jest.fn(() => mockActivationLockClient);
 const mockAddDeploymentJob = jest.fn();
 const mockCancelDeploymentJobsForAgent = jest.fn();
 const mockEnsureDemoProvider = jest.fn();
@@ -69,6 +75,10 @@ const mockGetDeploymentDefaults = jest.fn().mockResolvedValue({
 const mockGetAgentHubSourceApiKey = jest.fn().mockResolvedValue("nora_hub_test_key");
 const mockAssertKubernetesExecutionTargetAvailable = jest.fn().mockResolvedValue();
 jest.mock("../db", () => mockDb);
+jest.mock("pg", () => ({
+  ...jest.requireActual("pg"),
+  Client: mockPgClient,
+}));
 jest.mock("dockerode", () =>
   jest.fn().mockImplementation(() => ({
     ping: mockDockerPing,
@@ -357,6 +367,10 @@ beforeEach(() => {
   mockDb.connect.mockReset().mockResolvedValue(mockDbClient);
   mockDbClient.query.mockReset().mockResolvedValue({ rows: [] });
   mockDbClient.release.mockReset();
+  mockPgClient.mockReset().mockImplementation(() => mockActivationLockClient);
+  mockActivationLockClient.connect.mockReset().mockResolvedValue(undefined);
+  mockActivationLockClient.query.mockReset().mockResolvedValue({ rows: [] });
+  mockActivationLockClient.end.mockReset().mockResolvedValue(undefined);
   mockAddDeploymentJob.mockReset();
   mockCancelDeploymentJobsForAgent.mockReset().mockResolvedValue({ removed: 0, active: 0 });
   mockEnsureDemoProvider.mockReset().mockResolvedValue({
@@ -2362,9 +2376,10 @@ describe("POST /agents/activate-demo", () => {
       else locked = false;
     }
 
-    mockDb.connect.mockImplementation(async () => {
+    mockPgClient.mockImplementation(() => {
       const client = {
-        release: jest.fn(),
+        connect: jest.fn().mockResolvedValue(undefined),
+        end: jest.fn().mockResolvedValue(undefined),
         query: jest.fn(async (sql, params) => {
           if (sql.includes("pg_advisory_lock")) {
             await acquireLock();
@@ -2437,12 +2452,23 @@ describe("POST /agents/activate-demo", () => {
       }),
     );
     expect(clients).toHaveLength(2);
-    expect(clients.every((client) => client.release.mock.calls.length === 1)).toBe(true);
+    expect(clients.every((client) => client.connect.mock.calls.length === 1)).toBe(true);
+    expect(clients.every((client) => client.end.mock.calls.length === 1)).toBe(true);
+    expect(mockDb.connect).not.toHaveBeenCalled();
+    expect(mockPgClient).toHaveBeenCalledTimes(2);
+    for (const [config] of mockPgClient.mock.calls) {
+      expect(config).toEqual(
+        expect.objectContaining({ application_name: "nora-backend-demo-activation" }),
+      );
+      expect(config).not.toHaveProperty("max");
+      expect(config).not.toHaveProperty("idleTimeoutMillis");
+    }
   });
 
   it("removes the new deployment and agent when queueing fails", async () => {
     const client = {
-      release: jest.fn(),
+      connect: jest.fn().mockResolvedValue(undefined),
+      end: jest.fn().mockResolvedValue(undefined),
       query: jest.fn(async (sql, params) => {
         if (sql.includes("FROM agents") && sql.includes("template_payload @>")) {
           return { rows: [] };
@@ -2470,7 +2496,7 @@ describe("POST /agents/activate-demo", () => {
         return { rows: [] };
       }),
     };
-    mockDb.connect.mockResolvedValue(client);
+    mockPgClient.mockImplementation(() => client);
     mockAddDeploymentJob.mockRejectedValue(new Error("Redis unavailable"));
 
     const response = await auth(request(app).post("/agents/activate-demo").send({}));
@@ -2484,7 +2510,7 @@ describe("POST /agents/activate-demo", () => {
       "agent-demo-failed",
       "user-1",
     ]);
-    expect(client.release).toHaveBeenCalledTimes(1);
+    expect(client.end).toHaveBeenCalledTimes(1);
   });
 
   it("resets and requeues the same demo agent after a terminal deployment failure", async () => {
@@ -2509,7 +2535,8 @@ describe("POST /agents/activate-demo", () => {
     };
     const queuedAgent = { ...failedAgent, status: "queued", container_id: null };
     const client = {
-      release: jest.fn(),
+      connect: jest.fn().mockResolvedValue(undefined),
+      end: jest.fn().mockResolvedValue(undefined),
       query: jest.fn(async (sql) => {
         if (sql.includes("FROM agents") && sql.includes("template_payload @>")) {
           return { rows: [failedAgent] };
@@ -2520,7 +2547,7 @@ describe("POST /agents/activate-demo", () => {
         return { rows: [] };
       }),
     };
-    mockDb.connect.mockResolvedValue(client);
+    mockPgClient.mockImplementation(() => client);
     mockAddDeploymentJob.mockResolvedValue(undefined);
 
     const response = await auth(request(app).post("/agents/activate-demo").send({}));
@@ -2560,14 +2587,15 @@ describe("POST /agents/activate-demo", () => {
       container_name: "nora-oclaw-demo-agent-active",
     };
     const client = {
-      release: jest.fn(),
+      connect: jest.fn().mockResolvedValue(undefined),
+      end: jest.fn().mockResolvedValue(undefined),
       query: jest.fn(async (sql) =>
         sql.includes("FROM agents") && sql.includes("template_payload @>")
           ? { rows: [failedAgent] }
           : { rows: [] },
       ),
     };
-    mockDb.connect.mockResolvedValue(client);
+    mockPgClient.mockImplementation(() => client);
     mockCancelDeploymentJobsForAgent.mockResolvedValue({ removed: 0, active: 1 });
 
     const response = await auth(request(app).post("/agents/activate-demo").send({}));
@@ -2603,14 +2631,15 @@ describe("POST /agents/activate-demo", () => {
       container_id: "stopped-demo-container",
     };
     const client = {
-      release: jest.fn(),
+      connect: jest.fn().mockResolvedValue(undefined),
+      end: jest.fn().mockResolvedValue(undefined),
       query: jest.fn(async (sql) =>
         sql.includes("FROM agents") && sql.includes("template_payload @>")
           ? { rows: [stoppedAgent] }
           : { rows: [] },
       ),
     };
-    mockDb.connect.mockResolvedValue(client);
+    mockPgClient.mockImplementation(() => client);
 
     const response = await auth(request(app).post("/agents/activate-demo").send({}));
 
@@ -2624,7 +2653,8 @@ describe("POST /agents/activate-demo", () => {
 
   it("rejects activation with an actionable error when local Docker is unavailable", async () => {
     const client = {
-      release: jest.fn(),
+      connect: jest.fn().mockResolvedValue(undefined),
+      end: jest.fn().mockResolvedValue(undefined),
       query: jest.fn(async (sql) => {
         if (sql.includes("FROM agents") && sql.includes("template_payload @>")) {
           return { rows: [] };
@@ -2632,7 +2662,7 @@ describe("POST /agents/activate-demo", () => {
         return { rows: [] };
       }),
     };
-    mockDb.connect.mockResolvedValue(client);
+    mockPgClient.mockImplementation(() => client);
     mockDockerPing.mockImplementationOnce((callback) =>
       callback(new Error("connect ENOENT /var/run/docker.sock")),
     );
@@ -2661,14 +2691,15 @@ describe("POST /agents/activate-demo", () => {
       container_id: "restored-container",
     };
     const client = {
-      release: jest.fn(),
+      connect: jest.fn().mockResolvedValue(undefined),
+      end: jest.fn().mockResolvedValue(undefined),
       query: jest.fn(async (sql) =>
         sql.includes("FROM agents") && sql.includes("template_payload @>")
           ? { rows: [existingAgent] }
           : { rows: [] },
       ),
     };
-    mockDb.connect.mockResolvedValue(client);
+    mockPgClient.mockImplementation(() => client);
     mockDockerPing.mockImplementationOnce((callback) =>
       callback(new Error("connect ENOENT /var/run/docker.sock")),
     );
@@ -2685,10 +2716,11 @@ describe("POST /agents/activate-demo", () => {
   it("rejects durable demo activation when the Docker deploy target is disabled", async () => {
     process.env.ENABLED_BACKENDS = "k8s";
     const client = {
-      release: jest.fn(),
+      connect: jest.fn().mockResolvedValue(undefined),
+      end: jest.fn().mockResolvedValue(undefined),
       query: jest.fn().mockResolvedValue({ rows: [] }),
     };
-    mockDb.connect.mockResolvedValue(client);
+    mockPgClient.mockImplementation(() => client);
 
     const response = await auth(request(app).post("/agents/activate-demo").send({}));
 

--- a/backend-api/__tests__/authSync.test.ts
+++ b/backend-api/__tests__/authSync.test.ts
@@ -9,6 +9,10 @@ const mockIsKubernetesAgent = jest.fn();
 const mockUpdateEnv = jest.fn();
 const mockPersistLifecycleRuntimeAddress = jest.fn();
 const mockGetProviderKeys = jest.fn();
+const mockGetProviderEndpoints = jest.fn();
+const mockBuildBaseUrlEnvVars = jest.fn();
+const mockBuildApiVersionEnvVars = jest.fn();
+const mockBuildDeploymentEnvVars = jest.fn();
 const mockBuildAuthProfiles = jest.fn();
 const mockGetIntegrationEnvVars = jest.fn();
 const mockEvictConnection = jest.fn();
@@ -26,9 +30,23 @@ jest.mock("../llmProviders", () => ({
   PROVIDERS: [
     { id: "openai", envVar: "OPENAI_API_KEY" },
     { id: "google", envVar: "GEMINI_API_KEY" },
+    { id: "microsoft-foundry", envVar: "MICROSOFT_FOUNDRY_API_KEY" },
   ],
   getProviderKeys: mockGetProviderKeys,
+  getProviderEndpoints: mockGetProviderEndpoints,
+  buildBaseUrlEnvVars: mockBuildBaseUrlEnvVars,
+  buildApiVersionEnvVars: mockBuildApiVersionEnvVars,
+  buildDeploymentEnvVars: mockBuildDeploymentEnvVars,
   buildAuthProfiles: mockBuildAuthProfiles,
+  getManagedProviderEnvNames: ({ runtimeFamily } = {}) =>
+    runtimeFamily === "hermes"
+      ? [
+          "OPENAI_API_KEY",
+          "GEMINI_API_KEY",
+          "NORA_HERMES_MANAGED_ENV_B64",
+          "NORA_HERMES_MODEL_CONFIG_B64",
+        ]
+      : ["OPENAI_API_KEY", "GEMINI_API_KEY", "NORA_DEFAULT_OPENCLAW_MODEL"],
 }));
 jest.mock("../integrations", () => ({
   getIntegrationEnvVars: mockGetIntegrationEnvVars,
@@ -46,6 +64,7 @@ const {
   runContainerCommand,
   syncAuthToUserAgents,
   writeAuthToContainer,
+  writeHermesEnvToContainer,
 } = require("../authSync");
 
 function jsonResponse(body, status = 200) {
@@ -101,6 +120,16 @@ describe("auth sync", () => {
     mockGetProviderKeys.mockReset().mockResolvedValue({
       OPENAI_API_KEY: "sk-live-test",
     });
+    mockGetProviderEndpoints.mockReset().mockResolvedValue({
+      byEnvVar: {},
+      byProvider: {},
+      apiVersionByEnvVar: {},
+      apiVersionByProvider: {},
+      deploymentByEnvVar: {},
+    });
+    mockBuildBaseUrlEnvVars.mockReset().mockReturnValue({});
+    mockBuildApiVersionEnvVars.mockReset().mockReturnValue({});
+    mockBuildDeploymentEnvVars.mockReset().mockReturnValue({});
     mockBuildAuthProfiles.mockReset().mockReturnValue({
       version: 1,
       profiles: {
@@ -207,17 +236,107 @@ describe("auth sync", () => {
         gatewayPort: 18789,
       }),
     );
+    const runtimeWriteOrders = global.fetch.mock.invocationCallOrder;
+    expect(Math.max(...runtimeWriteOrders)).toBeLessThan(mockRestart.mock.invocationCallOrder[0]);
+    expect(mockRestart.mock.invocationCallOrder[0]).toBeLessThan(
+      mockWaitForAgentReadiness.mock.invocationCallOrder[0],
+    );
     expect(JSON.parse(global.fetch.mock.calls[1][1].body).command).toContain(
       '"primary": "openai/gpt-5.5"',
     );
     // Kubernetes restarts are rollouts: the replacement pod re-seeds auth
     // from the Deployment env, so the sync must patch it too.
-    expect(mockUpdateEnv).toHaveBeenCalledWith(expect.objectContaining({ id: "agent-k8s-1" }), {
-      GITHUB_TOKEN: "gh-tok",
-      OPENAI_API_KEY: "sk-live-test",
-      NORA_DEFAULT_OPENCLAW_MODEL: "openai/gpt-5.5",
-    });
+    expect(mockUpdateEnv).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "agent-k8s-1" }),
+      {
+        GITHUB_TOKEN: "gh-tok",
+        OPENAI_API_KEY: "sk-live-test",
+        NORA_DEFAULT_OPENCLAW_MODEL: "openai/gpt-5.5",
+      },
+      {
+        managedEnvNames: ["OPENAI_API_KEY", "GEMINI_API_KEY", "NORA_DEFAULT_OPENCLAW_MODEL"],
+      },
+    );
     expect(results).toEqual([{ agentId: "agent-k8s-1", status: "synced" }]);
+  });
+
+  it("writes auth, custom providers, and the default model before one restart with readiness last", async () => {
+    const foundryBaseUrl = "https://resource.openai.azure.com/openai/v1";
+    mockDb.query
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            provider: "microsoft-foundry",
+            model: "openai/gpt-5.5-1",
+            config: { base_url: foundryBaseUrl },
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: "agent-k8s-foundry",
+            container_id: "oclaw-foundry-123",
+            backend_type: "k8s",
+            host: "agent.internal",
+            runtime_host: "runtime.internal",
+            runtime_port: 9090,
+            gateway_host_port: null,
+            gateway_host: "gateway.internal",
+            gateway_port: 18789,
+          },
+        ],
+      });
+    mockGetProviderKeys.mockResolvedValue({ MICROSOFT_FOUNDRY_API_KEY: "ms-live-test" });
+    mockGetProviderEndpoints.mockResolvedValue({
+      byEnvVar: { MICROSOFT_FOUNDRY_API_KEY: foundryBaseUrl },
+      byProvider: { "microsoft-foundry": foundryBaseUrl },
+      apiVersionByEnvVar: {},
+      apiVersionByProvider: {},
+      deploymentByEnvVar: { MICROSOFT_FOUNDRY_API_KEY: "gpt-5.5-1" },
+    });
+    mockBuildBaseUrlEnvVars.mockReturnValue({ MICROSOFT_FOUNDRY_BASE_URL: foundryBaseUrl });
+    mockBuildDeploymentEnvVars.mockReturnValue({
+      MICROSOFT_FOUNDRY_DEPLOYMENT: "gpt-5.5-1",
+    });
+    mockBuildAuthProfiles.mockReturnValue({
+      version: 1,
+      profiles: {
+        "microsoft-foundry:default": {
+          type: "api_key",
+          provider: "microsoft-foundry",
+          key: "ms-live-test",
+          endpoint: foundryBaseUrl,
+        },
+      },
+      order: { "microsoft-foundry": ["microsoft-foundry:default"] },
+      lastGood: { "microsoft-foundry": "microsoft-foundry:default" },
+    });
+    global.fetch
+      .mockResolvedValueOnce(jsonResponse({ exitCode: 0, stdout: "", stderr: "" }))
+      .mockResolvedValueOnce(jsonResponse({ exitCode: 0, stdout: "", stderr: "" }))
+      .mockResolvedValueOnce(jsonResponse({ exitCode: 0, stdout: "", stderr: "" }));
+    mockWaitForAgentReadiness.mockImplementationOnce(async () => {
+      expect(global.fetch).toHaveBeenCalledTimes(3);
+      expect(mockRestart).toHaveBeenCalledTimes(1);
+      return { ok: true, runtime: { ok: true }, gateway: { ok: true } };
+    });
+
+    const results = await syncAuthToUserAgents("user-1");
+
+    const commands = global.fetch.mock.calls.map(([, options]) => JSON.parse(options.body).command);
+    expect(commands[0]).toContain("__NORA_OPENCLAW_AUTH_SQLITE_IMPORT__");
+    expect(commands[1]).toContain('"azure-openai-responses"');
+    expect(commands[1]).toContain('"apiKey": "ms-live-test"');
+    expect(commands[2]).toContain('"primary": "azure-openai-responses/gpt-5.5-1"');
+    expect(mockRestart).toHaveBeenCalledTimes(1);
+    expect(Math.max(...global.fetch.mock.invocationCallOrder)).toBeLessThan(
+      mockRestart.mock.invocationCallOrder[0],
+    );
+    expect(mockRestart.mock.invocationCallOrder[0]).toBeLessThan(
+      mockWaitForAgentReadiness.mock.invocationCallOrder[0],
+    );
+    expect(results).toEqual([{ agentId: "agent-k8s-foundry", status: "synced" }]);
   });
 
   it("uses a refreshed Proxmox address for readiness after auth-sync restart", async () => {
@@ -469,6 +588,12 @@ describe("auth sync", () => {
         checkGateway: false,
       }),
     );
+    expect(Math.max(...mockExec.mock.invocationCallOrder)).toBeLessThan(
+      mockRestart.mock.invocationCallOrder[0],
+    );
+    expect(mockRestart.mock.invocationCallOrder[0]).toBeLessThan(
+      mockWaitForAgentReadiness.mock.invocationCallOrder[0],
+    );
     expect(global.fetch).not.toHaveBeenCalled();
     expect(results).toEqual([{ agentId: "agent-hermes-1", status: "synced" }]);
   });
@@ -511,6 +636,124 @@ describe("auth sync", () => {
     expect(configScript).toContain("repair_surrogates(load_config() or {})");
     expect(configScript).toContain("save_config(config)");
     expect(configScript).not.toContain("json.dumps(config, indent=2)");
+  });
+
+  it("replaces Kubernetes Hermes provider env and model bootstrap in one update", async () => {
+    mockDb.query
+      .mockResolvedValueOnce({
+        rows: [{ provider: "openai", model: "gpt-5.5", config: {} }],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: "agent-hermes-k8s",
+            container_id: "hermes-agent-k8s",
+            backend_type: "k8s",
+            runtime_family: "hermes",
+            host: "hermes-agent.hermes-agents.svc.cluster.local",
+            runtime_host: "hermes-agent.hermes-agents.svc.cluster.local",
+            runtime_port: 8642,
+            gateway_host_port: null,
+            gateway_host: null,
+            gateway_port: null,
+          },
+        ],
+      });
+
+    const results = await syncAuthToUserAgents("user-1");
+
+    expect(mockUpdateEnv).toHaveBeenCalledTimes(1);
+    const [, managedEnv, options] = mockUpdateEnv.mock.calls[0];
+    expect(managedEnv.OPENAI_API_KEY).toBe("sk-live-test");
+    expect(managedEnv.NORA_HERMES_MANAGED_ENV_B64).toBeTruthy();
+    expect(
+      JSON.parse(Buffer.from(managedEnv.NORA_HERMES_MODEL_CONFIG_B64, "base64").toString("utf8")),
+    ).toEqual(
+      expect.objectContaining({
+        provider: "custom",
+        defaultModel: "gpt-5.5",
+        baseUrl: "https://api.openai.com/v1",
+        apiKey: "sk-live-test",
+      }),
+    );
+    expect(options.managedEnvNames).toEqual(
+      expect.arrayContaining([
+        "OPENAI_API_KEY",
+        "NORA_HERMES_MANAGED_ENV_B64",
+        "NORA_HERMES_MODEL_CONFIG_B64",
+      ]),
+    );
+    expect(mockExec).not.toHaveBeenCalled();
+    expect(mockRestart).toHaveBeenCalledTimes(1);
+    expect(results).toEqual([{ agentId: "agent-hermes-k8s", status: "synced" }]);
+  });
+
+  it("preserves the Kubernetes Hermes model bootstrap during channel-only env writes", async () => {
+    await writeHermesEnvToContainer(
+      {
+        id: "agent-hermes-k8s-channel",
+        backend_type: "k8s",
+        runtime_family: "hermes",
+        container_id: "hermes-agent-k8s-channel",
+      },
+      { TELEGRAM_BOT_TOKEN: "telegram-test-token" },
+    );
+
+    expect(mockUpdateEnv).toHaveBeenCalledTimes(1);
+    const [, managedEnv, options] = mockUpdateEnv.mock.calls[0];
+    expect(managedEnv.NORA_HERMES_MANAGED_ENV_B64).toBeTruthy();
+    expect(managedEnv.NORA_HERMES_MODEL_CONFIG_B64).toBeUndefined();
+    expect(options.managedEnvNames).toEqual(
+      expect.arrayContaining(["OPENAI_API_KEY", "GEMINI_API_KEY", "NORA_HERMES_MANAGED_ENV_B64"]),
+    );
+    expect(options.managedEnvNames).not.toContain("NORA_HERMES_MODEL_CONFIG_B64");
+  });
+
+  it("removes Kubernetes Hermes managed provider state after the last provider is deleted", async () => {
+    mockGetProviderKeys.mockResolvedValue({});
+    mockGetIntegrationEnvVars.mockResolvedValue({});
+    mockDb.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: "agent-hermes-k8s-empty",
+            container_id: "hermes-agent-k8s-empty",
+            backend_type: "k8s",
+            runtime_family: "hermes",
+            host: "hermes-agent.hermes-agents.svc.cluster.local",
+            runtime_host: "hermes-agent.hermes-agents.svc.cluster.local",
+            runtime_port: 8642,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            model_config: {
+              provider: "custom",
+              defaultModel: "gpt-5.5",
+              baseUrl: "https://api.openai.com/v1",
+              apiKey: "deleted-secret",
+            },
+            channel_configs: {},
+          },
+        ],
+      });
+
+    await syncAuthToUserAgents("user-1");
+
+    expect(mockUpdateEnv).toHaveBeenCalledTimes(1);
+    const [, managedEnv, options] = mockUpdateEnv.mock.calls[0];
+    expect(managedEnv).toEqual({});
+    expect(options.managedEnvNames).toEqual(
+      expect.arrayContaining([
+        "OPENAI_API_KEY",
+        "NORA_HERMES_MANAGED_ENV_B64",
+        "NORA_HERMES_MODEL_CONFIG_B64",
+      ]),
+    );
+    expect(mockRestart).toHaveBeenCalledTimes(1);
   });
 
   it("builds a shell-parseable Hermes env rewrite command", () => {

--- a/backend-api/__tests__/containerManager.test.ts
+++ b/backend-api/__tests__/containerManager.test.ts
@@ -398,6 +398,38 @@ describe("containerManager NemoClaw routing", () => {
     expect(mockStart).not.toHaveBeenCalled();
   });
 
+  it("reloads a remote host profile for each lifecycle operation", async () => {
+    mockGetRemoteHostProfile
+      .mockResolvedValueOnce({
+        id: "my-laptop",
+        executionTargetId: "remote:my-laptop",
+        sshHost: "198.51.100.10",
+        sshUser: "operator",
+        configured: true,
+      })
+      .mockResolvedValueOnce({
+        id: "my-laptop",
+        executionTargetId: "remote:my-laptop",
+        sshHost: "198.51.100.11",
+        sshUser: "operator",
+        configured: true,
+      });
+    const containerManager = require("../containerManager");
+    const agent = {
+      runtime_family: "openclaw",
+      deploy_target: "remote-docker",
+      execution_target_id: "remote:my-laptop",
+      backend_type: "remote-docker",
+      container_id: "oclaw-agent-remote",
+    };
+
+    await containerManager.start(agent);
+    await containerManager.start(agent);
+
+    expect(mockGetRemoteHostProfile).toHaveBeenCalledTimes(2);
+    expect(mockRemoteStart).toHaveBeenCalledTimes(2);
+  });
+
   it("routes a remote Hermes agent to the remote-hermes backend (not remote-docker)", async () => {
     mockGetRemoteHostProfile.mockResolvedValue({
       id: "my-laptop",

--- a/backend-api/__tests__/llmProviders.test.ts
+++ b/backend-api/__tests__/llmProviders.test.ts
@@ -1,9 +1,15 @@
 // @ts-nocheck
-const mockDbClient = { query: jest.fn(), release: jest.fn() };
-const mockDb = { query: jest.fn(), connect: jest.fn() };
+const mockDbClient = {
+  connect: jest.fn(),
+  query: jest.fn(),
+  end: jest.fn(),
+};
+const mockDb = { query: jest.fn() };
+const mockPgClient = jest.fn(() => mockDbClient);
 const mockEncrypt = jest.fn((value) => `enc(${value})`);
 
 jest.mock("../db", () => mockDb);
+jest.mock("pg", () => ({ Client: mockPgClient }));
 jest.mock("../crypto", () => ({
   encrypt: mockEncrypt,
   decrypt: jest.fn(),
@@ -13,15 +19,19 @@ jest.mock("../crypto", () => ({
 const {
   addProvider,
   buildAuthProfiles,
+  deleteProvider,
   ensureDemoProvider,
   getDeploymentProvider,
+  getManagedProviderEnvNames,
+  updateProvider,
 } = require("../llmProviders");
 
 beforeEach(() => {
   mockDb.query.mockReset();
-  mockDb.connect.mockReset().mockResolvedValue(mockDbClient);
-  mockDbClient.query.mockReset();
-  mockDbClient.release.mockReset();
+  mockPgClient.mockClear();
+  mockDbClient.connect.mockReset().mockResolvedValue(undefined);
+  mockDbClient.query.mockReset().mockResolvedValue({ rows: [] });
+  mockDbClient.end.mockReset().mockResolvedValue(undefined);
   mockEncrypt.mockClear();
 });
 
@@ -102,8 +112,8 @@ describe("llmProviders demo/default transitions", () => {
 
   it("promotes the first real provider when demo is the current default", async () => {
     mockDbClient.query
+      .mockResolvedValueOnce({ rows: [] }) // session advisory lock
       .mockResolvedValueOnce({ rows: [] }) // BEGIN
-      .mockResolvedValueOnce({ rows: [] }) // advisory lock
       .mockResolvedValueOnce({ rows: [{ provider_count: 1, demo_is_default: true }] })
       .mockResolvedValueOnce({ rows: [] }) // clear demo default
       .mockResolvedValueOnce({
@@ -125,7 +135,7 @@ describe("llmProviders demo/default transitions", () => {
       "UPDATE llm_providers SET is_default = false WHERE user_id = $1",
       ["user-1"],
     );
-    expect(mockDbClient.release).toHaveBeenCalledTimes(1);
+    expect(mockDbClient.end).toHaveBeenCalledTimes(1);
   });
 
   it("does not replace an existing real default when ensuring demo", async () => {
@@ -156,7 +166,9 @@ describe("llmProviders demo/default transitions", () => {
     mockDbClient.query
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [{ provider_count: 2, demo_is_default: false }] })
+      .mockResolvedValueOnce({
+        rows: [{ provider_count: 2, has_default: true, demo_is_default: false }],
+      })
       .mockResolvedValueOnce({
         rows: [{ id: "provider-groq", provider: "groq", model: null, is_default: false }],
       })
@@ -171,6 +183,215 @@ describe("llmProviders demo/default transitions", () => {
     expect(mockDbClient.query).not.toHaveBeenCalledWith(
       "UPDATE llm_providers SET is_default = false WHERE user_id = $1",
       expect.anything(),
+    );
+  });
+
+  it("serializes default changes and the provider update in one mutation-lock transaction", async () => {
+    mockDbClient.query
+      .mockResolvedValueOnce({ rows: [] }) // session advisory lock
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // clear previous default
+      .mockResolvedValueOnce({
+        rows: [{ id: "provider-openai", provider: "openai", model: "gpt-5.5", is_default: true }],
+      })
+      .mockResolvedValueOnce({ rows: [] }); // COMMIT
+
+    const result = await updateProvider("provider-openai", "user-1", {
+      model: "gpt-5.5",
+      is_default: true,
+    });
+
+    expect(result).toEqual(expect.objectContaining({ id: "provider-openai", is_default: true }));
+    expect(mockDb.query).not.toHaveBeenCalled();
+    expect(
+      mockDbClient.query.mock.calls.map(([sql]) => sql.trim().split(/\s+/).slice(0, 3).join(" ")),
+    ).toEqual([
+      "SELECT pg_advisory_lock(hashtextextended($1, 0))",
+      "BEGIN",
+      "UPDATE llm_providers SET",
+      "UPDATE llm_providers SET",
+      "COMMIT",
+      "SELECT pg_advisory_unlock(hashtextextended($1, 0))",
+    ]);
+    expect(mockDbClient.end).toHaveBeenCalledTimes(1);
+  });
+
+  it("repairs a historical missing default when adding another provider", async () => {
+    mockDbClient.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [{ provider_count: 1, has_default: false, demo_is_default: false }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ id: "provider-groq", provider: "groq", model: null, is_default: true }],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await expect(addProvider("user-1", "groq", "gsk-live")).resolves.toEqual(
+      expect.objectContaining({ id: "provider-groq", is_default: true }),
+    );
+  });
+
+  it("serializes provider deletion with deployment finalization", async () => {
+    mockDbClient.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: "provider-openai" }] })
+      .mockResolvedValueOnce({ rows: [{ id: "provider-google" }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await expect(deleteProvider("provider-openai", "user-1")).resolves.toEqual({ success: true });
+
+    expect(mockDb.query).not.toHaveBeenCalled();
+    expect(mockDbClient.query).toHaveBeenNthCalledWith(
+      1,
+      "SELECT pg_advisory_lock(hashtextextended($1, 0))",
+      ["nora:llm-providers:user-1"],
+    );
+    expect(mockDbClient.query).toHaveBeenNthCalledWith(
+      3,
+      "DELETE FROM llm_providers WHERE id = $1 AND user_id = $2 RETURNING id",
+      ["provider-openai", "user-1"],
+    );
+    expect(mockDbClient.query.mock.calls[3][0]).toContain("NOT EXISTS");
+    expect(mockDbClient.end).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs afterCommit after commit while the session advisory lock is still held", async () => {
+    const order = [];
+    mockDb.query.mockImplementation(async () => {
+      order.push("main-pool-sync");
+      return { rows: [] };
+    });
+    mockDbClient.query.mockImplementation(async (sql) => {
+      if (sql.includes("pg_advisory_lock")) order.push("lock");
+      else if (sql === "BEGIN") order.push("begin");
+      else if (sql.startsWith("UPDATE llm_providers SET model")) {
+        order.push("update");
+        return {
+          rows: [
+            {
+              id: "provider-openai",
+              provider: "openai",
+              model: "gpt-5.5-pro",
+              is_default: true,
+            },
+          ],
+        };
+      } else if (sql.includes("WITH candidate")) order.push("repair-default");
+      else if (sql === "COMMIT") order.push("commit");
+      else if (sql.includes("pg_advisory_unlock")) order.push("unlock");
+      return { rows: [] };
+    });
+
+    await updateProvider(
+      "provider-openai",
+      "user-1",
+      { model: "gpt-5.5-pro" },
+      {
+        afterCommit: async (result) => {
+          order.push(`sync:${result.model}`);
+          await mockDb.query("SELECT provider sync state");
+        },
+      },
+    );
+
+    expect(order).toEqual([
+      "lock",
+      "begin",
+      "update",
+      "repair-default",
+      "commit",
+      "sync:gpt-5.5-pro",
+      "main-pool-sync",
+      "unlock",
+    ]);
+    expect(mockPgClient).toHaveBeenCalledWith(
+      expect.objectContaining({
+        application_name: "nora-backend-provider-mutation",
+      }),
+    );
+    expect(mockPgClient.mock.calls[0][0]).not.toHaveProperty("max");
+    expect(mockPgClient.mock.calls[0][0]).not.toHaveProperty("idleTimeoutMillis");
+  });
+
+  it("does not run afterCommit when the mutation rolls back", async () => {
+    const afterCommit = jest.fn();
+    mockDbClient.query
+      .mockResolvedValueOnce({ rows: [] }) // lock
+      .mockResolvedValueOnce({ rows: [] }) // BEGIN
+      .mockResolvedValueOnce({ rows: [] }) // clear defaults
+      .mockResolvedValueOnce({ rows: [] }) // missing provider
+      .mockResolvedValueOnce({ rows: [] }) // ROLLBACK
+      .mockResolvedValueOnce({ rows: [{ pg_advisory_unlock: true }] });
+
+    await expect(
+      updateProvider("missing-provider", "user-1", { is_default: true }, { afterCommit }),
+    ).rejects.toThrow("Provider not found");
+
+    expect(afterCommit).not.toHaveBeenCalled();
+    expect(mockDbClient.query).toHaveBeenLastCalledWith(
+      "SELECT pg_advisory_unlock(hashtextextended($1, 0))",
+      ["nora:llm-providers:user-1"],
+    );
+  });
+
+  it("keeps a sole provider as the default when a client tries to unset it", async () => {
+    mockDbClient.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({
+        rows: [{ id: "provider-openai", provider: "openai", model: "gpt-5.5", is_default: false }],
+      })
+      .mockResolvedValueOnce({ rows: [{ id: "provider-openai" }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await expect(
+      updateProvider("provider-openai", "user-1", { is_default: false }),
+    ).resolves.toEqual(expect.objectContaining({ id: "provider-openai", is_default: true }));
+  });
+
+  it("rolls back a default switch when the target provider does not exist", async () => {
+    mockDbClient.query
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await expect(
+      updateProvider("missing-provider", "user-1", { is_default: true }),
+    ).rejects.toThrow("Provider not found");
+
+    expect(mockDbClient.query).toHaveBeenCalledWith("ROLLBACK");
+    expect(mockDbClient.query).not.toHaveBeenCalledWith("COMMIT");
+    expect(mockDbClient.query).toHaveBeenLastCalledWith(
+      "SELECT pg_advisory_unlock(hashtextextended($1, 0))",
+      ["nora:llm-providers:user-1"],
+    );
+    expect(mockDbClient.end).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects non-boolean default flags before opening a transaction", async () => {
+    await expect(
+      updateProvider("provider-openai", "user-1", { is_default: "false" }),
+    ).rejects.toThrow("is_default must be a boolean");
+    expect(mockPgClient).not.toHaveBeenCalled();
+  });
+
+  it("enumerates the runtime-owned provider env set for replacement updates", () => {
+    expect(getManagedProviderEnvNames({ runtimeFamily: "openclaw" })).toEqual(
+      expect.arrayContaining([
+        "OPENAI_API_KEY",
+        "OPENAI_BASE_URL",
+        "OPENAI_API_VERSION",
+        "MICROSOFT_FOUNDRY_DEPLOYMENT",
+        "NORA_DEFAULT_OPENCLAW_MODEL",
+      ]),
+    );
+    expect(getManagedProviderEnvNames({ runtimeFamily: "hermes" })).toEqual(
+      expect.arrayContaining(["NORA_HERMES_MANAGED_ENV_B64", "NORA_HERMES_MODEL_CONFIG_B64"]),
     );
   });
 

--- a/backend-api/__tests__/llmProvidersRoutes.test.ts
+++ b/backend-api/__tests__/llmProvidersRoutes.test.ts
@@ -3,14 +3,16 @@ const request = require("supertest");
 const express = require("express");
 
 const mockAddProvider = jest.fn();
+const mockUpdateProvider = jest.fn();
+const mockDeleteProvider = jest.fn();
 const mockSyncAuthToUserAgents = jest.fn();
 
 jest.mock("../llmProviders", () => ({
   addProvider: mockAddProvider,
   listProviders: jest.fn(),
   getAvailableProviders: jest.fn(),
-  updateProvider: jest.fn(),
-  deleteProvider: jest.fn(),
+  updateProvider: mockUpdateProvider,
+  deleteProvider: mockDeleteProvider,
 }));
 jest.mock("../authSync", () => ({
   syncAuthToUserAgents: mockSyncAuthToUserAgents,
@@ -27,11 +29,73 @@ app.use("/llm-providers", router);
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockAddProvider.mockResolvedValue({
-    id: "provider-openai",
-    provider: "openai",
-    model: "gpt-5.5",
-    is_default: true,
+  mockAddProvider.mockImplementation(async (...args) => {
+    const result = {
+      id: "provider-openai",
+      provider: "openai",
+      model: "gpt-5.5",
+      is_default: true,
+    };
+    await args[5]?.afterCommit?.(result);
+    return result;
+  });
+  mockUpdateProvider.mockImplementation(async (...args) => {
+    const result = {
+      id: "provider-openai",
+      provider: "openai",
+      model: "gpt-5.5-pro",
+      is_default: true,
+    };
+    await args[3]?.afterCommit?.(result);
+    return result;
+  });
+  mockDeleteProvider.mockImplementation(async (...args) => {
+    const result = { success: true };
+    await args[2]?.afterCommit?.(result);
+    return result;
+  });
+});
+
+describe("PUT/DELETE /llm-providers/:id", () => {
+  it("awaits update sync and reports per-agent failures", async () => {
+    mockSyncAuthToUserAgents.mockResolvedValue([
+      { agentId: "agent-1", status: "failed", error: "runtime unavailable" },
+    ]);
+
+    const response = await request(app)
+      .put("/llm-providers/provider-openai")
+      .send({ model: "gpt-5.5-pro" });
+
+    expect(response.status).toBe(200);
+    expect(mockUpdateProvider).toHaveBeenCalledWith(
+      "provider-openai",
+      "user-1",
+      { model: "gpt-5.5-pro" },
+      { afterCommit: expect.any(Function) },
+    );
+    expect(mockSyncAuthToUserAgents).toHaveBeenCalledWith("user-1");
+    expect(response.body.sync_warning).toMatch(/1 running agent/i);
+    expect(response.body.sync_results[0]).toEqual(
+      expect.objectContaining({ agentId: "agent-1", status: "failed" }),
+    );
+  });
+
+  it("awaits delete sync and returns a warning when synchronization rejects", async () => {
+    mockSyncAuthToUserAgents.mockRejectedValue(new Error("runtime sync crashed"));
+
+    const response = await request(app).delete("/llm-providers/provider-openai");
+
+    expect(response.status).toBe(200);
+    expect(mockDeleteProvider).toHaveBeenCalledWith("provider-openai", "user-1", {
+      afterCommit: expect.any(Function),
+    });
+    expect(response.body).toEqual(
+      expect.objectContaining({
+        success: true,
+        sync_results: [],
+        sync_warning: expect.stringMatching(/provider deleted/i),
+      }),
+    );
   });
 });
 
@@ -55,6 +119,7 @@ describe("POST /llm-providers", () => {
       "sk-live",
       "gpt-5.5",
       undefined,
+      { afterCommit: expect.any(Function) },
     );
     expect(mockSyncAuthToUserAgents).toHaveBeenCalledWith("user-1");
     expect(response.body).toEqual(

--- a/backend-api/__tests__/migrationPostgres.test.ts
+++ b/backend-api/__tests__/migrationPostgres.test.ts
@@ -15,6 +15,7 @@ describeWithPostgres("PostgreSQL legacy migration gate", () => {
   let migrationPool;
   let schemaName;
   let migrateDB;
+  let userId;
 
   beforeAll(async () => {
     schemaName = `nora_migration_${process.pid}_${Date.now()}`;
@@ -48,7 +49,7 @@ describeWithPostgres("PostgreSQL legacy migration gate", () => {
        VALUES($1, 'admin', 'Migration Test') RETURNING id`,
       [`migration-${Date.now()}@example.test`],
     );
-    const userId = userResult.rows[0].id;
+    userId = userResult.rows[0].id;
     const agentResult = await migrationPool.query(
       `INSERT INTO agents(user_id, name) VALUES($1, 'Legacy agent') RETURNING id`,
       [userId],
@@ -78,6 +79,13 @@ describeWithPostgres("PostgreSQL legacy migration gate", () => {
          ('installation', 'legacy-full', $1, NULL),
          ('legacy-agent', 'legacy-runtime', $1, $2)`,
       [userId, agentId],
+    );
+    await migrationPool.query(
+      `INSERT INTO llm_providers(user_id, provider, api_key, model, is_default)
+       VALUES
+         ($1, 'demo', 'legacy-demo', 'nora-demo-1', false),
+         ($1, 'openai', 'legacy-openai', 'gpt-5.5', false)`,
+      [userId],
     );
 
     const snapshots = await migrationPool.query(
@@ -146,6 +154,18 @@ describeWithPostgres("PostgreSQL legacy migration gate", () => {
        HAVING COUNT(*) > 1`,
     );
     expect(duplicateSlugs.rows).toEqual([]);
+
+    const providerDefaults = await migrationPool.query(
+      `SELECT provider, is_default
+         FROM llm_providers
+        WHERE user_id = $1
+        ORDER BY provider`,
+      [userId],
+    );
+    expect(providerDefaults.rows).toEqual([
+      { provider: "demo", is_default: false },
+      { provider: "openai", is_default: true },
+    ]);
 
     const ledger = await migrationPool.query(
       "SELECT COUNT(*)::int AS count FROM schema_migrations",

--- a/backend-api/__tests__/migrationPostgres.test.ts
+++ b/backend-api/__tests__/migrationPostgres.test.ts
@@ -42,6 +42,16 @@ describeWithPostgres("PostgreSQL legacy migration gate", () => {
       ALTER TABLE workspace_agents
         DROP CONSTRAINT IF EXISTS workspace_agents_workspace_id_agent_id_key;
       DROP INDEX IF EXISTS idx_workspace_agents_unique;
+      CREATE TABLE llm_providers (
+        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+        user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+        provider VARCHAR(30) NOT NULL,
+        api_key TEXT,
+        model VARCHAR(100),
+        config JSONB DEFAULT '{}',
+        is_default BOOLEAN DEFAULT false,
+        created_at TIMESTAMPTZ DEFAULT NOW()
+      );
     `);
 
     const userResult = await migrationPool.query(

--- a/backend-api/__tests__/provisionerProviderSelection.test.ts
+++ b/backend-api/__tests__/provisionerProviderSelection.test.ts
@@ -3,6 +3,12 @@ const mockWorkerDb = {
   query: jest.fn(),
   connect: jest.fn(),
 };
+const mockLockClient = {
+  connect: jest.fn(),
+  query: jest.fn(),
+  end: jest.fn(),
+};
+const mockPgClient = jest.fn(() => mockLockClient);
 const mockGetDeploymentProvider = jest.fn();
 const mockWorkerOn = jest.fn();
 let mockDeploymentProcessor;
@@ -24,6 +30,7 @@ jest.mock("../../workers/provisioner/node_modules/bullmq", () => ({
 }));
 jest.mock("../../workers/provisioner/node_modules/ioredis", () => jest.fn());
 jest.mock("../../workers/provisioner/node_modules/pg", () => ({
+  Client: mockPgClient,
   Pool: jest.fn().mockImplementation(() => mockWorkerDb),
 }));
 jest.mock("../lib/connectionConfig", () => ({
@@ -32,6 +39,8 @@ jest.mock("../lib/connectionConfig", () => ({
 }));
 jest.mock("../llmProviders", () => ({
   getDeploymentProvider: mockGetDeploymentProvider,
+  getManagedProviderEnvNames: jest.fn(() => []),
+  providerMutationLockKey: (userId) => `nora:llm-providers:${userId}`,
 }));
 jest.mock("../redisQueue", () => ({
   ALERT_DELIVERY_ATTEMPTS: 1,
@@ -60,6 +69,9 @@ const {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockLockClient.connect.mockReset().mockResolvedValue(undefined);
+  mockLockClient.query.mockReset().mockResolvedValue({ rows: [] });
+  mockLockClient.end.mockReset().mockResolvedValue(undefined);
   delete process.env.KEY_STORAGE;
 });
 
@@ -360,14 +372,9 @@ describe("provisioner deployment lifecycle", () => {
   });
 
   it("refuses to provision a replacement while a prior runtime identity remains", async () => {
-    const lockClient = {
-      query: jest
-        .fn()
-        .mockResolvedValueOnce({ rows: [{ locked: true }] })
-        .mockResolvedValueOnce({ rows: [{ pg_advisory_unlock: true }] }),
-      release: jest.fn(),
-    };
-    mockWorkerDb.connect.mockResolvedValue(lockClient);
+    mockLockClient.query
+      .mockResolvedValueOnce({ rows: [{ locked: true }] })
+      .mockResolvedValueOnce({ rows: [{ pg_advisory_unlock: true }] });
     mockWorkerDb.query.mockImplementation(async (sql) => {
       if (sql.includes("SELECT image, template_payload")) {
         return {
@@ -420,6 +427,6 @@ describe("provisioner deployment lifecycle", () => {
     expect(
       mockWorkerDb.query.mock.calls.some(([sql]) => String(sql).includes("status = 'deploying'")),
     ).toBe(false);
-    expect(lockClient.release).toHaveBeenCalledTimes(1);
+    expect(mockLockClient.end).toHaveBeenCalledTimes(1);
   });
 });

--- a/backend-api/__tests__/provisioning.test.ts
+++ b/backend-api/__tests__/provisioning.test.ts
@@ -528,14 +528,70 @@ describe("provisioning runtime/gateway contracts", () => {
 
     // Deployment env references the Secret; only non-sensitive values inline.
     const patch = mockPatchNamespacedDeployment.mock.calls[0][0].body;
-    const envOps = patch.filter((op) => op.path.includes("/env"));
-    const sensitiveOp = envOps.find((op) => op.value?.name === "OPENAI_API_KEY");
-    expect(sensitiveOp.value.valueFrom).toEqual({
+    const envOp = patch.find((op) => op.path.includes("/env"));
+    const sensitiveEntry = envOp.value.find((entry) => entry.name === "OPENAI_API_KEY");
+    expect(sensitiveEntry.valueFrom).toEqual({
       secretKeyRef: { name: "nora-oclaw-nora-qa-123-env", key: "OPENAI_API_KEY" },
     });
-    expect(sensitiveOp.value.value).toBeUndefined();
-    const plainOp = envOps.find((op) => op.value?.name === "PLAIN_SETTING");
-    expect(plainOp.value).toEqual({ name: "PLAIN_SETTING", value: "value" });
+    expect(sensitiveEntry.value).toBeUndefined();
+    expect(envOp.value).toContainEqual({ name: "PLAIN_SETTING", value: "value" });
+  });
+
+  it("replaces provider-owned env and Secret keys without removing unrelated settings", async () => {
+    const K8sBackend = require("../../workers/provisioner/backends/k8s");
+    const backend = new K8sBackend(k8sProfile());
+
+    mockReadNamespacedDeployment.mockResolvedValue({
+      metadata: { name: "nora-oclaw-nora-qa-123" },
+      spec: {
+        template: {
+          spec: {
+            containers: [
+              {
+                name: "agent",
+                env: [
+                  {
+                    name: "OPENAI_API_KEY",
+                    valueFrom: { secretKeyRef: { name: "env", key: "OPENAI_API_KEY" } },
+                  },
+                  { name: "OPENAI_BASE_URL", value: "https://old.example/v1" },
+                  { name: "UNRELATED_SETTING", value: "keep-me" },
+                ],
+              },
+            ],
+          },
+        },
+      },
+    });
+    mockReadNamespacedSecret.mockResolvedValue({
+      metadata: { name: "nora-oclaw-nora-qa-123-env", resourceVersion: "secret-rv" },
+      type: "Opaque",
+      data: { OPENAI_API_KEY: "b2xk", UNRELATED_TOKEN: "a2VlcA==" },
+    });
+
+    await backend.updateEnv(
+      "nora-oclaw-nora-qa-123",
+      { GEMINI_API_KEY: "gm-new" },
+      {
+        managedEnvNames: ["OPENAI_API_KEY", "OPENAI_BASE_URL", "GEMINI_API_KEY"],
+      },
+    );
+
+    const replacedSecret = mockReplaceNamespacedSecret.mock.calls[0][0].body;
+    expect(replacedSecret.data).toEqual({ UNRELATED_TOKEN: "a2VlcA==" });
+    expect(replacedSecret.stringData).toEqual({ GEMINI_API_KEY: "gm-new" });
+
+    const patch = mockPatchNamespacedDeployment.mock.calls[0][0].body;
+    const envOp = patch.find((op) => op.path.endsWith("/env"));
+    expect(envOp.value).toContainEqual({ name: "UNRELATED_SETTING", value: "keep-me" });
+    expect(envOp.value).toContainEqual({
+      name: "GEMINI_API_KEY",
+      valueFrom: {
+        secretKeyRef: { name: "nora-oclaw-nora-qa-123-env", key: "GEMINI_API_KEY" },
+      },
+    });
+    expect(envOp.value.some((entry) => entry.name === "OPENAI_API_KEY")).toBe(false);
+    expect(envOp.value.some((entry) => entry.name === "OPENAI_BASE_URL")).toBe(false);
   });
 
   it("returns node-port endpoints for docker-hosted kind verification", async () => {

--- a/backend-api/__tests__/proxmoxBackend.test.ts
+++ b/backend-api/__tests__/proxmoxBackend.test.ts
@@ -209,6 +209,13 @@ describe("ProxmoxBackend", () => {
       gatewayPort: 18789,
     });
     const onRuntimeIdentity = jest.fn().mockResolvedValue(undefined);
+    const mcpServers = [
+      {
+        name: "gitlab",
+        npmPackage: "@modelcontextprotocol/server-gitlab",
+        env: { GITLAB_PERSONAL_ACCESS_TOKEN: "glpat-proxmox" },
+      },
+    ];
 
     const result = await backend.create({
       id: "agent-1",
@@ -220,6 +227,7 @@ describe("ProxmoxBackend", () => {
       runtimeFamily: "openclaw",
       sandboxProfile: "standard",
       env: { AGENT_ID: "agent-1" },
+      mcpServers,
       onRuntimeIdentity,
     });
 
@@ -258,6 +266,10 @@ describe("ProxmoxBackend", () => {
       containerId: "101",
       containerName: "promo-agent",
     });
+    expect(backend._bootstrapOpenClaw).toHaveBeenCalledWith(
+      "101",
+      expect.objectContaining({ mcpServers }),
+    );
   });
 
   it("cleans up a partially created LXC and honors an already-aborted create", async () => {
@@ -566,7 +578,7 @@ describe("ProxmoxBackend", () => {
     ).rejects.toThrow(/does not provide the enforced OpenShell sandbox/i);
   });
 
-  it("keeps OpenClaw credentials out of the readable startup script", async () => {
+  it("keeps OpenClaw credentials out of the startup script and wires per-agent MCP", async () => {
     const backend = new ProxmoxBackend();
     jest.spyOn(backend, "_prepareOpenClawBase").mockResolvedValue(undefined);
     const writes = [];
@@ -583,6 +595,13 @@ describe("ProxmoxBackend", () => {
         AGENT_ID: "agent-3",
       },
       templatePayload: {},
+      mcpServers: [
+        {
+          name: "gitlab",
+          npmPackage: "@modelcontextprotocol/server-gitlab",
+          env: { GITLAB_PERSONAL_ACCESS_TOKEN: "glpat-proxmox-secret" },
+        },
+      ],
     });
 
     const envWrite = writes.find(([, targetPath]) => targetPath === "/etc/nora/openclaw.env.b64");
@@ -592,6 +611,9 @@ describe("ProxmoxBackend", () => {
     const customProviderWrite = writes.find(
       ([, targetPath]) => targetPath === "/etc/nora/openclaw-custom-providers.json",
     );
+    const gatewayConfigWrite = writes.find(
+      ([, targetPath]) => targetPath === "/etc/nora/openclaw-gateway-config.json",
+    );
     const serviceWrite = writes.find(
       ([, targetPath]) => targetPath === "/etc/systemd/system/nora-openclaw.service",
     );
@@ -600,14 +622,50 @@ describe("ProxmoxBackend", () => {
     expect(envWrite[3]).toBe("0600");
     expect(startWrite[2]).not.toContain("sk-live-secret");
     expect(startWrite[2]).not.toContain("foundry-secret");
+    expect(startWrite[2]).not.toContain("glpat-proxmox-secret");
     expect(startWrite[2]).toContain("openclaw.env.b64");
     expect(startWrite[2]).toContain(".nora-proxmox-bootstrap-complete");
+    expect(startWrite[2]).toContain('const replaceKeys = new Set(["mcpServers"])');
+    expect(startWrite[2]).toContain("delete next[key]");
     expect(startWrite[3]).toBe("0700");
+    expect(gatewayConfigWrite[3]).toBe("0600");
+    expect(JSON.parse(gatewayConfigWrite[2]).mcpServers).toEqual({
+      gitlab: {
+        command: "npx",
+        args: ["-y", "@modelcontextprotocol/server-gitlab"],
+        env: { GITLAB_PERSONAL_ACCESS_TOKEN: "glpat-proxmox-secret" },
+      },
+    });
     expect(customProviderWrite[2]).toContain("foundry-secret");
     expect(customProviderWrite[3]).toBe("0600");
     expect(spawnSync("sh", ["-n"], { input: startWrite[2] }).status).toBe(0);
     expect(serviceWrite[2]).toContain("NoNewPrivileges=true");
     expect(serviceWrite[2]).toContain("UMask=0077");
+  });
+
+  it("removes template MCP entries when the agent has no enabled servers", async () => {
+    const backend = new ProxmoxBackend();
+    jest.spyOn(backend, "_prepareOpenClawBase").mockResolvedValue(undefined);
+    const writes = [];
+    jest.spyOn(backend, "_writeFile").mockImplementation(async (...args) => writes.push(args));
+    jest.spyOn(backend, "_pctExec").mockResolvedValue({ stdout: "", stderr: "", code: 0 });
+
+    await backend._bootstrapOpenClaw("103", {
+      id: "agent-without-mcp",
+      env: { AGENT_ID: "agent-without-mcp" },
+      templatePayload: {},
+      mcpServers: [],
+    });
+
+    const gatewayConfigWrite = writes.find(
+      ([, targetPath]) => targetPath === "/etc/nora/openclaw-gateway-config.json",
+    );
+    const startWrite = writes.find(
+      ([, targetPath]) => targetPath === "/opt/openclaw-runtime/start.sh",
+    );
+    expect(JSON.parse(gatewayConfigWrite[2]).mcpServers).toEqual({});
+    expect(startWrite[2]).toContain('const replaceKeys = new Set(["mcpServers"])');
+    expect(startWrite[2]).toContain("delete next[key]");
   });
 
   it("streams file contents over SSH stdin instead of exposing secrets in pct argv", async () => {

--- a/backend-api/__tests__/remoteHostGatewayAllowlist.test.ts
+++ b/backend-api/__tests__/remoteHostGatewayAllowlist.test.ts
@@ -5,11 +5,32 @@
  * RFC1918), while never widening the allowlist for other agents and still
  * enforcing the hard blocked-IP floor.
  */
-jest.mock("../db", () => ({ query: jest.fn() }));
+const mockDbQuery = jest.fn();
+jest.mock("../db", () => ({ query: (...args) => mockDbQuery(...args) }));
 jest.mock("../integrations", () => ({}));
 jest.mock("../metrics", () => ({ recordMetric: jest.fn(), recordTokenUsage: jest.fn() }));
 jest.mock("../agentBudgets", () => ({ checkAndEnforce: jest.fn() }));
-jest.mock("ws", () => ({ WebSocket: class {}, WebSocketServer: class {} }));
+jest.mock("ws", () => {
+  class MockWebSocket {
+    static OPEN = 1;
+    static CONNECTING = 0;
+  }
+
+  class MockWebSocketServer {
+    constructor() {
+      this.handlers = {};
+    }
+
+    on(event, handler) {
+      this.handlers[event] = handler;
+      return this;
+    }
+
+    handleUpgrade() {}
+  }
+
+  return { WebSocket: MockWebSocket, WebSocketServer: MockWebSocketServer };
+});
 
 const mockGetRemoteHostByExecutionTarget = jest.fn();
 const mockUserCanUseRemoteHost = jest.fn().mockResolvedValue(false);
@@ -19,12 +40,16 @@ jest.mock("../remoteHosts", () => ({
 }));
 
 const {
+  allowedGatewayHostsForAgent,
+  attachGatewayWS,
   resolveSafeGatewayHttpTarget,
   resolveSafeHermesDashboardTarget,
   assertExternalEndpointReachable,
+  rpcCall,
 } = require("../gatewayProxy");
 
 const PUBLIC_IP = "203.0.113.5";
+const originalPlatformMode = process.env.PLATFORM_MODE;
 
 function remoteAgent(overrides = {}) {
   return {
@@ -39,9 +64,16 @@ function remoteAgent(overrides = {}) {
 }
 
 beforeEach(() => {
+  process.env.PLATFORM_MODE = "selfhosted";
+  mockDbQuery.mockReset();
   mockGetRemoteHostByExecutionTarget.mockReset();
   mockUserCanUseRemoteHost.mockReset();
   mockUserCanUseRemoteHost.mockResolvedValue(false);
+});
+
+afterAll(() => {
+  if (originalPlatformMode === undefined) delete process.env.PLATFORM_MODE;
+  else process.env.PLATFORM_MODE = originalPlatformMode;
 });
 
 describe("remote-host gateway allowlist (HTTP proxy)", () => {
@@ -129,6 +161,24 @@ describe("remote-host gateway allowlist (HTTP proxy)", () => {
     );
   });
 
+  it("blocks historical Remote Docker rows before a hosted-mode registry lookup", async () => {
+    process.env.PLATFORM_MODE = "paas";
+    mockGetRemoteHostByExecutionTarget.mockResolvedValue({
+      id: "my-vps",
+      ownerUserId: "user-1",
+      gatewayHost: "10.0.0.7",
+      sshHost: "10.0.0.7",
+    });
+
+    await expect(
+      resolveSafeGatewayHttpTarget(remoteAgent({ gateway_host: "10.0.0.7" }), "status"),
+    ).rejects.toMatchObject({
+      code: "REMOTE_HOSTS_DISABLED_IN_PAAS",
+      statusCode: 403,
+    });
+    expect(mockGetRemoteHostByExecutionTarget).not.toHaveBeenCalled();
+  });
+
   it("trusts a k8s agent's operator-provisioned (public LoadBalancer) address", async () => {
     // k8s exposure addresses (LB/NodePort) are operator-provisioned, so RPC/WS/HTTP
     // must reach them even when public — without a registry lookup.
@@ -177,6 +227,71 @@ describe("remote-host gateway allowlist (HTTP proxy)", () => {
     });
     const target = await resolveSafeGatewayHttpTarget(dockerAgent, "status");
     expect(target.url).toBe("http://10.0.0.10:19000/status");
+    expect(mockGetRemoteHostByExecutionTarget).not.toHaveBeenCalled();
+  });
+});
+
+describe("hosted-mode Remote Docker gateway shutdown", () => {
+  beforeEach(() => {
+    process.env.PLATFORM_MODE = "paas";
+    mockGetRemoteHostByExecutionTarget.mockResolvedValue({
+      id: "my-vps",
+      ownerUserId: "user-1",
+      gatewayHost: PUBLIC_IP,
+      sshHost: PUBLIC_IP,
+    });
+  });
+
+  it("rejects the shared allowlist boundary even when a historical public host resolves", async () => {
+    await expect(allowedGatewayHostsForAgent(remoteAgent())).rejects.toMatchObject({
+      code: "REMOTE_HOSTS_DISABLED_IN_PAAS",
+      statusCode: 403,
+    });
+    expect(mockGetRemoteHostByExecutionTarget).not.toHaveBeenCalled();
+  });
+
+  it("rejects pooled RPC before opening or reusing a remote gateway connection", async () => {
+    await expect(
+      rpcCall(remoteAgent({ gateway_token: "legacy-gateway-token" }), "status"),
+    ).rejects.toMatchObject({
+      code: "REMOTE_HOSTS_DISABLED_IN_PAAS",
+      statusCode: 403,
+    });
+    expect(mockGetRemoteHostByExecutionTarget).not.toHaveBeenCalled();
+  });
+
+  it("rejects the Remote Hermes embed path before consulting the host registry", async () => {
+    await expect(
+      resolveSafeHermesDashboardTarget({
+        ...remoteAgent(),
+        runtime_family: "hermes",
+        runtime_host: PUBLIC_IP,
+        dashboard_port: 19044,
+      }),
+    ).rejects.toMatchObject({
+      code: "REMOTE_HOSTS_DISABLED_IN_PAAS",
+      statusCode: 403,
+    });
+    expect(mockGetRemoteHostByExecutionTarget).not.toHaveBeenCalled();
+  });
+
+  it("rejects the WebSocket relay for a historical Remote Docker agent", async () => {
+    const agent = {
+      ...remoteAgent(),
+      status: "running",
+      gateway_token: "legacy-gateway-token",
+    };
+    mockDbQuery.mockResolvedValue({ rows: [agent] });
+    const server = { on: jest.fn() };
+    const wss = attachGatewayWS(server);
+    const ws = { send: jest.fn(), close: jest.fn() };
+
+    await wss.handlers.connection(ws, {}, agent.id, { id: agent.user_id });
+
+    expect(ws.send).toHaveBeenCalledWith(
+      expect.stringContaining("Remote Docker gateway access is disabled in hosted mode"),
+    );
+    expect(ws.close).toHaveBeenCalledTimes(1);
     expect(mockGetRemoteHostByExecutionTarget).not.toHaveBeenCalled();
   });
 });

--- a/backend-api/__tests__/remoteHosts.test.ts
+++ b/backend-api/__tests__/remoteHosts.test.ts
@@ -66,6 +66,7 @@ class FakeSshClient extends EventEmitter {
 jest.mock("ssh2", () => ({ Client: FakeSshClient }));
 
 const remoteHosts = require("../remoteHosts");
+const originalPlatformMode = process.env.PLATFORM_MODE;
 
 function remoteHostRow(overrides = {}) {
   return {
@@ -93,9 +94,15 @@ function remoteHostRow(overrides = {}) {
 }
 
 beforeEach(() => {
+  process.env.PLATFORM_MODE = "selfhosted";
   mockDb.query.mockReset();
   mockEnsureEncryptionConfigured.mockReset();
   sshScenario = null;
+});
+
+afterAll(() => {
+  if (originalPlatformMode === undefined) delete process.env.PLATFORM_MODE;
+  else process.env.PLATFORM_MODE = originalPlatformMode;
 });
 
 describe("rowToProfile", () => {
@@ -154,6 +161,21 @@ describe("createRemoteHost", () => {
     ).rejects.toThrow(/ENCRYPTION_KEY/);
     expect(mockDb.query).not.toHaveBeenCalled();
   });
+
+  it("disables Remote Docker registration in hosted mode", async () => {
+    process.env.PLATFORM_MODE = "paas";
+
+    await expect(
+      remoteHosts.createRemoteHost({
+        id: "internal-pivot",
+        ownerUserId: "user-1",
+        sshHost: "127.0.0.1",
+        sshUser: "operator",
+        sshPrivateKey: "PRIVATE-KEY",
+      }),
+    ).rejects.toMatchObject({ code: "REMOTE_HOSTS_DISABLED_IN_PAAS", statusCode: 403 });
+    expect(mockDb.query).not.toHaveBeenCalled();
+  });
 });
 
 describe("updateRemoteHost", () => {
@@ -166,9 +188,8 @@ describe("updateRemoteHost", () => {
     const update = mockDb.query.mock.calls[1];
     expect(update[0]).toMatch(/UPDATE remote_hosts/);
     expect(update[1][14]).toBe(true); // resetTest flag → wipes last_test_*
-    // The host-key pin is also cleared on a connection-input change so the next
-    // test re-pins the (now different) host instead of failing as a false MITM.
-    expect(update[0]).toMatch(/ssh_host_key = CASE WHEN \$15 THEN NULL ELSE ssh_host_key END/);
+    expect(update[1][15]).toBe(true); // SSH host identity changed → clear pin
+    expect(update[0]).toMatch(/ssh_host_key = CASE WHEN \$16 THEN NULL ELSE ssh_host_key END/);
   });
 
   it("keeps the prior test result when only the label changes", async () => {
@@ -178,6 +199,31 @@ describe("updateRemoteHost", () => {
     await remoteHosts.updateRemoteHost("my-laptop", { label: "Renamed" });
 
     expect(mockDb.query.mock.calls[1][1][14]).toBe(false);
+  });
+
+  it("requires a retest after credential rotation but preserves the SSH host-key pin", async () => {
+    mockDb.query.mockResolvedValueOnce({ rows: [remoteHostRow({ ssh_host_key: "pinned-key" })] });
+    mockDb.query.mockResolvedValueOnce({
+      rows: [remoteHostRow({ ssh_private_key_encrypted: "enc(NEW-KEY)", last_test_status: null })],
+    });
+
+    await remoteHosts.updateRemoteHost("my-laptop", { sshPrivateKey: "NEW-KEY" });
+
+    const update = mockDb.query.mock.calls[1];
+    expect(update[1][14]).toBe(true);
+    expect(update[1][15]).toBe(false);
+  });
+
+  it("requires a retest when the advertised gateway address changes", async () => {
+    mockDb.query.mockResolvedValueOnce({ rows: [remoteHostRow()] });
+    mockDb.query.mockResolvedValueOnce({
+      rows: [remoteHostRow({ gateway_host: "gateway.example.com", last_test_status: null })],
+    });
+
+    await remoteHosts.updateRemoteHost("my-laptop", { gatewayHost: "gateway.example.com" });
+
+    expect(mockDb.query.mock.calls[1][1][14]).toBe(true);
+    expect(mockDb.query.mock.calls[1][1][15]).toBe(false);
   });
 });
 

--- a/backend-api/agentMigrations.ts
+++ b/backend-api/agentMigrations.ts
@@ -11,6 +11,7 @@ const db = require("./db");
 const llmProviders = require("./llmProviders");
 const integrations = require("./integrations");
 const channels = require("./channels");
+const containerManager = require("./containerManager");
 const {
   buildTemplatePayloadFromAgent,
   ensureCoreTemplateFiles,
@@ -797,6 +798,19 @@ function manifestFromHermesSource({ name, workspaceFiles = [], snapshot = {}, so
   });
 }
 
+async function resolveHermesDockerContainer(agent, backendResolver = containerManager.backendFor) {
+  const backend = await backendResolver(agent);
+  if (!backend?.docker || typeof backend.docker.getContainer !== "function") {
+    const err = new Error(
+      `Hermes migration capture is not supported by the ${agent?.deploy_target || agent?.backend_type || "selected"} backend`,
+    );
+    err.statusCode = 409;
+    err.code = "MIGRATION_CAPTURE_UNSUPPORTED";
+    throw err;
+  }
+  return backend.docker.getContainer(agent.container_id);
+}
+
 async function buildLiveMigrationManifest(input = {}) {
   const runtimeFamily =
     String(input.runtime_family || input.runtimeFamily || "")
@@ -1038,7 +1052,7 @@ async function buildMigrationManifestFromAgent(agent, { userId }) {
     err.code = "NO_CONTAINER";
     throw err;
   }
-  const container = docker.getContainer(agent.container_id);
+  const container = await resolveHermesDockerContainer(agent);
   const [workspaceFiles, providerEntries, overrideMap, liveSnapshot, persistedState] =
     await Promise.all([
       getDockerArchiveFiles(container, "/opt/data/workspace"),
@@ -1316,5 +1330,6 @@ module.exports = {
   normalizeMigrationManifest,
   packMigrationBundle,
   parseUploadedMigrationBuffer,
+  resolveHermesDockerContainer,
   summarizeManifest,
 };

--- a/backend-api/authSync.ts
+++ b/backend-api/authSync.ts
@@ -20,7 +20,10 @@ const {
   buildOpenClawDefaultModelCommand,
   buildOpenClawModelForProvider,
 } = require("../agent-runtime/lib/runtimeBootstrap");
-const { buildHermesRuntimeBootstrapEnv } = require("../agent-runtime/lib/hermesRuntimeBootstrap");
+const {
+  HERMES_MODEL_CONFIG_ENV,
+  buildHermesRuntimeBootstrapEnv,
+} = require("../agent-runtime/lib/hermesRuntimeBootstrap");
 const { NEMOCLAW_DEFAULT_MODEL } = require("../agent-runtime/lib/nemoclawDefaults");
 
 const providerCatalog = Array.isArray(llmProviders.PROVIDERS)
@@ -120,8 +123,11 @@ function resolveHermesModelApiKey(defaultProvider = null, envVars = {}) {
 function attachHermesCustomApiKey(modelConfig = null, defaultProvider = null, envVars = {}) {
   if (!modelConfig || String(modelConfig.provider || "").trim() !== "custom") return modelConfig;
 
+  const sanitized = { ...modelConfig };
+  delete sanitized.apiKey;
+  delete sanitized.api_key;
   const apiKey = resolveHermesModelApiKey(defaultProvider, envVars);
-  if (!apiKey) return modelConfig;
+  if (!apiKey) return sanitized;
 
   const defaultBaseUrl = resolveHermesProviderBaseUrl(defaultProvider);
   const modelBaseUrl = String(modelConfig.baseUrl || "").trim();
@@ -130,10 +136,10 @@ function attachHermesCustomApiKey(modelConfig = null, defaultProvider = null, en
     defaultBaseUrl &&
     normalizeUrlForCompare(modelBaseUrl) !== normalizeUrlForCompare(defaultBaseUrl)
   ) {
-    return modelConfig;
+    return sanitized;
   }
 
-  return { ...modelConfig, apiKey };
+  return { ...sanitized, apiKey };
 }
 
 function resolveHermesProviderBaseUrl(defaultProvider = null) {
@@ -521,15 +527,29 @@ async function writeAuthToContainer(agent, authProfiles) {
   }
 }
 
-async function writeHermesEnvToContainer(agent, envVars) {
+async function writeHermesEnvToContainer(agent, envVars, modelConfig = undefined) {
   if (
     typeof containerManager.isKubernetesAgent === "function" &&
     containerManager.isKubernetesAgent(agent)
   ) {
-    return containerManager.updateEnv(agent, {
-      ...envVars,
-      ...buildHermesRuntimeBootstrapEnv({ envVars }),
-    });
+    const managedEnvNames = llmProviders.getManagedProviderEnvNames({ runtimeFamily: "hermes" });
+    // Channel-only writes intentionally omit modelConfig. Preserve the current
+    // Deployment model bootstrap in that case; provider synchronization passes
+    // either an object or null explicitly so it can replace or revoke it.
+    const replacementNames =
+      modelConfig === undefined
+        ? managedEnvNames.filter((name) => name !== HERMES_MODEL_CONFIG_ENV)
+        : managedEnvNames;
+    return containerManager.updateEnv(
+      agent,
+      {
+        ...envVars,
+        ...buildHermesRuntimeBootstrapEnv({ envVars, modelConfig }),
+      },
+      {
+        managedEnvNames: replacementNames,
+      },
+    );
   }
   return runContainerCommand(agent, buildHermesEnvWriteCommand(envVars));
 }
@@ -653,9 +673,11 @@ async function syncAuthToUserAgents(userId, agentId = null, options = {}) {
           hermesModelConfig = buildHermesModelConfig(defaultProvider, envVars);
           hasHermesModelConfig = true;
         }
-        const selectedHermesModelConfig = persistedModelConfig
-          ? attachHermesCustomApiKey(persistedModelConfig, defaultProvider, envVars)
-          : hermesModelConfig;
+        const selectedHermesModelConfig = defaultProvider
+          ? persistedModelConfig
+            ? attachHermesCustomApiKey(persistedModelConfig, defaultProvider, envVars)
+            : hermesModelConfig
+          : null;
         if (
           onlyIfAuthPresent &&
           Object.keys(envVars).length === 0 &&
@@ -665,11 +687,14 @@ async function syncAuthToUserAgents(userId, agentId = null, options = {}) {
           results.push({ agentId: agent.id, status: "skipped" });
           continue;
         }
-        if (selectedHermesModelConfig) {
+        const kubernetesAgent =
+          typeof containerManager.isKubernetesAgent === "function" &&
+          containerManager.isKubernetesAgent(agent);
+        if (!kubernetesAgent && (selectedHermesModelConfig || !defaultProvider)) {
           const { persistHermesModelConfig } = require("./hermesUi");
-          await persistHermesModelConfig(agent, selectedHermesModelConfig);
+          await persistHermesModelConfig(agent, selectedHermesModelConfig || {});
         }
-        await writeHermesEnvToContainer(agent, envVars);
+        await writeHermesEnvToContainer(agent, envVars, selectedHermesModelConfig);
         await restartAgentAndRefreshAddress(agent);
         const readiness = await waitForAgentReadiness({
           host: agent.host,
@@ -709,9 +734,11 @@ async function syncAuthToUserAgents(userId, agentId = null, options = {}) {
         typeof containerManager.updateEnv === "function"
       ) {
         const managedEnv = await buildOpenClawManagedEnvForAgent(userId, agent.id, defaultProvider);
-        if (Object.keys(managedEnv).length > 0) {
-          await containerManager.updateEnv(agent, managedEnv);
-        }
+        await containerManager.updateEnv(agent, managedEnv, {
+          managedEnvNames: llmProviders.getManagedProviderEnvNames({
+            runtimeFamily: "openclaw",
+          }),
+        });
       }
 
       await writeAuthToContainer(agent, authProfiles);
@@ -761,8 +788,19 @@ async function syncAuthToUserAgents(userId, agentId = null, options = {}) {
         }
       }
 
+      // Apply the default model before restarting as part of the same config
+      // reconciliation boundary. Writing it after readiness lets OpenClaw's
+      // config watcher reload an already-advertised gateway and makes the
+      // readiness result stale as soon as this function returns.
+      if (modelCommand) {
+        await runRuntimeCommand(agent, modelCommand, { timeout: 60000 });
+      }
+
       await restartAgentAndRefreshAddress(agent);
 
+      // Readiness is intentionally the final runtime operation. Every auth,
+      // provider, env, and default-model write above must be visible across
+      // the single restart before callers receive a successful sync result.
       const readiness = await waitForAgentReadiness({
         host: agent.host,
         runtimeHost: agent.runtime_host,
@@ -775,10 +813,6 @@ async function syncAuthToUserAgents(userId, agentId = null, options = {}) {
         throw new Error(
           `Agent runtime did not recover after auth sync restart (${readiness.runtime?.error || readiness.gateway?.error || "unreachable"})`,
         );
-      }
-
-      if (modelCommand) {
-        await runRuntimeCommand(agent, modelCommand, { timeout: 60000 });
       }
 
       console.log(`[authSync] Synced OpenClaw auth to agent ${agent.id} (backend restarted)`);

--- a/backend-api/containerManager.ts
+++ b/backend-api/containerManager.ts
@@ -194,7 +194,16 @@ async function getBackendInstance(type, agent = {}) {
       : type === "remote-hermes" || type === "remote-nemoclaw"
         ? `${type}:${resolveAgentExecutionTargetId(agent)}`
         : type;
-  if (backendCache[cacheKey]) return backendCache[cacheKey];
+  const profileBacked = [
+    "k8s",
+    "k3s",
+    "kubernetes",
+    "remote-docker",
+    "remote-hermes",
+    "remote-nemoclaw",
+  ].includes(type);
+  if (backendCache[cacheKey] && !profileBacked) return backendCache[cacheKey];
+  if (profileBacked) delete backendCache[cacheKey];
 
   switch (type) {
     case "docker": {
@@ -338,13 +347,17 @@ module.exports = {
       : backend.restart(id);
   },
 
-  async updateEnv(agent, envVars = {}) {
+  async updateEnv(agent, envVars = {}, options = {}) {
     const id = resolveKubernetesRuntimeId(agent, "update env");
     const backend = await backendFor(agent);
     if (typeof backend.updateEnv !== "function") {
       throw new Error(`Backend ${resolveAgentBackendType(agent)} does not support env updates`);
     }
-    return backend.updateEnv(id, envVars, lifecycleOptions(agent));
+    const managedEnvNames = Array.isArray(options.managedEnvNames) ? options.managedEnvNames : [];
+    return backend.updateEnv(id, envVars, {
+      ...lifecycleOptions(agent),
+      ...(managedEnvNames.length > 0 ? { managedEnvNames } : {}),
+    });
   },
 
   async destroy(agent) {

--- a/backend-api/gatewayProxy.ts
+++ b/backend-api/gatewayProxy.ts
@@ -13,6 +13,7 @@ const { decrypt } = require("./crypto");
 const integrations = require("./integrations");
 const { resolveAgentRuntimeFamily } = require("./agentRuntimeFields");
 const remoteHosts = require("./remoteHosts");
+const { PRIVATE_IP_RE } = require("./networkSafety");
 const { normalizeDeployTargetName } = require("../agent-runtime/lib/backendCatalog");
 
 const metrics = require("./metrics");
@@ -53,7 +54,7 @@ function assertSafeAgentAddress(addr, label = "agent gateway") {
     throw new Error(`${label} address is missing`);
   }
   const host = typeof addr.host === "string" ? addr.host.trim() : "";
-  if (!host || host.length > 253 || !GATEWAY_HOST_RE.test(host)) {
+  if (!host || host.length > 253 || (!net.isIP(host) && !GATEWAY_HOST_RE.test(host))) {
     throw new Error(`${label} host is not a valid hostname`);
   }
   const port = Number(addr.port);
@@ -120,6 +121,24 @@ function isBlockedGatewayIP(address) {
 
 const EMPTY_ALLOWED_HOSTS = new Set();
 
+function assertRemoteGatewayAccessSupported(agent) {
+  if (normalizeDeployTargetName(agent?.deploy_target) !== "remote-docker") return;
+  if (
+    String(process.env.PLATFORM_MODE || "selfhosted")
+      .trim()
+      .toLowerCase() !== "paas"
+  ) {
+    return;
+  }
+
+  const error = new Error(
+    "Remote Docker gateway access is disabled in hosted mode because runtime traffic is not end-to-end encrypted",
+  );
+  error.statusCode = 403;
+  error.code = "REMOTE_HOSTS_DISABLED_IN_PAAS";
+  throw error;
+}
+
 // A registered remote host's advertised address is operator-trusted, so allow
 // it even though it is not RFC1918/loopback. Scoped to the agent's OWN host
 // (looked up by execution target) AND to a user who may use it — the agent's
@@ -130,6 +149,10 @@ async function allowedRemoteHostsForAgent(agent) {
   if (normalizeDeployTargetName(agent?.deploy_target) !== "remote-docker") {
     return EMPTY_ALLOWED_HOSTS;
   }
+  // Fail before consulting the registry. This protects historical/imported
+  // remote-agent rows too, and every caller (HTTP proxy, RPC pool, Hermes
+  // embed, and WS relay) shares this boundary.
+  assertRemoteGatewayAccessSupported(agent);
   try {
     const host = await remoteHosts.getRemoteHostByExecutionTarget(agent.execution_target_id);
     if (!host) return EMPTY_ALLOWED_HOSTS;
@@ -144,6 +167,8 @@ async function allowedRemoteHostsForAgent(agent) {
     const allowed = new Set();
     if (host.gatewayHost) allowed.add(String(host.gatewayHost).toLowerCase());
     if (host.sshHost) allowed.add(String(host.sshHost).toLowerCase());
+    if (host.rawGatewayHost) allowed.add(String(host.rawGatewayHost).toLowerCase());
+    if (host.rawSshHost) allowed.add(String(host.rawSshHost).toLowerCase());
     return allowed;
   } catch {
     return EMPTY_ALLOWED_HOSTS;
@@ -194,9 +219,17 @@ function isAllowedGatewayIP(address, hostname, extraAllowedHosts) {
   return false;
 }
 
-async function resolveGatewayHostForProxy(host, label = "agent gateway", extraAllowedHosts) {
+async function resolveGatewayHostForProxy(
+  host,
+  label = "agent gateway",
+  extraAllowedHosts,
+  { publicOnly = false } = {},
+) {
   const normalizedHost = String(host || "").trim();
   if (net.isIP(normalizedHost)) {
+    if (publicOnly && PRIVATE_IP_RE.test(normalizedHost)) {
+      throw new Error(`${label} host must be public in hosted mode`);
+    }
     if (!isAllowedGatewayIP(normalizedHost, normalizedHost, extraAllowedHosts)) {
       throw new Error(`${label} host is not an allowed gateway address`);
     }
@@ -210,8 +243,10 @@ async function resolveGatewayHostForProxy(host, label = "agent gateway", extraAl
     throw new Error(`${label} host could not be resolved (${error.code || error.message})`);
   }
 
-  const firstAllowed = addresses.find((entry) =>
-    isAllowedGatewayIP(entry.address, normalizedHost, extraAllowedHosts),
+  const firstAllowed = addresses.find(
+    (entry) =>
+      (!publicOnly || !PRIVATE_IP_RE.test(entry.address)) &&
+      isAllowedGatewayIP(entry.address, normalizedHost, extraAllowedHosts),
   );
   if (!firstAllowed) {
     throw new Error(`${label} host does not resolve to an allowed gateway network`);
@@ -258,6 +293,11 @@ async function resolveSafeGatewayHttpTarget(agent, gatewayPath = "", search = ""
     addr.host,
     "agent gateway",
     extraAllowedHosts,
+    {
+      publicOnly:
+        String(process.env.PLATFORM_MODE || "selfhosted").toLowerCase() === "paas" &&
+        normalizeDeployTargetName(agent?.deploy_target) === "remote-docker",
+    },
   );
   // The connection is pinned to the validated, resolved IP (no re-resolution at
   // fetch time, so no DNS-rebinding window). The Host header intentionally keeps
@@ -298,6 +338,11 @@ async function resolveSafeHermesDashboardTarget(agent) {
     addr.host,
     "hermes dashboard",
     extraAllowedHosts,
+    {
+      publicOnly:
+        String(process.env.PLATFORM_MODE || "selfhosted").toLowerCase() === "paas" &&
+        normalizeDeployTargetName(agent?.deploy_target) === "remote-docker",
+    },
   );
   return { host: resolvedHost, port: addr.port };
 }
@@ -717,6 +762,10 @@ function retireConflictingConnections(key, agent, addr) {
 }
 
 async function getConnection(agent) {
+  // Check before a pooled connection can be reused. PLATFORM_MODE is normally
+  // process-static, but this keeps the hosted-mode contract fail closed even
+  // if a process is reconfigured while an old remote connection is alive.
+  assertRemoteGatewayAccessSupported(agent);
   const rawAddr = resolveGatewayAddress(agent);
   if (!rawAddr) throw new Error("Agent gateway not yet provisioned");
   const addr = assertSafeAgentAddress(rawAddr);

--- a/backend-api/hermesUi.ts
+++ b/backend-api/hermesUi.ts
@@ -720,6 +720,8 @@ if api_key_present:
         model.pop("api_key", None)
 elif provider and provider != "custom":
     model.pop("api_key", None)
+elif not provider:
+    model.pop("api_key", None)
 
 if model:
     config["model"] = model

--- a/backend-api/llmProviders.ts
+++ b/backend-api/llmProviders.ts
@@ -2,9 +2,15 @@
 // LLM Provider key management — encrypted storage of user API keys
 
 const db = require("./db");
+const { Client } = require("pg");
 const { encrypt, decrypt, ensureEncryptionConfigured } = require("./crypto");
+const { buildPostgresConfig } = require("./lib/connectionConfig");
 const { DEMO_PROVIDER_ID, DEMO_MODEL_ID, deriveDemoToken, demoLlmBaseUrl } = require("./demoLlm");
 const { NEMOCLAW_DEFAULT_MODEL } = require("../agent-runtime/lib/nemoclawDefaults");
+const {
+  HERMES_MANAGED_ENV_ENV,
+  HERMES_MODEL_CONFIG_ENV,
+} = require("../agent-runtime/lib/hermesRuntimeBootstrap");
 
 // Approved LLM providers and their env var names
 // Models updated per https://docs.openclaw.ai/providers (April 2026)
@@ -153,6 +159,31 @@ function getProviderEnvVar(providerId) {
   return p ? p.envVar : null;
 }
 
+function getManagedProviderEnvNames({ runtimeFamily = "openclaw" } = {}) {
+  const names = new Set();
+  for (const provider of PROVIDERS) {
+    const envVar = String(provider.envVar || "").trim();
+    if (!envVar) continue;
+    names.add(envVar);
+    const baseUrlEnv = envVar.replace(/_API_KEY$|_TOKEN$/, "_BASE_URL");
+    const apiVersionEnv = envVar.replace(/_API_KEY$|_TOKEN$/, "_API_VERSION");
+    if (baseUrlEnv !== envVar) names.add(baseUrlEnv);
+    if (apiVersionEnv !== envVar) names.add(apiVersionEnv);
+  }
+  names.add("MICROSOFT_FOUNDRY_DEPLOYMENT");
+  if (
+    String(runtimeFamily || "")
+      .trim()
+      .toLowerCase() === "hermes"
+  ) {
+    names.add(HERMES_MANAGED_ENV_ENV);
+    names.add(HERMES_MODEL_CONFIG_ENV);
+  } else {
+    names.add("NORA_DEFAULT_OPENCLAW_MODEL");
+  }
+  return [...names].sort();
+}
+
 /** Mask an API key for safe display: keep first 4 and last 4 chars */
 function maskKey(key) {
   if (!key || key.length < 12) return "••••••••";
@@ -188,18 +219,44 @@ function providerMutationLockKey(userId) {
   return `nora:llm-providers:${String(userId || "")}`;
 }
 
-async function withProviderMutationLock(userId, operation) {
-  const client = await db.connect();
+function createProviderMutationClient() {
+  const {
+    max: _max,
+    idleTimeoutMillis: _idleTimeoutMillis,
+    ...clientConfig
+  } = buildPostgresConfig({
+    ...process.env,
+    DB_APPLICATION_NAME: "nora-backend-provider-mutation",
+  });
+  return new Client(clientConfig);
+}
+
+async function withProviderMutationLock(userId, operation, { afterCommit } = {}) {
+  // This must not borrow from the main backend pool: afterCommit performs
+  // provider/runtime reads through that pool, and holding its last available
+  // connection here would deadlock installations configured with DB_POOL_MAX=1.
+  const client = createProviderMutationClient();
+  const lockKey = providerMutationLockKey(userId);
+  let connected = false;
+  let lockHeld = false;
   let transactionOpen = false;
   try {
+    await client.connect();
+    connected = true;
+    // Use a session lock rather than an xact lock so the post-commit runtime
+    // synchronization remains serialized with deployment finalization. The
+    // database mutation is committed before afterCommit runs, allowing auth
+    // sync to read the durable provider state while the same lock is held.
+    await client.query("SELECT pg_advisory_lock(hashtextextended($1, 0))", [lockKey]);
+    lockHeld = true;
     await client.query("BEGIN");
     transactionOpen = true;
-    await client.query("SELECT pg_advisory_xact_lock(hashtextextended($1, 0))", [
-      providerMutationLockKey(userId),
-    ]);
     const result = await operation(client);
     await client.query("COMMIT");
     transactionOpen = false;
+    if (typeof afterCommit === "function") {
+      await afterCommit(result);
+    }
     return result;
   } catch (error) {
     if (transactionOpen) {
@@ -207,8 +264,46 @@ async function withProviderMutationLock(userId, operation) {
     }
     throw error;
   } finally {
-    client.release();
+    if (lockHeld) {
+      await client
+        .query("SELECT pg_advisory_unlock(hashtextextended($1, 0))", [lockKey])
+        .catch((error) =>
+          console.warn(
+            `[llmProviders] Provider advisory unlock failed for user ${userId}: ${error.message}`,
+          ),
+        );
+    }
+    if (connected) {
+      await client
+        .end()
+        .catch((error) =>
+          console.warn(
+            `[llmProviders] Provider mutation connection close failed for user ${userId}: ${error.message}`,
+          ),
+        );
+    }
   }
+}
+
+async function ensureUserDefaultProvider(userId, queryable) {
+  const result = await queryable.query(
+    `WITH candidate AS (
+       SELECT id
+         FROM llm_providers
+        WHERE user_id = $1
+        ORDER BY CASE WHEN provider = $2 THEN 1 ELSE 0 END, created_at, id
+        LIMIT 1
+     )
+     UPDATE llm_providers
+        SET is_default = true
+      WHERE id = (SELECT id FROM candidate)
+        AND NOT EXISTS (
+          SELECT 1 FROM llm_providers WHERE user_id = $1 AND is_default = true
+        )
+     RETURNING id`,
+    [userId, DEMO_PROVIDER_ID],
+  );
+  return result.rows[0]?.id || null;
 }
 
 /**
@@ -262,46 +357,58 @@ async function ensureDemoProvider(userId, queryable = db) {
   return inserted.rows[0];
 }
 
-async function addProvider(userId, provider, apiKey, model, config = {}) {
+async function addProvider(userId, provider, apiKey, model, config = {}, mutationOptions = {}) {
   if (!PROVIDERS.find((p) => p.id === provider)) {
     throw new Error(`Unknown LLM provider: ${provider}`);
   }
   if (provider === DEMO_PROVIDER_ID) {
     // Deliberately no ensureEncryptionConfigured: the derived demo token is
     // not user secret material and must work on a fresh installation.
-    return withProviderMutationLock(userId, (client) => ensureDemoProvider(userId, client));
+    return withProviderMutationLock(
+      userId,
+      (client) => ensureDemoProvider(userId, client),
+      mutationOptions,
+    );
   }
   if (!apiKey) throw new Error("API key is required");
   ensureEncryptionConfigured("LLM provider credential storage");
   const encryptedKey = encrypt(apiKey);
 
-  return withProviderMutationLock(userId, async (client) => {
-    const providerState = await client.query(
-      `SELECT COUNT(*)::int AS provider_count,
-              COALESCE(bool_or(is_default AND provider = $2), false) AS demo_is_default
-         FROM llm_providers
-        WHERE user_id = $1`,
-      [userId, DEMO_PROVIDER_ID],
-    );
-    const state = providerState.rows[0] || {};
-    const isDefault = Number(state.provider_count || 0) === 0 || state.demo_is_default === true;
+  return withProviderMutationLock(
+    userId,
+    async (client) => {
+      const providerState = await client.query(
+        `SELECT COUNT(*)::int AS provider_count,
+                COALESCE(bool_or(is_default), false) AS has_default,
+                COALESCE(bool_or(is_default AND provider = $2), false) AS demo_is_default
+           FROM llm_providers
+          WHERE user_id = $1`,
+        [userId, DEMO_PROVIDER_ID],
+      );
+      const state = providerState.rows[0] || {};
+      const isDefault =
+        Number(state.provider_count || 0) === 0 ||
+        state.has_default === false ||
+        state.demo_is_default === true;
 
-    // The built-in demo is a temporary onboarding default. The first real
-    // provider replaces it atomically; an existing real default is preserved.
-    if (state.demo_is_default === true) {
-      await client.query("UPDATE llm_providers SET is_default = false WHERE user_id = $1", [
-        userId,
-      ]);
-    }
+      // The built-in demo is a temporary onboarding default. The first real
+      // provider replaces it atomically; an existing real default is preserved.
+      if (state.demo_is_default === true) {
+        await client.query("UPDATE llm_providers SET is_default = false WHERE user_id = $1", [
+          userId,
+        ]);
+      }
 
-    const result = await client.query(
-      `INSERT INTO llm_providers(user_id, provider, api_key, model, config, is_default)
-       VALUES($1, $2, $3, $4, $5, $6)
-       RETURNING id, provider, model, is_default, created_at`,
-      [userId, provider, encryptedKey, model || null, JSON.stringify(config), isDefault],
-    );
-    return result.rows[0];
-  });
+      const result = await client.query(
+        `INSERT INTO llm_providers(user_id, provider, api_key, model, config, is_default)
+         VALUES($1, $2, $3, $4, $5, $6)
+         RETURNING id, provider, model, is_default, created_at`,
+        [userId, provider, encryptedKey, model || null, JSON.stringify(config), isDefault],
+      );
+      return result.rows[0];
+    },
+    mutationOptions,
+  );
 }
 
 async function getDeploymentProvider(userId, providerId = null, queryable = db) {
@@ -333,7 +440,7 @@ async function getDeploymentProvider(userId, providerId = null, queryable = db) 
   return fallback.rows[0] || null;
 }
 
-async function updateProvider(id, userId, updates) {
+async function updateProvider(id, userId, updates, mutationOptions = {}) {
   const sets = [];
   const params = [];
   let idx = 1;
@@ -352,9 +459,8 @@ async function updateProvider(id, userId, updates) {
     params.push(JSON.stringify(updates.config));
   }
   if (updates.is_default !== undefined) {
-    // If setting as default, unset all others first
-    if (updates.is_default) {
-      await db.query("UPDATE llm_providers SET is_default = false WHERE user_id = $1", [userId]);
+    if (typeof updates.is_default !== "boolean") {
+      throw new Error("is_default must be a boolean");
     }
     sets.push(`is_default = $${idx++}`);
     params.push(updates.is_default);
@@ -362,22 +468,48 @@ async function updateProvider(id, userId, updates) {
 
   if (sets.length === 0) throw new Error("No fields to update");
 
-  params.push(id, userId);
-  const result = await db.query(
-    `UPDATE llm_providers SET ${sets.join(", ")} WHERE id = $${idx++} AND user_id = $${idx} RETURNING id, provider, model, is_default`,
-    params,
+  return withProviderMutationLock(
+    userId,
+    async (client) => {
+      // Default selection and the target-row update must be one locked
+      // transaction so a deployment finalizer cannot observe the half-state.
+      if (updates.is_default) {
+        await client.query("UPDATE llm_providers SET is_default = false WHERE user_id = $1", [
+          userId,
+        ]);
+      }
+
+      const queryParams = [...params, id, userId];
+      const result = await client.query(
+        `UPDATE llm_providers SET ${sets.join(", ")} WHERE id = $${idx++} AND user_id = $${idx} RETURNING id, provider, model, is_default`,
+        queryParams,
+      );
+      if (result.rows.length === 0) throw new Error("Provider not found");
+      const row = result.rows[0];
+      if (updates.is_default !== true) {
+        const promotedId = await ensureUserDefaultProvider(userId, client);
+        if (promotedId === row.id) row.is_default = true;
+      }
+      return row;
+    },
+    mutationOptions,
   );
-  if (result.rows.length === 0) throw new Error("Provider not found");
-  return result.rows[0];
 }
 
-async function deleteProvider(id, userId) {
-  const result = await db.query(
-    "DELETE FROM llm_providers WHERE id = $1 AND user_id = $2 RETURNING id",
-    [id, userId],
+async function deleteProvider(id, userId, mutationOptions = {}) {
+  return withProviderMutationLock(
+    userId,
+    async (client) => {
+      const result = await client.query(
+        "DELETE FROM llm_providers WHERE id = $1 AND user_id = $2 RETURNING id",
+        [id, userId],
+      );
+      if (result.rows.length === 0) throw new Error("Provider not found");
+      await ensureUserDefaultProvider(userId, client);
+      return { success: true };
+    },
+    mutationOptions,
   );
-  if (result.rows.length === 0) throw new Error("Provider not found");
-  return { success: true };
 }
 
 /**
@@ -589,6 +721,7 @@ function buildAuthProfiles(
 module.exports = {
   getAvailableProviders,
   getProviderEnvVar,
+  getManagedProviderEnvNames,
   listProviders,
   addProvider,
   ensureDemoProvider,

--- a/backend-api/remoteHosts.ts
+++ b/backend-api/remoteHosts.ts
@@ -13,11 +13,15 @@
 
 const db = require("./db");
 const { decrypt, encrypt, ensureEncryptionConfigured } = require("./crypto");
+const dns = require("node:dns").promises;
+const net = require("node:net");
+const { PRIVATE_IP_RE } = require("./networkSafety");
 
 const AUTH_MODES = new Set(["key", "password"]);
 const DEFAULT_SSH_PORT = 22;
 const DEFAULT_TEST_TIMEOUT_MS = 10000;
 const DOCKER_VERSION_PROBE = "docker version --format '{{.Server.Version}}'";
+const REMOTE_HOSTNAME_RE = /^[A-Za-z0-9._-]+$/;
 
 let sshClientCtor = null;
 
@@ -30,6 +34,102 @@ function getSshClientCtor() {
 
 function normalizeText(value) {
   return typeof value === "string" ? value.trim() : "";
+}
+
+function isPaaSMode() {
+  return (
+    String(process.env.PLATFORM_MODE || "selfhosted")
+      .trim()
+      .toLowerCase() === "paas"
+  );
+}
+
+function assertRemoteHostsSupported() {
+  if (!isPaaSMode()) return;
+  const error = new Error(
+    "Remote Docker hosts are disabled in hosted mode because agent runtime traffic is not end-to-end encrypted; use a self-hosted Nora control plane on the same private network",
+  );
+  error.statusCode = 403;
+  error.code = "REMOTE_HOSTS_DISABLED_IN_PAAS";
+  throw error;
+}
+
+function normalizeRemoteAddress(value, label) {
+  const host = normalizeText(value);
+  if (!host) return "";
+  if (host.length > 253 || (!net.isIP(host) && !REMOTE_HOSTNAME_RE.test(host))) {
+    const error = new Error(
+      `${label} must be a plain hostname or IP address without a scheme or port`,
+    );
+    error.statusCode = 400;
+    throw error;
+  }
+  return host;
+}
+
+function isUnroutableRemoteAddress(address) {
+  const normalized = String(address || "")
+    .trim()
+    .toLowerCase();
+  if (PRIVATE_IP_RE.test(normalized)) return true;
+  if (normalized.startsWith("ff")) return true;
+  if (net.isIP(normalized) === 4) {
+    const first = Number.parseInt(normalized.split(".")[0], 10);
+    return first >= 224;
+  }
+  return false;
+}
+
+async function resolveRemoteAddressForRuntime(value, label, { publicOnly = isPaaSMode() } = {}) {
+  const host = normalizeRemoteAddress(value, label);
+  if (!host) return "";
+  if (net.isIP(host)) {
+    if (publicOnly && isUnroutableRemoteAddress(host)) {
+      const error = new Error(`${label} must use a public address in hosted mode`);
+      error.statusCode = 400;
+      throw error;
+    }
+    return host;
+  }
+  if (!publicOnly) return host;
+
+  let addresses;
+  try {
+    addresses = await dns.lookup(host, { all: true, verbatim: true });
+  } catch (error) {
+    const validationError = new Error(
+      `${label} hostname ${host} could not be resolved (${error.code || error.message})`,
+    );
+    validationError.statusCode = 400;
+    throw validationError;
+  }
+  const unsafe = addresses.find((entry) => isUnroutableRemoteAddress(entry.address));
+  if (unsafe) {
+    const error = new Error(
+      `${label} must resolve only to public addresses in hosted mode (${unsafe.address} is private or unroutable)`,
+    );
+    error.statusCode = 400;
+    throw error;
+  }
+  if (!addresses[0]?.address) {
+    const error = new Error(`${label} hostname ${host} did not resolve to an address`);
+    error.statusCode = 400;
+    throw error;
+  }
+  // Hosted-mode callers use the validated IP directly, closing the DNS
+  // rebinding window between registry lookup and SSH/readiness/proxy traffic.
+  return addresses[0].address;
+}
+
+async function resolveRemoteHostRuntimeProfile(profile) {
+  if (!profile) return null;
+  const rawSshHost = profile.sshHost;
+  const rawGatewayHost = profile.gatewayHost || profile.sshHost;
+  const [sshHost, gatewayHost] = await Promise.all([
+    resolveRemoteAddressForRuntime(rawSshHost, "Remote SSH host"),
+    resolveRemoteAddressForRuntime(rawGatewayHost, "Remote gateway address"),
+  ]);
+  return { ...profile, rawSshHost, rawGatewayHost, sshHost, gatewayHost };
 }
 
 function normalizeSlug(value) {
@@ -228,14 +328,20 @@ function normalizeHostInput(input = {}, existing = null) {
     label: label || id,
     enabled: normalizeBool(input.enabled, existing?.enabled ?? true),
     isDefault: normalizeBool(input.isDefault ?? input.is_default, existing?.is_default ?? false),
-    sshHost: normalizeText(input.sshHost ?? input.ssh_host ?? existing?.ssh_host),
+    sshHost: normalizeRemoteAddress(
+      input.sshHost ?? input.ssh_host ?? existing?.ssh_host,
+      "Remote SSH host",
+    ),
     sshPort: parsePort(input.sshPort ?? input.ssh_port, existing?.ssh_port ?? DEFAULT_SSH_PORT),
     sshUser: normalizeText(input.sshUser ?? input.ssh_user ?? existing?.ssh_user),
     sshAuthMode: authMode,
     sshPrivateKeyEncrypted: privateKeyEncrypted,
     sshPasswordEncrypted: passwordEncrypted,
     sshPassphraseEncrypted: passphraseEncrypted,
-    gatewayHost: normalizeText(input.gatewayHost ?? input.gateway_host ?? existing?.gateway_host),
+    gatewayHost: normalizeRemoteAddress(
+      input.gatewayHost ?? input.gateway_host ?? existing?.gateway_host,
+      "Remote gateway address",
+    ),
     dockerHost: normalizeText(input.dockerHost ?? input.docker_host ?? existing?.docker_host),
   };
 }
@@ -252,7 +358,16 @@ function connectionInputChanged(existing, host) {
     normalizeText(existing.ssh_password_encrypted) !== normalizeText(host.sshPasswordEncrypted) ||
     normalizeText(existing.ssh_passphrase_encrypted) !==
       normalizeText(host.sshPassphraseEncrypted) ||
+    normalizeText(existing.gateway_host) !== host.gatewayHost ||
     normalizeText(existing.docker_host) !== host.dockerHost
+  );
+}
+
+function sshHostIdentityChanged(existing, host) {
+  if (!existing) return false;
+  return (
+    normalizeText(existing.ssh_host) !== host.sshHost ||
+    parsePort(existing.ssh_port, DEFAULT_SSH_PORT) !== host.sshPort
   );
 }
 
@@ -287,6 +402,7 @@ async function listRemoteHosts(options = {}) {
 }
 
 async function listRemoteHostExecutionTargets(options = {}) {
+  if (isPaaSMode()) return [];
   const hosts = await listRemoteHosts({ ...options, includeDisabled: false });
   return hosts.filter((host) => host.available);
 }
@@ -298,10 +414,11 @@ async function getHostRow(hostId) {
 }
 
 async function getRemoteHostProfile(executionTargetId) {
+  if (isPaaSMode()) return null;
   const normalized = normalizeRemoteExecutionTargetId(executionTargetId);
   if (!normalized) return null;
   const row = await getHostRow(normalized.slice("remote:".length));
-  return rowToProfile(row, { includeSecret: true });
+  return resolveRemoteHostRuntimeProfile(rowToProfile(row, { includeSecret: true }));
 }
 
 // Masked single-host lookup by id (no secrets) — used by the route layer to
@@ -314,9 +431,11 @@ async function getRemoteHost(hostId) {
 // Masked lookup by execution target ("remote:<id>"), no secret decryption —
 // used by the gateway proxy to learn a remote host's advertised address.
 async function getRemoteHostByExecutionTarget(executionTargetId) {
+  if (isPaaSMode()) return null;
   const normalized = normalizeRemoteExecutionTargetId(executionTargetId);
   if (!normalized) return null;
-  return getRemoteHost(normalized.slice("remote:".length));
+  const host = await getRemoteHost(normalized.slice("remote:".length));
+  return resolveRemoteHostRuntimeProfile(host);
 }
 
 async function clearOtherDefaults(hostId, ownerUserId) {
@@ -330,7 +449,12 @@ async function clearOtherDefaults(hostId, ownerUserId) {
 }
 
 async function createRemoteHost(input = {}) {
+  assertRemoteHostsSupported();
   const host = normalizeHostInput(input);
+  await resolveRemoteHostRuntimeProfile({
+    sshHost: host.sshHost,
+    gatewayHost: host.gatewayHost || host.sshHost,
+  });
   const result = await db.query(
     `INSERT INTO remote_hosts(
        id, owner_user_id, label, enabled, is_default,
@@ -366,6 +490,7 @@ async function createRemoteHost(input = {}) {
 }
 
 async function updateRemoteHost(hostId, input = {}) {
+  assertRemoteHostsSupported();
   const existing = await getHostRow(hostId);
   if (!existing) {
     const error = new Error("Remote host not found");
@@ -374,6 +499,11 @@ async function updateRemoteHost(hostId, input = {}) {
   }
   const host = normalizeHostInput(input, existing);
   const resetTest = connectionInputChanged(existing, host);
+  const resetHostKey = sshHostIdentityChanged(existing, host);
+  await resolveRemoteHostRuntimeProfile({
+    sshHost: host.sshHost,
+    gatewayHost: host.gatewayHost || host.sshHost,
+  });
   const result = await db.query(
     `UPDATE remote_hosts
         SET label = $2,
@@ -392,11 +522,10 @@ async function updateRemoteHost(hostId, input = {}) {
             last_test_status = CASE WHEN $15 THEN NULL ELSE last_test_status END,
             last_test_message = CASE WHEN $15 THEN NULL ELSE last_test_message END,
             last_tested_at = CASE WHEN $15 THEN NULL ELSE last_tested_at END,
-            -- Clear the host-key pin too when connection inputs change, so the
-            -- next test re-pins (trust-on-first-use) the now-different host. A
-            -- key change WITHOUT a connection-input change keeps the pin, so a
-            -- silent MITM on the same target still fails closed.
-            ssh_host_key = CASE WHEN $15 THEN NULL ELSE ssh_host_key END,
+            -- The host-key pin belongs to the SSH network identity, not to the
+            -- credential. Rotating a password/key must retain the pin; only an
+            -- explicit SSH host/port change returns to trust-on-first-use.
+            ssh_host_key = CASE WHEN $16 THEN NULL ELSE ssh_host_key END,
             updated_at = NOW()
       WHERE id = $1
       RETURNING *`,
@@ -416,6 +545,7 @@ async function updateRemoteHost(hostId, input = {}) {
       host.gatewayHost,
       host.dockerHost,
       resetTest,
+      resetHostKey,
     ],
   );
   if (host.isDefault) await clearOtherDefaults(existing.id, host.ownerUserId);
@@ -558,6 +688,7 @@ function runRemoteDockerProbe(profile, { timeoutMs = DEFAULT_TEST_TIMEOUT_MS } =
 }
 
 async function testRemoteHost(hostId, options = {}) {
+  assertRemoteHostsSupported();
   const profile = await getRemoteHostProfile(`remote:${hostId}`);
   if (!profile) {
     const error = new Error("Remote host not found");
@@ -636,6 +767,7 @@ async function userCanUseRemoteHost(userId, hostId) {
 // belong to (read-only). Each entry is masked (no secrets) and annotated with the
 // access kind + whether the user may deploy (editor+).
 async function listAccessibleRemoteHosts(userId) {
+  if (isPaaSMode()) return [];
   const owned = (await listRemoteHosts({ ownerUserId: userId, includeDisabled: true })).map(
     (host) => ({
       ...host,
@@ -708,6 +840,7 @@ async function assertRemoteHostExecutionTargetAvailable(runtimeFields = {}, opti
   if (!isRemoteDockerTarget(runtimeFields.deploy_target ?? runtimeFields.deployTarget)) {
     return null;
   }
+  assertRemoteHostsSupported();
   const executionTargetId = normalizeRemoteExecutionTargetId(
     runtimeFields.execution_target_id || runtimeFields.executionTargetId,
   );
@@ -762,6 +895,7 @@ async function assertRemoteHostExecutionTargetAvailable(runtimeFields = {}, opti
 
 module.exports = {
   assertRemoteHostExecutionTargetAvailable,
+  assertRemoteHostsSupported,
   createRemoteHost,
   deleteRemoteHost,
   getRemoteHost,
@@ -772,6 +906,8 @@ module.exports = {
   listAccessibleRemoteHosts,
   listRemoteHostExecutionTargets,
   normalizeRemoteExecutionTargetId,
+  resolveRemoteAddressForRuntime,
+  resolveRemoteHostRuntimeProfile,
   rowToProfile,
   testRemoteHost,
   updateRemoteHost,

--- a/backend-api/routes/agents.ts
+++ b/backend-api/routes/agents.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 const express = require("express");
+const { Client } = require("pg");
 const db = require("../db");
 const { encrypt, decrypt } = require("../crypto");
 const { addDeploymentJob, cancelDeploymentJobsForAgent } = require("../redisQueue");
@@ -80,6 +81,7 @@ const agentVersions = require("../agentVersions");
 const { assertKubernetesExecutionTargetAvailable } = require("../kubernetesClusters");
 const { assertRemoteHostExecutionTargetAvailable } = require("../remoteHosts");
 const { releaseGatewayPort } = require("../portAllocations");
+const { buildPostgresConfig } = require("../lib/connectionConfig");
 
 const router = express.Router();
 router.use(createMutationFailureAuditMiddleware("agent"));
@@ -88,6 +90,18 @@ router.use(createMutationFailureAuditMiddleware("agent"));
 router.use(scopeByMethod("agents:read", "agents:write"));
 
 const DEMO_ACTIVATION_MARKER = "local-docker-demo-v1";
+
+function createDemoActivationLockClient() {
+  const {
+    max: _max,
+    idleTimeoutMillis: _idleTimeoutMillis,
+    ...clientConfig
+  } = buildPostgresConfig({
+    ...process.env,
+    DB_APPLICATION_NAME: "nora-backend-demo-activation",
+  });
+  return new Client(clientConfig);
+}
 
 function demoActivationJobId(agentId) {
   return `demo-activation-${agentId}`;
@@ -1457,11 +1471,17 @@ router.post("/activate-demo", async (req, res) => {
   const userId = req.user.id;
   const lockKey = llmProviders.providerMutationLockKey(userId);
   let client;
+  let connected = false;
   let lockHeld = false;
   let transactionOpen = false;
 
   try {
-    client = await db.connect();
+    // The activation lock spans pool-backed capability, billing, scheduler,
+    // queue, and audit work. Keep it off the main pool so DB_POOL_MAX=1 does
+    // not self-deadlock while the session lock is held.
+    client = createDemoActivationLockClient();
+    await client.connect();
+    connected = true;
     await client.query("SELECT pg_advisory_lock(hashtextextended($1, 0))", [lockKey]);
     lockHeld = true;
 
@@ -1612,7 +1632,7 @@ router.post("/activate-demo", async (req, res) => {
     }
     return res.status(error.statusCode || 500).json({ error: error.message });
   } finally {
-    if (client) {
+    if (connected && client) {
       if (lockHeld) {
         await client
           .query("SELECT pg_advisory_unlock(hashtextextended($1, 0))", [lockKey])
@@ -1620,7 +1640,11 @@ router.post("/activate-demo", async (req, res) => {
             console.warn("[agents.activate-demo] Advisory unlock failed:", error.message),
           );
       }
-      client.release();
+      await client
+        .end()
+        .catch((error) =>
+          console.warn("[agents.activate-demo] Lock connection close failed:", error.message),
+        );
     }
   }
 });

--- a/backend-api/routes/llmProviders.ts
+++ b/backend-api/routes/llmProviders.ts
@@ -6,7 +6,7 @@ const { syncAuthToUserAgents } = require("../authSync");
 
 const router = express.Router();
 
-async function syncAfterProviderSave(userId) {
+async function syncAfterProviderSave(userId, successMessage = "Provider saved") {
   try {
     const results = await syncAuthToUserAgents(userId);
     const failed = results.filter((result) => result.status === "failed");
@@ -22,9 +22,19 @@ async function syncAfterProviderSave(userId) {
     console.warn("[llmProviders] Post-save auth sync failed:", error.message);
     return {
       sync_results: [],
-      sync_warning: "Provider saved, but running agents could not be updated automatically",
+      sync_warning: `${successMessage}, but running agents could not be updated automatically`,
     };
   }
+}
+
+async function mutateProviderAndSync(userId, successMessage, mutation) {
+  let sync = { sync_results: [] };
+  const result = await mutation({
+    afterCommit: async () => {
+      sync = await syncAfterProviderSave(userId, successMessage);
+    },
+  });
+  return { ...result, ...sync };
 }
 
 router.get("/available", (req, res) => {
@@ -46,9 +56,11 @@ router.post("/", async (req, res) => {
     // derived server-side); every real provider still requires a key.
     if (!provider || (!apiKey && provider !== "demo"))
       return res.status(400).json({ error: "provider and apiKey required" });
-    const result = await llmProviders.addProvider(req.user.id, provider, apiKey, model, config);
-    const sync = await syncAfterProviderSave(req.user.id);
-    res.json({ ...result, ...sync });
+    res.json(
+      await mutateProviderAndSync(req.user.id, "Provider saved", (mutationOptions) =>
+        llmProviders.addProvider(req.user.id, provider, apiKey, model, config, mutationOptions),
+      ),
+    );
   } catch (e) {
     res.status(400).json({ error: e.message });
   }
@@ -56,11 +68,11 @@ router.post("/", async (req, res) => {
 
 router.put("/:id", async (req, res) => {
   try {
-    const result = await llmProviders.updateProvider(req.params.id, req.user.id, req.body);
-    syncAuthToUserAgents(req.user.id).catch((error) =>
-      console.warn("[llmProviders] Post-save auth sync failed:", error.message),
+    res.json(
+      await mutateProviderAndSync(req.user.id, "Provider updated", (mutationOptions) =>
+        llmProviders.updateProvider(req.params.id, req.user.id, req.body, mutationOptions),
+      ),
     );
-    res.json(result);
   } catch (e) {
     res.status(400).json({ error: e.message });
   }
@@ -68,11 +80,11 @@ router.put("/:id", async (req, res) => {
 
 router.delete("/:id", async (req, res) => {
   try {
-    await llmProviders.deleteProvider(req.params.id, req.user.id);
-    syncAuthToUserAgents(req.user.id).catch((error) =>
-      console.warn("[llmProviders] Post-save auth sync failed:", error.message),
+    res.json(
+      await mutateProviderAndSync(req.user.id, "Provider deleted", (mutationOptions) =>
+        llmProviders.deleteProvider(req.params.id, req.user.id, mutationOptions),
+      ),
     );
-    res.json({ success: true });
   } catch (e) {
     res.status(400).json({ error: e.message });
   }

--- a/backend-api/server.ts
+++ b/backend-api/server.ts
@@ -1278,6 +1278,31 @@ const LEGACY_COMPATIBILITY_REPAIRS = [
       END
     $nora$`,
   },
+  {
+    name: "repair-llm-provider-defaults",
+    sql: `DO $nora$
+      BEGIN
+        IF to_regclass('llm_providers') IS NOT NULL THEN
+          WITH ranked AS (
+            SELECT id,
+                   ROW_NUMBER() OVER (
+                     PARTITION BY user_id
+                     ORDER BY is_default DESC,
+                              CASE WHEN provider = 'demo' THEN 1 ELSE 0 END,
+                              created_at ASC NULLS LAST,
+                              id ASC
+                   ) AS provider_position
+              FROM llm_providers
+          )
+          UPDATE llm_providers AS provider
+             SET is_default = (ranked.provider_position = 1)
+            FROM ranked
+           WHERE provider.id = ranked.id
+             AND provider.is_default IS DISTINCT FROM (ranked.provider_position = 1);
+        END IF;
+      END
+    $nora$`,
+  },
 ];
 
 async function migrateDB(database = db, env = process.env) {

--- a/docs/api/overview.mdx
+++ b/docs/api/overview.mdx
@@ -8,9 +8,9 @@ The Nora REST API is a JSON-over-HTTP interface that lets you deploy agents, man
   Every Nora instance also serves a machine-readable **OpenAPI 3.1 spec** at `GET /api/api.json` and
   an **interactive API reference** at `/api/api-docs`. The spec covers agents, schedules and
   versions, monitoring, LLM providers, auth, workspaces, API keys, alerts, integrations, channels,
-  backups, Agent Hub, remote hosts, and the admin doctor endpoint. CI drift-tests those operations
-  against the actual routers, so documented routes cannot silently disappear; browser-only admin and
-  experimental surfaces remain intentionally outside the spec.
+  backups, Agent Hub, self-hosted-only remote hosts, and the admin doctor endpoint. CI drift-tests
+  those operations against the actual routers, so documented routes cannot silently disappear;
+  browser-only admin and experimental surfaces remain intentionally outside the spec.
 </Tip>
 
 ## Base URL
@@ -108,8 +108,11 @@ GET /health
 Returns `{"status":"ok"}` after the server has finished its startup sequence, including database migrations and catalog seeding. The API does not bind its HTTP listener until that sequence succeeds.
 
 <CodeGroup>
-  ```bash curl theme={null}
-  curl http://localhost:8080/api/health ```
+
+```bash curl theme={null}
+curl http://localhost:8080/api/health
+```
+
 </CodeGroup>
 
 ```json theme={null}
@@ -177,18 +180,19 @@ Returns the NemoClaw sandbox configuration for the current deployment.
 The following request authenticates and lists your agents:
 
 <CodeGroup>
-  ```bash curl theme={null}
-  # 1. Get a token
-  TOKEN=$(curl -s -X POST http://localhost:8080/api/auth/login \
-    -H "Content-Type: application/json" \
-    -d '{"email":"you@example.com","password":"yourpassword"}' \
-    | jq -r .token)
+
+```bash curl theme={null}
+# 1. Get a token
+TOKEN=$(curl -s -X POST http://localhost:8080/api/auth/login \
+  -H "Content-Type: application/json" \
+  -d '{"email":"you@example.com","password":"yourpassword"}' \
+  | jq -r .token)
 
 # 2. Call a protected endpoint
 
 curl http://localhost:8080/api/agents \
- -H "Authorization: Bearer $TOKEN"
+-H "Authorization: Bearer $TOKEN"
 
 ```
+
 </CodeGroup>
-```

--- a/docs/concepts/security.mdx
+++ b/docs/concepts/security.mdx
@@ -28,7 +28,7 @@ Nora is built to be trustworthy in real operator environments: you run it on you
 
 ## Runtime access control
 
-- **The gateway proxy is the only path to a runtime's API**, and it restricts which upstream addresses can be proxied to an allowlist of ranges.
+- **The authenticated gateway proxy is the normal browser and control-plane path to a runtime's API**, and it restricts upstream addresses to an allowlist of ranges. Remote Docker also publishes runtime ports on the registered host so Nora's workers can reach them; those ports must stay behind the documented firewall and private encrypted network.
 - **Live exec, log, and metrics WebSocket streams enforce access control** — runtime terminal and log streaming are authenticated, not open sockets.
 - **Proxied agent assets are token-validated** before they are served.
 - **BYOC remote hosts pin their SSH host key.** The first successful connection test records the remote host's SSH public key (trust-on-first-use); every later connection — connection tests and deploys alike — rejects a host presenting a different key, so a changed/spoofed host (man-in-the-middle) fails closed rather than silently connecting.

--- a/docs/configuration/provisioner-backends.mdx
+++ b/docs/configuration/provisioner-backends.mdx
@@ -1,15 +1,23 @@
 # Choose a provisioner backend for agents
 
-> Compare Docker, Kubernetes, experimental Proxmox LXC placement, and the experimental NemoClaw sandbox profile to pick the right agent isolation and scaling strategy for your Nora deployment.
+> Compare Docker, Remote Docker, Kubernetes, experimental Proxmox LXC placement, and the experimental NemoClaw sandbox profile to pick the right agent isolation and scaling strategy for your Nora deployment.
 
-Nora provisions agent runtimes onto execution targets selected in the Deploy flow. Docker and Kubernetes are GA paths. Docker is the default. Kubernetes clusters are registered in **Admin -> Kubernetes** so one Nora control plane can manage several clusters at once. Proxmox is an opt-in experimental LXC target for OpenClaw and prepared Hermes images. NemoClaw is an experimental sandbox profile layered onto supported targets, but NemoClaw on Proxmox remains blocked.
+Nora provisions agent runtimes onto execution targets selected in the Deploy flow. Docker and Kubernetes are GA paths. Docker is the default. Remote Docker is a self-hosted-only, experimental bring-your-own-compute path for operator-registered Docker machines reached over SSH. Kubernetes clusters are registered in **Admin -> Kubernetes** so one Nora control plane can manage several clusters at once. Proxmox is an opt-in experimental LXC target for OpenClaw and prepared Hermes images. NemoClaw is an experimental OpenClaw sandbox profile layered onto supported targets, but NemoClaw on Proxmox remains blocked.
 
 ![Deploy wizard — Execution Target picker rendering the enabled backends](/images/configuration/deploy-backend-picker.png)
 
-<CardGroup cols={3}>
+<CardGroup cols={2}>
   <Card title="Docker" icon="docker" href="/configuration/provisioner-backends/docker">
     Single-host deployments, local development, and quick evaluation.
   </Card>
+
+<Card
+  title="Remote Docker (experimental)"
+  icon="network-wired"
+  href="/configuration/provisioner-backends/remote-docker"
+>
+  Operator-owned Docker hosts reached through encrypted credentials and pinned SSH.
+</Card>
 
 <Card
   title="Proxmox (experimental)"
@@ -26,14 +34,14 @@ Nora provisions agent runtimes onto execution targets selected in the Deploy flo
 
 ## Comparing backends
 
-|                        | Docker                                  | Proxmox                                      | Kubernetes                                |
-| ---------------------- | --------------------------------------- | -------------------------------------------- | ----------------------------------------- |
-| **Support status**     | GA                                      | Experimental                                 | GA                                        |
-| **Deployment scale**   | Single host                             | Private VM/LXC fleet                         | Multi-node cluster                        |
-| **Agent isolation**    | Container                               | Proxmox LXC                                  | Pod and namespace boundaries              |
-| **Setup complexity**   | Low                                     | Medium - Proxmox API plus SSH bootstrap      | Medium to high - cluster and kubeconfig   |
-| **Best for**           | Local dev, evaluation, lean self-hosted | On-prem and private infrastructure operators | Cloud-native and managed-cluster rollouts |
-| **Horizontal scaling** | No                                      | Limited by Proxmox fleet capacity            | Yes                                       |
+|                        | Docker                                  | Remote Docker                                      | Proxmox                                      | Kubernetes                                |
+| ---------------------- | --------------------------------------- | -------------------------------------------------- | -------------------------------------------- | ----------------------------------------- |
+| **Support status**     | GA                                      | Experimental                                       | Experimental                                 | GA                                        |
+| **Deployment scale**   | Nora control-plane host                 | One or more registered standalone hosts            | Private VM/LXC fleet                         | Multi-node cluster                        |
+| **Agent isolation**    | Container                               | Container on the selected remote host              | Proxmox LXC                                  | Pod and namespace boundaries              |
+| **Setup complexity**   | Low                                     | Medium - SSH, Docker access, routing, and firewall | Medium - Proxmox API plus SSH bootstrap      | Medium to high - cluster and kubeconfig   |
+| **Best for**           | Local dev, evaluation, lean self-hosted | BYOC machines, private VPSs, and edge hosts        | On-prem and private infrastructure operators | Cloud-native and managed-cluster rollouts |
+| **Horizontal scaling** | No                                      | Manual placement across registered hosts           | Limited by Proxmox fleet capacity            | Yes                                       |
 
 ## Runtime selection
 
@@ -46,6 +54,8 @@ ENABLED_SANDBOX_PROFILES=standard
 ```
 
 Use `ENABLED_BACKENDS=docker` for normal onboarding, or `docker,proxmox` to opt into the experimental LXC path after secure API/SSH configuration. Cluster-only control planes such as the official Helm install use `ENABLED_BACKENDS=k8s` as a sentinel that disables the local Docker target; it does not create a generic selectable cluster. Concrete Kubernetes deploy targets still come only from the Admin cluster registry. Run the live Proxmox smoke before production use.
+
+Do not add `remote-docker` to `ENABLED_BACKENDS`. On a self-hosted Nora control plane, register hosts in **App -> Remote Hosts** and run **Test**; each enabled, configured host with a successful Docker-over-SSH test is injected dynamically as `remote:<id>`. The current Deploy picker exposes those registered targets only for OpenClaw. Hermes support exists in the backend and worker as an advanced API path, but the current Hermes picker does not list remote hosts. See [Remote Docker](/configuration/provisioner-backends/remote-docker) for the SSH host-key and firewall requirements.
 
 Register Kubernetes clusters in **Admin -> Kubernetes**. Each enabled registry row with a passing **Test** result becomes a separate deploy target with an id like `k8s:aks-eastus2`, while persisted agents still use the base `k8s` adapter internally. Failed, untested, or disabled clusters stay visible in Admin but are hidden from the Deploy page for both OpenClaw and Hermes. The Deploy page shows the cluster label, provider, actual cluster name, namespace, and exposure mode so operators can tell AKS, GKE, EKS, K3s, Kind, or generic clusters apart.
 

--- a/docs/configuration/provisioner-backends/remote-docker.mdx
+++ b/docs/configuration/provisioner-backends/remote-docker.mdx
@@ -1,0 +1,155 @@
+# Remote Docker provisioner backend
+
+> Run Nora agents on an operator-owned Docker machine that the Nora control plane reaches over SSH.
+
+Remote Docker is Nora's experimental bring-your-own-compute path for a standalone Docker host. You register the machine in the operator dashboard, test the SSH and Docker connection, and then select its `remote:<id>` execution target when deploying an agent.
+
+<Warning>
+  Remote Docker is experimental. Validate lifecycle, readiness, networking, backups, and recovery on
+  your exact host before placing production workloads on it. Remote agent ports bind to `0.0.0.0` on
+  the registered machine, so the firewall requirements below are mandatory on any shared or
+  internet-reachable network. Remote Docker is available only from a self-hosted Nora control plane;
+  hosted mode disables registration and use.
+</Warning>
+
+## How it works
+
+Nora connects to the registered machine's Docker daemon through SSH. It does not require an unauthenticated Docker TCP socket or a Docker context on the Nora host. The remote adapter reuses Nora's Docker lifecycle and runtime bootstrap, while PostgreSQL reserves the published ports independently for each registered host.
+
+SSH encrypts Docker control traffic only. Readiness, runtime APIs, OpenClaw gateway traffic, Hermes dashboard traffic, and OpenClaw live backup/export reads use plain HTTP or WebSocket connections to the published agent ports. Remote Hermes backup capture instead uses the Docker API over the same SSH transport as lifecycle operations. Put the Nora control plane and remote host on the same trusted private network or an encrypted overlay such as WireGuard or Tailscale. Do not send the published agent ports across the public internet.
+
+Remote hosts are user-owned records. Registration and configuration require a signed-in browser session at **App -> Remote Hosts** (`/app/remote-hosts`). The Admin **Remote Hosts** page is a fleet-wide, read-only inventory; it is not where hosts are registered.
+
+## Prerequisites
+
+Before registration, prepare the remote machine with:
+
+- an SSH server reachable from `backend-api`, `worker-provisioner`, and `worker-backup`;
+- a Docker CLI and running Docker daemon;
+- an SSH account that can run `docker version` and manage containers without an interactive prompt;
+- outbound DNS and HTTPS access to the container registries, package registries, model providers, and integrations used by the selected runtime;
+- enough CPU, memory, storage, and image-cache space for the planned agents; and
+- a stable address that the Nora control plane can use for SSH and agent gateway traffic.
+
+Docker daemon access is effectively root-equivalent on most hosts. Prefer a dedicated remote machine and a dedicated SSH identity, and protect that identity as a privileged credential.
+
+The Nora control plane must have a valid `ENCRYPTION_KEY`. Remote-host private keys, passwords, and key passphrases are encrypted before storage and are never returned by the API.
+
+```bash theme={null}
+# 32 random bytes encoded as 64 hexadecimal characters
+ENCRYPTION_KEY=<64-hex-character-key>
+
+ENABLED_RUNTIME_FAMILIES=openclaw,hermes
+ENABLED_BACKENDS=docker
+ENABLED_SANDBOX_PROFILES=standard,nemoclaw
+```
+
+Do not add `remote-docker` to `ENABLED_BACKENDS`. Successfully tested hosts are injected dynamically as concrete targets such as `remote:build-host`; `ENABLED_BACKENDS` controls only the static backend list.
+
+## Network and firewall requirements
+
+The default published-port range is configurable with `DOCKER_AGENT_PORT_RANGE_MIN` and `DOCKER_AGENT_PORT_RANGE_MAX`, but both values must remain inside `19000-19999`.
+
+| Source                                                        | Destination                         | Protocol and port                            | Purpose                                                                                                                    | Recommended restriction                                                             |
+| ------------------------------------------------------------- | ----------------------------------- | -------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| Nora `backend-api`, `worker-provisioner`, and `worker-backup` | Remote host                         | TCP `22` or the configured SSH port          | Connection test, Docker transport, lifecycle operations, and Remote Hermes backup capture                                  | Allow only every Nora control-plane or worker egress address                        |
+| Nora `backend-api`, `worker-provisioner`, and `worker-backup` | Remote host's gateway address       | TCP configured subrange within `19000-19999` | Readiness, OpenClaw gateway/runtime traffic, Hermes runtime/dashboard proxy traffic, and OpenClaw live backup/export reads | Allow only Nora control-plane and worker addresses; never expose the range publicly |
+| Remote host                                                   | Registries and configured providers | DNS plus outbound HTTPS                      | Pull images/packages and reach model or integration APIs                                                                   | Use an egress allowlist where practical                                             |
+| Operator browser                                              | Nora application origin             | HTTPS                                        | Registration, deployment, logs, terminal, and proxied runtime UI                                                           | The browser does not need direct SSH or Docker access                               |
+
+Remote OpenClaw and Hermes adapters publish their required host ports on `0.0.0.0` because the control plane is on another machine. Hermes publishes both its runtime API and dashboard port; treat the dashboard as sensitive even though Nora normally reaches it through the authenticated proxy.
+
+Tailscale, WireGuard, or another encrypted private network can provide the SSH and gateway path. Use the private address as **SSH host** and, when necessary, **Gateway address**. Tailscale is connectivity transport, not a Nora provisioner backend, and Nora does not install or configure it.
+
+## Register a host
+
+1. Sign in to Nora and open **App -> Remote Hosts**.
+2. Enter the connection details and choose key or password authentication.
+3. Select **Register host**.
+4. Select **Test** on the new host. A host is not deployable until this test succeeds.
+
+| Field               | Required          | Description                                                                                                                            |
+| ------------------- | ----------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| **Label**           | Yes               | Human-readable name. The dashboard derives the stable target id from this label; API callers may supply an explicit id instead.        |
+| **Gateway address** | No                | Hostname or IP that `backend-api` should use for published agent ports. Defaults to the SSH host. Do not include a URL scheme or port. |
+| **SSH host**        | Yes               | DNS name or IP reachable from Nora's backend and provisioner worker.                                                                   |
+| **Port**            | Yes               | SSH port, normally `22`.                                                                                                               |
+| **SSH user**        | Yes               | Account allowed to run Docker without an interactive prompt.                                                                           |
+| **Authentication**  | Yes               | **SSH private key** is preferred; password authentication is available when required.                                                  |
+| **SSH private key** | For key auth      | Complete private-key content. Use a dedicated key with the narrowest practical host access.                                            |
+| **Key passphrase**  | No                | Passphrase for an encrypted private key.                                                                                               |
+| **SSH password**    | For password auth | Password used only when password authentication is selected.                                                                           |
+
+When editing a host, leave secret fields blank to preserve the stored values. Changing SSH connection details, credentials, Docker settings, or the gateway address clears the previous successful-test state, so the host must pass **Test** again. Credential rotation preserves the existing host-key pin. Changing the SSH host or port clears that pin because it identifies a different network endpoint.
+
+## SSH host-key security
+
+The first successful **Test** connects over SSH, runs `docker version`, and pins the public host key presented by the server. This is trust on first use (TOFU): perform the first test from a trusted network and verify that the DNS name or IP reaches the intended machine.
+
+After the key is pinned, a different key for the same registration is rejected. Nora does not silently replace the pin. If the machine was intentionally rebuilt or its SSH host key was rotated, verify the new key through a trusted console or another out-of-band path, then delete and re-register the host before testing it again.
+
+<Warning>
+  A successful SSH login alone is not sufficient. **Test** must also run `docker version`
+  successfully as the registered user. Do not work around Docker permission errors by exposing an
+  insecure Docker TCP listener.
+</Warning>
+
+## Runtime support
+
+| Runtime path        | Adapter status | Current operator UI                                                                                                                              |
+| ------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| OpenClaw + standard | Experimental   | Registered, tested hosts are selectable in the Deploy flow.                                                                                      |
+| OpenClaw + NemoClaw | Experimental   | Selectable when `nemoclaw` is enabled and the remote host satisfies the NemoClaw prerequisites.                                                  |
+| Hermes + standard   | Experimental   | Backend, API, worker, readiness, dashboard, and backup support are implemented. The current Hermes Deploy picker does not list registered hosts. |
+| Hermes + NemoClaw   | Unsupported    | Hermes supports only the standard sandbox profile.                                                                                               |
+
+The current Deploy picker adds registered hosts only to OpenClaw target selections. Treat Hermes Remote Docker as an advanced API path until the Hermes picker exposes it.
+
+## Deploy and validate
+
+After **Test** reports that Docker is reachable:
+
+1. Open **Deploy Agent** and select **OpenClaw**.
+2. Choose the remote host by its label and `remote:<id>` target.
+3. Select **Standard** or **NemoClaw**, configure the model and resources, and deploy.
+4. Wait for Nora's readiness check to report the agent as ready.
+5. From the agent page, verify lifecycle actions, logs, terminal access, chat/gateway access, and any enabled integrations.
+6. On the remote machine, confirm that the Nora-managed containers are running and that their published ports are inside the configured range.
+
+```bash theme={null}
+ssh operator@remote-host 'docker version && docker ps'
+```
+
+For a production candidate, also test restart, credential rotation, backup/restore, host reboot recovery, and agent deletion. Remote Hermes backup/export uses the registered Docker-over-SSH backend; it does not read the Nora host's local Docker socket. A successful connection test proves SSH and Docker reachability; it is not a complete workload smoke test.
+
+## Operations and workspace sharing
+
+- Ports are reserved in PostgreSQL by remote host, agent, and purpose. OpenClaw may reserve gateway and runtime ports; remote Hermes reserves runtime and dashboard ports.
+- Keep the selected port subrange free from unrelated services. Nora reports a range-exhaustion error instead of assigning a conflicting reservation.
+- Changing connection inputs invalidates the prior test. Run **Test** again before the host can return to the picker. The next deploy, lifecycle action, or backup reloads the current profile; control-plane services do not need a restart.
+- The host owner can share a host with a workspace from **App -> Remote Hosts**. Viewers see it read-only; editors, admins, and owners can deploy to it using the owner's encrypted credentials.
+- Host configuration and credentials remain owner-only. Workspace access does not reveal stored secrets.
+- A host cannot be deleted while non-deleted agents still reference its `remote:<id>` target. Delete or migrate those agents first.
+- Admins can inspect the fleet-wide registry from the Admin dashboard, but cannot edit another owner's host there.
+
+## Troubleshooting
+
+| Symptom                                | Checks                                                                                                                                                                                                                             |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Host is missing from Deploy            | Confirm the host is enabled, has credentials, and has a successful **Test** result. Confirm OpenClaw is enabled. A viewer of a shared host cannot deploy, and the current Hermes picker does not inject remote hosts consistently. |
+| SSH connection times out or is refused | Check the address and port, SSH service, route or VPN, and firewall rules from both `backend-api` and `worker-provisioner`.                                                                                                        |
+| Authentication fails                   | Confirm the SSH user and selected auth mode. Paste the complete private key, supply its passphrase when required, and check the server's authorized-key or password policy.                                                        |
+| `docker version` fails                 | Install/start Docker and grant the SSH account non-interactive daemon access. Test with the same user outside Nora.                                                                                                                |
+| Host-key mismatch                      | Stop and verify the machine identity out of band. If rotation or rebuild was intentional, delete and re-register the host; otherwise treat it as a possible interception attempt.                                                  |
+| Agent deploys but never becomes ready  | Verify **Gateway address**, allow the configured `19000-19999` subrange from Nora, and confirm the published container ports are listening on the remote host.                                                                     |
+| Hermes dashboard cannot load           | Confirm both the allocated runtime and dashboard ports are firewalled to and reachable from `backend-api`. Do not expose the dashboard directly to the internet.                                                                   |
+| No free gateway port is available      | Remove stale agents/reservations where appropriate, free unrelated listeners, or widen the configured subrange while keeping it inside `19000-19999`.                                                                              |
+| Image pull or provider calls fail      | Check remote-host DNS, outbound HTTPS, registry credentials, provider credentials, and any egress proxy or allowlist.                                                                                                              |
+
+## Related references
+
+- [Choose a provisioner backend](/configuration/provisioner-backends)
+- [Docker backend](/configuration/provisioner-backends/docker)
+- [Environment variables](/configuration/environment-variables#docker-agent-published-ports)
+- [Deploy an agent](/guides/deploy-agent)
+- [NemoClaw sandbox](/guides/nemoclaw)

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -46,6 +46,7 @@
             "pages": [
               "configuration/provisioner-backends",
               "configuration/provisioner-backends/docker",
+              "configuration/provisioner-backends/remote-docker",
               "configuration/provisioner-backends/proxmox",
               {
                 "group": "Kubernetes",

--- a/docs/guides/nemoclaw.mdx
+++ b/docs/guides/nemoclaw.mdx
@@ -42,12 +42,12 @@ NemoClaw agents use NVIDIA's Nemotron family of models via the NVIDIA API. The f
 
 NemoClaw runs as an OpenClaw sandbox profile on these deploy targets:
 
-| Target           | Status    | Notes                                                                                                                    |
-| ---------------- | --------- | ------------------------------------------------------------------------------------------------------------------------ |
-| Local Docker     | Supported | Uses the local Docker socket and the NemoClaw sandbox image.                                                             |
-| Remote Docker    | Supported | Requires a connected remote host target such as `remote:gpu-vps`; Nora publishes the gateway port on that host.          |
-| K3s / Kubernetes | Supported | Uses the Kubernetes adapter with `sandbox_profile=nemoclaw`; API keys are injected through per-agent Kubernetes Secrets. |
-| AKS / GKE / EKS  | Supported | Same Kubernetes adapter as K3s; use LoadBalancer exposure or the cluster exposure mode configured in Admin.              |
+| Target           | Status       | Notes                                                                                                                             |
+| ---------------- | ------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| Local Docker     | Supported    | Uses the local Docker socket and the NemoClaw sandbox image.                                                                      |
+| Remote Docker    | Experimental | Requires a connected self-hosted remote target such as `remote:gpu-vps`; keep its published ports on a private encrypted network. |
+| K3s / Kubernetes | Supported    | Uses the Kubernetes adapter with `sandbox_profile=nemoclaw`; API keys are injected through per-agent Kubernetes Secrets.          |
+| AKS / GKE / EKS  | Supported    | Same Kubernetes adapter as K3s; use LoadBalancer exposure or the cluster exposure mode configured in Admin.                       |
 
 The default sandbox image is `ghcr.io/solomon2773/nora-nemoclaw-agent:latest`. For air-gapped
 hosts or private clusters, build `nora-nemoclaw-agent:local`, preload it onto the target nodes, and

--- a/docs/self-hosting.mdx
+++ b/docs/self-hosting.mdx
@@ -157,7 +157,7 @@ Run Nora itself on a Kubernetes cluster with the public OCI chart at `oci://ghcr
 
 ```bash
 helm install nora oci://ghcr.io/solomon2773/nora \
-  --version 0.7.0 \
+  --version 0.7.1 \
   --namespace nora --create-namespace \
   --set secrets.jwtSecret="$(openssl rand -hex 32)" \
   --set secrets.encryptionKey="$(openssl rand -hex 32)" \
@@ -176,7 +176,13 @@ inherit it. For a public deployment set `publicUrl`, enable `ingress.*`, and ter
 Ingress controller.
 
 <Warning>
-  A cluster-hosted control plane deploys agents to **Kubernetes targets only** (`ENABLED_BACKENDS=k8s`): pods have no Docker socket, so the Docker deploy target is unavailable. Register agent clusters under Admin → Kubernetes and mount their kubeconfigs with `kubeconfigs.existingSecret`. In-place release upgrades from the Admin UI are a Docker Compose feature — upgrade with `helm upgrade nora oci://ghcr.io/solomon2773/nora --version <chart-version> --reuse-values` instead.
+  A cluster-hosted control plane cannot use the **local Docker** target (`ENABLED_BACKENDS=k8s`)
+  because its pods have no Docker socket. It can still use operator-registered [Remote
+  Docker](/configuration/provisioner-backends/remote-docker) targets over SSH when Nora is
+  self-hosted and the control-plane pods can reach the private remote-host network. Register agent
+  clusters under Admin → Kubernetes and mount their kubeconfigs with `kubeconfigs.existingSecret`.
+  In-place release upgrades from the Admin UI are a Docker Compose feature — use the Helm upgrade
+  command from the chart README instead.
 </Warning>
 
 See the [chart README](https://github.com/solomon2773/nora/blob/master/infra/helm/nora/README.md) for all values, design notes, and the local Kind smoke test.

--- a/docs/support/faq.mdx
+++ b/docs/support/faq.mdx
@@ -73,7 +73,7 @@ If you are evaluating Nora or have just started self-hosting it, the questions b
   <Accordion title="What is NemoClaw?">
     NemoClaw is an experimental sandbox profile with OpenShell policy controls, powered by NVIDIA Nemotron models. It provides a secure, isolated execution environment for agent runtimes that require tighter operational controls.
 
-    NemoClaw is disabled by default. To enable it, add `nemoclaw` to `ENABLED_SANDBOX_PROFILES` (e.g. `ENABLED_SANDBOX_PROFILES=standard,nemoclaw`) and save an NVIDIA provider key in **Settings** or provide a platform fallback with `NVIDIA_API_KEY`. It can deploy to local Docker, remote Docker hosts, k3s, and managed Kubernetes targets once those execution targets are connected. See the [troubleshooting guide](/support/troubleshooting) if NemoClaw fails to start after enabling it.
+    NemoClaw is an OpenClaw-only profile and is disabled by default. To enable it, add `nemoclaw` to `ENABLED_SANDBOX_PROFILES` (e.g. `ENABLED_SANDBOX_PROFILES=standard,nemoclaw`) and save an NVIDIA provider key in **Settings** or provide a platform fallback with `NVIDIA_API_KEY`. It can deploy to local Docker, self-hosted Remote Docker hosts, k3s, and managed Kubernetes targets once those execution targets are connected. Hermes does not support NemoClaw, and NemoClaw on Proxmox remains blocked. See the [troubleshooting guide](/support/troubleshooting) if NemoClaw fails to start after enabling it.
 
   </Accordion>
 

--- a/e2e/specs/demo-activation.spec.ts
+++ b/e2e/specs/demo-activation.spec.ts
@@ -7,13 +7,7 @@ import {
   ensureUserSession,
   isJsonRecord,
 } from "./support/app";
-import {
-  deleteAgent,
-  getAgent,
-  listProviders,
-  waitForAgentStatus,
-  waitForOpenClawGateway,
-} from "./support/agents";
+import { deleteAgent, listProviders, waitForAgentStatus } from "./support/agents";
 
 type AgentRecord = Record<string, unknown> & {
   id: string;
@@ -103,33 +97,33 @@ test.describe("Built-in demo activation", () => {
       const providers = await listProviders(request, operator.token);
       expect(providers.filter((provider) => provider?.provider === "demo")).toHaveLength(1);
 
-      await waitForAgentStatus(request, operator.token, agentId, ["running", "warning"], {
+      const runningAgent = await waitForAgentStatus(request, operator.token, agentId, "running", {
         timeoutMs: 10 * 60 * 1000,
-        intervalMs: 3000,
-      });
-      await waitForOpenClawGateway(request, operator.token, agentId, {
-        timeoutMs: 3 * 60 * 1000,
-        intervalMs: 3000,
-      });
-      await waitForAgentStatus(request, operator.token, agentId, "running", {
-        timeoutMs: 30_000,
         intervalMs: 1000,
       });
-      expect((await getAgent(request, operator.token, agentId)).status).toBe("running");
+      expect(runningAgent.status).toBe("running");
 
+      // This must be the first gateway request after the control plane publishes
+      // final readiness. Do not warm the connection with /gateway/status or retry
+      // chat here: either would mask a worker that marks the agent running before
+      // its post-deploy auth reconciliation restart has settled.
       const prompt = `demo activation e2e ${Date.now()}`;
-      const { body: chatBody } = await apiJson<string>(
+      const { response: chatResponse, body: chatBody } = await apiJson<unknown>(
         request,
         `/api/agents/${agentId}/gateway/chat`,
         {
           method: "POST",
           token: operator.token,
           data: { message: prompt, stream: true },
+          failOnStatus: false,
         },
       );
+      const rawChatBody =
+        typeof chatBody === "string" ? chatBody : JSON.stringify(chatBody ?? null);
+      expect(chatResponse.status(), `First chat response:\n${rawChatBody}`).toBe(200);
       expect(typeof chatBody).toBe("string");
-      const reply = finalAssistantText(String(chatBody));
-      expect(reply, `Raw gateway SSE:\n${String(chatBody)}`).toContain(
+      const reply = finalAssistantText(rawChatBody);
+      expect(reply, `Raw gateway SSE:\n${rawChatBody}`).toContain(
         "Hi! I'm Nora's demo agent, running on a built-in stub model — no API key required.",
       );
       // OpenClaw prepends sender metadata and a timestamp before the user text;

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "nora",
   "description": "Operate self-hosted OpenClaw and Hermes agent fleets from Gemini CLI.",
-  "version": "1.16.0",
+  "version": "1.16.1",
   "settings": [
     {
       "name": "Nora API URL",

--- a/infra/helm/nora/Chart.yaml
+++ b/infra/helm/nora/Chart.yaml
@@ -5,8 +5,8 @@ description: >-
   (nginx edge, marketing/operator/admin frontends, backend API, provisioner and
   backup workers) plus optional in-chart PostgreSQL and Redis.
 type: application
-version: 0.7.0
-appVersion: "1.16.0"
+version: 0.7.1
+appVersion: "1.16.1"
 home: https://github.com/solomon2773/nora
 icon: https://raw.githubusercontent.com/solomon2773/nora/master/frontend-marketing/public/icon-512.png
 sources:

--- a/infra/helm/nora/files/nginx-k8s.conf
+++ b/infra/helm/nora/files/nginx-k8s.conf
@@ -15,8 +15,15 @@ http {
 
     server_tokens off;
 
+    map $uri $surface_x_frame_options {
+        default "DENY";
+        ~^/api(/|$) "";
+        ~^/(app|admin)(/|$) "SAMEORIGIN";
+        ~^/_next/ "";
+    }
+
     add_header X-Content-Type-Options nosniff always;
-    add_header X-Frame-Options DENY always;
+    add_header X-Frame-Options $surface_x_frame_options always;
     add_header Referrer-Policy strict-origin-when-cross-origin always;
     add_header Cross-Origin-Opener-Policy same-origin always;
 

--- a/infra/nginx_public.conf.template
+++ b/infra/nginx_public.conf.template
@@ -55,6 +55,40 @@ http {
     limit_req_zone $binary_remote_addr zone=api_limit:10m rate=30r/s;
     limit_req_status 429;
 
+    # Marketing-only browser policy and homepage edge-cache eligibility. Empty
+    # map values suppress these headers on APIs, dashboards, and Next assets.
+    map $uri $marketing_content_security_policy {
+        default "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self' 'unsafe-inline' https:; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https:; frame-src https://challenges.cloudflare.com https://www.google.com https://recaptcha.google.com; worker-src 'self' blob:; media-src 'self'; manifest-src 'self'; upgrade-insecure-requests";
+        ~^/(api|app|admin)(/|$) "";
+        ~^/_next/ "";
+    }
+
+    map $uri $marketing_cache_control {
+        default "";
+        "/" "public, max-age=0, s-maxage=300, stale-while-revalidate=60";
+    }
+
+    # Marketing pages must not be framed. Authenticated dashboards remain
+    # same-origin only, while API responses preserve backend-owned headers
+    # (the gateway embed route deliberately emits SAMEORIGIN).
+    map $uri $surface_x_frame_options {
+        default "DENY";
+        ~^/api(/|$) "";
+        ~^/(app|admin)(/|$) "SAMEORIGIN";
+        ~^/_next/ "";
+    }
+
+    server_tokens off;
+    add_header X-Content-Type-Options nosniff always;
+    add_header X-Frame-Options $surface_x_frame_options always;
+    add_header Referrer-Policy strict-origin-when-cross-origin always;
+    add_header Cross-Origin-Opener-Policy same-origin always;
+    # This header is ignored by direct HTTP clients but is preserved when a
+    # TLS-terminating reverse proxy such as Cloudflare fronts this origin.
+    add_header Strict-Transport-Security "max-age=63072000" always;
+    add_header Content-Security-Policy $marketing_content_security_policy always;
+    add_header Cache-Control $marketing_cache_control always;
+
     # WebSocket support mapping
     map $http_upgrade $connection_upgrade {
         default upgrade;
@@ -175,6 +209,11 @@ http {
         }
 
         # 4. Marketing Pages (Root)
+        location = / {
+            proxy_hide_header Cache-Control;
+            proxy_pass $marketing_site;
+        }
+
         location / {
             proxy_pass $marketing_site;
         }

--- a/infra/nginx_tls.conf
+++ b/infra/nginx_tls.conf
@@ -65,10 +65,38 @@ http {
     limit_req_zone $binary_remote_addr zone=api_limit:10m rate=30r/s;
     limit_req_status 429;
 
+    # Marketing pages receive an enforced browser policy without applying it
+    # to the authenticated dashboards, APIs, or proxied OpenClaw UI. The
+    # latter surfaces have different frame/connect requirements.
+    map $uri $marketing_content_security_policy {
+        default "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; script-src 'self' 'unsafe-inline' https:; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; font-src 'self' data:; connect-src 'self' https:; frame-src https://challenges.cloudflare.com https://www.google.com https://recaptcha.google.com; worker-src 'self' blob:; media-src 'self'; manifest-src 'self'; upgrade-insecure-requests";
+        ~^/(api|app|admin)(/|$) "";
+        ~^/_next/ "";
+    }
+
+    # Keep authenticated and signup/login HTML dynamic. Only the public home
+    # page is intentionally eligible for short shared-edge caching.
+    map $uri $marketing_cache_control {
+        default "";
+        "/" "public, max-age=0, s-maxage=300, stale-while-revalidate=60";
+    }
+
+    map $uri $surface_x_frame_options {
+        default "DENY";
+        ~^/api(/|$) "";
+        ~^/(app|admin)(/|$) "SAMEORIGIN";
+        ~^/_next/ "";
+    }
+
     # Security headers
+    server_tokens off;
     add_header X-Content-Type-Options nosniff always;
-    add_header X-Frame-Options DENY always;
+    add_header X-Frame-Options $surface_x_frame_options always;
     add_header Referrer-Policy strict-origin-when-cross-origin always;
+    add_header Cross-Origin-Opener-Policy same-origin always;
+    add_header Strict-Transport-Security "max-age=63072000" always;
+    add_header Content-Security-Policy $marketing_content_security_policy always;
+    add_header Cache-Control $marketing_cache_control always;
 
     map $http_upgrade $connection_upgrade {
         default upgrade;
@@ -108,9 +136,6 @@ http {
         ssl_prefer_server_ciphers on;
         ssl_session_cache   shared:SSL:10m;
         ssl_session_timeout 10m;
-
-        # HSTS (uncomment after confirming TLS works)
-        # add_header Strict-Transport-Security "max-age=63072000; includeSubDomains; preload" always;
 
         # Shared proxy settings
         proxy_http_version 1.1;
@@ -208,7 +233,13 @@ http {
             proxy_set_header Connection $connection_upgrade;
         }
 
-        # 4. Marketing Pages (Root)
+        # 4. Marketing Pages (Root). Hide any framework cache policy only for
+        # the homepage so the shared-edge directive above is unambiguous.
+        location = / {
+            proxy_hide_header Cache-Control;
+            proxy_pass $marketing_site;
+        }
+
         location / {
             proxy_pass $marketing_site;
         }

--- a/infra/render-public-nginx.sh
+++ b/infra/render-public-nginx.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: infra/render-public-nginx.sh <env-file> [compose-files]
+
+Refreshes the generated root nginx.public.conf from the tracked public or TLS
+template. Custom NGINX_CONFIG_FILE values and local-only nginx.conf installs are
+left untouched.
+EOF
+}
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+  usage >&2
+  exit 2
+fi
+
+env_file="$1"
+compose_files="${2:-}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_dir="$(cd "$script_dir/.." && pwd)"
+
+if [ ! -f "$env_file" ]; then
+  echo "Missing deploy env file: $env_file" >&2
+  exit 1
+fi
+
+read_env_value() {
+  local name="$1"
+  awk -v name="$name" '
+    function trim(value) {
+      sub(/^[[:space:]]+/, "", value)
+      sub(/[[:space:]]+$/, "", value)
+      return value
+    }
+
+    $0 ~ "^[[:space:]]*" name "[[:space:]]*=" {
+      line = $0
+      sub(/^[^=]*=/, "", line)
+      line = trim(line)
+      if ((substr(line, 1, 1) == "\"" && substr(line, length(line), 1) == "\"") ||
+          (substr(line, 1, 1) == "\047" && substr(line, length(line), 1) == "\047")) {
+        line = substr(line, 2, length(line) - 2)
+      }
+      value = line
+    }
+
+    END {
+      print value
+    }
+  ' "$env_file"
+}
+
+nginx_config_file="$(read_env_value NGINX_CONFIG_FILE)"
+case "$nginx_config_file" in
+  ""|nginx.conf)
+    echo "Local nginx config is active; no generated public config refresh is needed."
+    exit 0
+    ;;
+  nginx.public.conf)
+    ;;
+  *)
+    echo "Custom NGINX_CONFIG_FILE=$nginx_config_file is active; leaving it unchanged."
+    exit 0
+    ;;
+esac
+
+public_url="$(read_env_value NORA_PUBLIC_URL)"
+if [ -z "$public_url" ]; then
+  public_url="$(read_env_value NEXTAUTH_URL)"
+fi
+
+domain=""
+if [[ "$public_url" == *://* ]]; then
+  authority="${public_url#*://}"
+  authority="${authority%%/*}"
+  authority="${authority##*@}"
+  domain="${authority%%:*}"
+fi
+
+output_path="$repo_dir/nginx.public.conf"
+if [ -z "$domain" ] && [ -f "$output_path" ]; then
+  domain="$(awk '$1 == "server_name" { gsub(/;/, "", $2); print $2; exit }' "$output_path")"
+fi
+
+if [[ ! "$domain" =~ ^[A-Za-z0-9.-]+$ ]] || [[ "$domain" != *.* ]]; then
+  echo "Could not derive a valid public domain from NORA_PUBLIC_URL or NEXTAUTH_URL." >&2
+  exit 1
+fi
+
+tls_enabled=false
+if [[ ":$compose_files:" == *":infra/docker-compose.public-tls.yml:"* ]] ||
+  { [ -f "$output_path" ] && grep -Eq '^[[:space:]]*(listen[[:space:]]+443[[:space:]]+ssl|ssl_certificate[[:space:]])' "$output_path"; }; then
+  tls_enabled=true
+else
+  IFS=':' read -r -a compose_paths <<< "$compose_files"
+  for compose_path in "${compose_paths[@]}"; do
+    [ -n "$compose_path" ] || continue
+    if [[ "$compose_path" != /* ]]; then
+      compose_path="$repo_dir/$compose_path"
+    fi
+    if [ -f "$compose_path" ] && grep -Eq '443:443|/etc/letsencrypt' "$compose_path"; then
+      tls_enabled=true
+      break
+    fi
+  done
+fi
+
+template="$script_dir/nginx_public.conf.template"
+if [ "$tls_enabled" = true ]; then
+  template="$script_dir/nginx_tls.conf"
+fi
+
+tmp_file="$(mktemp "$repo_dir/.nginx.public.conf.XXXXXX")"
+cleanup() {
+  rm -f "$tmp_file"
+}
+trap cleanup EXIT
+
+awk -v domain="$domain" '{ gsub(/\$\{DOMAIN\}/, domain); print }' "$template" > "$tmp_file"
+chmod 644 "$tmp_file"
+mv -f "$tmp_file" "$output_path"
+trap - EXIT
+
+echo "Refreshed nginx.public.conf from ${template#"$repo_dir/"} for $domain."

--- a/infra/update-release-env.sh
+++ b/infra/update-release-env.sh
@@ -10,6 +10,7 @@ Updates or appends:
   NORA_CURRENT_VERSION
   NORA_CURRENT_COMMIT
   NORA_GITHUB_REPO (when provided)
+  DOCKER_GID (from the live Docker socket)
   NORA_AGENT_HUB_API_KEY_HASH_SECRET (only when missing or empty)
 
 Removes retired release metadata token keys:
@@ -48,6 +49,30 @@ fi
 
 env_dir="$(dirname "$env_file")"
 
+resolve_docker_gid() {
+  socket_path="${NORA_DOCKER_SOCKET_PATH:-/var/run/docker.sock}"
+  if [ ! -S "$socket_path" ]; then
+    echo "Docker socket does not exist or is not a Unix socket: $socket_path" >&2
+    return 1
+  fi
+
+  socket_gid="$(
+    stat -c '%g' "$socket_path" 2>/dev/null ||
+      stat -f '%g' "$socket_path" 2>/dev/null ||
+      true
+  )"
+  case "$socket_gid" in
+    ''|*[!0-9]*)
+      echo "Could not determine the numeric Docker socket group for $socket_path" >&2
+      return 1
+      ;;
+  esac
+
+  printf '%s\n' "$socket_gid"
+}
+
+docker_gid="$(resolve_docker_gid)"
+
 env_has_agent_hub_hash_secret() {
   awk -F= '
     /^[[:space:]]*NORA_AGENT_HUB_API_KEY_HASH_SECRET[[:space:]]*=/ {
@@ -82,12 +107,14 @@ awk \
   -v version="$version" \
   -v commit="$commit" \
   -v github_repo="$github_repo" \
+  -v docker_gid="$docker_gid" \
   -v agent_hub_hash_secret="$agent_hub_hash_secret" \
   '
   BEGIN {
     saw_version = 0
     saw_commit = 0
     saw_repo = 0
+    saw_docker_gid = 0
     saw_agent_hub_hash_secret = 0
   }
 
@@ -113,6 +140,14 @@ awk \
     next
   }
 
+  /^DOCKER_GID=/ {
+    if (!saw_docker_gid) {
+      print "DOCKER_GID=" docker_gid
+      saw_docker_gid = 1
+    }
+    next
+  }
+
   /^[[:space:]]*NORA_AGENT_HUB_API_KEY_HASH_SECRET[[:space:]]*=/ && agent_hub_hash_secret != "" {
     if (!saw_agent_hub_hash_secret) {
       print "NORA_AGENT_HUB_API_KEY_HASH_SECRET=" agent_hub_hash_secret
@@ -134,6 +169,9 @@ awk \
     }
     if (github_repo != "" && !saw_repo) {
       print "NORA_GITHUB_REPO=" github_repo
+    }
+    if (!saw_docker_gid) {
+      print "DOCKER_GID=" docker_gid
     }
     if (agent_hub_hash_secret != "" && !saw_agent_hub_hash_secret) {
       print "NORA_AGENT_HUB_API_KEY_HASH_SECRET=" agent_hub_hash_secret

--- a/nginx.conf
+++ b/nginx.conf
@@ -10,11 +10,18 @@ http {
     # Don't advertise the nginx version in error pages or the Server header.
     server_tokens off;
 
+    map $uri $surface_x_frame_options {
+        default "DENY";
+        ~^/api(/|$) "";
+        ~^/(app|admin)(/|$) "SAMEORIGIN";
+        ~^/_next/ "";
+    }
+
     # Baseline security headers applied to every response. nginx.public.conf
     # adds HSTS on top of these (only safe behind always-on TLS). Use `always`
     # so headers also appear on 4xx/5xx responses.
     add_header X-Content-Type-Options nosniff always;
-    add_header X-Frame-Options DENY always;
+    add_header X-Frame-Options $surface_x_frame_options always;
     add_header Referrer-Policy strict-origin-when-cross-origin always;
     add_header Cross-Origin-Opener-Policy same-origin always;
 

--- a/scripts/infra-security.test.mjs
+++ b/scripts/infra-security.test.mjs
@@ -111,6 +111,61 @@ test("marketing Compose services use an explicit environment allowlist", () => {
   }
 });
 
+test("public nginx templates enforce marketing security and homepage cache headers", () => {
+  for (const file of ["infra/nginx_public.conf.template", "infra/nginx_tls.conf"]) {
+    const source = read(file);
+    assert.match(source, /server_tokens off;/, `${file} must suppress version disclosure`);
+    assert.match(
+      source,
+      /Strict-Transport-Security "max-age=63072000" always;/,
+      `${file} must emit HSTS`,
+    );
+    assert.doesNotMatch(
+      source,
+      /Strict-Transport-Security[^;]*includeSubDomains/,
+      `${file} must not pin unrelated subdomains by default`,
+    );
+    assert.match(
+      source,
+      /add_header Content-Security-Policy \$marketing_content_security_policy always;/,
+      `${file} must emit the marketing CSP`,
+    );
+    assert.match(source, /frame-ancestors 'none'/, `${file} must prevent marketing framing`);
+    assert.match(
+      source,
+      /~\^\/\(api\|app\|admin\)\(\/\|\$\) "";/,
+      `${file} must exclude protected surfaces from the marketing CSP`,
+    );
+    assert.match(
+      source,
+      /add_header X-Frame-Options \$surface_x_frame_options always;/,
+      `${file} must choose frame policy by surface`,
+    );
+    assert.match(
+      source,
+      /map \$uri \$surface_x_frame_options \{[\s\S]*?~\^\/api\(\/\|\$\) "";[\s\S]*?~\^\/\(app\|admin\)\(\/\|\$\) "SAMEORIGIN";/,
+      `${file} must preserve backend embed headers and protect dashboards`,
+    );
+    assert.match(
+      source,
+      /"\/" "public, max-age=0, s-maxage=300, stale-while-revalidate=60";/,
+      `${file} must mark only the homepage for shared caching`,
+    );
+    assert.match(source, /location = \/ \{[\s\S]*?proxy_hide_header Cache-Control;/);
+  }
+});
+
+test("every active nginx edge preserves backend embed framing headers", () => {
+  for (const file of ["nginx.conf", "infra/helm/nora/files/nginx-k8s.conf"]) {
+    const source = read(file);
+    assert.match(source, /map \$uri \$surface_x_frame_options \{/);
+    assert.match(source, /~\^\/api\(\/\|\$\) "";/);
+    assert.match(source, /~\^\/\(app\|admin\)\(\/\|\$\) "SAMEORIGIN";/);
+    assert.match(source, /add_header X-Frame-Options \$surface_x_frame_options always;/);
+    assert.doesNotMatch(source, /add_header X-Frame-Options DENY always;/);
+  }
+});
+
 test("production Compose mounts core secrets and fails closed on ownership migration", () => {
   const rootCompose = read("docker-compose.yml");
   assert.match(rootCompose, /target: JWT_SECRET/);
@@ -143,6 +198,16 @@ test("production Compose mounts core secrets and fails closed on ownership migra
     assert.match(permissionCommand, /set -eu/);
     assert.match(permissionCommand, /Failed to migrate Nora volume ownership/);
     assert.match(permissionCommand, /exit 1/);
+  }
+});
+
+test("backup worker images include backend adapters for remote agent capture", () => {
+  for (const file of ["workers/backup/Dockerfile", "workers/backup/Dockerfile.prod"]) {
+    assert.match(
+      read(file),
+      /COPY workers\/provisioner\/backends \/backend-api\/backends/,
+      `${file} must package the backend selected by containerManager`,
+    );
   }
 });
 
@@ -451,6 +516,8 @@ test("setup and entrypoint retain fail-closed secret handling contracts", () => 
   assert.match(composeSecretMaterializer, /symlinked path component/);
   assert.match(powershellSetup, /unexpected entry/);
   assert.match(deployWorkflow, /bash scripts\/materialize-compose-secrets\.sh "\$DEPLOY_ENV_FILE"/);
+  assert.match(deployWorkflow, /Verifying Docker socket access from \$\{service\}/);
+  assert.match(deployWorkflow, /socketPath:"\/var\/run\/docker\.sock"/);
   assert.match(proxmoxWorkflow, /NORA_COMPOSE_SECRETS_DIR=%s/);
   assert.match(proxmoxWorkflow, /bash scripts\/materialize-compose-secrets\.sh "\$env_file"/);
   assert.match(proxmoxWorkflow, /rm -rf "\$secrets_dir"/);
@@ -515,6 +582,95 @@ test("setup and entrypoint retain fail-closed secret handling contracts", () => 
      ln -s "$real_parent" "$fixture_dir/linked-parent"
      sed "s#^NORA_COMPOSE_SECRETS_DIR=.*#NORA_COMPOSE_SECRETS_DIR=$fixture_dir/linked-parent/secrets#" "$env_file" > "$fixture_dir/symlink.env"
      ! bash scripts/materialize-compose-secrets.sh "$fixture_dir/symlink.env"`,
+  ]);
+});
+
+test("release env refreshes and deduplicates the live Docker socket group", () => {
+  runChecked("bash", [
+    "-c",
+    `set -euo pipefail
+     fixture_dir="$(mktemp -d /tmp/nora-release-docker-gid.XXXXXX)"
+     socket_pid=""
+     cleanup() {
+       if [ -n "$socket_pid" ]; then
+         kill "$socket_pid" >/dev/null 2>&1 || true
+         wait "$socket_pid" >/dev/null 2>&1 || true
+       fi
+       rm -rf "$fixture_dir"
+     }
+     trap cleanup EXIT
+     env_file="$fixture_dir/.env"
+     socket_path="$fixture_dir/docker.sock"
+     fake_bin="$fixture_dir/bin"
+     mkdir -p "$fake_bin"
+     printf '%s\n' \
+       '#!/bin/sh' \
+       'if [ "$1" = "-c" ] && [ "$2" = "%g" ]; then printf "990\\n"; exit 0; fi' \
+       'exec /usr/bin/stat "$@"' > "$fake_bin/stat"
+     chmod 755 "$fake_bin/stat"
+     printf '%s\n' \
+       'NORA_CURRENT_VERSION=v1.16.0' \
+       'NORA_CURRENT_COMMIT=old-commit' \
+       'NORA_GITHUB_REPO=old/repo' \
+       'DOCKER_GID=0' \
+       'DOCKER_GID=123' \
+       'NORA_AGENT_HUB_API_KEY_HASH_SECRET=existing-secret' > "$env_file"
+     chmod 600 "$env_file"
+     node -e 'const net=require("node:net");const server=net.createServer();server.listen(process.argv[1]);process.on("SIGTERM",()=>server.close(()=>process.exit(0)));' "$socket_path" &
+     socket_pid=$!
+     for _ in $(seq 1 50); do
+       [ -S "$socket_path" ] && break
+       sleep 0.02
+     done
+     test -S "$socket_path"
+     PATH="$fake_bin:$PATH" NORA_DOCKER_SOCKET_PATH="$socket_path" \
+       bash infra/update-release-env.sh "$env_file" v1.16.1 new-commit solomon2773/nora
+     test "$(grep -c '^DOCKER_GID=' "$env_file")" -eq 1
+     grep -Fxq 'DOCKER_GID=990' "$env_file"
+     grep -Fxq 'NORA_CURRENT_VERSION=v1.16.1' "$env_file"
+     grep -Fxq 'NORA_CURRENT_COMMIT=new-commit' "$env_file"
+     grep -Fxq 'NORA_GITHUB_REPO=solomon2773/nora' "$env_file"
+     grep -Fxq 'NORA_AGENT_HUB_API_KEY_HASH_SECRET=existing-secret' "$env_file"
+     test "$(stat -c '%a' "$env_file")" = 600`,
+  ]);
+});
+
+test("production deploy refreshes generated public nginx config without touching custom configs", () => {
+  const deployWorkflow = read(".github/workflows/deploy-production.yml");
+  assert.match(
+    deployWorkflow,
+    /bash infra\/render-public-nginx\.sh[\s\S]*?"\$DEPLOY_ENV_FILE"[\s\S]*?"\$DEPLOY_COMPOSE_FILES"/,
+  );
+
+  runChecked("bash", [
+    "-c",
+    `set -euo pipefail
+     fixture_dir="$(mktemp -d /tmp/nora-render-public-nginx.XXXXXX)"
+     cleanup() {
+       rm -rf "$fixture_dir"
+     }
+     trap cleanup EXIT
+     fixture_repo="$fixture_dir/repo"
+     mkdir -p "$fixture_repo/infra"
+     cp infra/render-public-nginx.sh infra/nginx_public.conf.template infra/nginx_tls.conf "$fixture_repo/infra/"
+     env_file="$fixture_repo/.env"
+
+     printf '%s\n' \\
+       'NGINX_CONFIG_FILE=nginx.public.conf' \\
+       'NEXTAUTH_URL=https://launch.example.com' > "$env_file"
+     bash "$fixture_repo/infra/render-public-nginx.sh" "$env_file" 'docker-compose.yml:infra/docker-compose.public-tls.yml'
+     grep -Fq 'server_name launch.example.com;' "$fixture_repo/nginx.public.conf"
+     grep -Fq 'ssl_certificate     /etc/letsencrypt/live/launch.example.com/fullchain.pem;' "$fixture_repo/nginx.public.conf"
+     grep -Fq 'Strict-Transport-Security "max-age=63072000" always;' "$fixture_repo/nginx.public.conf"
+     grep -Fq 'add_header X-Frame-Options $surface_x_frame_options always;' "$fixture_repo/nginx.public.conf"
+
+     printf '%s\n' \\
+       'NGINX_CONFIG_FILE=custom-nginx.conf' \\
+       'NEXTAUTH_URL=https://ignored.example.com' > "$env_file"
+     before="$(sha256sum "$fixture_repo/nginx.public.conf" | awk '{ print $1 }')"
+     bash "$fixture_repo/infra/render-public-nginx.sh" "$env_file" 'docker-compose.yml:infra/docker-compose.public-prod.yml'
+     after="$(sha256sum "$fixture_repo/nginx.public.conf" | awk '{ print $1 }')"
+     test "$before" = "$after"`,
   ]);
 });
 

--- a/workers/backup/Dockerfile
+++ b/workers/backup/Dockerfile
@@ -11,6 +11,7 @@ COPY tsconfig.base.json /tsconfig.base.json
 COPY workers/backup/ ./
 COPY backend-api /backend-api
 COPY agent-runtime /agent-runtime
+COPY workers/provisioner/backends /backend-api/backends
 RUN cd /backend-api && (npm ci --omit=dev || npm install --omit=dev)
 
 CMD ["npm", "start"]

--- a/workers/backup/Dockerfile.prod
+++ b/workers/backup/Dockerfile.prod
@@ -14,6 +14,7 @@ COPY tsconfig.base.json /tsconfig.base.json
 COPY workers/backup/ ./
 COPY backend-api /backend-api
 COPY agent-runtime /agent-runtime
+COPY workers/provisioner/backends /backend-api/backends
 COPY --chown=root:root infra/container-entrypoint.sh /usr/local/bin/nora-container-entrypoint
 RUN cd /backend-api && (npm ci --omit=dev || npm install --omit=dev)
 RUN mkdir -p /var/lib/nora-backups /tmp/nora-home /tmp/npm-cache \

--- a/workers/provisioner/backends/k8s.ts
+++ b/workers/provisioner/backends/k8s.ts
@@ -1738,6 +1738,41 @@ class K8sBackend extends ProvisionerBackend {
     return name;
   }
 
+  async _replaceManagedEnvSecretData(
+    deployName,
+    stringData = {},
+    managedNames = [],
+    namespace = this.namespace,
+  ) {
+    const name = this._envSecretName(deployName);
+    const managed = new Set((managedNames || []).map((entry) => String(entry || "").trim()));
+    let current = null;
+    try {
+      current = this._serviceObject(await this.coreApi.readNamespacedSecret({ name, namespace }));
+    } catch (error) {
+      if (!this._isNotFoundError(error)) throw error;
+    }
+
+    if (!current) {
+      if (Object.keys(stringData).length === 0) return name;
+      return this._upsertEnvSecret(deployName, stringData, {}, namespace);
+    }
+
+    const data = Object.fromEntries(
+      Object.entries(current.data || {}).filter(([key]) => !managed.has(key)),
+    );
+    const body = {
+      apiVersion: "v1",
+      kind: "Secret",
+      metadata: current.metadata,
+      type: current.type || "Opaque",
+      data,
+      stringData,
+    };
+    await this.coreApi.replaceNamespacedSecret({ name, namespace, body });
+    return name;
+  }
+
   async _deleteEnvSecretIfExists(deployName, namespace) {
     const name = this._envSecretName(deployName);
     try {
@@ -2663,7 +2698,12 @@ class K8sBackend extends ProvisionerBackend {
   async updateEnv(containerId, envVars = {}, options = {}) {
     const deployName = containerId;
     const entries = Object.entries(envVars || {}).filter(([key]) => key);
-    if (entries.length === 0) return;
+    const managedEnvNames = new Set(
+      (Array.isArray(options?.managedEnvNames) ? options.managedEnvNames : [])
+        .map((name) => String(name || "").trim())
+        .filter(Boolean),
+    );
+    if (entries.length === 0 && managedEnvNames.size === 0) return;
 
     const { deployment, namespace } = await this._readDeploymentInCandidateNamespace(
       deployName,
@@ -2673,7 +2713,6 @@ class K8sBackend extends ProvisionerBackend {
     const containerIndex = containers.findIndex((container) => container?.name === "agent");
     const index = containerIndex >= 0 ? containerIndex : 0;
     const env = Array.isArray(containers[index]?.env) ? containers[index].env : [];
-    const envIndexByName = new Map(env.map((entry, entryIndex) => [entry.name, entryIndex]));
     const envPath = `/spec/template/spec/containers/${index}/env`;
     const patch = [];
 
@@ -2691,16 +2730,13 @@ class K8sBackend extends ProvisionerBackend {
       });
     }
 
-    if (!Array.isArray(containers[index]?.env)) {
-      patch.push({ op: "add", path: envPath, value: [] });
-    }
-
     // Sensitive values go into the env Secret and are referenced via
     // secretKeyRef — replacing an existing secretKeyRef entry with a literal
     // value would put the decrypted key into the pod spec (readable by
     // anyone with `get deployment`) and let the Secret drift.
     const secretName = this._envSecretName(deployName);
     const sensitiveData = {};
+    const nextEntries = [];
     for (const [name, value] of entries) {
       const key = String(name);
       const stringValue = String(value ?? "");
@@ -2711,17 +2747,31 @@ class K8sBackend extends ProvisionerBackend {
       } else {
         nextEntry = { name: key, value: stringValue };
       }
-      const existingIndex = envIndexByName.get(key);
-      if (Number.isInteger(existingIndex)) {
-        patch.push({ op: "replace", path: `${envPath}/${existingIndex}`, value: nextEntry });
-      } else {
-        patch.push({ op: "add", path: `${envPath}/-`, value: nextEntry });
-      }
+      nextEntries.push(nextEntry);
     }
+
+    const replacedNames = new Set([...managedEnvNames, ...entries.map(([name]) => String(name))]);
+    const nextEnv = [
+      ...env.filter((entry) => !replacedNames.has(String(entry?.name || ""))),
+      ...nextEntries,
+    ];
+    patch.push({
+      op: Array.isArray(containers[index]?.env) ? "replace" : "add",
+      path: envPath,
+      value: nextEnv,
+    });
 
     // Update the Secret before the Deployment so secretKeyRef entries resolve
     // as soon as the rollout (or the caller's explicit restart) starts pods.
-    if (Object.keys(sensitiveData).length > 0) {
+    const managedSensitiveNames = [...managedEnvNames].filter(isSensitiveEnvName);
+    if (managedSensitiveNames.length > 0) {
+      await this._replaceManagedEnvSecretData(
+        deployName,
+        sensitiveData,
+        managedSensitiveNames,
+        namespace,
+      );
+    } else if (Object.keys(sensitiveData).length > 0) {
       await this._mergeEnvSecretData(deployName, sensitiveData, namespace);
     }
 

--- a/workers/provisioner/backends/proxmox.ts
+++ b/workers/provisioner/backends/proxmox.ts
@@ -11,6 +11,7 @@ const ProvisionerBackend = require("./interface");
 const {
   buildOpenClawAuthImportFromFileCommand,
   buildOpenClawInstallCommand,
+  buildMcpServersConfig,
   buildOpenClawCustomProviders,
   buildIntegrationToolWrapperScript,
   buildRuntimeBootstrapFiles,
@@ -53,7 +54,7 @@ const PROXMOX_NEMOCLAW_UNSUPPORTED =
 const PROXMOX_AGENT_OWNERSHIP_MARKER_PREFIX = "nora-agent:";
 const PROXMOX_CREATE_OWNERSHIP_MARKER_PREFIX = "nora-owner:";
 const ENV_NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
-const PROXMOX_TEMPLATE_RE = /^[A-Za-z0-9_.-]+:vztmpl\/[A-Za-z0-9._+~:-]+$/;
+const PROXMOX_TEMPLATE_RE = /^[A-Za-z0-9_.-]+:vztmpl\/[A-Za-z0-9._+~-]+\.tar\.zst$/;
 
 function sleep(ms) {
   return new Promise((resolve) => setTimeout(resolve, ms));
@@ -143,7 +144,10 @@ function environmentLoaderLines(filePath) {
   ];
 }
 
-function openClawManagedConfigMergeLines(filePath, { removeAfter = false } = {}) {
+function openClawManagedConfigMergeLines(filePath, { removeAfter = false, replaceKeys = [] } = {}) {
+  const normalizedReplaceKeys = Array.isArray(replaceKeys)
+    ? replaceKeys.map((key) => String(key)).filter(Boolean)
+    : [];
   return [
     `if [ -f ${shellSingleQuote(filePath)} ]; then`,
     "node <<'__NORA_PROXMOX_MANAGED_CONFIG__'",
@@ -151,11 +155,17 @@ function openClawManagedConfigMergeLines(filePath, { removeAfter = false } = {})
     "const path = require('path');",
     "const configPath = '/root/.openclaw/openclaw.json';",
     `const managedPath = ${JSON.stringify(filePath)};`,
+    `const replaceKeys = new Set(${JSON.stringify(normalizedReplaceKeys)});`,
     "function isPlainObject(value) { return Boolean(value) && typeof value === 'object' && !Array.isArray(value); }",
     "function mergeConfig(current, managed) {",
     "  if (!isPlainObject(managed)) return managed;",
     "  const next = isPlainObject(current) ? { ...current } : {};",
     "  for (const [key, value] of Object.entries(managed)) {",
+    "    if (replaceKeys.has(key)) {",
+    "      if (isPlainObject(value) && Object.keys(value).length === 0) delete next[key];",
+    "      else next[key] = value;",
+    "      continue;",
+    "    }",
     "    next[key] = isPlainObject(value) ? mergeConfig(next[key], value) : value;",
     "  }",
     "  return next;",
@@ -703,6 +713,7 @@ class ProxmoxBackend extends ProvisionerBackend {
       env,
       container_name,
       templatePayload,
+      mcpServers,
       runtimeFamily = "openclaw",
       sandboxProfile = "standard",
       abortSignal,
@@ -787,6 +798,7 @@ class ProxmoxBackend extends ProvisionerBackend {
               id,
               env,
               templatePayload,
+              mcpServers,
               signal: abortSignal,
             });
       console.log(`[proxmox] LXC ${vmid} started at ${host}`);
@@ -981,11 +993,15 @@ class ProxmoxBackend extends ProvisionerBackend {
     await this._pctExec(vmid, command, { timeout: 300000, signal: options.signal });
   }
 
-  async _bootstrapOpenClaw(vmid, { id, env = {}, templatePayload = {}, signal } = {}) {
+  async _bootstrapOpenClaw(
+    vmid,
+    { id, env = {}, templatePayload = {}, mcpServers = [], signal } = {},
+  ) {
     await this._prepareOpenClawBase(vmid, { signal });
     throwIfAborted(signal, "OpenClaw Proxmox bootstrap");
     const gatewayToken = crypto.randomBytes(32).toString("hex");
     const pairedJson = derivePairedDevice(gatewayToken);
+    const managedMcpServers = buildMcpServersConfig(mcpServers);
     const runtimeEnv = normalizeEnv({
       ...(env || {}),
       ...buildRuntimeEnv(),
@@ -1008,6 +1024,10 @@ class ProxmoxBackend extends ProvisionerBackend {
             reload: { mode: "hot" },
             auth: { password: gatewayToken },
           },
+          // Nora owns this block. An empty object deliberately removes MCP
+          // entries baked into a prepared template; a populated object is the
+          // worker's credential-resolved per-agent selection.
+          mcpServers: managedMcpServers,
         },
         null,
         2,
@@ -1069,7 +1089,9 @@ class ProxmoxBackend extends ProvisionerBackend {
       ...environmentLoaderLines(OPENCLAW_ENV_FILE),
       buildOpenClawInstallCommand([openClawPackage]),
       "mkdir -p ~/.openclaw/devices /var/log /root/.openclaw/workspace /root/.openclaw/agents/main/agent",
-      ...openClawManagedConfigMergeLines(OPENCLAW_GATEWAY_CONFIG_FILE),
+      ...openClawManagedConfigMergeLines(OPENCLAW_GATEWAY_CONFIG_FILE, {
+        replaceKeys: ["mcpServers"],
+      }),
       "if [ ! -f /root/.openclaw/.nora-proxmox-bootstrap-complete ]; then",
       // Register provision-time custom providers once. Live auth sync owns
       // later provider changes; replaying the original env on every restart

--- a/workers/provisioner/deploymentLifecycle.test.js
+++ b/workers/provisioner/deploymentLifecycle.test.js
@@ -1,0 +1,541 @@
+const assert = require("node:assert/strict");
+const test = require("node:test");
+
+const {
+  acquireDedicatedSessionLock,
+  finalizeProvisionedDeployment,
+  fingerprintEffectiveProviderState,
+  isBuiltInDemoActivation,
+  persistProvisionedRuntimeMetadata,
+  reconcileProviderStateUntilStable,
+  runProvisioningReadinessBarrier,
+  runRuntimeReconciliationBoundary,
+  shouldReconcileEffectiveProviderState,
+} = require("./deploymentLifecycle.ts");
+
+test("dedicated session locks leave a one-connection work pool available", async () => {
+  const events = [];
+  let mainPoolInUse = false;
+  const oneConnectionMainPool = {
+    query: async () => {
+      assert.equal(mainPoolInUse, false, "the main pool connection was already reserved");
+      mainPoolInUse = true;
+      events.push("main:query");
+      await new Promise((resolve) => setImmediate(resolve));
+      mainPoolInUse = false;
+      return { rows: [{ ok: true }] };
+    },
+  };
+  const dedicatedClient = {
+    connect: async () => events.push("lock:connect"),
+    query: async (sql) => {
+      events.push(sql.includes("unlock") ? "lock:unlock" : "lock:acquire");
+      return { rows: [{ locked: true }] };
+    },
+    end: async () => events.push("lock:end"),
+  };
+
+  const lock = await acquireDedicatedSessionLock({
+    createClient: () => dedicatedClient,
+    acquire: (client) => client.query("SELECT pg_try_advisory_lock(1) AS locked"),
+    release: (client) => client.query("SELECT pg_advisory_unlock(1)"),
+    isAcquired: (result) => result.rows[0]?.locked,
+  });
+
+  const work = await oneConnectionMainPool.query("SELECT finalization_work");
+  assert.deepEqual(work.rows, [{ ok: true }]);
+  await lock.release();
+
+  assert.deepEqual(events, [
+    "lock:connect",
+    "lock:acquire",
+    "main:query",
+    "lock:unlock",
+    "lock:end",
+  ]);
+});
+
+test("busy dedicated session locks close their connection and preserve the busy error", async () => {
+  const events = [];
+  const lockError = new Error("agent is busy");
+  lockError.code = "PROVISION_LOCK_BUSY";
+
+  await assert.rejects(
+    acquireDedicatedSessionLock({
+      createClient: () => ({
+        connect: async () => events.push("connect"),
+        query: async () => ({ rows: [{ locked: false }] }),
+        end: async () => events.push("end"),
+      }),
+      acquire: (client) => client.query("SELECT pg_try_advisory_lock(1) AS locked"),
+      release: (client) => client.query("SELECT pg_advisory_unlock(1)"),
+      isAcquired: (result) => result.rows[0]?.locked,
+      busyError: () => lockError,
+    }),
+    (error) => error === lockError && error.code === "PROVISION_LOCK_BUSY",
+  );
+
+  assert.deepEqual(events, ["connect", "end"]);
+});
+
+test("dedicated session locks close exactly once when advisory unlock fails", async () => {
+  const events = [];
+  const lock = await acquireDedicatedSessionLock({
+    createClient: () => ({
+      connect: async () => events.push("connect"),
+      query: async (sql) => {
+        if (sql.includes("unlock")) {
+          events.push("unlock");
+          throw new Error("connection dropped during unlock");
+        }
+        events.push("acquire");
+        return { rows: [{ locked: true }] };
+      },
+      end: async () => events.push("end"),
+    }),
+    acquire: (client) => client.query("SELECT pg_try_advisory_lock(1) AS locked"),
+    release: (client) => client.query("SELECT pg_advisory_unlock(1)"),
+    isAcquired: (result) => result.rows[0]?.locked,
+    onReleaseError: (error) => events.push(`release-error:${error.message}`),
+  });
+
+  await lock.release();
+  await lock.release();
+
+  assert.deepEqual(events, [
+    "connect",
+    "acquire",
+    "unlock",
+    "release-error:connection dropped during unlock",
+    "end",
+  ]);
+});
+
+test("effective provider fingerprints are canonical and detect runtime-relevant drift", () => {
+  const first = fingerprintEffectiveProviderState({
+    envVars: {
+      NORA_DEMO_LLM_TOKEN: "demo-token",
+      NORA_DEMO_LLM_BASE_URL: "http://backend-api:4000/demo-llm/v1",
+    },
+    defaultProvider: {
+      id: "provider-1",
+      provider: "demo",
+      model: "nora-demo-1",
+      config: '{"baseUrl":"http://backend-api:4000/demo-llm/v1","nested":{"b":2,"a":1}}',
+    },
+  });
+  const reordered = fingerprintEffectiveProviderState({
+    envVars: {
+      NORA_DEMO_LLM_BASE_URL: "http://backend-api:4000/demo-llm/v1",
+      NORA_DEMO_LLM_TOKEN: "demo-token",
+    },
+    defaultProvider: {
+      id: "replacement-row-with-same-effective-state",
+      provider: "demo",
+      model: "nora-demo-1",
+      config: {
+        nested: { a: 1, b: 2 },
+        baseUrl: "http://backend-api:4000/demo-llm/v1",
+      },
+    },
+  });
+  const changed = fingerprintEffectiveProviderState({
+    envVars: {
+      NORA_DEMO_LLM_TOKEN: "rotated-token",
+      NORA_DEMO_LLM_BASE_URL: "http://backend-api:4000/demo-llm/v1",
+    },
+    defaultProvider: {
+      provider: "demo",
+      model: "nora-demo-1",
+      config: { baseUrl: "http://backend-api:4000/demo-llm/v1" },
+    },
+  });
+
+  assert.equal(first, reordered);
+  assert.notEqual(first, changed);
+  assert.equal(
+    shouldReconcileEffectiveProviderState(first, {
+      envVars: {
+        NORA_DEMO_LLM_BASE_URL: "http://backend-api:4000/demo-llm/v1",
+        NORA_DEMO_LLM_TOKEN: "demo-token",
+      },
+      defaultProvider: {
+        provider: "demo",
+        model: "nora-demo-1",
+        config: {
+          nested: { b: 2, a: 1 },
+          baseUrl: "http://backend-api:4000/demo-llm/v1",
+        },
+      },
+    }),
+    false,
+  );
+  assert.equal(
+    shouldReconcileEffectiveProviderState(first, {
+      envVars: {
+        NORA_DEMO_LLM_TOKEN: "rotated-token",
+        NORA_DEMO_LLM_BASE_URL: "http://backend-api:4000/demo-llm/v1",
+      },
+      defaultProvider: {
+        provider: "demo",
+        model: "nora-demo-1",
+        config: { baseUrl: "http://backend-api:4000/demo-llm/v1" },
+      },
+    }),
+    true,
+  );
+});
+
+test("strict demo readiness applies only to the explicitly pinned zero-key activation", () => {
+  assert.equal(
+    isBuiltInDemoActivation({
+      jobId: "demo-activation-agent-1",
+      agentId: "agent-1",
+      llmProviderId: "provider-demo",
+      defaultProvider: { provider: "demo" },
+    }),
+    true,
+  );
+  assert.equal(
+    isBuiltInDemoActivation({
+      jobId: "demo-activation-agent-1",
+      agentId: "agent-1",
+      llmProviderId: null,
+      defaultProvider: { provider: "demo" },
+    }),
+    false,
+  );
+  assert.equal(
+    isBuiltInDemoActivation({
+      jobId: "demo-activation-agent-1",
+      agentId: "agent-1",
+      llmProviderId: "provider-openai",
+      defaultProvider: { provider: "openai" },
+    }),
+    false,
+  );
+});
+
+test("an ordinary redeploy using the demo provider is not first activation", () => {
+  assert.equal(
+    isBuiltInDemoActivation({
+      jobId: "redeploy-agent-1",
+      agentId: "agent-1",
+      llmProviderId: "provider-demo",
+      defaultProvider: { provider: "demo" },
+    }),
+    false,
+  );
+});
+
+test("runtime metadata persistence keeps the deployment behind the deploying barrier", async () => {
+  let sql = "";
+  const queryable = {
+    query: async (statement) => {
+      sql = statement;
+      return { rows: [{ id: "agent-1", container_id: "runtime-1" }] };
+    },
+  };
+
+  const result = await persistProvisionedRuntimeMetadata(queryable, {
+    agentId: "agent-1",
+    containerId: "runtime-1",
+    backendType: "docker",
+    runtimeFamily: "openclaw",
+    deployTarget: "docker",
+    executionTargetId: "docker",
+    sandboxProfile: "standard",
+    sandboxType: "standard",
+  });
+
+  assert.deepEqual(result, { persisted: true, containerId: "runtime-1" });
+  assert.match(sql, /AND status = 'deploying'/);
+  assert.match(sql, /container_id IS NULL OR container_id = \$2/);
+  assert.doesNotMatch(sql, /SET status = 'running'/);
+});
+
+test("readiness finalization waits for auth reconciliation to settle", async () => {
+  const order = [];
+  let releaseReconciliation;
+  const reconciliationGate = new Promise((resolve) => {
+    releaseReconciliation = resolve;
+  });
+
+  const pending = runProvisioningReadinessBarrier({
+    checkReadiness: async () => {
+      order.push("readiness");
+      return { ok: true };
+    },
+    reconcileAuth: async () => {
+      order.push("reconcile:start");
+      await reconciliationGate;
+      order.push("reconcile:end");
+      return { status: "synced" };
+    },
+    finalize: async () => {
+      order.push("finalize");
+      return { finalized: true };
+    },
+  });
+
+  await new Promise((resolve) => setImmediate(resolve));
+  assert.deepEqual(order, ["readiness", "reconcile:start"]);
+
+  releaseReconciliation();
+  const result = await pending;
+
+  assert.equal(result.status, "running");
+  assert.deepEqual(order, ["readiness", "reconcile:start", "reconcile:end", "finalize"]);
+});
+
+test("failed initial readiness never reconciles or publishes running", async () => {
+  let reconciled = false;
+  let finalized = false;
+  let warned = false;
+
+  const result = await runProvisioningReadinessBarrier({
+    checkReadiness: async () => ({ ok: false, gateway: { error: "connection refused" } }),
+    onReadinessWarning: async () => {
+      warned = true;
+    },
+    reconcileAuth: async () => {
+      reconciled = true;
+      return { status: "synced" };
+    },
+    finalize: async () => {
+      finalized = true;
+      return { finalized: true };
+    },
+  });
+
+  assert.equal(result.status, "warning");
+  assert.equal(warned, true);
+  assert.equal(reconciled, false);
+  assert.equal(finalized, false);
+});
+
+test("demo readiness failure fails closed without warning, reconciliation, or finalization", async () => {
+  let warned = false;
+  let reconciled = false;
+  let finalized = false;
+
+  await assert.rejects(
+    runProvisioningReadinessBarrier({
+      checkReadiness: async () => ({ ok: false, gateway: { error: "connection refused" } }),
+      failClosedOnReadinessFailure: true,
+      onReadinessWarning: async () => {
+        warned = true;
+      },
+      reconcileAuth: async () => {
+        reconciled = true;
+        return { status: "synced" };
+      },
+      finalize: async () => {
+        finalized = true;
+        return { finalized: true };
+      },
+    }),
+    (error) => {
+      assert.equal(error.code, "INITIAL_RUNTIME_READINESS_FAILED");
+      assert.match(error.message, /connection refused/);
+      return true;
+    },
+  );
+
+  assert.equal(warned, false);
+  assert.equal(reconciled, false);
+  assert.equal(finalized, false);
+});
+
+test("auth reconciliation failure never publishes running", async () => {
+  let finalized = false;
+
+  await assert.rejects(
+    runProvisioningReadinessBarrier({
+      checkReadiness: async () => ({ ok: true }),
+      reconcileAuth: async () => {
+        throw new Error("gateway did not recover after auth restart");
+      },
+      finalize: async () => {
+        finalized = true;
+        return { finalized: true };
+      },
+    }),
+    /gateway did not recover/,
+  );
+
+  assert.equal(finalized, false);
+});
+
+test("provider finalization retries drift and commits only while mutation state is stable", async () => {
+  const order = [];
+  const fingerprints = ["provider-v2", "provider-v2"];
+  let reconcilePass = 0;
+
+  const result = await reconcileProviderStateUntilStable({
+    bootstrappedFingerprint: "provider-v1",
+    reconcile: async (previousFingerprint) => {
+      order.push(`reconcile:${previousFingerprint}`);
+      reconcilePass += 1;
+      return {
+        status: "synced",
+        providerFingerprint: reconcilePass === 1 ? "provider-v1" : "provider-v2",
+      };
+    },
+    readFingerprint: async () => {
+      const fingerprint = fingerprints.shift();
+      order.push(`verify:${fingerprint}`);
+      return fingerprint;
+    },
+    withMutationLock: async (operation) => {
+      order.push("lock");
+      try {
+        return await operation();
+      } finally {
+        order.push("unlock");
+      }
+    },
+    finalize: async () => {
+      order.push("finalize");
+      return { finalized: true };
+    },
+  });
+
+  assert.equal(result.passes, 2);
+  assert.equal(result.finalization.finalized, true);
+  assert.deepEqual(order, [
+    "reconcile:provider-v1",
+    "lock",
+    "verify:provider-v2",
+    "unlock",
+    "reconcile:provider-v1",
+    "lock",
+    "verify:provider-v2",
+    "finalize",
+    "unlock",
+  ]);
+});
+
+test("provider finalization fails closed when mutations never settle", async () => {
+  let version = 1;
+  let finalized = false;
+
+  await assert.rejects(
+    reconcileProviderStateUntilStable({
+      bootstrappedFingerprint: "provider-v0",
+      reconcile: async () => ({
+        status: "synced",
+        providerFingerprint: `provider-v${version++}`,
+      }),
+      readFingerprint: async () => `provider-v${version++}`,
+      withMutationLock: async (operation) => operation(),
+      finalize: async () => {
+        finalized = true;
+        return { finalized: true };
+      },
+      maxPasses: 2,
+    }),
+    (error) => {
+      assert.equal(error.code, "PROVIDER_STATE_UNSTABLE");
+      return true;
+    },
+  );
+
+  assert.equal(finalized, false);
+});
+
+test("runtime reconciliation applies every mutation before one restart and checks readiness last", async () => {
+  const order = [];
+
+  const readiness = await runRuntimeReconciliationBoundary({
+    mutations: [
+      async () => order.push("auth"),
+      async () => order.push("custom-provider"),
+      async () => order.push("default-model"),
+    ],
+    restart: async () => order.push("restart"),
+    checkReadiness: async () => {
+      order.push("readiness");
+      return { ok: true };
+    },
+  });
+
+  assert.deepEqual(order, ["auth", "custom-provider", "default-model", "restart", "readiness"]);
+  assert.deepEqual(readiness, { ok: true });
+});
+
+test("guarded finalization atomically completes only the matching deploying runtime", async () => {
+  const calls = [];
+  const responses = [
+    { rows: [] },
+    { rows: [{ id: "agent-1" }] },
+    { rows: [{ agent_id: "agent-1" }] },
+    { rows: [] },
+    { rows: [] },
+  ];
+  const client = {
+    query: async (sql, params) => {
+      calls.push({ sql, params });
+      return responses.shift();
+    },
+    release: () => calls.push({ sql: "RELEASE" }),
+  };
+
+  const result = await finalizeProvisionedDeployment(
+    { connect: async () => client },
+    {
+      agentId: "agent-1",
+      containerId: "runtime-1",
+      name: "Demo Agent",
+      backend: "docker",
+      host: "172.18.0.27",
+    },
+  );
+
+  assert.deepEqual(result, { finalized: true });
+  assert.equal(calls[0].sql, "BEGIN");
+  assert.match(calls[1].sql, /status = 'deploying'/);
+  assert.match(calls[1].sql, /container_id = \$2/);
+  assert.match(calls[2].sql, /SET status = 'completed'/);
+  assert.match(calls[3].sql, /INSERT INTO events/);
+  assert.equal(calls[4].sql, "COMMIT");
+  assert.equal(calls[5].sql, "RELEASE");
+});
+
+test("deleted or replaced runtimes cannot be finalized", async () => {
+  const calls = [];
+  const responses = [{ rows: [] }, { rows: [] }, { rows: [] }];
+  const client = {
+    query: async (sql, params) => {
+      calls.push({ sql, params });
+      return responses.shift();
+    },
+    release: () => calls.push({ sql: "RELEASE" }),
+  };
+
+  const result = await finalizeProvisionedDeployment(
+    { connect: async () => client },
+    {
+      agentId: "agent-1",
+      containerId: "stale-runtime",
+      name: "Demo Agent",
+      backend: "docker",
+    },
+  );
+
+  assert.deepEqual(result, {
+    finalized: false,
+    reason: "agent-missing-or-runtime-replaced",
+  });
+  assert.equal(calls[0].sql, "BEGIN");
+  assert.equal(calls[2].sql, "ROLLBACK");
+  assert.equal(calls[3].sql, "RELEASE");
+  assert.equal(
+    calls.some(({ sql }) => /UPDATE deployments/.test(sql)),
+    false,
+  );
+  assert.equal(
+    calls.some(({ sql }) => /INSERT INTO events/.test(sql)),
+    false,
+  );
+});

--- a/workers/provisioner/deploymentLifecycle.ts
+++ b/workers/provisioner/deploymentLifecycle.ts
@@ -1,0 +1,407 @@
+// @ts-nocheck
+const crypto = require("crypto");
+
+function normalizeProviderConfig(config) {
+  if (typeof config !== "string") return config ?? null;
+  try {
+    return JSON.parse(config);
+  } catch {
+    return config;
+  }
+}
+
+function canonicalize(value) {
+  if (Array.isArray(value)) return value.map(canonicalize);
+  if (!value || typeof value !== "object") return value;
+
+  return Object.fromEntries(
+    Object.keys(value)
+      .sort()
+      .map((key) => [key, canonicalize(value[key])]),
+  );
+}
+
+function buildEffectiveProviderState({ envVars = {}, defaultProvider = null } = {}) {
+  const normalizedEnv = Object.fromEntries(
+    Object.entries(envVars || {})
+      .filter(([key, value]) => key && value != null && String(value) !== "")
+      .map(([key, value]) => [key, String(value)]),
+  );
+  const normalizedProvider = defaultProvider
+    ? {
+        provider: defaultProvider.provider || null,
+        model: defaultProvider.model || null,
+        config: normalizeProviderConfig(defaultProvider.config),
+      }
+    : null;
+
+  return canonicalize({
+    env: normalizedEnv,
+    defaultProvider: normalizedProvider,
+  });
+}
+
+function fingerprintEffectiveProviderState(state = {}) {
+  return crypto
+    .createHash("sha256")
+    .update(JSON.stringify(buildEffectiveProviderState(state)))
+    .digest("hex");
+}
+
+function shouldReconcileEffectiveProviderState(bootstrappedFingerprint, currentState = {}) {
+  if (!bootstrappedFingerprint) return true;
+  return fingerprintEffectiveProviderState(currentState) !== bootstrappedFingerprint;
+}
+
+function isBuiltInDemoActivation({ jobId, agentId, llmProviderId, defaultProvider } = {}) {
+  const expectedJobId = agentId ? `demo-activation-${agentId}` : "";
+  return Boolean(
+    expectedJobId &&
+    String(jobId || "") === expectedJobId &&
+    llmProviderId &&
+    defaultProvider?.provider === "demo",
+  );
+}
+
+async function acquireDedicatedSessionLock({
+  createClient,
+  acquire,
+  release,
+  isAcquired = () => true,
+  busyError = () => new Error("PostgreSQL advisory lock is already held"),
+  onReleaseError,
+  onCloseError,
+} = {}) {
+  if (typeof createClient !== "function") {
+    throw new Error("createClient is required");
+  }
+  if (typeof acquire !== "function") {
+    throw new Error("acquire is required");
+  }
+  if (typeof release !== "function") {
+    throw new Error("release is required");
+  }
+
+  const client = createClient();
+  if (!client || typeof client.connect !== "function" || typeof client.end !== "function") {
+    throw new Error("createClient must return a connectable PostgreSQL client");
+  }
+
+  let connected = false;
+  try {
+    await client.connect();
+    connected = true;
+    const result = await acquire(client);
+    if (!isAcquired(result)) {
+      const error = typeof busyError === "function" ? busyError(result) : busyError;
+      throw error instanceof Error ? error : new Error(String(error || "Advisory lock is busy"));
+    }
+  } catch (error) {
+    if (connected) {
+      await client.end().catch((closeError) => onCloseError?.(closeError));
+    }
+    throw error;
+  }
+
+  let released = false;
+  return {
+    release: async () => {
+      if (released) return;
+      released = true;
+      try {
+        await release(client);
+      } catch (error) {
+        if (typeof onReleaseError === "function") {
+          onReleaseError(error);
+        } else {
+          throw error;
+        }
+      } finally {
+        await client.end().catch((closeError) => onCloseError?.(closeError));
+      }
+    },
+  };
+}
+
+async function persistProvisionedRuntimeMetadata(
+  queryable,
+  {
+    agentId,
+    containerId,
+    host,
+    backendType,
+    gatewayToken,
+    containerName,
+    gatewayHostPort,
+    runtimeHost,
+    runtimePort,
+    gatewayHost,
+    gatewayPort,
+    image,
+    runtimeFamily,
+    deployTarget,
+    executionTargetId,
+    sandboxProfile,
+    sandboxType,
+    networkPolicyStatus,
+    dashboardPort,
+  } = {},
+) {
+  const result = await queryable.query(
+    `UPDATE agents
+        SET container_id = $2,
+            host = $3,
+            backend_type = $4,
+            gateway_token = $5,
+            container_name = COALESCE($6, container_name),
+            gateway_host_port = $7,
+            runtime_host = $8,
+            runtime_port = $9,
+            gateway_host = $10,
+            gateway_port = $11,
+            image = COALESCE($12, image),
+            runtime_family = $13,
+            deploy_target = $14,
+            execution_target_id = $15,
+            sandbox_profile = $16,
+            sandbox_type = $17,
+            network_policy_status = $18,
+            dashboard_port = $19
+      WHERE id = $1
+        AND status = 'deploying'
+        AND (container_id IS NULL OR container_id = $2)
+      RETURNING id, container_id`,
+    [
+      agentId,
+      containerId,
+      host,
+      backendType,
+      gatewayToken,
+      containerName || null,
+      gatewayHostPort ? parseInt(gatewayHostPort, 10) : null,
+      runtimeHost || null,
+      runtimePort ? parseInt(runtimePort, 10) : null,
+      gatewayHost || null,
+      gatewayPort ? parseInt(gatewayPort, 10) : null,
+      image || null,
+      runtimeFamily,
+      deployTarget,
+      executionTargetId,
+      sandboxProfile,
+      sandboxType,
+      networkPolicyStatus,
+      dashboardPort ? parseInt(dashboardPort, 10) : null,
+    ],
+  );
+
+  return {
+    persisted: Boolean(result.rows[0]),
+    containerId: result.rows[0]?.container_id || null,
+  };
+}
+
+async function finalizeProvisionedDeployment(
+  queryable,
+  { agentId, containerId, name, backend, host } = {},
+) {
+  const ownsClient = typeof queryable?.connect === "function";
+  const client = ownsClient ? await queryable.connect() : queryable;
+  let transactionOpen = false;
+
+  try {
+    await client.query("BEGIN");
+    transactionOpen = true;
+
+    const agentUpdate = await client.query(
+      `UPDATE agents
+          SET status = 'running'
+        WHERE id = $1
+          AND status = 'deploying'
+          AND container_id = $2
+        RETURNING id`,
+      [agentId, containerId],
+    );
+    if (!agentUpdate.rows[0]) {
+      await client.query("ROLLBACK");
+      transactionOpen = false;
+      return { finalized: false, reason: "agent-missing-or-runtime-replaced" };
+    }
+
+    const deploymentUpdate = await client.query(
+      `UPDATE deployments
+          SET status = 'completed'
+        WHERE agent_id = $1
+          AND status = 'deploying'
+        RETURNING agent_id`,
+      [agentId],
+    );
+    if (!deploymentUpdate.rows[0]) {
+      throw new Error(`Deployment ${agentId} was not in deploying state during finalization`);
+    }
+
+    await client.query("INSERT INTO events(type, message, metadata) VALUES($1, $2, $3)", [
+      "agent_deployed",
+      `Agent "${name}" is now running on ${backend}`,
+      JSON.stringify({ agentId, containerId, host }),
+    ]);
+    await client.query("COMMIT");
+    transactionOpen = false;
+    return { finalized: true };
+  } catch (error) {
+    if (transactionOpen) {
+      await client.query("ROLLBACK").catch(() => {});
+    }
+    throw error;
+  } finally {
+    if (ownsClient && typeof client?.release === "function") {
+      client.release();
+    }
+  }
+}
+
+async function runProvisioningReadinessBarrier({
+  checkReadiness,
+  reconcileAuth,
+  reconcileAndFinalize,
+  finalize,
+  failClosedOnReadinessFailure = false,
+  onReadinessWarning,
+} = {}) {
+  if (typeof checkReadiness !== "function") {
+    throw new Error("checkReadiness is required");
+  }
+  if (typeof finalize !== "function") {
+    throw new Error("finalize is required");
+  }
+
+  const readiness = await checkReadiness();
+  if (!readiness?.ok) {
+    if (failClosedOnReadinessFailure) {
+      const failureDetail =
+        readiness?.runtime?.error ||
+        readiness?.gateway?.error ||
+        readiness?.runtime?.status ||
+        readiness?.gateway?.status ||
+        "unreachable";
+      const error = new Error(`Initial runtime readiness failed (${failureDetail})`);
+      error.code = "INITIAL_RUNTIME_READINESS_FAILED";
+      error.readiness = readiness;
+      throw error;
+    }
+    if (typeof onReadinessWarning === "function") {
+      await onReadinessWarning(readiness);
+    }
+    return { status: "warning", readiness, reconciliation: null, finalization: null };
+  }
+
+  const settled =
+    typeof reconcileAndFinalize === "function"
+      ? await reconcileAndFinalize()
+      : {
+          reconciliation:
+            typeof reconcileAuth === "function" ? await reconcileAuth() : { status: "skipped" },
+          finalization: await finalize(),
+        };
+  const reconciliation = settled?.reconciliation || { status: "skipped" };
+  const finalization = settled?.finalization || null;
+  return {
+    status: finalization?.finalized ? "running" : "canceled",
+    readiness,
+    reconciliation,
+    finalization,
+  };
+}
+
+async function reconcileProviderStateUntilStable({
+  bootstrappedFingerprint,
+  reconcile,
+  readFingerprint,
+  withMutationLock,
+  finalize,
+  maxPasses = 3,
+} = {}) {
+  if (typeof reconcile !== "function") {
+    throw new Error("reconcile is required");
+  }
+  if (typeof readFingerprint !== "function") {
+    throw new Error("readFingerprint is required");
+  }
+  if (typeof withMutationLock !== "function") {
+    throw new Error("withMutationLock is required");
+  }
+  if (typeof finalize !== "function") {
+    throw new Error("finalize is required");
+  }
+
+  const passLimit = Number.isFinite(Number(maxPasses))
+    ? Math.max(1, Math.min(10, Number(maxPasses)))
+    : 3;
+  let appliedFingerprint = bootstrappedFingerprint || null;
+  let reconciliation = { status: "skipped", reason: "unchanged" };
+
+  for (let pass = 1; pass <= passLimit; pass += 1) {
+    reconciliation = await reconcile(appliedFingerprint);
+    const reconciledFingerprint = reconciliation?.providerFingerprint;
+    if (!reconciledFingerprint) {
+      throw new Error("provider reconciliation did not return a provider fingerprint");
+    }
+    appliedFingerprint = reconciledFingerprint;
+
+    const verification = await withMutationLock(async () => {
+      const currentFingerprint = await readFingerprint();
+      if (!currentFingerprint) {
+        throw new Error("provider verification did not return a provider fingerprint");
+      }
+      if (currentFingerprint !== appliedFingerprint) {
+        return { stable: false, currentFingerprint };
+      }
+      return { stable: true, finalization: await finalize() };
+    });
+
+    if (verification?.stable) {
+      return {
+        reconciliation,
+        finalization: verification.finalization,
+        providerFingerprint: appliedFingerprint,
+        passes: pass,
+      };
+    }
+  }
+
+  const error = new Error(
+    `LLM provider state changed during ${passLimit} consecutive deployment finalization passes`,
+  );
+  error.code = "PROVIDER_STATE_UNSTABLE";
+  throw error;
+}
+
+async function runRuntimeReconciliationBoundary({ mutations = [], restart, checkReadiness } = {}) {
+  if (typeof restart !== "function") {
+    throw new Error("restart is required");
+  }
+  if (typeof checkReadiness !== "function") {
+    throw new Error("checkReadiness is required");
+  }
+
+  for (const mutation of mutations) {
+    if (typeof mutation !== "function") {
+      throw new Error("runtime reconciliation mutations must be functions");
+    }
+    await mutation();
+  }
+  await restart();
+  return checkReadiness();
+}
+
+module.exports = {
+  acquireDedicatedSessionLock,
+  buildEffectiveProviderState,
+  finalizeProvisionedDeployment,
+  fingerprintEffectiveProviderState,
+  isBuiltInDemoActivation,
+  persistProvisionedRuntimeMetadata,
+  reconcileProviderStateUntilStable,
+  runProvisioningReadinessBarrier,
+  runRuntimeReconciliationBoundary,
+  shouldReconcileEffectiveProviderState,
+};

--- a/workers/provisioner/package.json
+++ b/workers/provisioner/package.json
@@ -6,6 +6,7 @@
   },
   "scripts": {
     "start": "tsx worker.ts",
+    "test": "node --test \"*.test.js\"",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/workers/provisioner/worker.ts
+++ b/workers/provisioner/worker.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 const { UnrecoverableError, Worker } = require("bullmq");
 const IORedis = require("ioredis");
-const { Pool } = require("pg");
+const { Client, Pool } = require("pg");
 const {
   buildPostgresConfig,
   createRedisClient,
@@ -20,7 +20,11 @@ const {
 } = require("../../agent-runtime/lib/backendCatalog");
 const { buildAgentRuntimeFields } = require("../../agent-runtime/lib/agentRuntimeFields");
 const { getAgentSecretEnvVars } = require("../../backend-api/agentSecretOverrides");
-const { getDeploymentProvider } = require("../../backend-api/llmProviders");
+const {
+  getDeploymentProvider,
+  getManagedProviderEnvNames,
+  providerMutationLockKey,
+} = require("../../backend-api/llmProviders");
 const {
   buildHermesSeedArchive,
   getMigrationManifestForAgent,
@@ -75,6 +79,17 @@ const {
 } = require("../../agent-runtime/lib/hermesRuntimeBootstrap");
 const { waitForAgentReadiness } = require("./healthChecks");
 const { buildReadinessWarningDetail, persistReadinessWarning } = require("./readinessWarning");
+const {
+  acquireDedicatedSessionLock,
+  finalizeProvisionedDeployment,
+  fingerprintEffectiveProviderState,
+  isBuiltInDemoActivation,
+  persistProvisionedRuntimeMetadata,
+  reconcileProviderStateUntilStable,
+  runProvisioningReadinessBarrier,
+  runRuntimeReconciliationBoundary,
+  shouldReconcileEffectiveProviderState,
+} = require("./deploymentLifecycle");
 const { shellSingleQuote } = require("../../agent-runtime/lib/containerCommand");
 const {
   computeMissingSavedSkills,
@@ -94,6 +109,18 @@ const db = new Pool(
     DB_APPLICATION_NAME: process.env.DB_APPLICATION_NAME || "nora-worker-provisioner",
   }),
 );
+
+function createProvisionerLockClient(scope) {
+  const {
+    max: _max,
+    idleTimeoutMillis: _idleTimeoutMillis,
+    ...clientConfig
+  } = buildPostgresConfig({
+    ...process.env,
+    DB_APPLICATION_NAME: `nora-worker-provisioner-${scope}`,
+  });
+  return new Client(clientConfig);
+}
 
 // Hash any agent ID (uuid string or integer) to a signed 64-bit BigInt suitable
 // for pg_try_advisory_lock(bigint). Uses FNV-1a over the string form. The lock
@@ -120,49 +147,69 @@ function advisoryLockKeyForAgent(agentId) {
  * lock is released by Postgres automatically.
  */
 async function acquireAgentProvisionLock(agentId) {
-  const client = await db.connect();
   const lockKey = advisoryLockKeyForAgent(agentId);
-  const res = await client.query("SELECT pg_try_advisory_lock($1) AS locked", [lockKey.toString()]);
-  if (!res.rows[0]?.locked) {
-    client.release();
-    const err = new Error(`Agent ${agentId} is already being provisioned by another worker`);
-    err.code = "PROVISION_LOCK_BUSY";
-    throw err;
-  }
-  let released = false;
-  return {
-    release: async () => {
-      if (released) return;
-      released = true;
-      try {
-        await client.query("SELECT pg_advisory_unlock($1)", [lockKey.toString()]);
-      } catch (e) {
-        console.warn(`[provisioner] advisory unlock failed for agent ${agentId}: ${e.message}`);
-      } finally {
-        client.release();
-      }
+  return acquireDedicatedSessionLock({
+    createClient: () => createProvisionerLockClient("agent-lock"),
+    acquire: (client) =>
+      client.query("SELECT pg_try_advisory_lock($1) AS locked", [lockKey.toString()]),
+    release: (client) => client.query("SELECT pg_advisory_unlock($1)", [lockKey.toString()]),
+    isAcquired: (result) => Boolean(result.rows[0]?.locked),
+    busyError: () => {
+      const error = new Error(`Agent ${agentId} is already being provisioned by another worker`);
+      error.code = "PROVISION_LOCK_BUSY";
+      return error;
     },
-  };
+    onReleaseError: (error) =>
+      console.warn(`[provisioner] advisory unlock failed for agent ${agentId}: ${error.message}`),
+    onCloseError: (error) =>
+      console.warn(
+        `[provisioner] advisory lock connection close failed for agent ${agentId}: ${error.message}`,
+      ),
+  });
+}
+
+async function withProviderMutationLock(userId, operation) {
+  if (!userId || typeof operation !== "function") {
+    throw new Error("userId and operation are required for the provider mutation lock");
+  }
+  const lockKey = providerMutationLockKey(userId);
+  const lock = await acquireDedicatedSessionLock({
+    createClient: () => createProvisionerLockClient("provider-mutation-lock"),
+    acquire: (client) =>
+      client.query("SELECT pg_advisory_lock(hashtextextended($1, 0))", [lockKey]),
+    release: (client) =>
+      client.query("SELECT pg_advisory_unlock(hashtextextended($1, 0))", [lockKey]),
+    onReleaseError: (error) =>
+      console.warn(
+        `[provisioner] provider advisory unlock failed for user ${userId}: ${error.message}`,
+      ),
+    onCloseError: (error) =>
+      console.warn(
+        `[provisioner] provider lock connection close failed for user ${userId}: ${error.message}`,
+      ),
+  });
+  try {
+    return await operation();
+  } finally {
+    await lock.release();
+  }
 }
 
 async function acquireKubernetesPolicyReconcileLock(clusterId) {
-  const client = await db.connect();
   const lockKey = advisoryLockKeyForAgent(`k8s-policy:${clusterId}`);
-  await client.query("SELECT pg_advisory_lock($1)", [lockKey.toString()]);
-  let released = false;
-  return {
-    release: async () => {
-      if (released) return;
-      released = true;
-      try {
-        await client.query("SELECT pg_advisory_unlock($1)", [lockKey.toString()]);
-      } catch (e) {
-        console.warn(`[k8s-policy-settings] advisory unlock failed for ${clusterId}: ${e.message}`);
-      } finally {
-        client.release();
-      }
-    },
-  };
+  return acquireDedicatedSessionLock({
+    createClient: () => createProvisionerLockClient("k8s-policy-lock"),
+    acquire: (client) => client.query("SELECT pg_advisory_lock($1)", [lockKey.toString()]),
+    release: (client) => client.query("SELECT pg_advisory_unlock($1)", [lockKey.toString()]),
+    onReleaseError: (error) =>
+      console.warn(
+        `[k8s-policy-settings] advisory unlock failed for ${clusterId}: ${error.message}`,
+      ),
+    onCloseError: (error) =>
+      console.warn(
+        `[k8s-policy-settings] lock connection close failed for ${clusterId}: ${error.message}`,
+      ),
+  });
 }
 
 function parseTimeoutMs(rawValue, fallbackMs) {
@@ -453,6 +500,38 @@ async function reconcileProvisioningFailureRuntime({
     persistIdentity: runtimeIdentity?.persistIdentity !== false,
   });
   return { ...cleanup, containerId: unresolvedContainerId };
+}
+
+async function cleanupCanceledProvisionedRuntime({
+  queryable = db,
+  provisioner,
+  agentId,
+  containerId,
+  reason,
+} = {}) {
+  const cleanup = await cleanupProvisionedRuntimeAfterFailure({
+    queryable,
+    provisioner,
+    agentId,
+    containerId,
+  });
+  if (!cleanup.retrySafe) {
+    const error = buildUnresolvedRuntimeError({
+      agentId,
+      containerId,
+      error:
+        cleanup.error ||
+        new Error(`Canceled deployment cleanup could not be verified (${cleanup.reason})`),
+    });
+    error.code = "CANCELED_RUNTIME_CLEANUP_FAILED";
+    error.cancellationReason = reason || "deployment-canceled";
+    throw error;
+  }
+  return { canceled: true, reason: reason || "deployment-canceled", cleanup };
+}
+
+function isCanceledRuntimeCleanupFailure(error) {
+  return error?.code === "CANCELED_RUNTIME_CLEANUP_FAILED";
 }
 
 const OPENCLAW_WORKSPACE_PATH = "/root/.openclaw/workspace";
@@ -972,6 +1051,33 @@ async function fetchDeploymentProvider(userId, providerId = null) {
   }
 }
 
+async function fetchEffectiveProviderState(userId, providerId = null) {
+  const [envVars, defaultProvider] = await Promise.all([
+    fetchUserLlmEnvVars(userId, providerId),
+    fetchDeploymentProvider(userId, providerId),
+  ]);
+  return {
+    envVars,
+    defaultProvider,
+    fingerprint: fingerprintEffectiveProviderState({ envVars, defaultProvider }),
+  };
+}
+
+function buildKubernetesProviderEnv(runtimeFamily, defaultProvider, llmEnvVars = {}) {
+  if (runtimeFamily === "hermes") {
+    return {
+      ...buildHermesRuntimeBootstrapEnvFor(defaultProvider, llmEnvVars),
+      ...llmEnvVars,
+    };
+  }
+
+  const defaultModel = buildDefaultOpenClawModel(defaultProvider);
+  return {
+    ...llmEnvVars,
+    ...(defaultModel ? { NORA_DEFAULT_OPENCLAW_MODEL: defaultModel } : {}),
+  };
+}
+
 async function runRuntimeCommand(agent, command, { timeout = 30000 } = {}) {
   const runtimeUrl = runtimeUrlForAgent(agent, "/exec");
   if (!runtimeUrl) {
@@ -1192,7 +1298,8 @@ function wrapCommandWithContainerTimeout(command, timeoutMs) {
  * @param {number|string} params.gatewayHostPort Gateway port exposed on the host.
  * @param {string} params.gatewayHost Gateway host used for readiness checks.
  * @param {number|string} params.gatewayPort Gateway port used for readiness checks.
- * @returns {Promise<{status: "skipped" | "synced"}>} `skipped` when there is
+ * @param {string} params.bootstrappedProviderFingerprint Canonical effective provider state injected before runtime creation.
+ * @returns {Promise<{status: "skipped" | "synced", reason?: string}>} `skipped` when there is
  * nothing to apply, otherwise `synced` after config write, restart, and
  * readiness verification succeed.
  */
@@ -1211,12 +1318,32 @@ async function reconcileRuntimeLlmAuth({
   gatewayHost,
   gatewayPort,
   gatewayToken,
+  bootstrappedProviderFingerprint,
 } = {}) {
-  const llmEnvVars = await fetchUserLlmEnvVars(userId, llmProviderId);
-  const defaultProvider = await fetchDeploymentProvider(userId, llmProviderId);
+  const providerState = await fetchEffectiveProviderState(userId, llmProviderId);
+  const { envVars: llmEnvVars, defaultProvider, fingerprint: providerFingerprint } = providerState;
+  if (!shouldReconcileEffectiveProviderState(bootstrappedProviderFingerprint, providerState)) {
+    return { status: "skipped", reason: "unchanged", providerFingerprint };
+  }
   const hasLlmKeys = Object.keys(llmEnvVars).length > 0;
   if (!hasLlmKeys && !defaultProvider) {
-    return { status: "skipped" };
+    const error = new Error(
+      "LLM provider state was removed while the runtime was provisioning; retrying from a clean bootstrap",
+    );
+    error.code = "PROVIDER_STATE_REMOVED_DURING_DEPLOYMENT";
+    throw error;
+  }
+
+  if (resolvedBackend === "k8s") {
+    if (typeof provisioner?.updateEnv !== "function") {
+      throw new Error("Kubernetes provider reconciliation requires updateEnv support");
+    }
+    const managedEnv = buildKubernetesProviderEnv(runtimeFamily, defaultProvider, llmEnvVars);
+    await provisioner.updateEnv(containerId, managedEnv, {
+      agentId,
+      runtimeFamily,
+      managedEnvNames: getManagedProviderEnvNames({ runtimeFamily }),
+    });
   }
 
   const agentRef = {
@@ -1284,24 +1411,28 @@ async function reconcileRuntimeLlmAuth({
         `Hermes runtime did not recover after auth reconcile (${readiness.runtime?.error || "unreachable"})`,
       );
     }
-    return { status: "synced" };
+    return { status: "synced", providerFingerprint };
   }
 
   const authProfiles = buildAuthProfiles(llmEnvVars);
   const modelCommand = buildDefaultModelCommand(defaultProvider);
   if (Object.keys(authProfiles).length === 0 && !modelCommand) {
-    return { status: "skipped" };
+    return { status: "skipped", providerFingerprint };
   }
 
   const authWriteCommand = buildAuthProfilesWriteCommand(authProfiles);
-  try {
-    await runRuntimeCommand(agentRef, authWriteCommand);
-  } catch (error) {
-    if (!DOCKER_EXEC_FALLBACK_BACKENDS.has(resolvedBackend)) {
-      throw error;
-    }
-    await runProvisionerExecCommand(provisioner, containerId, authWriteCommand, { agentId });
-  }
+  const reconciliationMutations = [
+    async () => {
+      try {
+        await runRuntimeCommand(agentRef, authWriteCommand);
+      } catch (error) {
+        if (!DOCKER_EXEC_FALLBACK_BACKENDS.has(resolvedBackend)) {
+          throw error;
+        }
+        await runProvisionerExecCommand(provisioner, containerId, authWriteCommand, { agentId });
+      }
+    },
+  ];
 
   // Merge custom-provider registrations (Microsoft Foundry) into openclaw.json
   // before the restart so model strings like `microsoft-foundry/<deployment>`
@@ -1321,26 +1452,41 @@ async function reconcileRuntimeLlmAuth({
     const providerMergeCommand = buildOpenClawConfigMergeCommand({
       models: { providers: customProviders },
     });
-    try {
-      await runRuntimeCommand(agentRef, providerMergeCommand);
-    } catch (error) {
-      if (!DOCKER_EXEC_FALLBACK_BACKENDS.has(resolvedBackend)) {
-        throw error;
+    reconciliationMutations.push(async () => {
+      try {
+        await runRuntimeCommand(agentRef, providerMergeCommand);
+      } catch (error) {
+        if (!DOCKER_EXEC_FALLBACK_BACKENDS.has(resolvedBackend)) {
+          throw error;
+        }
+        await runProvisionerExecCommand(provisioner, containerId, providerMergeCommand, {
+          agentId,
+        });
       }
-      await runProvisionerExecCommand(provisioner, containerId, providerMergeCommand, {
-        agentId,
-      });
-    }
+    });
   }
 
-  await provisioner.restart(containerId, { agentId });
-  const readiness = await waitForAgentReadiness({
-    host,
-    runtimeHost,
-    runtimePort,
-    gatewayHostPort,
-    gatewayHost,
-    gatewayPort,
+  // Apply the default model inside the same reconciliation boundary. Readiness
+  // must be the final runtime operation; otherwise the config watcher can reload
+  // a gateway immediately after the worker publishes it as running.
+  if (modelCommand) {
+    reconciliationMutations.push(() =>
+      runRuntimeCommand(agentRef, modelCommand, { timeout: 60000 }),
+    );
+  }
+
+  const readiness = await runRuntimeReconciliationBoundary({
+    mutations: reconciliationMutations,
+    restart: () => provisioner.restart(containerId, { agentId }),
+    checkReadiness: () =>
+      waitForAgentReadiness({
+        host,
+        runtimeHost,
+        runtimePort,
+        gatewayHostPort,
+        gatewayHost,
+        gatewayPort,
+      }),
   });
   if (!readiness.ok) {
     throw new Error(
@@ -1348,11 +1494,7 @@ async function reconcileRuntimeLlmAuth({
     );
   }
 
-  if (modelCommand) {
-    await runRuntimeCommand(agentRef, modelCommand, { timeout: 60000 });
-  }
-
-  return { status: "synced" };
+  return { status: "synced", providerFingerprint };
 }
 
 function sleep(ms) {
@@ -1387,11 +1529,16 @@ function backendInstanceKey(runtimeFields = {}) {
 
 async function loadBackend(runtimeFields = {}) {
   const key = backendInstanceKey(runtimeFields);
-  // Kubernetes execution targets are Admin-managed records whose exposure mode,
-  // namespaces, kube context, and policy metadata can change at runtime. Rebuild
-  // the adapter from the latest stored profile instead of reusing a stale cached
-  // instance across deploys.
-  if (backendInstances.has(key) && !key.startsWith("k8s:")) return backendInstances.get(key);
+  // Profile-backed targets can change at runtime. Rebuild from the latest
+  // stored profile so credential rotation, host-key pins, addresses, namespaces,
+  // and exposure settings take effect without restarting control-plane services.
+  const profileBacked =
+    key.startsWith("k8s:") ||
+    key.startsWith("remote:") ||
+    key.startsWith("hermes:remote:") ||
+    key.startsWith("nemoclaw:remote:");
+  if (backendInstances.has(key) && !profileBacked) return backendInstances.get(key);
+  if (profileBacked) backendInstances.delete(key);
 
   let instance;
   switch (key) {
@@ -2289,8 +2436,18 @@ const worker = new Worker(
       });
 
       // Fetch user's LLM provider keys from DB for injection into container
-      const llmEnvVars = await fetchUserLlmEnvVars(userId, llmProviderId);
-      const defaultLlmProvider = await fetchDeploymentProvider(userId, llmProviderId);
+      const bootstrappedProviderState = await fetchEffectiveProviderState(userId, llmProviderId);
+      const {
+        envVars: llmEnvVars,
+        defaultProvider: defaultLlmProvider,
+        fingerprint: bootstrappedProviderFingerprint,
+      } = bootstrappedProviderState;
+      const builtInDemoActivation = isBuiltInDemoActivation({
+        jobId: job.id,
+        agentId: id,
+        llmProviderId,
+        defaultProvider: defaultLlmProvider,
+      });
       const defaultOpenClawModel = buildDefaultOpenClawModel(defaultLlmProvider);
       const hermesRuntimeBootstrapEnv =
         resolvedRuntimeFields.runtime_family === "hermes"
@@ -2781,8 +2938,13 @@ const worker = new Worker(
               console.warn(
                 `[provisioner] Agent ${id} was deleted during create; removing runtime ${containerId}`,
               );
-              await provisioner.destroy(containerId, { agentId: id }).catch(() => {});
-              return { canceled: true, reason: "agent-deleted-during-create" };
+              return cleanupCanceledProvisionedRuntime({
+                queryable: db,
+                provisioner,
+                agentId: id,
+                containerId,
+                reason: "agent-deleted-during-create",
+              });
             }
           } catch (e) {
             console.error(
@@ -2881,6 +3043,7 @@ const worker = new Worker(
           }
         }
       } catch (err) {
+        if (isCanceledRuntimeCleanupFailure(err)) throw err;
         console.error(
           `[${resolvedBackend}] Provisioning failed for agent ${id} (attempt ${job.attemptsMade + 1}/${job.opts?.attempts || 1}):`,
           err.message,
@@ -2925,120 +3088,155 @@ const worker = new Worker(
       const { encrypt } = require("./crypto");
       const gatewayTokenForStorage = gatewayToken ? encrypt(gatewayToken) : gatewayToken;
       try {
-        const finalUpdate = await db.query(
-          `UPDATE agents
-          SET status = 'running',
-              container_id = $2,
-              host = $3,
-              backend_type = $4,
-              gateway_token = $5,
-              container_name = COALESCE($6, container_name),
-              gateway_host_port = $7,
-              runtime_host = $8,
-              runtime_port = $9,
-              gateway_host = $10,
-              gateway_port = $11,
-              image = COALESCE($12, image),
-              runtime_family = $13,
-              deploy_target = $14,
-              execution_target_id = $15,
-              sandbox_profile = $16,
-              sandbox_type = $17,
-              network_policy_status = $18,
-              dashboard_port = $19
-        WHERE id = $1
-        RETURNING id`,
-          [
-            id,
-            containerId,
-            host,
-            resolvedRuntimeFields.backend_type,
-            gatewayTokenForStorage,
-            containerName || null,
-            gatewayHostPort ? parseInt(gatewayHostPort, 10) : null,
-            runtimeHost || null,
-            runtimePort ? parseInt(runtimePort, 10) : null,
-            gatewayHost || null,
-            gatewayPort ? parseInt(gatewayPort, 10) : null,
-            resolvedImage || null,
-            resolvedRuntimeFields.runtime_family,
-            resolvedRuntimeFields.deploy_target,
-            resolvedRuntimeFields.execution_target_id,
-            resolvedRuntimeFields.sandbox_profile,
-            resolvedRuntimeFields.sandbox_type,
-            networkPolicyStatus,
-            dashboardPort ? parseInt(dashboardPort, 10) : null,
-          ],
-        );
-        if (!finalUpdate.rows[0]) {
-          console.warn(
-            `[provisioner] Agent ${id} was deleted before final persistence; removing runtime ${containerId}`,
-          );
-          if (containerId) {
-            await provisioner.destroy(containerId, { agentId: id }).catch(() => {});
-          }
-          return { canceled: true, reason: "agent-deleted-before-final-update" };
-        }
-        await db.query("UPDATE deployments SET status = 'completed' WHERE agent_id = $1", [id]);
-        await db.query("INSERT INTO events(type, message, metadata) VALUES($1, $2, $3)", [
-          "agent_deployed",
-          `Agent "${name}" is now running on ${resolvedBackend}`,
-          JSON.stringify({ agentId: id, containerId, host }),
-        ]);
-        console.log(`Agent ${id} deployed: containerId=${containerId} host=${host}`);
-
-        // Post-deploy readiness check: verify both the runtime sidecar and the gateway.
-        // First boot may need time for npm installation and initial startup, so we allow
-        // generous bounded retries and emit a warning state with explicit component detail.
-        const readiness = await waitForAgentReadiness({
+        const metadataPersistence = await persistProvisionedRuntimeMetadata(db, {
+          agentId: id,
+          containerId,
           host,
+          backendType: resolvedRuntimeFields.backend_type,
+          gatewayToken: gatewayTokenForStorage,
+          containerName,
+          gatewayHostPort,
           runtimeHost,
           runtimePort,
           gatewayHost,
-          gatewayHostPort,
           gatewayPort,
-          checkGateway: resolvedRuntimeFields.runtime_family !== "hermes",
+          image: resolvedImage,
+          runtimeFamily: resolvedRuntimeFields.runtime_family,
+          deployTarget: resolvedRuntimeFields.deploy_target,
+          executionTargetId: resolvedRuntimeFields.execution_target_id,
+          sandboxProfile: resolvedRuntimeFields.sandbox_profile,
+          sandboxType: resolvedRuntimeFields.sandbox_type,
+          networkPolicyStatus,
+          dashboardPort,
         });
-        if (!readiness.ok) {
-          const detail = buildReadinessWarningDetail(readiness);
-          console.warn(`[provisioner] Readiness check failed for agent ${id}: ${detail}`);
-          await persistReadinessWarning(db, { agentId: id, name, host, readiness });
+        if (!metadataPersistence.persisted) {
+          console.warn(
+            `[provisioner] Agent ${id} was deleted or replaced before runtime metadata persistence; removing runtime ${containerId}`,
+          );
+          return cleanupCanceledProvisionedRuntime({
+            queryable: db,
+            provisioner,
+            agentId: id,
+            containerId,
+            reason: "agent-deleted-before-metadata-persistence",
+          });
         }
 
-        // Fresh deploys should land with the current control-plane LLM credentials
-        // and runtime model selection, not only the startup env captured earlier.
-        if (userId && readiness.ok) {
-          try {
-            const authSyncResult = await reconcileRuntimeLlmAuth({
-              agentId: id,
-              userId,
-              llmProviderId,
-              runtimeFamily: resolvedRuntimeFields.runtime_family,
-              resolvedBackend,
-              containerId,
-              provisioner,
+        // Keep the durable lifecycle in `deploying` until the first readiness
+        // check and any credential-drift restart have both settled. Gateway
+        // routes reject `deploying`, so operators cannot race the restart with
+        // their first chat request.
+        const readinessBarrier = await runProvisioningReadinessBarrier({
+          checkReadiness: () =>
+            waitForAgentReadiness({
               host,
               runtimeHost,
               runtimePort,
-              gatewayHostPort,
               gatewayHost,
+              gatewayHostPort,
               gatewayPort,
-              gatewayToken,
-            });
-            if (authSyncResult.status === "synced") {
-              console.log(`[provisioner] Post-deploy LLM auth sync completed for agent ${id}`);
-            }
-          } catch (e) {
-            console.warn(
-              `[provisioner] Failed to reconcile runtime LLM auth for agent ${id}:`,
-              e.message,
+              checkGateway: resolvedRuntimeFields.runtime_family !== "hermes",
+            }),
+          failClosedOnReadinessFailure: builtInDemoActivation,
+          onReadinessWarning: async (readiness) => {
+            const detail = buildReadinessWarningDetail(readiness);
+            console.warn(`[provisioner] Readiness check failed for agent ${id}: ${detail}`);
+            await persistReadinessWarning(db, { agentId: id, name, host, readiness });
+          },
+          reconcileAuth: userId
+            ? () =>
+                reconcileRuntimeLlmAuth({
+                  agentId: id,
+                  userId,
+                  llmProviderId,
+                  runtimeFamily: resolvedRuntimeFields.runtime_family,
+                  resolvedBackend,
+                  containerId,
+                  provisioner,
+                  host,
+                  runtimeHost,
+                  runtimePort,
+                  gatewayHostPort,
+                  gatewayHost,
+                  gatewayPort,
+                  gatewayToken,
+                  bootstrappedProviderFingerprint,
+                })
+            : null,
+          reconcileAndFinalize: userId
+            ? () =>
+                reconcileProviderStateUntilStable({
+                  bootstrappedFingerprint: bootstrappedProviderFingerprint,
+                  reconcile: (appliedFingerprint) =>
+                    reconcileRuntimeLlmAuth({
+                      agentId: id,
+                      userId,
+                      llmProviderId,
+                      runtimeFamily: resolvedRuntimeFields.runtime_family,
+                      resolvedBackend,
+                      containerId,
+                      provisioner,
+                      host,
+                      runtimeHost,
+                      runtimePort,
+                      gatewayHostPort,
+                      gatewayHost,
+                      gatewayPort,
+                      gatewayToken,
+                      bootstrappedProviderFingerprint: appliedFingerprint,
+                    }),
+                  readFingerprint: async () =>
+                    (await fetchEffectiveProviderState(userId, llmProviderId)).fingerprint,
+                  withMutationLock: (operation) => withProviderMutationLock(userId, operation),
+                  finalize: () =>
+                    finalizeProvisionedDeployment(db, {
+                      agentId: id,
+                      containerId,
+                      name,
+                      backend: resolvedBackend,
+                      host,
+                    }),
+                })
+            : null,
+          finalize: () =>
+            finalizeProvisionedDeployment(db, {
+              agentId: id,
+              containerId,
+              name,
+              backend: resolvedBackend,
+              host,
+            }),
+        });
+        const { readiness } = readinessBarrier;
+        if (readinessBarrier.status === "canceled") {
+          console.warn(
+            `[provisioner] Agent ${id} was deleted or its runtime changed before readiness finalization; removing runtime ${containerId}`,
+          );
+          return cleanupCanceledProvisionedRuntime({
+            queryable: db,
+            provisioner,
+            agentId: id,
+            containerId,
+            reason: "agent-deleted-before-readiness-finalization",
+          });
+        } else if (readinessBarrier.status === "running") {
+          if (readinessBarrier.reconciliation?.status === "synced") {
+            console.log(`[provisioner] Post-deploy LLM auth sync completed for agent ${id}`);
+          } else if (readinessBarrier.reconciliation?.reason === "unchanged") {
+            console.log(
+              `[provisioner] Post-deploy LLM auth sync skipped for agent ${id}; bootstrap state is current`,
             );
           }
+          console.log(`Agent ${id} deployed: containerId=${containerId} host=${host}`);
         }
 
         // Reseed persisted channel config before skills/integrations so a
         // redeploy comes back with its Telegram/Slack/Discord channels wired.
-        if (resolvedRuntimeFields.runtime_family === "openclaw" && readiness.ok) {
+        if (
+          !builtInDemoActivation &&
+          resolvedRuntimeFields.runtime_family === "openclaw" &&
+          readiness.ok
+        ) {
           try {
             const channelSeed = await reconcileOpenClawChannelState({
               agentId: id,
@@ -3063,7 +3261,11 @@ const worker = new Worker(
           }
         }
 
-        if (resolvedRuntimeFields.runtime_family === "openclaw" && containerId) {
+        if (
+          !builtInDemoActivation &&
+          resolvedRuntimeFields.runtime_family === "openclaw" &&
+          containerId
+        ) {
           try {
             await reconcileClawhubSkills({
               agentId: id,
@@ -3078,52 +3280,58 @@ const worker = new Worker(
           }
         }
 
-        // Sync integrations to newly deployed agent container
-        try {
-          const intResult = await db.query(
-            `SELECT i.id, i.provider, i.catalog_id, i.config, i.status,
+        // The built-in demo activation is deliberately mutation-free after
+        // readiness finalization. Its payload has no channels, skills, or
+        // integrations, and skipping these generic reseed passes guarantees
+        // the first chat cannot race a post-finalization gateway reload.
+        if (!builtInDemoActivation) {
+          try {
+            const intResult = await db.query(
+              `SELECT i.id, i.provider, i.catalog_id, i.config, i.status,
                 ic.name as catalog_name, ic.category as catalog_category,
                 ic.auth_type, ic.config_schema
          FROM integrations i
          LEFT JOIN integration_catalog ic ON i.catalog_id = ic.id
          WHERE i.agent_id = $1 AND i.status = 'active'`,
-            [id],
-          );
-          const syncData = intResult.rows.map(buildIntegrationSyncEntry);
-          if (resolvedRuntimeFields.runtime_family === "openclaw") {
-            const runtimeUrl = runtimeUrlForAgent(
-              {
-                host,
-                runtime_host: runtimeHost,
-                runtime_port: runtimePort,
-              },
-              "/integrations/sync",
+              [id],
             );
-            await fetch(runtimeUrl, {
-              method: "POST",
-              headers: {
-                "Content-Type": "application/json",
-                ...buildRuntimeAuthHeaders(gatewayToken),
-              },
-              body: JSON.stringify({ integrations: syncData }),
-            });
-            console.log(`[provisioner] Synced ${syncData.length} integration(s) to agent ${id}`);
-          } else if (resolvedRuntimeFields.runtime_family === "hermes" && containerId) {
-            await runProvisionerExecCommand(
-              provisioner,
-              containerId,
-              buildHermesIntegrationInstallCommand(syncData),
-              { timeout: 30000, agentId: id },
-            );
-            console.log(
-              `[provisioner] Installed Nora integration skill with ${syncData.length} integration(s) to Hermes agent ${id}`,
-            );
+            const syncData = intResult.rows.map(buildIntegrationSyncEntry);
+            if (resolvedRuntimeFields.runtime_family === "openclaw") {
+              const runtimeUrl = runtimeUrlForAgent(
+                {
+                  host,
+                  runtime_host: runtimeHost,
+                  runtime_port: runtimePort,
+                },
+                "/integrations/sync",
+              );
+              await fetch(runtimeUrl, {
+                method: "POST",
+                headers: {
+                  "Content-Type": "application/json",
+                  ...buildRuntimeAuthHeaders(gatewayToken),
+                },
+                body: JSON.stringify({ integrations: syncData }),
+              });
+              console.log(`[provisioner] Synced ${syncData.length} integration(s) to agent ${id}`);
+            } else if (resolvedRuntimeFields.runtime_family === "hermes" && containerId) {
+              await runProvisionerExecCommand(
+                provisioner,
+                containerId,
+                buildHermesIntegrationInstallCommand(syncData),
+                { timeout: 30000, agentId: id },
+              );
+              console.log(
+                `[provisioner] Installed Nora integration skill with ${syncData.length} integration(s) to Hermes agent ${id}`,
+              );
+            }
+          } catch (e) {
+            console.warn(`[provisioner] Failed to sync integrations for agent ${id}:`, e.message);
           }
-        } catch (e) {
-          console.warn(`[provisioner] Failed to sync integrations for agent ${id}:`, e.message);
         }
       } catch (err) {
-        console.error("Failed to update agent status:", err.message);
+        if (isCanceledRuntimeCleanupFailure(err)) throw err;
+        console.error("Failed to finalize provisioned runtime:", err.message);
         const cleanup = await reconcileProvisioningFailureRuntime({
           queryable: db,
           provisioner,


### PR DESCRIPTION
## Summary

- keep zero-key activation behind a final readiness/auth barrier so the first chat cannot race a restart
- serialize provider mutations, runtime sync, and deployment finalization without starving low-capacity PostgreSQL pools
- fail closed for hosted Remote Docker, reload rotated target profiles, preserve SSH host pins, and route Remote Hermes backup capture through its selected Docker-over-SSH backend
- harden Proxmox preflight/bootstrap while retaining Experimental status and the real-hardware promotion gate
- publish a complete Remote Docker operator guide and align security/press copy
- carry hardened nginx/cache/Docker-socket release defaults into production deployment
- prepare Nora v1.16.1 and Helm chart 0.7.1 metadata

## Validation

- Nora local CI pre-push script: passed
- backend Jest: 166 suites passed, 1 skipped; 1,610 tests passed
- agent-runtime Vitest: 26 passed
- worker lifecycle tests: 16 passed
- package typechecks: all passed
- secret scan, production dependency audits, license policy: passed
- Helm lint + kubeconform / infra validation: passed
- production Docker image builds: passed
- compose Playwright: 30 passed, 65 real-credential specs skipped as expected; includes worker-backed signup -> activation -> immediate first chat -> cleanup
- Mintlify `mint validate`: passed
- Remote Hermes backup production-image module resolution: passed

## Release note

Proxmox remains **Experimental**. This PR does not claim production readiness without the protected real-hardware smoke workflow.
