### PR TITLE
fix(deploy): preserve post-recreate verification

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -226,7 +226,7 @@ jobs:
           docker compose "${compose_args[@]}" up -d --build
           echo "Recreating nginx so the regenerated bind-mounted config inode is active."
           docker compose "${compose_args[@]}" up -d --force-recreate --no-deps nginx
-          docker compose "${compose_args[@]}" exec -T nginx nginx -t
+          docker compose "${compose_args[@]}" exec -T nginx nginx -t </dev/null
           docker compose "${compose_args[@]}" ps
 
           health_attempts=221
@@ -235,7 +235,7 @@ jobs:
           echo "Waiting for backend-api health: ${health_attempts} attempts every ${health_interval_seconds}s (${health_window_seconds}s from first to final attempt)."
           for attempt in $(seq 1 "$health_attempts"); do
             if docker compose "${compose_args[@]}" exec -T backend-api \
-              node -e "require('http').get('http://localhost:4000/health', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"; then
+              node -e "require('http').get('http://localhost:4000/health', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))" </dev/null; then
               echo "backend-api is healthy."
               break
             fi
@@ -253,7 +253,7 @@ jobs:
           docker_probe='const http=require("http");const request=http.request({socketPath:"/var/run/docker.sock",path:"/_ping",method:"GET"},response=>{let body="";response.setEncoding("utf8");response.on("data",chunk=>body+=chunk);response.on("end",()=>process.exit(response.statusCode===200&&body.trim()==="OK"?0:1));});request.setTimeout(5000,()=>request.destroy(new Error("Docker socket timeout")));request.on("error",error=>{console.error(error.message);process.exit(1);});request.end();'
           for service in backend-api worker-provisioner worker-backup; do
             echo "Verifying Docker socket access from ${service}."
-            if ! docker compose "${compose_args[@]}" exec -T "$service" node -e "$docker_probe"; then
+            if ! docker compose "${compose_args[@]}" exec -T "$service" node -e "$docker_probe" </dev/null; then
               echo "${service} cannot access /var/run/docker.sock after deployment." >&2
               docker compose "${compose_args[@]}" ps "$service" >&2 || true
               docker compose "${compose_args[@]}" logs --tail=80 "$service" >&2 || true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ supported update path instead of remaining pinned to an older bind-mounted file 
   the edge instead of reactivating an old generated file.
 - SSH-driven deploys no longer let the one-off nginx validator consume the remaining remote
   heredoc before the rebuild, health checks, and Docker-socket verification execute.
+- Active nginx checks and container probes also read from `/dev/null`, so streamed Bash installs
+  and SSH deploys cannot stop after recreation while silently skipping readiness verification.
 - Public edges now emit one host-only HSTS field while preserving backend-owned API browser
   policy, and every Next.js surface disables framework disclosure through `X-Powered-By`.
 - Public nginx now restores visitor addresses only from Cloudflare's published proxy networks,

--- a/docs/configuration/tls-domains.mdx
+++ b/docs/configuration/tls-domains.mdx
@@ -63,7 +63,7 @@ By default, Nora listens on `localhost:8080` and is only reachable from the mach
     docker compose run --rm --no-deps --interactive=false -T nginx nginx -t
     docker compose up -d
     docker compose up -d --force-recreate --no-deps nginx
-    docker compose exec -T nginx nginx -t
+    docker compose exec -T nginx nginx -t </dev/null
     ```
 
     Nora is now accessible at `http://app.example.com` (port 80 must be open on your host firewall and the DNS A record must point to your server's public IP).
@@ -126,7 +126,7 @@ By default, Nora listens on `localhost:8080` and is only reachable from the mach
     docker compose run --rm --no-deps --interactive=false -T nginx nginx -t
     docker compose up -d
     docker compose up -d --force-recreate --no-deps nginx
-    docker compose exec -T nginx nginx -t
+    docker compose exec -T nginx nginx -t </dev/null
     ```
 
     If you are using explicit Compose overlays, include the tracked TLS layer directly:
@@ -173,8 +173,8 @@ crontab -l | grep 'certbot.*renew'
 If you manage renewal yourself, keep the same post-renewal sequence:
 
 ```bash theme={null}
