### PR TITLE
fix(release): finish nginx activation hardening

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -221,7 +221,7 @@ jobs:
 
           export NORA_ENV_FILE="$DEPLOY_ENV_FILE"
           echo "Pre-validating the generated nginx config before replacing services."
-          docker compose "${compose_args[@]}" run --rm --no-deps nginx nginx -t
+          docker compose "${compose_args[@]}" run --rm --no-deps --interactive=false -T nginx nginx -t
           echo "Code update only: preserving compose volumes and provisioned agent Docker/K8s/VM instances."
           docker compose "${compose_args[@]}" up -d --build
           echo "Recreating nginx so the regenerated bind-mounted config inode is active."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ supported update path instead of remaining pinned to an older bind-mounted file 
 ### Changed
 
 - Production deploys, Bash/PowerShell setup updates, and direct release upgrades pre-validate
-  and refresh the generated nginx configuration, recreate only the edge container to remount it,
-  and then validate the active configuration.
+  the generated nginx configuration without attaching stdin, refresh it, recreate only the edge
+  container to remount it, and then validate the active configuration.
 - Infrastructure validation now executes the nginx/secret/release regression suite in CI, and
   TLS renewal validates then gracefully reloads nginx so renewed certificates take effect.
 - Release metadata advances the Gemini extension manifest to `1.16.2` and the Helm chart to
@@ -26,6 +26,8 @@ supported update path instead of remaining pinned to an older bind-mounted file 
   eligibility, and backend-owned API framing headers take effect in the same deployment.
 - Installer and direct-upgrade paths now refresh generated public nginx policy before recreating
   the edge instead of reactivating an old generated file.
+- SSH-driven deploys no longer let the one-off nginx validator consume the remaining remote
+  heredoc before the rebuild, health checks, and Docker-socket verification execute.
 
 ## [v1.16.1](https://github.com/solomon2773/nora/releases/tag/v1.16.1) — 2026-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ supported update path instead of remaining pinned to an older bind-mounted file 
   heredoc before the rebuild, health checks, and Docker-socket verification execute.
 - Public edges now emit one host-only HSTS field while preserving backend-owned API browser
   policy, and every Next.js surface disables framework disclosure through `X-Powered-By`.
+- Public nginx now restores visitor addresses only from Cloudflare's published proxy networks,
+  keeping launch-day per-IP limits accurate without trusting spoofed direct-client headers.
 
 ## [v1.16.1](https://github.com/solomon2773/nora/releases/tag/v1.16.1) — 2026-07-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ supported update path instead of remaining pinned to an older bind-mounted file 
   the edge instead of reactivating an old generated file.
 - SSH-driven deploys no longer let the one-off nginx validator consume the remaining remote
   heredoc before the rebuild, health checks, and Docker-socket verification execute.
+- Public edges now emit one host-only HSTS field while preserving backend-owned API browser
+  policy, and every Next.js surface disables framework disclosure through `X-Powered-By`.
 
 ## [v1.16.1](https://github.com/solomon2773/nora/releases/tag/v1.16.1) — 2026-07-12
 

