### PR TITLE
fix(deploy): activate regenerated nginx config

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -220,8 +220,13 @@ jobs:
           done
 
           export NORA_ENV_FILE="$DEPLOY_ENV_FILE"
+          echo "Pre-validating the generated nginx config before replacing services."
+          docker compose "${compose_args[@]}" run --rm --no-deps nginx nginx -t
           echo "Code update only: preserving compose volumes and provisioned agent Docker/K8s/VM instances."
           docker compose "${compose_args[@]}" up -d --build
+          echo "Recreating nginx so the regenerated bind-mounted config inode is active."
+          docker compose "${compose_args[@]}" up -d --force-recreate --no-deps nginx
+          docker compose "${compose_args[@]}" exec -T nginx nginx -t
           docker compose "${compose_args[@]}" ps
 
           health_attempts=221

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to Nora are documented here. Each entry summarizes the
 corresponding [GitHub release](https://github.com/solomon2773/nora/releases),
 which carries the full notes and verification details.
 
+## [v1.16.2](https://github.com/solomon2773/nora/releases/tag/v1.16.2) — 2026-07-12
+
+Edge-activation patch: generated public nginx policy is now applied immediately during every
+supported update path instead of remaining pinned to an older bind-mounted file inode.
+
+### Changed
+
+- Production deploys, Bash/PowerShell setup updates, and direct release upgrades pre-validate
+  and refresh the generated nginx configuration, recreate only the edge container to remount it,
+  and then validate the active configuration.
+- Infrastructure validation now executes the nginx/secret/release regression suite in CI, and
+  TLS renewal validates then gracefully reloads nginx so renewed certificates take effect.
+- Release metadata advances the Gemini extension manifest to `1.16.2` and the Helm chart to
+  `0.7.2` for exact-tag publication.
+
+### Fixed
+
+- Atomically replacing `nginx.public.conf` no longer leaves the running edge container bound to
+  the previous file inode, so marketing CSP, frame denial, host-only HSTS, homepage cache
+  eligibility, and backend-owned API framing headers take effect in the same deployment.
+- Installer and direct-upgrade paths now refresh generated public nginx policy before recreating
+  the edge instead of reactivating an old generated file.
+
 ## [v1.16.1](https://github.com/solomon2773/nora/releases/tag/v1.16.1) — 2026-07-12
 
 Activation-reliability patch: the zero-key first proof now stays behind a final readiness

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ iwr -useb https://raw.githubusercontent.com/solomon2773/nora/master/setup.ps1 | 
 **Kubernetes (Helm):**
 
 ```bash
-helm show chart oci://ghcr.io/solomon2773/nora --version 0.7.1
+helm show chart oci://ghcr.io/solomon2773/nora --version 0.7.2
 ```
 
 The public OCI chart installs the full Nora control plane. See the [Helm instructions](https://noradocs.solomontsao.com/self-hosting#kubernetes-helm) for the required secrets and Ingress options.

--- a/docs/configuration/tls-domains.mdx
+++ b/docs/configuration/tls-domains.mdx
@@ -56,10 +56,14 @@ By default, Nora listens on `localhost:8080` and is only reachable from the mach
   </Step>
 
   <Step title="Start the stack">
-    Bring the stack up (or restart it if it is already running):
+    Pre-validate the generated file, bring the stack up, and recreate nginx so its single-file
+    bind mount is guaranteed to use the current file inode:
 
     ```bash theme={null}
+    docker compose run --rm --no-deps nginx nginx -t
     docker compose up -d
+    docker compose up -d --force-recreate --no-deps nginx
+    docker compose exec -T nginx nginx -t
     ```
 
     Nora is now accessible at `http://app.example.com` (port 80 must be open on your host firewall and the DNS A record must point to your server's public IP).
@@ -112,11 +116,17 @@ By default, Nora listens on `localhost:8080` and is only reachable from the mach
 
   </Step>
 
-  <Step title="Restart the stack">
-    Bring the stack down and back up to apply the new nginx config. For a standard single-file Compose run, Docker Compose auto-loads the generated `docker-compose.override.yml`:
+  <Step title="Activate the TLS config">
+    The helper stops the old nginx process before writing the TLS config. Pre-validate the new
+    file, start the stack, and recreate nginx so the generated file is mounted from its current
+    inode. For a standard single-file Compose run, Docker Compose auto-loads the generated
+    `docker-compose.override.yml`:
 
     ```bash theme={null}
+    docker compose run --rm --no-deps nginx nginx -t
     docker compose up -d
+    docker compose up -d --force-recreate --no-deps nginx
+    docker compose exec -T nginx nginx -t
     ```
 
     If you are using explicit Compose overlays, include the tracked TLS layer directly:
@@ -126,7 +136,22 @@ By default, Nora listens on `localhost:8080` and is only reachable from the mach
       -f docker-compose.yml \
       -f infra/docker-compose.public-tls.yml \
       -f <your-backend-overlay>.yml \
+      run --rm --no-deps nginx nginx -t
+    docker compose \
+      -f docker-compose.yml \
+      -f infra/docker-compose.public-tls.yml \
+      -f <your-backend-overlay>.yml \
       up -d --build
+    docker compose \
+      -f docker-compose.yml \
+      -f infra/docker-compose.public-tls.yml \
+      -f <your-backend-overlay>.yml \
+      up -d --force-recreate --no-deps nginx
+    docker compose \
+      -f docker-compose.yml \
+      -f infra/docker-compose.public-tls.yml \
+      -f <your-backend-overlay>.yml \
+      exec -T nginx nginx -t
     ```
 
     Nora is now available at `https://app.example.com` with a valid Let's Encrypt certificate.
@@ -136,11 +161,20 @@ By default, Nora listens on `localhost:8080` and is only reachable from the mach
 
 ## Certificate renewal
 
-Let's Encrypt certificates expire after 90 days. Set up a cron job on your host to renew the certificate and reload nginx:
+Let's Encrypt certificates expire after 90 days. `infra/setup-tls.sh` installs a daily 3 AM cron
+entry that runs Certbot renewal, validates the live nginx configuration, and then sends nginx a
+graceful reload signal so renewed certificate files take effect without replacing the edge
+container.
 
 ```bash theme={null}
-# Run at 3 AM on the 1st and 15th of each month
-0 3 1,15 * * DOMAIN=app.example.com EMAIL=admin@example.com /path/to/nora/infra/setup-tls.sh && docker compose -f /path/to/nora/docker-compose.yml up -d
+crontab -l | grep 'certbot.*renew'
+```
+
+If you manage renewal yourself, keep the same post-renewal sequence:
+
+```bash theme={null}
+docker compose exec -T nginx nginx -t
+docker compose exec -T nginx nginx -s reload
 ```
 
 <Tip>

--- a/docs/guides/upgrades.mdx
+++ b/docs/guides/upgrades.mdx
@@ -11,6 +11,11 @@ Nora supports two upgrade paths for source-based self-hosted installs:
 
 Both paths rebuild the same Docker Compose stack. For public TLS and Kubernetes backends, make sure the deploy env file and compose file list match the command you normally use.
 
+Both supported upgrade runners also refresh generated public nginx policy, pre-validate it in a
+one-off container, and recreate only nginx after the main rebuild. This remount is required
+because `nginx.public.conf` is replaced atomically and an already-running single-file bind mount
+otherwise remains attached to the previous inode.
+
 ## Manual upgrade
 
 Run the manual upgrade from the Nora repo root on the host:
@@ -19,15 +24,23 @@ Run the manual upgrade from the Nora repo root on the host:
 ./setup.sh --update
 ```
 
-For deployments that do not use `setup.sh`, run the same compose stack that started the instance. Public TLS plus any Kubernetes backend uses:
+For deployments that do not use `setup.sh`, refresh the public config and run the same Compose
+stack that started the instance. Public TLS plus any Kubernetes backend uses:
 
 ```bash
-docker compose \
+compose=(docker compose \
   --env-file .env \
   -f docker-compose.yml \
   -f infra/docker-compose.public-tls.yml \
-  -f docker-compose.kubernetes.yml \
-  up -d --build
+  -f docker-compose.kubernetes.yml)
+
+bash infra/render-public-nginx.sh \
+  .env \
+  'docker-compose.yml:infra/docker-compose.public-tls.yml:docker-compose.kubernetes.yml'
+"${compose[@]}" run --rm --no-deps nginx nginx -t
+"${compose[@]}" up -d --build
+"${compose[@]}" up -d --force-recreate --no-deps nginx
+"${compose[@]}" exec -T nginx nginx -t
 ```
 
 The Kubernetes overlay is shared by AKS, GKE, EKS, k3s, and other kubeconfig-based Kubernetes targets. Provider selection happens through the Admin Kubernetes cluster settings and mounted kubeconfigs, not through separate provider-specific compose files.
@@ -51,7 +64,7 @@ NORA_UPGRADE_COMPOSE_FILES=docker-compose.yml:infra/docker-compose.public-tls.ym
 NORA_UPGRADE_PUBLIC_HEALTH_URL=https://stage.example.com/api/health
 ```
 
-The backend mounts the host checkout read-only at `/nora-host-repo` for preflight file checks. The temporary upgrade runner mounts `NORA_HOST_REPO_DIR` read-write so it can fetch the target release, update release tracking in the deploy env file, and rebuild the stack.
+The backend mounts the host checkout read-only at `/nora-host-repo` for preflight file checks. The temporary upgrade runner mounts `NORA_HOST_REPO_DIR` read-write so it can fetch the target release, update release tracking in the deploy env file, refresh and activate generated nginx policy, and rebuild the stack.
 
 ## Admin flow
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "nora",
   "description": "Operate self-hosted OpenClaw and Hermes agent fleets from Gemini CLI.",
-  "version": "1.16.1",
+  "version": "1.16.2",
   "settings": [
     {
       "name": "Nora API URL",

--- a/infra/helm/nora/Chart.yaml
+++ b/infra/helm/nora/Chart.yaml
@@ -5,8 +5,8 @@ description: >-
   (nginx edge, marketing/operator/admin frontends, backend API, provisioner and
   backup workers) plus optional in-chart PostgreSQL and Redis.
 type: application
-version: 0.7.1
-appVersion: "1.16.1"
+version: 0.7.2
+appVersion: "1.16.2"
 home: https://github.com/solomon2773/nora
 icon: https://raw.githubusercontent.com/solomon2773/nora/master/frontend-marketing/public/icon-512.png
 sources:

--- a/infra/run-release-upgrade.sh
+++ b/infra/run-release-upgrade.sh
@@ -308,12 +308,18 @@ run_upgrade() {
       return $?
     fi
     bash scripts/materialize-compose-secrets.sh "$env_file"
+    bash infra/render-public-nginx.sh "$env_file" "$compose_files"
     echo "Rebuilding and restarting Nora services..."
   fi
 
   build_compose_args "$env_file" "$compose_files" || return $?
   if [ ! -f setup.sh ] || [ "${NORA_UPGRADE_USE_SETUP:-true}" = "false" ]; then
+    echo "Pre-validating nginx configuration..."
+    docker compose "${COMPOSE_ARGS[@]}" run --rm --no-deps nginx nginx -t
     docker compose "${COMPOSE_ARGS[@]}" up -d --build
+    echo "Recreating nginx so generated configuration mounts are refreshed..."
+    docker compose "${COMPOSE_ARGS[@]}" up -d --force-recreate --no-deps nginx
+    docker compose "${COMPOSE_ARGS[@]}" exec -T nginx nginx -t
   fi
   docker compose "${COMPOSE_ARGS[@]}" ps
 

--- a/infra/setup-tls.sh
+++ b/infra/setup-tls.sh
@@ -115,7 +115,7 @@ echo "[2/3] Config ready"
 echo
 echo "[3/3] Setting up auto-renewal..."
 
-CRON_CMD="0 3 * * * docker run --rm -v /etc/letsencrypt:/etc/letsencrypt -v /var/lib/letsencrypt:/var/lib/letsencrypt -v ${WEBROOT}:/var/www/certbot certbot/certbot renew --quiet && cd ${REPO_DIR} && docker compose up -d nginx"
+CRON_CMD="0 3 * * * docker run --rm -v /etc/letsencrypt:/etc/letsencrypt -v /var/lib/letsencrypt:/var/lib/letsencrypt -v ${WEBROOT}:/var/www/certbot certbot/certbot renew --quiet && cd ${REPO_DIR} && docker compose exec -T nginx nginx -t && docker compose exec -T nginx nginx -s reload"
 
 (crontab -l 2>/dev/null | grep -v 'certbot.*renew' || true; echo "$CRON_CMD") | crontab -
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "ci:license-check": "node .github/workflows/scripts/license-check.mjs",
     "ci:lint": "eslint --ext .js,.jsx,.ts,.tsx,.cjs,.mjs --max-warnings=0",
     "ci:secret-scan": "node .github/workflows/scripts/scan-sensitive-config.mjs",
-    "ci:validate-infra": "node .github/workflows/scripts/validate-infra.mjs"
+    "ci:validate-infra": "node .github/workflows/scripts/validate-infra.mjs && node --test scripts/infra-security.test.mjs"
   },
   "devDependencies": {
     "@eslint/js": "^9.38.0",

--- a/scripts/infra-security.test.mjs
+++ b/scripts/infra-security.test.mjs
@@ -635,11 +635,52 @@ test("release env refreshes and deduplicates the live Docker socket group", () =
   ]);
 });
 
-test("production deploy refreshes generated public nginx config without touching custom configs", () => {
+test("production update paths activate refreshed nginx config without touching custom configs", () => {
   const deployWorkflow = read(".github/workflows/deploy-production.yml");
+  const rootPackage = JSON.parse(read("package.json"));
+  const setupBash = read("setup.sh");
+  const setupPowerShell = read("setup.ps1");
+  const releaseUpgrade = read("infra/run-release-upgrade.sh");
+  const setupTls = read("infra/setup-tls.sh");
+  assert.match(
+    rootPackage.scripts["ci:validate-infra"],
+    /node --test scripts\/infra-security\.test\.mjs/,
+  );
   assert.match(
     deployWorkflow,
     /bash infra\/render-public-nginx\.sh[\s\S]*?"\$DEPLOY_ENV_FILE"[\s\S]*?"\$DEPLOY_COMPOSE_FILES"/,
+  );
+  assert.match(
+    deployWorkflow,
+    /docker compose "\$\{compose_args\[@\]\}" run --rm --no-deps nginx nginx -t[\s\S]*?docker compose "\$\{compose_args\[@\]\}" up -d --build[\s\S]*?docker compose "\$\{compose_args\[@\]\}" up -d --force-recreate --no-deps nginx[\s\S]*?docker compose "\$\{compose_args\[@\]\}" exec -T nginx nginx -t/,
+  );
+  assert.match(
+    setupBash,
+    /bash infra\/render-public-nginx\.sh "\$ENV_FILE" "\$compose_file_value"/,
+  );
+  assert.match(
+    setupBash,
+    /docker compose run --rm --no-deps nginx nginx -t[\s\S]*?docker compose up -d --build[\s\S]*?docker compose up -d --force-recreate --no-deps nginx[\s\S]*?docker compose exec -T nginx nginx -t/,
+  );
+  assert.match(
+    setupPowerShell,
+    /Write-PublicNginxConfig -TemplatePath \$updateNginxTemplate -Domain \$parsedPublicUri\.Host/,
+  );
+  assert.match(
+    setupPowerShell,
+    /docker compose run --rm --no-deps nginx nginx -t[\s\S]*?docker compose up -d --build[\s\S]*?docker compose up -d --force-recreate --no-deps nginx[\s\S]*?docker compose exec -T nginx nginx -t/,
+  );
+  assert.match(
+    releaseUpgrade,
+    /bash infra\/render-public-nginx\.sh "\$env_file" "\$compose_files"/,
+  );
+  assert.match(
+    releaseUpgrade,
+    /docker compose "\$\{COMPOSE_ARGS\[@\]\}" run --rm --no-deps nginx nginx -t[\s\S]*?docker compose "\$\{COMPOSE_ARGS\[@\]\}" up -d --build[\s\S]*?docker compose "\$\{COMPOSE_ARGS\[@\]\}" up -d --force-recreate --no-deps nginx[\s\S]*?docker compose "\$\{COMPOSE_ARGS\[@\]\}" exec -T nginx nginx -t/,
+  );
+  assert.match(
+    setupTls,
+    /certbot renew --quiet[\s\S]*?docker compose exec -T nginx nginx -t[\s\S]*?docker compose exec -T nginx nginx -s reload/,
   );
 
   runChecked("bash", [

--- a/setup.ps1
+++ b/setup.ps1
@@ -716,8 +716,17 @@ function Start-NoraComposeStack {
     Write-Info "Starting Nora (docker compose up -d --build)..."
     Write-Info "Preserving Docker volumes and provisioned agent instances."
     Write-Host ""
+    Write-Info "Pre-validating nginx configuration..."
+    docker compose run --rm --no-deps nginx nginx -t
+    if ($LASTEXITCODE -ne 0) { Write-Err "nginx configuration validation failed"; exit 1 }
     docker compose up -d --build
     if ($LASTEXITCODE -ne 0) { Write-Err "docker compose failed to start Nora"; exit 1 }
+    Write-Info "Recreating nginx so generated configuration mounts are refreshed..."
+    docker compose up -d --force-recreate --no-deps nginx
+    if ($LASTEXITCODE -ne 0) { Write-Err "nginx recreation failed"; exit 1 }
+    docker compose exec -T nginx nginx -t
+    if ($LASTEXITCODE -ne 0) { Write-Err "active nginx configuration validation failed"; exit 1 }
+    Write-Ok "Nginx configuration activated"
     Test-NoraRuntimePermissions
     Write-Host ""
     Write-Ok "Nora is running!"
@@ -1382,6 +1391,27 @@ if ($SETUP_MODE -eq "update") {
     Ensure-BackupEncryptionKeyEnv -EnvPath $ENV_FILE
     Write-ComposeSecretFiles -EnvPath $ENV_FILE
     Update-ReleaseTrackingEnv -EnvPath $ENV_FILE
+    if ($nginxConfig -eq $PUBLIC_NGINX_CONF) {
+        $publicUrl = Read-EnvValue -EnvPath $ENV_FILE -Name "NORA_PUBLIC_URL" -Default ""
+        if (-not $publicUrl) {
+            $publicUrl = Read-EnvValue -EnvPath $ENV_FILE -Name "NEXTAUTH_URL" -Default ""
+        }
+        $parsedPublicUri = $null
+        if (-not [Uri]::TryCreate($publicUrl, [UriKind]::Absolute, [ref]$parsedPublicUri) -or
+            -not $parsedPublicUri.Host.Contains(".")) {
+            Write-Err "Could not derive a valid public domain from NORA_PUBLIC_URL or NEXTAUTH_URL."
+            exit 1
+        }
+        $updateNginxTemplate = if ($updateOverlayTemplate -eq $TLS_COMPOSE_OVERRIDE_TEMPLATE) {
+            $TLS_NGINX_TEMPLATE
+        } else {
+            $PUBLIC_NGINX_TEMPLATE
+        }
+        Write-PublicNginxConfig -TemplatePath $updateNginxTemplate -Domain $parsedPublicUri.Host
+        Write-Ok "Refreshed $PUBLIC_NGINX_CONF from $updateNginxTemplate"
+    } elseif ($nginxConfig -ne "nginx.conf") {
+        Write-Info "Custom NGINX_CONFIG_FILE=$nginxConfig is active; leaving it unchanged."
+    }
     Assert-NoraHostPortsAvailable -Checks (Get-NoraHostPortChecks -EnvPath $ENV_FILE)
     Start-NoraComposeStack
     Write-Host ""

--- a/setup.sh
+++ b/setup.sh
@@ -562,7 +562,13 @@ start_compose_stack() {
   info "Starting Nora (docker compose up -d --build)..."
   info "Preserving Docker volumes and provisioned agent instances."
   echo ""
+  info "Pre-validating nginx configuration..."
+  docker compose run --rm --no-deps nginx nginx -t
   docker compose up -d --build
+  info "Recreating nginx so generated configuration mounts are refreshed..."
+  docker compose up -d --force-recreate --no-deps nginx
+  docker compose exec -T nginx nginx -t
+  ok "Nginx configuration activated"
   verify_compose_runtime_permissions
   echo ""
   ok "Nora is running!"
@@ -1302,6 +1308,7 @@ if [ "$SETUP_MODE" = "update" ]; then
   ensure_backup_encryption_key_env "$ENV_FILE"
   materialize_compose_secret_files "$ENV_FILE"
   stamp_release_tracking_env "$ENV_FILE"
+  bash infra/render-public-nginx.sh "$ENV_FILE" "$compose_file_value"
   assert_nora_host_ports_available "$ENV_FILE"
   start_compose_stack
   echo ""


### PR DESCRIPTION
## Summary

- pre-validate generated nginx configuration, rebuild the stack, then force-recreate only nginx so atomic file replacement cannot leave its bind mount on the old inode
- refresh generated public nginx policy in Bash/PowerShell installer updates and the direct upgrade fallback; reload nginx after certificate renewal
- wire the existing infrastructure-security regression suite into `ci:validate-infra`, correct TLS/upgrade docs, and prepare `v1.16.2` / Helm `0.7.2`

## Production evidence

The `v1.16.1` deploy regenerated `nginx.public.conf`, but its log showed `nora-nginx-1` remained three weeks old. Public responses therefore kept the previous CSP/HSTS/cache/frame policy. An isolated Docker reproduction confirmed atomic replacement leaves a running single-file bind mount on the old inode; the prevalidate + force-recreate sequence remounts the new file.

## Validation

- full Nora pre-push CI script passed
- backend: 1,610 passed, 1 skipped
- agent runtime: 26 passed
- infrastructure regressions: 16 passed, 1 PowerShell-only check skipped locally
- all typechecks, audits, licenses, secret scan, Helm/kubeconform, production Docker builds passed
- Compose Playwright: 30 passed, 65 expected real-credential skips
- `mint validate` passed
- isolated Docker inode/remount reproduction passed
- `bash -n` and `git diff --check` passed

PowerShell 7 was unavailable on the Linux host for an additional parser-only check; the tracked static PowerShell contract coverage passed. Proxmox remains Experimental and is unchanged.