-docker compose exec -T nginx nginx -t
-docker compose exec -T nginx nginx -s reload
+docker compose exec -T nginx nginx -t </dev/null
+docker compose exec -T nginx nginx -s reload </dev/null
 ```
 
 <Tip>

--- a/docs/guides/upgrades.mdx
+++ b/docs/guides/upgrades.mdx
@@ -40,7 +40,7 @@ bash infra/render-public-nginx.sh \
 "${compose[@]}" run --rm --no-deps --interactive=false -T nginx nginx -t
 "${compose[@]}" up -d --build
 "${compose[@]}" up -d --force-recreate --no-deps nginx
-"${compose[@]}" exec -T nginx nginx -t
+"${compose[@]}" exec -T nginx nginx -t </dev/null
 ```
 
 The Kubernetes overlay is shared by AKS, GKE, EKS, k3s, and other kubeconfig-based Kubernetes targets. Provider selection happens through the Admin Kubernetes cluster settings and mounted kubeconfigs, not through separate provider-specific compose files.

--- a/infra/run-release-upgrade.sh
+++ b/infra/run-release-upgrade.sh
@@ -195,7 +195,7 @@ wait_for_backend_health() {
   echo "Waiting for ${service} health: ${attempts} attempts every ${interval}s (${window}s from first to final attempt)."
   for attempt in $(seq 1 "$attempts"); do
     if docker compose "${COMPOSE_ARGS[@]}" exec -T "$service" \
-      node -e "require('http').get('http://localhost:4000/health', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))"; then
+      node -e "require('http').get('http://localhost:4000/health', r => process.exit(r.statusCode === 200 ? 0 : 1)).on('error', () => process.exit(1))" </dev/null; then
       echo "${service} is healthy."
       break
     fi
@@ -319,7 +319,7 @@ run_upgrade() {
     docker compose "${COMPOSE_ARGS[@]}" up -d --build
     echo "Recreating nginx so generated configuration mounts are refreshed..."
     docker compose "${COMPOSE_ARGS[@]}" up -d --force-recreate --no-deps nginx
-    docker compose "${COMPOSE_ARGS[@]}" exec -T nginx nginx -t
+    docker compose "${COMPOSE_ARGS[@]}" exec -T nginx nginx -t </dev/null
   fi
   docker compose "${COMPOSE_ARGS[@]}" ps
 

--- a/infra/setup-tls.sh
+++ b/infra/setup-tls.sh
@@ -115,7 +115,7 @@ echo "[2/3] Config ready"
 echo
 echo "[3/3] Setting up auto-renewal..."
 
-CRON_CMD="0 3 * * * docker run --rm -v /etc/letsencrypt:/etc/letsencrypt -v /var/lib/letsencrypt:/var/lib/letsencrypt -v ${WEBROOT}:/var/www/certbot certbot/certbot renew --quiet && cd ${REPO_DIR} && docker compose exec -T nginx nginx -t && docker compose exec -T nginx nginx -s reload"
+CRON_CMD="0 3 * * * docker run --rm -v /etc/letsencrypt:/etc/letsencrypt -v /var/lib/letsencrypt:/var/lib/letsencrypt -v ${WEBROOT}:/var/www/certbot certbot/certbot renew --quiet && cd ${REPO_DIR} && docker compose exec -T nginx nginx -t </dev/null && docker compose exec -T nginx nginx -s reload </dev/null"
 
 (crontab -l 2>/dev/null | grep -v 'certbot.*renew' || true; echo "$CRON_CMD") | crontab -
 

--- a/scripts/infra-security.test.mjs
+++ b/scripts/infra-security.test.mjs
@@ -38,6 +38,10 @@ function read(relativePath) {
   return readFileSync(path.join(repoRoot, relativePath), "utf8");
 }
 
+function shellLogicalLines(source) {
+  return source.replace(/\\\r?\n\s*/g, " ").split(/\r?\n/);
+}
+
 function runChecked(command, args, options = {}) {
   const result = spawnSync(command, args, {
     cwd: repoRoot,
@@ -733,7 +737,15 @@ test("production update paths activate refreshed nginx config without touching c
   );
   assert.match(
     deployWorkflow,
-    /docker compose "\$\{compose_args\[@\]\}" run --rm --no-deps --interactive=false -T nginx nginx -t[\s\S]*?docker compose "\$\{compose_args\[@\]\}" up -d --build[\s\S]*?docker compose "\$\{compose_args\[@\]\}" up -d --force-recreate --no-deps nginx[\s\S]*?docker compose "\$\{compose_args\[@\]\}" exec -T nginx nginx -t/,
+    /docker compose "\$\{compose_args\[@\]\}" run --rm --no-deps --interactive=false -T nginx nginx -t[\s\S]*?docker compose "\$\{compose_args\[@\]\}" up -d --build[\s\S]*?docker compose "\$\{compose_args\[@\]\}" up -d --force-recreate --no-deps nginx[\s\S]*?docker compose "\$\{compose_args\[@\]\}" exec -T nginx nginx -t <\/dev\/null/,
+  );
+  assert.match(
+    deployWorkflow,
+    /docker compose "\$\{compose_args\[@\]\}" exec -T backend-api \\\s*\n\s*node -e [^\n]+ <\/dev\/null; then/,
+  );
+  assert.match(
+    deployWorkflow,
+    /docker compose "\$\{compose_args\[@\]\}" exec -T "\$service" node -e "\$docker_probe" <\/dev\/null; then/,
   );
   assert.match(
     setupBash,
@@ -741,7 +753,7 @@ test("production update paths activate refreshed nginx config without touching c
   );
   assert.match(
     setupBash,
-    /docker compose run --rm --no-deps --interactive=false -T nginx nginx -t[\s\S]*?docker compose up -d --build[\s\S]*?docker compose up -d --force-recreate --no-deps nginx[\s\S]*?docker compose exec -T nginx nginx -t/,
+    /docker compose run --rm --no-deps --interactive=false -T nginx nginx -t[\s\S]*?docker compose up -d --build[\s\S]*?docker compose up -d --force-recreate --no-deps nginx[\s\S]*?docker compose exec -T nginx nginx -t <\/dev\/null/,
   );
   assert.match(
     setupPowerShell,
@@ -757,26 +769,72 @@ test("production update paths activate refreshed nginx config without touching c
   );
   assert.match(
     releaseUpgrade,
-    /docker compose "\$\{COMPOSE_ARGS\[@\]\}" run --rm --no-deps --interactive=false -T nginx nginx -t[\s\S]*?docker compose "\$\{COMPOSE_ARGS\[@\]\}" up -d --build[\s\S]*?docker compose "\$\{COMPOSE_ARGS\[@\]\}" up -d --force-recreate --no-deps nginx[\s\S]*?docker compose "\$\{COMPOSE_ARGS\[@\]\}" exec -T nginx nginx -t/,
+    /docker compose "\$\{COMPOSE_ARGS\[@\]\}" run --rm --no-deps --interactive=false -T nginx nginx -t[\s\S]*?docker compose "\$\{COMPOSE_ARGS\[@\]\}" up -d --build[\s\S]*?docker compose "\$\{COMPOSE_ARGS\[@\]\}" up -d --force-recreate --no-deps nginx[\s\S]*?docker compose "\$\{COMPOSE_ARGS\[@\]\}" exec -T nginx nginx -t <\/dev\/null/,
   );
   assert.match(
     setupTls,
-    /certbot renew --quiet[\s\S]*?docker compose exec -T nginx nginx -t[\s\S]*?docker compose exec -T nginx nginx -s reload/,
+    /certbot renew --quiet[\s\S]*?docker compose exec -T nginx nginx -t <\/dev\/null[\s\S]*?docker compose exec -T nginx nginx -s reload <\/dev\/null/,
   );
+
+  for (const [file, source] of [
+    [".github/workflows/deploy-production.yml", deployWorkflow],
+    ["setup.sh", setupBash],
+    ["infra/run-release-upgrade.sh", releaseUpgrade],
+    ["infra/setup-tls.sh", setupTls],
+  ]) {
+    for (const line of shellLogicalLines(source)) {
+      if (!line.includes("docker compose") || !line.includes("exec -T")) continue;
+      const execCount = line.match(/\bexec -T\b/g)?.length || 0;
+      const nullInputCount = line.match(/<\/dev\/null/g)?.length || 0;
+      assert.equal(
+        nullInputCount,
+        execCount,
+        `${file} must detach stdin for every docker compose exec: ${line.trim()}`,
+      );
+    }
+  }
 
   const remoteValidation = deployWorkflow.match(
     /^\s*(docker compose "\$\{compose_args\[@\]\}" run --rm --no-deps --interactive=false -T nginx nginx -t)\s*$/m,
   );
   assert.ok(remoteValidation, "deploy workflow must expose a non-interactive nginx preflight");
+  const activeValidation = deployWorkflow.match(
+    /^\s*(docker compose "\$\{compose_args\[@\]\}" exec -T nginx nginx -t <\/dev\/null)\s*$/m,
+  );
+  assert.ok(activeValidation, "deploy workflow must detach stdin from active nginx validation");
+  const setupPreflight = setupBash.match(
+    /^\s*(docker compose run --rm --no-deps --interactive=false -T nginx nginx -t)\s*$/m,
+  );
+  assert.ok(setupPreflight, "setup must expose a non-interactive nginx preflight");
+  const setupActiveValidation = setupBash.match(
+    /^\s*(docker compose exec -T nginx nginx -t <\/dev\/null)\s*$/m,
+  );
+  assert.ok(setupActiveValidation, "setup must detach stdin from active nginx validation");
+  const verificationBlockStart = deployWorkflow.indexOf(
+    '          echo "Pre-validating the generated nginx config before replacing services."',
+  );
+  const verificationBlockEnd = deployWorkflow.indexOf("\n          REMOTE", verificationBlockStart);
+  assert.ok(verificationBlockStart >= 0, "deploy workflow must expose the verification block");
+  assert.ok(verificationBlockEnd > verificationBlockStart, "deploy verification block must end");
+  const verificationBlock = deployWorkflow
+    .slice(verificationBlockStart, verificationBlockEnd)
+    .replace(/^ {10}/gm, "");
   const stdinFixture = mkdtempSync(path.join(tmpdir(), "nora-nginx-preflight-stdin-"));
   try {
     const fakeDocker = path.join(stdinFixture, "docker");
-    const marker = path.join(stdinFixture, "continued");
+    const dockerLog = path.join(stdinFixture, "docker.log");
+    const deployMarker = path.join(stdinFixture, "deploy-continued");
+    const verificationMarker = path.join(stdinFixture, "verification-continued");
+    const setupMarker = path.join(stdinFixture, "setup-continued");
     writeFileSync(
       fakeDocker,
       `#!/usr/bin/env bash
 set -euo pipefail
-if [[ " $* " != *" --interactive=false "* ]]; then
+printf '%s\t%s\n' "$(readlink /proc/$$/fd/0 || true)" "$*" >> "\${FAKE_DOCKER_LOG:?}"
+if [[ " $* " == *" run "* && " $* " != *" --interactive=false "* ]]; then
+  cat >/dev/null
+fi
+if [[ " $* " == *" exec "* && "$(readlink /proc/$$/fd/0 || true)" != "/dev/null" ]]; then
   cat >/dev/null
 fi
 `,
@@ -785,16 +843,75 @@ fi
     const remoteScript = `set -euo pipefail
 compose_args=()
 ${remoteValidation[1]}
-printf continued > ${JSON.stringify(marker)}
+${activeValidation[1]}
+printf continued > ${JSON.stringify(deployMarker)}
 `;
-    const result = spawnSync("bash", ["-s"], {
+    const deployResult = spawnSync("bash", ["-s"], {
       cwd: repoRoot,
       encoding: "utf8",
       input: remoteScript,
-      env: { ...process.env, PATH: `${stdinFixture}:${process.env.PATH}` },
+      env: {
+        ...process.env,
+        FAKE_DOCKER_LOG: dockerLog,
+        PATH: `${stdinFixture}:${process.env.PATH}`,
+      },
     });
-    assert.equal(result.status, 0, result.stderr || result.stdout);
-    assert.equal(readFileSync(marker, "utf8"), "continued");
+    assert.equal(deployResult.status, 0, deployResult.stderr || deployResult.stdout);
+    assert.equal(readFileSync(deployMarker, "utf8"), "continued");
+
+    const verificationScript = `set -euo pipefail
+compose_args=()
+${verificationBlock}
+printf continued > ${JSON.stringify(verificationMarker)}
+`;
+    const verificationResult = spawnSync("bash", ["-s"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      input: verificationScript,
+      env: {
+        ...process.env,
+        FAKE_DOCKER_LOG: dockerLog,
+        PATH: `${stdinFixture}:${process.env.PATH}`,
+      },
+    });
+    assert.equal(
+      verificationResult.status,
+      0,
+      verificationResult.stderr || verificationResult.stdout,
+    );
+    assert.equal(readFileSync(verificationMarker, "utf8"), "continued");
+    const execCalls = readFileSync(dockerLog, "utf8")
+      .split("\n")
+      .filter((line) => line.includes("\tcompose exec "));
+    assert.equal(execCalls.length, 6, "expected one focused and five full-block exec calls");
+    assert.ok(
+      execCalls.every((line) => line.startsWith("/dev/null\t")),
+      `all Compose exec calls must detach stdin:\n${execCalls.join("\n")}`,
+    );
+    for (const service of ["backend-api", "worker-provisioner", "worker-backup"]) {
+      assert.ok(
+        execCalls.some((line) => line.includes(`exec -T ${service} node -e`)),
+        `verification block must probe ${service}`,
+      );
+    }
+
+    const setupScript = `set -euo pipefail
+${setupPreflight[1]}
+${setupActiveValidation[1]}
+printf continued > ${JSON.stringify(setupMarker)}
+`;
+    const setupResult = spawnSync("bash", ["-s"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+      input: setupScript,
+      env: {
+        ...process.env,
+        FAKE_DOCKER_LOG: dockerLog,
+        PATH: `${stdinFixture}:${process.env.PATH}`,
+      },
+    });
+    assert.equal(setupResult.status, 0, setupResult.stderr || setupResult.stdout);
+    assert.equal(readFileSync(setupMarker, "utf8"), "continued");
   } finally {
     rmSync(stdinFixture, { recursive: true, force: true });
   }

--- a/setup.sh
+++ b/setup.sh
@@ -567,7 +567,7 @@ start_compose_stack() {
   docker compose up -d --build
   info "Recreating nginx so generated configuration mounts are refreshed..."
   docker compose up -d --force-recreate --no-deps nginx
-  docker compose exec -T nginx nginx -t
+  docker compose exec -T nginx nginx -t </dev/null
   ok "Nginx configuration activated"
   verify_compose_runtime_permissions
   echo ""
@@ -579,7 +579,7 @@ run_compose_node_probe() {
   local attempt
   info "Waiting for ${service} probe: ${attempts} attempts every ${interval}s (${window}s from first to final attempt)."
   for attempt in $(seq 1 "$attempts"); do
-    if docker compose exec -T "$service" node -e "$script" >/dev/null 2>&1; then
+    if docker compose exec -T "$service" node -e "$script" </dev/null >/dev/null 2>&1; then
       ok "$description"
       return 0
     fi
@@ -588,7 +588,7 @@ run_compose_node_probe() {
     fi
   done
 
-  docker compose exec -T "$service" node -e "$script" || true
+  docker compose exec -T "$service" node -e "$script" </dev/null || true
   error "$description failed after ${attempts} attempts every ${interval}s (${window}s first-to-final window). Inspect: docker compose logs --tail=100 $service"
   return 1
 }


### PR DESCRIPTION
## Summary

- detach stdin from the active nginx validation, backend health probe, and all three Docker-socket probes in the production SSH heredoc
- apply the same `/dev/null` isolation to Bash setup, direct release upgrades, TLS renewal, and documented operator commands
- execute the actual workflow block in the infra regression and prove all five post-recreate `exec` calls see `/dev/null`, all three services are probed, and a final marker still runs

## Production evidence

Automatic deploy run `29215596555` for master SHA `d84c2de2caf99c56fd80afd3324be8c76b0beee1` successfully ran prevalidation, rebuild, forced nginx recreation, and the active `nginx -t`. The log then jumped directly to the GitHub summary: the explicit backend health loop and Docker-socket checks never ran.

`docker compose exec -T` disables TTY allocation but still attaches stdin. The active nginx check therefore consumed the remaining SSH heredoc, just as the earlier one-off `run` command had done.

## Validation

- full Nora pre-push CI passed
- backend: 1,610 passed, 1 skipped
- agent runtime: 26 passed
- infrastructure regressions: 17 passed, 1 expected PowerShell-only skip
- Compose Playwright: 30 passed, 65 expected real-credential skips
- executable full-workflow stdin regression passed
- `bash -n` passed for all changed shell scripts
- Mintlify validation passed
- `git diff --check` passed

This is required before tagging `v1.16.2`; no release has been created yet.