--- a/admin-dashboard/next.config.ts
+++ b/admin-dashboard/next.config.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
+  poweredByHeader: false,
   output: "standalone",
   basePath: "/admin",
   i18n: {

--- a/docs/concepts/security.mdx
+++ b/docs/concepts/security.mdx
@@ -24,7 +24,7 @@ Nora is built to be trustworthy in real operator environments: you run it on you
 - **helmet** security headers and **CORS** restricted to the configured `CORS_ORIGINS` allowlist.
 - **Layered rate limiting**: a global limiter plus a stricter limiter on mutating requests in the API, and nginx-level rate-limit zones for auth and API paths at the public edge.
 - **No raw error leakage**: unexpected failures route through a central error handler with correlation IDs, so 5xx responses never expose exception internals.
-- **TLS setup is scripted** (`infra/setup-tls.sh`) for public deployments, with Cloudflare real-IP guidance for proxied edges.
+- **TLS setup is scripted** (`infra/setup-tls.sh`) for public deployments, and public nginx trusts `CF-Connecting-IP` only from Cloudflare's published networks so proxied per-IP controls remain accurate without accepting direct-header spoofing.
 
 ## Runtime access control
 

--- a/docs/configuration/tls-domains.mdx
+++ b/docs/configuration/tls-domains.mdx
@@ -60,7 +60,7 @@ By default, Nora listens on `localhost:8080` and is only reachable from the mach
     bind mount is guaranteed to use the current file inode:
 
     ```bash theme={null}
-    docker compose run --rm --no-deps nginx nginx -t
+    docker compose run --rm --no-deps --interactive=false -T nginx nginx -t
     docker compose up -d
     docker compose up -d --force-recreate --no-deps nginx
     docker compose exec -T nginx nginx -t
@@ -123,7 +123,7 @@ By default, Nora listens on `localhost:8080` and is only reachable from the mach
     `docker-compose.override.yml`:
 
     ```bash theme={null}
-    docker compose run --rm --no-deps nginx nginx -t
+    docker compose run --rm --no-deps --interactive=false -T nginx nginx -t
     docker compose up -d
     docker compose up -d --force-recreate --no-deps nginx
     docker compose exec -T nginx nginx -t
@@ -136,7 +136,7 @@ By default, Nora listens on `localhost:8080` and is only reachable from the mach
       -f docker-compose.yml \
       -f infra/docker-compose.public-tls.yml \
       -f <your-backend-overlay>.yml \
-      run --rm --no-deps nginx nginx -t
+      run --rm --no-deps --interactive=false -T nginx nginx -t
     docker compose \
       -f docker-compose.yml \
       -f infra/docker-compose.public-tls.yml \

--- a/docs/guides/upgrades.mdx
+++ b/docs/guides/upgrades.mdx
@@ -37,7 +37,7 @@ compose=(docker compose \
 bash infra/render-public-nginx.sh \
   .env \
   'docker-compose.yml:infra/docker-compose.public-tls.yml:docker-compose.kubernetes.yml'
-"${compose[@]}" run --rm --no-deps nginx nginx -t
+"${compose[@]}" run --rm --no-deps --interactive=false -T nginx nginx -t
 "${compose[@]}" up -d --build
 "${compose[@]}" up -d --force-recreate --no-deps nginx
 "${compose[@]}" exec -T nginx nginx -t

--- a/docs/self-hosting.mdx
+++ b/docs/self-hosting.mdx
@@ -157,7 +157,7 @@ Run Nora itself on a Kubernetes cluster with the public OCI chart at `oci://ghcr
 
 ```bash
 helm install nora oci://ghcr.io/solomon2773/nora \
-  --version 0.7.1 \
+  --version 0.7.2 \
   --namespace nora --create-namespace \
   --set secrets.jwtSecret="$(openssl rand -hex 32)" \
   --set secrets.encryptionKey="$(openssl rand -hex 32)" \

--- a/frontend-dashboard/next.config.ts
+++ b/frontend-dashboard/next.config.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
+  poweredByHeader: false,
   output: "standalone",
   basePath: "/app",
   i18n: {

--- a/frontend-marketing/next.config.ts
+++ b/frontend-marketing/next.config.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   reactStrictMode: true,
+  poweredByHeader: false,
   output: "standalone",
   i18n: {
     locales: ["en", "es", "fr", "zh-Hans", "zh-Hant"],

--- a/infra/cloudflare-launch.md
+++ b/infra/cloudflare-launch.md
@@ -47,8 +47,9 @@ Because the origin has a real Let's Encrypt cert, Full (strict) validates it end
 Do **not** use "Flexible" (it sends plaintext to the origin and breaks secure cookies).
 
 Also enable **SSL/TLS → Edge Certificates → Always Use HTTPS** and **Automatic HTTPS
-Rewrites**. You can turn on **HSTS** here instead of (or in addition to) the commented
-HSTS line in `infra/nginx_tls.conf`.
+Rewrites**. Nora's public nginx emits one host-only HSTS policy. Leave Cloudflare HSTS off
+unless you intentionally want a broader policy such as `includeSubDomains`; do not publish
+two conflicting HSTS fields.
 
 ## Step 3 — Restore the real client IP at the origin (required)
 
@@ -57,17 +58,18 @@ breaks the per-IP rate limiting added in `nginx_tls.conf` / `nginx_public.conf.t
 (`auth_limit` / `api_limit`): every visitor would share a handful of Cloudflare IPs, so a
 single edge IP could trip the limit for everyone.
 
-Both nginx templates ship a ready-to-enable block. **Uncomment** the
-`# ── Cloudflare real client IP restoration ──` section (the `set_real_ip_from …` ranges,
-`real_ip_header CF-Connecting-IP;`, `real_ip_recursive on;`), confirm the ranges against
-<https://www.cloudflare.com/ips/>, then regenerate + reload:
+Both public nginx templates enable Cloudflare real-IP restoration by default. The
+`CF-Connecting-IP` header is trusted only when the connection itself comes from one of
+Cloudflare's published IPv4/IPv6 networks, so direct clients cannot spoof it. Confirm the
+tracked ranges against <https://www.cloudflare.com/ips/> during release maintenance, then
+regenerate + recreate nginx:
 
 ```bash
 # regenerate nginx.public.conf from the template and reload
 DOMAIN=nora.solomontsao.com ./infra/setup-tls.sh    # or re-run your deploy
 docker compose --env-file .env -f docker-compose.yml \
   -f infra/docker-compose.public-prod.yml -f infra/docker-compose.public-tls.yml \
-  exec nginx nginx -s reload
+  up -d --force-recreate --no-deps nginx
 ```
 
 Verify: after enabling, `docker compose ... logs nginx` should show **real visitor IPs**,
@@ -117,11 +119,14 @@ longer reaches the Node process.
 **Cloudflare → Security → WAF → Rate limiting rules.** Add at least:
 
 - **Login protection:** path `/api/auth/login` (and `/api/auth/signup`, `/api/auth/oauth-login`)
-  → more than ~10 requests / minute / IP → **Block** for 1 minute. This sits in front of
-  the nginx `auth_limit` (5 r/s) and the Express `authLimiter` — three layers.
+  and method `POST` → use the strongest threshold and mitigation your plan exposes. On the
+  Free plan the counting period is 10 seconds, so a practical edge burst rule is more than
+  10 requests in 10 seconds per IP. Longer signup windows remain enforced by Nora itself.
+  This sits in front of nginx and the Express auth/signup limiters.
 
-The free plan includes one rate-limiting rule; use it on the auth surface, the most
-abused path.
+The Free plan includes one rate-limiting rule; use it on the auth surface, the most abused
+path. For a public promotion, also enable Nora's Turnstile integration so distributed,
+low-rate signup bots cannot simply rotate IPs.
 
 ## Step 6 — Streaming caveat (read before launch)
 
@@ -146,6 +151,7 @@ Run these against the live site **before** you post anywhere:
 - [ ] `curl -sI https://nora.solomontsao.com/api/health | grep -i cf-cache-status` →
       `BYPASS`/`DYNAMIC` (never `HIT`).
 - [ ] Sign up for a fresh account end-to-end (no cached/stale auth page; cookie sets).
+- [ ] `/api/auth/bootstrap-status` reports signup bot protection enabled and configured.
 - [ ] Log into `/app` and confirm the dashboard + a WebSocket log stream work.
 - [ ] Open an agent chat and confirm SSE streaming works (note the ~100s caveat).
 - [ ] OAuth login (Google/GitHub) round-trips (callbacks go through the marketing app).

--- a/infra/helm/nora/files/nginx-k8s.conf
+++ b/infra/helm/nora/files/nginx-k8s.conf
@@ -15,17 +15,32 @@ http {
 
     server_tokens off;
 
-    map $uri $surface_x_frame_options {
+    map $request_uri $surface_x_frame_options {
         default "DENY";
-        ~^/api(/|$) "";
-        ~^/(app|admin)(/|$) "SAMEORIGIN";
-        ~^/_next/ "";
+        ~^/api(/|\?|$) "";
+        ~^/(app|admin)(/|\?|$) "SAMEORIGIN";
+        ~^/_next(/|\?|$) "";
     }
 
-    add_header X-Content-Type-Options nosniff always;
+    map $request_uri $surface_x_content_type_options {
+        default "nosniff";
+        ~^/api(/|\?|$) "";
+    }
+
+    map $request_uri $surface_referrer_policy {
+        default "strict-origin-when-cross-origin";
+        ~^/api(/|\?|$) "";
+    }
+
+    map $request_uri $surface_cross_origin_opener_policy {
+        default "same-origin";
+        ~^/api(/|\?|$) "";
+    }
+
+    add_header X-Content-Type-Options $surface_x_content_type_options always;
     add_header X-Frame-Options $surface_x_frame_options always;
-    add_header Referrer-Policy strict-origin-when-cross-origin always;
-    add_header Cross-Origin-Opener-Policy same-origin always;
+    add_header Referrer-Policy $surface_referrer_policy always;
+    add_header Cross-Origin-Opener-Policy $surface_cross_origin_opener_policy always;
 
     large_client_header_buffers 4 32k;
     proxy_buffer_size 16k;

--- a/infra/nginx_public.conf.template
+++ b/infra/nginx_public.conf.template
@@ -12,35 +12,33 @@ http {
     resolver 127.0.0.11 ipv6=off valid=1s;
 
     # ── Cloudflare real client IP restoration ──────────────────────────
-    # REQUIRED when this origin sits behind Cloudflare (orange-cloud proxy).
-    # Without it nginx sees Cloudflare's edge IPs as $remote_addr, so the
-    # per-IP rate limits below would bucket every visitor together and a
-    # single edge IP could trip the limit for everyone. Uncomment to enable.
-    # Verify the ranges are current at https://www.cloudflare.com/ips/.
-    # set_real_ip_from 173.245.48.0/20;
-    # set_real_ip_from 103.21.244.0/22;
-    # set_real_ip_from 103.22.200.0/22;
-    # set_real_ip_from 103.31.4.0/22;
-    # set_real_ip_from 141.101.64.0/18;
-    # set_real_ip_from 108.162.192.0/18;
-    # set_real_ip_from 190.93.240.0/20;
-    # set_real_ip_from 188.114.96.0/20;
-    # set_real_ip_from 197.234.240.0/22;
-    # set_real_ip_from 198.41.128.0/17;
-    # set_real_ip_from 162.158.0.0/15;
-    # set_real_ip_from 104.16.0.0/13;
-    # set_real_ip_from 104.24.0.0/14;
-    # set_real_ip_from 172.64.0.0/13;
-    # set_real_ip_from 131.0.72.0/22;
-    # set_real_ip_from 2400:cb00::/32;
-    # set_real_ip_from 2606:4700::/32;
-    # set_real_ip_from 2803:f800::/32;
-    # set_real_ip_from 2405:b500::/32;
-    # set_real_ip_from 2405:8100::/32;
-    # set_real_ip_from 2a06:98c0::/29;
-    # set_real_ip_from 2c0f:f248::/32;
-    # real_ip_header CF-Connecting-IP;
-    # real_ip_recursive on;
+    # These directives are inert for direct/non-Cloudflare traffic because
+    # CF-Connecting-IP is trusted only from Cloudflare's published networks.
+    # Keep the ranges synchronized with https://www.cloudflare.com/ips/.
+    set_real_ip_from 173.245.48.0/20;
+    set_real_ip_from 103.21.244.0/22;
+    set_real_ip_from 103.22.200.0/22;
+    set_real_ip_from 103.31.4.0/22;
+    set_real_ip_from 141.101.64.0/18;
+    set_real_ip_from 108.162.192.0/18;
+    set_real_ip_from 190.93.240.0/20;
+    set_real_ip_from 188.114.96.0/20;
+    set_real_ip_from 197.234.240.0/22;
+    set_real_ip_from 198.41.128.0/17;
+    set_real_ip_from 162.158.0.0/15;
+    set_real_ip_from 104.16.0.0/13;
+    set_real_ip_from 104.24.0.0/14;
+    set_real_ip_from 172.64.0.0/13;
+    set_real_ip_from 131.0.72.0/22;
+    set_real_ip_from 2400:cb00::/32;
+    set_real_ip_from 2606:4700::/32;
+    set_real_ip_from 2803:f800::/32;
+    set_real_ip_from 2405:b500::/32;
+    set_real_ip_from 2405:8100::/32;
+    set_real_ip_from 2a06:98c0::/29;
+    set_real_ip_from 2c0f:f248::/32;
+    real_ip_header CF-Connecting-IP;
+    real_ip_recursive on;
 
     # Fix: 400 Bad Request – Request Header Or Cookie Too Large
     large_client_header_buffers 4 32k;

--- a/infra/nginx_public.conf.template
+++ b/infra/nginx_public.conf.template
@@ -71,18 +71,39 @@ http {
     # Marketing pages must not be framed. Authenticated dashboards remain
     # same-origin only, while API responses preserve backend-owned headers
     # (the gateway embed route deliberately emits SAMEORIGIN).
-    map $uri $surface_x_frame_options {
+    map $request_uri $surface_x_frame_options {
         default "DENY";
-        ~^/api(/|$) "";
-        ~^/(app|admin)(/|$) "SAMEORIGIN";
-        ~^/_next/ "";
+        ~^/api(/|\?|$) "";
+        ~^/(app|admin)(/|\?|$) "SAMEORIGIN";
+        ~^/_next(/|\?|$) "";
     }
 
+    # APIs retain backend-owned browser policy so specialized responses such
+    # as gateway embeds can narrow it without an edge-level duplicate.
+    map $request_uri $surface_x_content_type_options {
+        default "nosniff";
+        ~^/api(/|\?|$) "";
+    }
+
+    map $request_uri $surface_referrer_policy {
+        default "strict-origin-when-cross-origin";
+        ~^/api(/|\?|$) "";
+    }
+
+    map $request_uri $surface_cross_origin_opener_policy {
+        default "same-origin";
+        ~^/api(/|\?|$) "";
+    }
+
+    # HSTS is transport-edge policy. Hide the upstream Helmet default so the
+    # host-only value below is the single authoritative field.
+    proxy_hide_header Strict-Transport-Security;
+
     server_tokens off;
-    add_header X-Content-Type-Options nosniff always;
+    add_header X-Content-Type-Options $surface_x_content_type_options always;
     add_header X-Frame-Options $surface_x_frame_options always;
-    add_header Referrer-Policy strict-origin-when-cross-origin always;
-    add_header Cross-Origin-Opener-Policy same-origin always;
+    add_header Referrer-Policy $surface_referrer_policy always;
+    add_header Cross-Origin-Opener-Policy $surface_cross_origin_opener_policy always;
     # This header is ignored by direct HTTP clients but is preserved when a
     # TLS-terminating reverse proxy such as Cloudflare fronts this origin.
     add_header Strict-Transport-Security "max-age=63072000" always;
@@ -211,6 +232,7 @@ http {
         # 4. Marketing Pages (Root)
         location = / {
             proxy_hide_header Cache-Control;
+            proxy_hide_header Strict-Transport-Security;
             proxy_pass $marketing_site;
         }
 

--- a/infra/nginx_tls.conf
+++ b/infra/nginx_tls.conf
@@ -23,35 +23,33 @@ http {
     resolver 127.0.0.11 ipv6=off valid=1s;
 
     # ── Cloudflare real client IP restoration ──────────────────────────
-    # REQUIRED when this origin sits behind Cloudflare (orange-cloud proxy).
-    # Without it nginx sees Cloudflare's edge IPs as $remote_addr, so the
-    # per-IP rate limits below would bucket every visitor together and a
-    # single edge IP could trip the limit for everyone. Uncomment to enable.
-    # Verify the ranges are current at https://www.cloudflare.com/ips/.
-    # set_real_ip_from 173.245.48.0/20;
-    # set_real_ip_from 103.21.244.0/22;
-    # set_real_ip_from 103.22.200.0/22;
-    # set_real_ip_from 103.31.4.0/22;
-    # set_real_ip_from 141.101.64.0/18;
-    # set_real_ip_from 108.162.192.0/18;
-    # set_real_ip_from 190.93.240.0/20;
-    # set_real_ip_from 188.114.96.0/20;
-    # set_real_ip_from 197.234.240.0/22;
-    # set_real_ip_from 198.41.128.0/17;
-    # set_real_ip_from 162.158.0.0/15;
-    # set_real_ip_from 104.16.0.0/13;
-    # set_real_ip_from 104.24.0.0/14;
-    # set_real_ip_from 172.64.0.0/13;
-    # set_real_ip_from 131.0.72.0/22;
-    # set_real_ip_from 2400:cb00::/32;
-    # set_real_ip_from 2606:4700::/32;
-    # set_real_ip_from 2803:f800::/32;
-    # set_real_ip_from 2405:b500::/32;
-    # set_real_ip_from 2405:8100::/32;
-    # set_real_ip_from 2a06:98c0::/29;
-    # set_real_ip_from 2c0f:f248::/32;
-    # real_ip_header CF-Connecting-IP;
-    # real_ip_recursive on;
+    # These directives are inert for direct/non-Cloudflare traffic because
+    # CF-Connecting-IP is trusted only from Cloudflare's published networks.
+    # Keep the ranges synchronized with https://www.cloudflare.com/ips/.
+    set_real_ip_from 173.245.48.0/20;
+    set_real_ip_from 103.21.244.0/22;
+    set_real_ip_from 103.22.200.0/22;
+    set_real_ip_from 103.31.4.0/22;
+    set_real_ip_from 141.101.64.0/18;
+    set_real_ip_from 108.162.192.0/18;
+    set_real_ip_from 190.93.240.0/20;
+    set_real_ip_from 188.114.96.0/20;
+    set_real_ip_from 197.234.240.0/22;
+    set_real_ip_from 198.41.128.0/17;
+    set_real_ip_from 162.158.0.0/15;
+    set_real_ip_from 104.16.0.0/13;
+    set_real_ip_from 104.24.0.0/14;
+    set_real_ip_from 172.64.0.0/13;
+    set_real_ip_from 131.0.72.0/22;
+    set_real_ip_from 2400:cb00::/32;
+    set_real_ip_from 2606:4700::/32;
+    set_real_ip_from 2803:f800::/32;
+    set_real_ip_from 2405:b500::/32;
+    set_real_ip_from 2405:8100::/32;
+    set_real_ip_from 2a06:98c0::/29;
+    set_real_ip_from 2c0f:f248::/32;
+    real_ip_header CF-Connecting-IP;
+    real_ip_recursive on;
 
     large_client_header_buffers 4 32k;
     proxy_buffer_size 16k;

--- a/infra/nginx_tls.conf
+++ b/infra/nginx_tls.conf
@@ -81,19 +81,40 @@ http {
         "/" "public, max-age=0, s-maxage=300, stale-while-revalidate=60";
     }
 
-    map $uri $surface_x_frame_options {
+    map $request_uri $surface_x_frame_options {
         default "DENY";
-        ~^/api(/|$) "";
-        ~^/(app|admin)(/|$) "SAMEORIGIN";
-        ~^/_next/ "";
+        ~^/api(/|\?|$) "";
+        ~^/(app|admin)(/|\?|$) "SAMEORIGIN";
+        ~^/_next(/|\?|$) "";
     }
+
+    # APIs retain backend-owned browser policy so specialized responses such
+    # as gateway embeds can narrow it without an edge-level duplicate.
+    map $request_uri $surface_x_content_type_options {
+        default "nosniff";
+        ~^/api(/|\?|$) "";
+    }
+
+    map $request_uri $surface_referrer_policy {
+        default "strict-origin-when-cross-origin";
+        ~^/api(/|\?|$) "";
+    }
+
+    map $request_uri $surface_cross_origin_opener_policy {
+        default "same-origin";
+        ~^/api(/|\?|$) "";
+    }
+
+    # HSTS is transport-edge policy. Hide the upstream Helmet default so the
+    # host-only value below is the single authoritative field.
+    proxy_hide_header Strict-Transport-Security;
 
     # Security headers
     server_tokens off;
-    add_header X-Content-Type-Options nosniff always;
+    add_header X-Content-Type-Options $surface_x_content_type_options always;
     add_header X-Frame-Options $surface_x_frame_options always;
-    add_header Referrer-Policy strict-origin-when-cross-origin always;
-    add_header Cross-Origin-Opener-Policy same-origin always;
+    add_header Referrer-Policy $surface_referrer_policy always;
+    add_header Cross-Origin-Opener-Policy $surface_cross_origin_opener_policy always;
     add_header Strict-Transport-Security "max-age=63072000" always;
     add_header Content-Security-Policy $marketing_content_security_policy always;
     add_header Cache-Control $marketing_cache_control always;
@@ -237,6 +258,7 @@ http {
         # the homepage so the shared-edge directive above is unambiguous.
         location = / {
             proxy_hide_header Cache-Control;
+            proxy_hide_header Strict-Transport-Security;
             proxy_pass $marketing_site;
         }
 

--- a/infra/run-release-upgrade.sh
+++ b/infra/run-release-upgrade.sh
@@ -315,7 +315,7 @@ run_upgrade() {
   build_compose_args "$env_file" "$compose_files" || return $?
   if [ ! -f setup.sh ] || [ "${NORA_UPGRADE_USE_SETUP:-true}" = "false" ]; then
     echo "Pre-validating nginx configuration..."
-    docker compose "${COMPOSE_ARGS[@]}" run --rm --no-deps nginx nginx -t
+    docker compose "${COMPOSE_ARGS[@]}" run --rm --no-deps --interactive=false -T nginx nginx -t
     docker compose "${COMPOSE_ARGS[@]}" up -d --build
     echo "Recreating nginx so generated configuration mounts are refreshed..."
     docker compose "${COMPOSE_ARGS[@]}" up -d --force-recreate --no-deps nginx

--- a/nginx.conf
+++ b/nginx.conf
@@ -10,20 +10,35 @@ http {
     # Don't advertise the nginx version in error pages or the Server header.
     server_tokens off;
 
-    map $uri $surface_x_frame_options {
+    map $request_uri $surface_x_frame_options {
         default "DENY";
-        ~^/api(/|$) "";
-        ~^/(app|admin)(/|$) "SAMEORIGIN";
-        ~^/_next/ "";
+        ~^/api(/|\?|$) "";
+        ~^/(app|admin)(/|\?|$) "SAMEORIGIN";
+        ~^/_next(/|\?|$) "";
+    }
+
+    map $request_uri $surface_x_content_type_options {
+        default "nosniff";
+        ~^/api(/|\?|$) "";
+    }
+
+    map $request_uri $surface_referrer_policy {
+        default "strict-origin-when-cross-origin";
+        ~^/api(/|\?|$) "";
+    }
+
+    map $request_uri $surface_cross_origin_opener_policy {
+        default "same-origin";
+        ~^/api(/|\?|$) "";
     }
 
     # Baseline security headers applied to every response. nginx.public.conf
     # adds HSTS on top of these (only safe behind always-on TLS). Use `always`
     # so headers also appear on 4xx/5xx responses.
-    add_header X-Content-Type-Options nosniff always;
+    add_header X-Content-Type-Options $surface_x_content_type_options always;
     add_header X-Frame-Options $surface_x_frame_options always;
-    add_header Referrer-Policy strict-origin-when-cross-origin always;
-    add_header Cross-Origin-Opener-Policy same-origin always;
+    add_header Referrer-Policy $surface_referrer_policy always;
+    add_header Cross-Origin-Opener-Policy $surface_cross_origin_opener_policy always;
 
     # Fix: 400 Bad Request – Request Header Or Cookie Too Large
     large_client_header_buffers 4 32k;

--- a/scripts/infra-security.test.mjs
+++ b/scripts/infra-security.test.mjs
@@ -62,6 +62,14 @@ function serviceSection(source, serviceName) {
   return match[1];
 }
 
+function nginxRequestMapSection(source, variableName) {
+  const match = source.match(
+    new RegExp(`map \\$request_uri \\$${variableName} \\{([\\s\\S]*?)\\n    \\}`),
+  );
+  assert.ok(match, `missing request map ${variableName}`);
+  return match[1];
+}
+
 function manifestDocument(source, kind, name) {
   const document = source
     .split(/^---\s*$/m)
@@ -127,6 +135,11 @@ test("public nginx templates enforce marketing security and homepage cache heade
     );
     assert.match(
       source,
+      /proxy_hide_header Strict-Transport-Security;/,
+      `${file} must hide upstream HSTS`,
+    );
+    assert.match(
+      source,
       /add_header Content-Security-Policy \$marketing_content_security_policy always;/,
       `${file} must emit the marketing CSP`,
     );
@@ -142,8 +155,8 @@ test("public nginx templates enforce marketing security and homepage cache heade
       `${file} must choose frame policy by surface`,
     );
     assert.match(
-      source,
-      /map \$uri \$surface_x_frame_options \{[\s\S]*?~\^\/api\(\/\|\$\) "";[\s\S]*?~\^\/\(app\|admin\)\(\/\|\$\) "SAMEORIGIN";/,
+      nginxRequestMapSection(source, "surface_x_frame_options"),
+      /~\^\/api\(\/\|\\\?\|\$\) "";[\s\S]*?~\^\/\(app\|admin\)\(\/\|\\\?\|\$\) "SAMEORIGIN";/,
       `${file} must preserve backend embed headers and protect dashboards`,
     );
     assert.match(
@@ -151,18 +164,52 @@ test("public nginx templates enforce marketing security and homepage cache heade
       /"\/" "public, max-age=0, s-maxage=300, stale-while-revalidate=60";/,
       `${file} must mark only the homepage for shared caching`,
     );
-    assert.match(source, /location = \/ \{[\s\S]*?proxy_hide_header Cache-Control;/);
+    assert.match(
+      source,
+      /location = \/ \{[\s\S]*?proxy_hide_header Cache-Control;[\s\S]*?proxy_hide_header Strict-Transport-Security;/,
+    );
   }
 });
 
-test("every active nginx edge preserves backend embed framing headers", () => {
-  for (const file of ["nginx.conf", "infra/helm/nora/files/nginx-k8s.conf"]) {
+test("Next.js frontends suppress framework disclosure headers", () => {
+  for (const file of [
+    "frontend-marketing/next.config.ts",
+    "frontend-dashboard/next.config.ts",
+    "admin-dashboard/next.config.ts",
+  ]) {
+    assert.match(read(file), /poweredByHeader:\s*false/, `${file} must hide X-Powered-By`);
+  }
+});
+
+test("every active nginx edge preserves backend API-owned browser policy", () => {
+  for (const file of [
+    "nginx.conf",
+    "infra/nginx_public.conf.template",
+    "infra/nginx_tls.conf",
+    "infra/helm/nora/files/nginx-k8s.conf",
+  ]) {
     const source = read(file);
-    assert.match(source, /map \$uri \$surface_x_frame_options \{/);
-    assert.match(source, /~\^\/api\(\/\|\$\) "";/);
-    assert.match(source, /~\^\/\(app\|admin\)\(\/\|\$\) "SAMEORIGIN";/);
+    const frameMap = nginxRequestMapSection(source, "surface_x_frame_options");
+    assert.match(frameMap, /~\^\/api\(\/\|\\\?\|\$\) "";/);
+    assert.match(frameMap, /~\^\/\(app\|admin\)\(\/\|\\\?\|\$\) "SAMEORIGIN";/);
     assert.match(source, /add_header X-Frame-Options \$surface_x_frame_options always;/);
     assert.doesNotMatch(source, /add_header X-Frame-Options DENY always;/);
+    for (const [header, variable] of [
+      ["X-Content-Type-Options", "surface_x_content_type_options"],
+      ["Referrer-Policy", "surface_referrer_policy"],
+      ["Cross-Origin-Opener-Policy", "surface_cross_origin_opener_policy"],
+    ]) {
+      assert.match(
+        nginxRequestMapSection(source, variable),
+        /~\^\/api\(\/\|\\\?\|\$\) "";/,
+        `${file} must preserve backend ${header} on APIs`,
+      );
+      assert.match(
+        source,
+        new RegExp(`add_header ${header} \\$${variable} always;`),
+        `${file} must apply edge ${header} outside APIs`,
+      );
+    }
   }
 });
 

--- a/scripts/infra-security.test.mjs
+++ b/scripts/infra-security.test.mjs
@@ -120,8 +120,42 @@ test("marketing Compose services use an explicit environment allowlist", () => {
 });
 
 test("public nginx templates enforce marketing security and homepage cache headers", () => {
+  const cloudflareNetworks = [
+    "173.245.48.0/20",
+    "103.21.244.0/22",
+    "103.22.200.0/22",
+    "103.31.4.0/22",
+    "141.101.64.0/18",
+    "108.162.192.0/18",
+    "190.93.240.0/20",
+    "188.114.96.0/20",
+    "197.234.240.0/22",
+    "198.41.128.0/17",
+    "162.158.0.0/15",
+    "104.16.0.0/13",
+    "104.24.0.0/14",
+    "172.64.0.0/13",
+    "131.0.72.0/22",
+    "2400:cb00::/32",
+    "2606:4700::/32",
+    "2803:f800::/32",
+    "2405:b500::/32",
+    "2405:8100::/32",
+    "2a06:98c0::/29",
+    "2c0f:f248::/32",
+  ];
   for (const file of ["infra/nginx_public.conf.template", "infra/nginx_tls.conf"]) {
     const source = read(file);
+    for (const network of cloudflareNetworks) {
+      assert.match(
+        source,
+        new RegExp(`^\\s*set_real_ip_from ${network.replaceAll(".", "\\.")};$`, "m"),
+        `${file} must trust Cloudflare network ${network}`,
+      );
+    }
+    assert.match(source, /^\s*real_ip_header CF-Connecting-IP;$/m);
+    assert.match(source, /^\s*real_ip_recursive on;$/m);
+    assert.doesNotMatch(source, /^\s*#\s*(set_real_ip_from|real_ip_header|real_ip_recursive)/m);
     assert.match(source, /server_tokens off;/, `${file} must suppress version disclosure`);
     assert.match(
       source,

--- a/scripts/infra-security.test.mjs
+++ b/scripts/infra-security.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import path from "node:path";
@@ -652,7 +652,7 @@ test("production update paths activate refreshed nginx config without touching c
   );
   assert.match(
     deployWorkflow,
-    /docker compose "\$\{compose_args\[@\]\}" run --rm --no-deps nginx nginx -t[\s\S]*?docker compose "\$\{compose_args\[@\]\}" up -d --build[\s\S]*?docker compose "\$\{compose_args\[@\]\}" up -d --force-recreate --no-deps nginx[\s\S]*?docker compose "\$\{compose_args\[@\]\}" exec -T nginx nginx -t/,
+    /docker compose "\$\{compose_args\[@\]\}" run --rm --no-deps --interactive=false -T nginx nginx -t[\s\S]*?docker compose "\$\{compose_args\[@\]\}" up -d --build[\s\S]*?docker compose "\$\{compose_args\[@\]\}" up -d --force-recreate --no-deps nginx[\s\S]*?docker compose "\$\{compose_args\[@\]\}" exec -T nginx nginx -t/,
   );
   assert.match(
     setupBash,
@@ -660,7 +660,7 @@ test("production update paths activate refreshed nginx config without touching c
   );
   assert.match(
     setupBash,
-    /docker compose run --rm --no-deps nginx nginx -t[\s\S]*?docker compose up -d --build[\s\S]*?docker compose up -d --force-recreate --no-deps nginx[\s\S]*?docker compose exec -T nginx nginx -t/,
+    /docker compose run --rm --no-deps --interactive=false -T nginx nginx -t[\s\S]*?docker compose up -d --build[\s\S]*?docker compose up -d --force-recreate --no-deps nginx[\s\S]*?docker compose exec -T nginx nginx -t/,
   );
   assert.match(
     setupPowerShell,
@@ -668,7 +668,7 @@ test("production update paths activate refreshed nginx config without touching c
   );
   assert.match(
     setupPowerShell,
-    /docker compose run --rm --no-deps nginx nginx -t[\s\S]*?docker compose up -d --build[\s\S]*?docker compose up -d --force-recreate --no-deps nginx[\s\S]*?docker compose exec -T nginx nginx -t/,
+    /docker compose run --rm --no-deps --interactive=false -T nginx nginx -t[\s\S]*?docker compose up -d --build[\s\S]*?docker compose up -d --force-recreate --no-deps nginx[\s\S]*?docker compose exec -T nginx nginx -t/,
   );
   assert.match(
     releaseUpgrade,
@@ -676,12 +676,47 @@ test("production update paths activate refreshed nginx config without touching c
   );
   assert.match(
     releaseUpgrade,
-    /docker compose "\$\{COMPOSE_ARGS\[@\]\}" run --rm --no-deps nginx nginx -t[\s\S]*?docker compose "\$\{COMPOSE_ARGS\[@\]\}" up -d --build[\s\S]*?docker compose "\$\{COMPOSE_ARGS\[@\]\}" up -d --force-recreate --no-deps nginx[\s\S]*?docker compose "\$\{COMPOSE_ARGS\[@\]\}" exec -T nginx nginx -t/,
+    /docker compose "\$\{COMPOSE_ARGS\[@\]\}" run --rm --no-deps --interactive=false -T nginx nginx -t[\s\S]*?docker compose "\$\{COMPOSE_ARGS\[@\]\}" up -d --build[\s\S]*?docker compose "\$\{COMPOSE_ARGS\[@\]\}" up -d --force-recreate --no-deps nginx[\s\S]*?docker compose "\$\{COMPOSE_ARGS\[@\]\}" exec -T nginx nginx -t/,
   );
   assert.match(
     setupTls,
     /certbot renew --quiet[\s\S]*?docker compose exec -T nginx nginx -t[\s\S]*?docker compose exec -T nginx nginx -s reload/,
   );
+
+  const remoteValidation = deployWorkflow.match(
+    /^\s*(docker compose "\$\{compose_args\[@\]\}" run --rm --no-deps --interactive=false -T nginx nginx -t)\s*$/m,
+  );
+  assert.ok(remoteValidation, "deploy workflow must expose a non-interactive nginx preflight");
+  const stdinFixture = mkdtempSync(path.join(tmpdir(), "nora-nginx-preflight-stdin-"));
+  try {
+    const fakeDocker = path.join(stdinFixture, "docker");
+    const marker = path.join(stdinFixture, "continued");
+    writeFileSync(
+      fakeDocker,
+      `#!/usr/bin/env bash
+set -euo pipefail
+if [[ " $* " != *" --interactive=false "* ]]; then
+  cat >/dev/null
+fi
+`,
+    );
+    chmodSync(fakeDocker, 0o755);
+    const remoteScript = `set -euo pipefail
+compose_args=()
+${remoteValidation[1]}
+printf continued > ${JSON.stringify(marker)}
+`;
+    const result = spawnSync("bash", ["-s"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      input: remoteScript,
+      env: { ...process.env, PATH: `${stdinFixture}:${process.env.PATH}` },
+    });
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(readFileSync(marker, "utf8"), "continued");
+  } finally {
+    rmSync(stdinFixture, { recursive: true, force: true });
+  }
 
   runChecked("bash", [
     "-c",

--- a/setup.ps1
+++ b/setup.ps1
@@ -717,7 +717,7 @@ function Start-NoraComposeStack {
     Write-Info "Preserving Docker volumes and provisioned agent instances."
     Write-Host ""
     Write-Info "Pre-validating nginx configuration..."
-    docker compose run --rm --no-deps nginx nginx -t
+    docker compose run --rm --no-deps --interactive=false -T nginx nginx -t
     if ($LASTEXITCODE -ne 0) { Write-Err "nginx configuration validation failed"; exit 1 }
     docker compose up -d --build
     if ($LASTEXITCODE -ne 0) { Write-Err "docker compose failed to start Nora"; exit 1 }

--- a/setup.sh
+++ b/setup.sh
@@ -563,7 +563,7 @@ start_compose_stack() {
   info "Preserving Docker volumes and provisioned agent instances."
   echo ""
   info "Pre-validating nginx configuration..."
-  docker compose run --rm --no-deps nginx nginx -t
+  docker compose run --rm --no-deps --interactive=false -T nginx nginx -t
   docker compose up -d --build
   info "Recreating nginx so generated configuration mounts are refreshed..."
   docker compose up -d --force-recreate --no-deps nginx


### PR DESCRIPTION
## Summary

- run every one-off nginx validation container with `--interactive=false -T`, preventing SSH heredoc consumption before rebuild and verification
- make public HSTS edge-owned and singular while preserving backend-owned API CSP/XFO/XCTO/Referrer/COOP policy
- key nginx surface maps on `$request_uri` so local/Helm API rewrites cannot re-add duplicate headers
- restore client addresses only from Cloudflare's published proxy networks so per-IP controls remain accurate and spoof-resistant
- disable `X-Powered-By` on all three Next.js surfaces
- update the public Helm install example to chart `0.7.2` and correct the Cloudflare launch runbook
- add executable regressions for heredoc continuation, response-header ownership, rewrite-safe maps, Cloudflare networks, and framework disclosure

## Production evidence

Deploy run `29213694662` checked out `f49a5c5`, rendered and validated the new nginx file, then jumped directly to the GitHub summary. Compose kept stdin attached despite `-T`, consumed the rest of the SSH heredoc, and skipped rebuild, nginx recreation, health checks, and Docker-socket checks.

The still-active edge also exposes duplicate API security fields. A local nginx reproduction confirmed that upstream Helmet HSTS is emitted before edge HSTS; browsers therefore retain the upstream `includeSubDomains` policy instead of the intended host-only default. The final config hides upstream HSTS, emits one edge value, and leaves API browser-policy headers backend-owned.

Cloudflare currently fronts the origin while the tracked real-IP directives were commented out. The final public templates trust `CF-Connecting-IP` only from Cloudflare's published IPv4/IPv6 networks, so direct traffic cannot spoof the client address.

## Validation

- full Nora pre-push CI script passed on final head
- backend: 1,610 passed, 1 skipped
- agent runtime: 26 passed
- infrastructure regressions: 17 passed, 1 PowerShell-only check skipped locally
- all typechecks, audits, licenses, secret scan, Helm/kubeconform, and production Docker builds passed
- Compose Playwright: 30 passed, 65 expected real-credential skips
- Mintlify validation passed
- all four active nginx configurations passed `nginx -t`
- real Compose heredoc reproduction passed with `--interactive=false -T` and failed with `-T` alone
- `git diff --check` passed

This remains part of the unreleased `v1.16.2` patch. Remote Docker documentation is published and indexed. Proxmox remains Experimental and is unchanged.
