### PR TITLE
fix: harden activation and gateway readiness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -346,7 +346,7 @@ PROXMOX_SSH_INSECURE_ACCEPT_HOST_KEY=false
 PROXMOX_PCT_COMMAND=pct
 PROXMOX_SUDO=
 PROXMOX_NODE_MAJOR=24
-PROXMOX_OPENCLAW_PACKAGE=openclaw@latest
+PROXMOX_OPENCLAW_PACKAGE=openclaw@2026.6.11
 PROXMOX_HERMES_BIN=/opt/hermes/.venv/bin/hermes
 # Hermes dashboard stays loopback-only unless this explicit insecure opt-in is set.
 PROXMOX_HERMES_ENABLE_INSECURE_DASHBOARD=false
@@ -359,6 +359,9 @@ NEMOCLAW_DEFAULT_MODEL=nvidia/nemotron-3-super-120b-a12b
 # Defaults to the Nora-published GHCR image. For offline hosts or private
 # clusters, build/preload nora-nemoclaw-agent:local and override this value.
 NEMOCLAW_SANDBOX_IMAGE=ghcr.io/solomon2773/nora-nemoclaw-agent:latest
+
+# Nora's validated OpenClaw package. Override only for a deliberate compatibility test.
+OPENCLAW_DOCKER_PACKAGE=openclaw@2026.6.11
 
 # ── Security ─────────────────────────────────────────────────
 CORS_ORIGINS=http://localhost:8080                # comma-separated; use your public origin when exposed on a domain

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -192,6 +192,26 @@ jobs:
             exit 1
           fi
 
+          read_deploy_env_value() {
+            local env_path="$1" name="$2" default_value="$3" line value first last
+            line="$(grep -E "^[[:space:]]*${name}[[:space:]]*=" "$env_path" 2>/dev/null | tail -n 1 || true)"
+            if [ -z "$line" ]; then
+              printf '%s\n' "$default_value"
+              return 0
+            fi
+            value="${line#*=}"
+            value="${value#"${value%%[![:space:]]*}"}"
+            value="${value%"${value##*[![:space:]]}"}"
+            if [ "${#value}" -ge 2 ]; then
+              first="${value:0:1}"
+              last="${value: -1}"
+              if { [ "$first" = '"' ] && [ "$last" = '"' ]; } || { [ "$first" = "'" ] && [ "$last" = "'" ]; }; then
+                value="${value:1:${#value}-2}"
+              fi
+            fi
+            printf '%s\n' "$value"
+          }
+
           for required_key in JWT_SECRET ENCRYPTION_KEY DB_PASSWORD; do
             if ! grep -Eq "^${required_key}=.+" "$DEPLOY_ENV_FILE"; then
               echo "Deploy env file $DEPLOY_ENV_FILE is missing required key: $required_key" >&2
@@ -220,6 +240,25 @@ jobs:
           done
 
           export NORA_ENV_FILE="$DEPLOY_ENV_FILE"
+          echo "Rebuilding the pinned standard OpenClaw agent image."
+          docker build \
+            -f agent-runtime/Dockerfile.openclaw-agent \
+            -t nora-openclaw-agent:local \
+            agent-runtime/
+          enabled_sandbox_profiles="$(read_deploy_env_value "$DEPLOY_ENV_FILE" ENABLED_SANDBOX_PROFILES "")"
+          nemoclaw_sandbox_image="$(read_deploy_env_value "$DEPLOY_ENV_FILE" NEMOCLAW_SANDBOX_IMAGE "ghcr.io/solomon2773/nora-nemoclaw-agent:latest")"
+          normalized_sandbox_profiles="${enabled_sandbox_profiles//[[:space:]]/}"
+          case ",${normalized_sandbox_profiles}," in
+            *,nemoclaw,*)
+              if [ "$nemoclaw_sandbox_image" = "nora-nemoclaw-agent:local" ]; then
+                echo "Rebuilding the enabled local NemoClaw sandbox image."
+                docker build \
+                  -f agent-runtime/Dockerfile.nemoclaw-agent \
+                  -t nora-nemoclaw-agent:local \
+                  agent-runtime/
+              fi
+              ;;
+          esac
           echo "Pre-validating the generated nginx config before replacing services."
           docker compose "${compose_args[@]}" run --rm --no-deps --interactive=false -T nginx nginx -t
           echo "Code update only: preserving compose volumes and provisioned agent Docker/K8s/VM instances."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to Nora are documented here. Each entry summarizes the
 corresponding [GitHub release](https://github.com/solomon2773/nora/releases),
 which carries the full notes and verification details.
 
+## [v1.16.3](https://github.com/solomon2773/nora/releases/tag/v1.16.3) — 2026-07-13
+
+Activation and Cloudflare Access compatibility patch: demo agents now prove a real warmed Gateway
+reply before becoming runnable, while the bare Admin entrypoint normalizes to the protected
+trailing-slash route instead of serving a shell whose JavaScript may be intercepted separately.
+
+### Changed
+
+- Public nginx templates redirect exact `/admin` requests to `/admin/` before proxying the Admin
+  dashboard without dropping query parameters, preserving a consistent path boundary for
+  Cloudflare Access policies.
+- OpenClaw installs default to Nora's validated `2026.6.11` release across standard Docker,
+  Kubernetes, NemoClaw, and Proxmox paths; production rebuilds the standard image, mutable
+  NemoClaw images refresh before use, and writable bootstrap paths replace stale exact versions.
+- The Cloudflare launch runbook now requires cache-bypass and Access coverage for both exact
+  `/admin` and descendant routes, with an explicit pre-launch regression check.
+- Release metadata advances the Gemini extension manifest to `1.16.3` and the Helm chart to
+  `0.7.3` for exact-tag publication.
+
+### Fixed
+
+- Built-in demo activation no longer publishes `running` before OpenClaw has completed a real
+  Gateway-backed model turn, removing the cold first-chat timeout window.
+- Streaming chat no longer converts pre-token failures or a real timeout into a success-looking
+  empty response; terminal events are correlated to their run and current OpenClaw delta payloads
+  are accepted.
+- Anonymous visits to `/admin` no longer receive an unprotected HTML shell while `/admin/_next/*`
+  assets are redirected to Cloudflare Access, which previously left the page stuck on its loading
+  state under split exact-versus-wildcard Access rules.
+
 ## [v1.16.2](https://github.com/solomon2773/nora/releases/tag/v1.16.2) — 2026-07-12
 
 Edge-activation patch: generated public nginx policy is now applied immediately during every

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ iwr -useb https://raw.githubusercontent.com/solomon2773/nora/master/setup.ps1 | 
 **Kubernetes (Helm):**
 
 ```bash
-helm show chart oci://ghcr.io/solomon2773/nora --version 0.7.2
+helm show chart oci://ghcr.io/solomon2773/nora --version 0.7.3
 ```
 
 The public OCI chart installs the full Nora control plane. See the [Helm instructions](https://noradocs.solomontsao.com/self-hosting#kubernetes-helm) for the required secrets and Ingress options.

--- a/agent-runtime/Dockerfile.nemoclaw-agent
+++ b/agent-runtime/Dockerfile.nemoclaw-agent
@@ -16,7 +16,7 @@
 # Build (once per host, or after bumping upstream):
 #   docker build \
 #     --build-arg TSX_VERSION=4.21.0 \
-#     --build-arg OPENCLAW_VERSION=2026.6.9 \
+#     --build-arg OPENCLAW_VERSION=2026.6.11 \
 #     -f agent-runtime/Dockerfile.nemoclaw-agent \
 #     -t nora-nemoclaw-agent:local \
 #     agent-runtime/
@@ -39,18 +39,34 @@ FROM ${NEMOCLAW_SANDBOX_BASE}
 ARG TSX_VERSION=4.21.0
 # Patched OpenClaw: >= 2026.4.15 clears the base image's sandbox-escape CVEs.
 # Pinned exactly (not a floating tag) so the build stays reproducible.
-ARG OPENCLAW_VERSION=2026.6.9
+ARG OPENCLAW_VERSION=2026.6.11
 
 # Need to install as root; the base image's final layer is `USER sandbox`.
 USER root
 
-# Global install so every user sees the tsx binary. npm on this base image
-# uses `/usr` as its global prefix (not `/usr/local`) — `which openclaw` on
-# the base resolves to `/usr/bin/openclaw` for the same reason.  We inherit
-# that prefix and let the install drop `tsx` alongside.
-RUN npm install -g "tsx@${TSX_VERSION}" "openclaw@${OPENCLAW_VERSION}" \
- && /usr/bin/tsx --version \
+# Global install so every user sees both binaries. npm on this base image uses
+# `/usr` as its global prefix (not `/usr/local`). Remove the inherited ~863 MB
+# OpenClaw tree before reinstalling because npm's rename/retire path can stall
+# on overlayfs during clean builds. Drop any inherited tsx tree and both bin
+# links too, then replace them in the same prefix so no old vulnerable copy
+# remains separately reachable.
+RUN test "$(npm config get prefix)" = "/usr" \
+ && test "$(npm root -g)" = "/usr/lib/node_modules" \
+ && rm -rf \
+      /usr/lib/node_modules/openclaw \
+      /usr/lib/node_modules/tsx \
+ && rm -f \
+      /usr/bin/openclaw \
+      /usr/bin/tsx \
+ && npm install -g "tsx@${TSX_VERSION}" "openclaw@${OPENCLAW_VERSION}" \
+ && test "$(npm config get prefix)" = "/usr" \
+ && test "$(npm root -g)" = "/usr/lib/node_modules" \
+ && test "$(node -p 'require("/usr/lib/node_modules/openclaw/package.json").version')" = "${OPENCLAW_VERSION}" \
+ && test "$(node -p 'require("/usr/lib/node_modules/tsx/package.json").version')" = "${TSX_VERSION}" \
+ && test -x /usr/bin/openclaw \
+ && test -x /usr/bin/tsx \
  && /usr/bin/openclaw --version \
+ && /usr/bin/tsx --version \
  && npm cache clean --force \
  && rm -rf /root/.npm
 

--- a/agent-runtime/Dockerfile.openclaw-agent
+++ b/agent-runtime/Dockerfile.openclaw-agent
@@ -11,7 +11,7 @@
 #
 # Build (once per host, or after bumping a pinned version):
 #   docker build \
-#     --build-arg OPENCLAW_VERSION=latest \
+#     --build-arg OPENCLAW_VERSION=2026.6.11 \
 #     --build-arg TSX_VERSION=4.21.0 \
 #     -f agent-runtime/Dockerfile.openclaw-agent \
 #     -t nora-openclaw-agent:local \
@@ -22,7 +22,9 @@
 
 FROM node:24-slim
 
-ARG OPENCLAW_VERSION=latest
+# Keep aligned with lib/openclawDefaults.ts. Nora bumps this only after the
+# activation and Gateway compatibility proof passes for the new release.
+ARG OPENCLAW_VERSION=2026.6.11
 ARG TSX_VERSION=4.21.0
 
 # Git is needed by some openclaw skills that clone templates at runtime;

--- a/agent-runtime/lib/agentImages.ts
+++ b/agent-runtime/lib/agentImages.ts
@@ -8,6 +8,7 @@ const {
   normalizeSandboxProfileName,
 } = require("./backendCatalog");
 const { getNemoClawSandboxImage } = require("./nemoclawDefaults");
+const { DEFAULT_OPENCLAW_PACKAGE_SPEC } = require("./openclawDefaults");
 
 function getProvisionerBackendName() {
   return getDefaultDeployTarget(process.env, {
@@ -21,7 +22,7 @@ function getStandardDockerAgentImage() {
 }
 
 function getStandardDockerPackageSpec() {
-  return process.env.OPENCLAW_DOCKER_PACKAGE || "openclaw@latest";
+  return process.env.OPENCLAW_DOCKER_PACKAGE || DEFAULT_OPENCLAW_PACKAGE_SPEC;
 }
 
 function getHermesDockerAgentImage() {

--- a/agent-runtime/lib/openclawDefaults.ts
+++ b/agent-runtime/lib/openclawDefaults.ts
@@ -1,0 +1,14 @@
+// @ts-nocheck
+
+// Nora validates each supported OpenClaw release before making it the default.
+// Keep this exact: floating `latest` installs can change the Gateway protocol or
+// first-run behavior without a Nora release, which makes activation and rollback
+// evidence non-reproducible. Operators can still override the package spec with
+// OPENCLAW_DOCKER_PACKAGE (or PROXMOX_OPENCLAW_PACKAGE for that adapter).
+const DEFAULT_OPENCLAW_VERSION = "2026.6.11";
+const DEFAULT_OPENCLAW_PACKAGE_SPEC = `openclaw@${DEFAULT_OPENCLAW_VERSION}`;
+
+module.exports = {
+  DEFAULT_OPENCLAW_PACKAGE_SPEC,
+  DEFAULT_OPENCLAW_VERSION,
+};

--- a/agent-runtime/lib/runtimeBootstrap.ts
+++ b/agent-runtime/lib/runtimeBootstrap.ts
@@ -10,6 +10,7 @@ const {
   buildIntegrationSkillMarkdown,
   buildSplitIntegrationManifest,
 } = require("./integrationTools");
+const { DEFAULT_OPENCLAW_PACKAGE_SPEC } = require("./openclawDefaults");
 
 const TSX_PACKAGE_SPEC = process.env.OPENCLAW_TSX_PACKAGE || "tsx@4.21.0";
 
@@ -24,6 +25,7 @@ function readRuntimeSource(relPath) {
 const RUNTIME_FILES = [
   "containerCommand.ts",
   "contracts.ts",
+  "openclawDefaults.ts",
   "runtimeBootstrap.ts",
   // Required by runtimeBootstrap's require("./mcpServersConfig") — every module
   // runtimeBootstrap imports relatively must ship into the container with it,
@@ -765,7 +767,7 @@ function buildRuntimeBootstrapCommand() {
   ].join("");
 }
 
-function buildOpenClawInstallCommand(packages = ["openclaw@latest"]) {
+function buildOpenClawInstallCommand(packages = [DEFAULT_OPENCLAW_PACKAGE_SPEC]) {
   const normalizedPackages = (Array.isArray(packages) ? packages : [packages])
     .map((pkg) => String(pkg || "").trim())
     .filter(Boolean);
@@ -780,6 +782,9 @@ function buildOpenClawInstallCommand(packages = ["openclaw@latest"]) {
   }
 
   const packageList = [...normalizedPackages, TSX_PACKAGE_SPEC].join(" ");
+  const exactOpenClawVersion = normalizedPackages
+    .map((pkg) => pkg.match(/^openclaw@(\d{4}\.\d+\.\d+(?:[-+][a-zA-Z0-9.-]+)?)$/)?.[1] || "")
+    .find(Boolean);
 
   return [
     'OPENCLAW_BIN="${OPENCLAW_CLI_PATH:-/usr/local/bin/openclaw}"; ',
@@ -788,7 +793,11 @@ function buildOpenClawInstallCommand(packages = ["openclaw@latest"]) {
     'DETECTED_OPENCLAW_TSX_BIN="$(command -v tsx 2>/dev/null || true)"; ',
     'if [ -n "$DETECTED_OPENCLAW_BIN" ] && [ ! -x "$OPENCLAW_BIN" ]; then OPENCLAW_BIN="$DETECTED_OPENCLAW_BIN"; fi; ',
     'if [ -n "$DETECTED_OPENCLAW_TSX_BIN" ] && [ ! -x "$OPENCLAW_TSX_BIN" ]; then OPENCLAW_TSX_BIN="$DETECTED_OPENCLAW_TSX_BIN"; fi; ',
-    'if ([ -n "$OPENCLAW_BIN" ] && [ -x "$OPENCLAW_BIN" ] && "$OPENCLAW_BIN" --version >/dev/null 2>&1) && ([ -n "$OPENCLAW_TSX_BIN" ] && [ -x "$OPENCLAW_TSX_BIN" ] && "$OPENCLAW_TSX_BIN" --version >/dev/null 2>&1); then ',
+    `EXPECTED_OPENCLAW_VERSION=${shellSingleQuote(exactOpenClawVersion || "")}; `,
+    'OPENCLAW_VERSION_OUTPUT=""; OPENCLAW_VERSION_OK=1; ',
+    'if [ -n "$OPENCLAW_BIN" ] && [ -x "$OPENCLAW_BIN" ]; then OPENCLAW_VERSION_OUTPUT="$("$OPENCLAW_BIN" --version 2>/dev/null || true)"; fi; ',
+    'if [ -n "$EXPECTED_OPENCLAW_VERSION" ]; then case "$OPENCLAW_VERSION_OUTPUT" in "OpenClaw $EXPECTED_OPENCLAW_VERSION"|"OpenClaw $EXPECTED_OPENCLAW_VERSION "*) ;; *) OPENCLAW_VERSION_OK=0;; esac; fi; ',
+    'if ([ -n "$OPENCLAW_BIN" ] && [ -x "$OPENCLAW_BIN" ] && [ "$OPENCLAW_VERSION_OK" = 1 ]) && ([ -n "$OPENCLAW_TSX_BIN" ] && [ -x "$OPENCLAW_TSX_BIN" ] && "$OPENCLAW_TSX_BIN" --version >/dev/null 2>&1); then ',
     "  true; ",
     "else ",
     '  rm -f "${OPENCLAW_CLI_PATH:-/usr/local/bin/openclaw}"; ',
@@ -814,6 +823,7 @@ function buildOpenClawInstallCommand(packages = ["openclaw@latest"]) {
     '    OPENCLAW_TSX_BIN="${OPENCLAW_TSX_BIN:-$DETECTED_OPENCLAW_TSX_BIN}"; ',
     "  fi; ",
     '  if ! ([ -n "$OPENCLAW_BIN" ] && [ -x "$OPENCLAW_BIN" ] && "$OPENCLAW_BIN" --version >/dev/null 2>&1); then cat /tmp/openclaw-install.log >&2; exit 1; fi; ',
+    '  if [ -n "$EXPECTED_OPENCLAW_VERSION" ]; then OPENCLAW_VERSION_OUTPUT="$("$OPENCLAW_BIN" --version 2>/dev/null || true)"; case "$OPENCLAW_VERSION_OUTPUT" in "OpenClaw $EXPECTED_OPENCLAW_VERSION"|"OpenClaw $EXPECTED_OPENCLAW_VERSION "*) ;; *) cat /tmp/openclaw-install.log >&2; echo "Installed OpenClaw version does not match $EXPECTED_OPENCLAW_VERSION" >&2; exit 1;; esac; fi; ',
     '  if ! ([ -n "$OPENCLAW_TSX_BIN" ] && [ -x "$OPENCLAW_TSX_BIN" ] && "$OPENCLAW_TSX_BIN" --version >/dev/null 2>&1); then cat /tmp/openclaw-install.log >&2; exit 1; fi; ',
     "fi; ",
     'export OPENCLAW_CLI_PATH="$OPENCLAW_BIN"; ',

--- a/backend-api/__tests__/dockerBootstrap.test.ts
+++ b/backend-api/__tests__/dockerBootstrap.test.ts
@@ -2,6 +2,7 @@
 const fs = require("fs");
 const os = require("os");
 const path = require("path");
+const { PassThrough } = require("node:stream");
 const {
   buildOpenClawAuthProfilesWriteCommand,
   buildOpenClawConfigMergeScript,
@@ -16,6 +17,10 @@ const {
   FOUNDRY_OPENCLAW_PROVIDER_ID,
   resolveFoundryDeployment,
 } = require("../../workers/provisioner/runtimeBootstrap");
+const {
+  DEFAULT_OPENCLAW_PACKAGE_SPEC,
+  DEFAULT_OPENCLAW_VERSION,
+} = require("../../agent-runtime/lib/openclawDefaults");
 const DockerBackend = require("../../workers/provisioner/backends/docker");
 const tar = require(
   require.resolve("tar-stream", {
@@ -60,25 +65,28 @@ describe("OpenClaw bootstrap helpers", () => {
 
     expect(cmd).toContain("/opt/openclaw-runtime/lib/contracts.ts");
     expect(cmd).toContain("/opt/openclaw-runtime/lib/containerCommand.ts");
+    expect(cmd).toContain("/opt/openclaw-runtime/lib/openclawDefaults.ts");
     expect(cmd).toContain("/opt/openclaw-runtime/lib/server.ts");
     expect(cmd).toContain("/opt/openclaw-runtime/lib/execEndpoint.ts");
     expect(cmd).toContain("/opt/openclaw-runtime/lib/agent.ts");
   });
 
   it("verifies the OpenClaw CLI can execute before skipping installation", () => {
-    const cmd = buildOpenClawInstallCommand(["openclaw@latest"]);
+    const cmd = buildOpenClawInstallCommand();
 
     expect(cmd).toContain('OPENCLAW_BIN="${OPENCLAW_CLI_PATH:-/usr/local/bin/openclaw}"');
     expect(cmd).toContain('OPENCLAW_TSX_BIN="${OPENCLAW_TSX_BIN:-/usr/local/bin/tsx}"');
     expect(cmd).toContain('DETECTED_OPENCLAW_BIN="$(command -v openclaw 2>/dev/null || true)"');
     expect(cmd).toContain('DETECTED_OPENCLAW_TSX_BIN="$(command -v tsx 2>/dev/null || true)"');
     expect(cmd).toContain('[ -x "$OPENCLAW_BIN" ]');
-    expect(cmd).toContain('"$OPENCLAW_BIN" --version >/dev/null 2>&1');
+    expect(cmd).toContain(`EXPECTED_OPENCLAW_VERSION='${DEFAULT_OPENCLAW_VERSION}'`);
+    expect(cmd).toContain("OPENCLAW_VERSION_OK=1");
     expect(cmd).toContain('"$OPENCLAW_TSX_BIN" --version >/dev/null 2>&1');
     expect(cmd).toContain("npm uninstall -g openclaw tsx >/dev/null 2>&1 || true");
     expect(cmd).toContain(
-      "npm install -g openclaw@latest tsx@4.21.0 >/tmp/openclaw-install.log 2>&1",
+      `npm install -g ${DEFAULT_OPENCLAW_PACKAGE_SPEC} tsx@4.21.0 >/tmp/openclaw-install.log 2>&1`,
     );
+    expect(cmd).toContain("Installed OpenClaw version does not match");
     expect(cmd).toContain("hash -r 2>/dev/null || true");
     expect(cmd).toContain('export OPENCLAW_CLI_PATH="$OPENCLAW_BIN"');
     expect(cmd).toContain('export OPENCLAW_TSX_BIN="$OPENCLAW_TSX_BIN"');
@@ -497,6 +505,35 @@ exit 2
 });
 
 describe("Provisioner backends", () => {
+  it("demuxes non-TTY Docker exec output before command consumers read it", async () => {
+    const dockerBackend = new DockerBackend();
+    const rawStream = new PassThrough();
+    const payload = Buffer.from(`${'{"status":"ok"}'.padEnd(67, " ")}\n`);
+    const frame = Buffer.alloc(8 + payload.length);
+    frame[0] = 1;
+    frame.writeUInt32BE(payload.length, 4);
+    payload.copy(frame, 8);
+    const execInstance = {
+      start: jest.fn(async () => {
+        setImmediate(() => rawStream.end(frame));
+        return rawStream;
+      }),
+    };
+    dockerBackend.docker.getContainer = jest.fn(() => ({
+      exec: jest.fn(async () => execInstance),
+    }));
+
+    const result = await dockerBackend.exec("container-1", {
+      cmd: ["/bin/sh", "-lc", "printf json"],
+      tty: false,
+    });
+    const chunks = [];
+    for await (const chunk of result.stream) chunks.push(chunk);
+
+    expect(Buffer.concat(chunks).toString("utf8")).toBe(payload.toString("utf8"));
+    expect(execInstance.start).toHaveBeenCalledWith({ hijack: true, stdin: true, Tty: false });
+  });
+
   it("builds a Docker startup script with the executable guard and runtime bootstrap", () => {
     const dockerBackend = new DockerBackend();
     const files = dockerBackend._buildBootstrapFiles({
@@ -511,6 +548,7 @@ describe("Provisioner backends", () => {
       expect.arrayContaining([
         "opt/openclaw-runtime/lib/contracts.ts",
         "opt/openclaw-runtime/lib/containerCommand.ts",
+        "opt/openclaw-runtime/lib/openclawDefaults.ts",
         "opt/openclaw-runtime/lib/server.ts",
         "opt/openclaw-runtime/lib/execEndpoint.ts",
         "opt/openclaw-runtime/lib/agent.ts",
@@ -529,6 +567,7 @@ describe("Provisioner backends", () => {
     expect(startupScript.content).toContain(
       'DETECTED_OPENCLAW_BIN="$(command -v openclaw 2>/dev/null || true)"',
     );
+    expect(startupScript.content).toContain(DEFAULT_OPENCLAW_PACKAGE_SPEC);
     expect(startupScript.content).toContain('export OPENCLAW_CLI_PATH="$OPENCLAW_BIN"');
     expect(startupScript.content).toContain(
       "mkdir -p /var/log /root/.openclaw/workspace /root/.openclaw/agents/main/agent",
@@ -653,6 +692,7 @@ describe("Provisioner backends", () => {
     expect(k8sSource).toContain("getStandardDockerPackageSpec()");
     expect(k8sSource).toContain('"nemoclaw@latest"');
     expect(nemoclawSource).toContain("buildOpenClawInstallCommand([");
+    expect(nemoclawSource).toContain("getStandardDockerPackageSpec()");
 
     expect(k8sSource).toContain("ensureOpenClawCmd +");
     expect(nemoclawSource).toContain('Cmd: ["/opt/openclaw-runtime/start.sh"]');

--- a/backend-api/__tests__/gatewayProxy.test.ts
+++ b/backend-api/__tests__/gatewayProxy.test.ts
@@ -106,42 +106,114 @@ class mockFakeWebSocket extends EventEmitter {
       });
     }
 
+    if (msg.method === "sessions.messages.subscribe") {
+      mockFakeWebSocket.sessionMessageSubscriptions.push(msg.params);
+      mockFakeWebSocket.onSessionMessageSubscribe?.(msg.params);
+      if (mockFakeWebSocket.subscriptionMode === "timeout") return;
+      const canonicalKey = mockFakeWebSocket.canonicalizeSessionKey(msg.params.key);
+      const registryKey = mockFakeWebSocket.sessionMessageSubscriptionRegistryKey(msg.params);
+      const respondToSubscription = () => {
+        if (mockFakeWebSocket.subscriptionMode !== "error") {
+          mockFakeWebSocket.sessionMessageSubscriptionRegistry.add(registryKey);
+        }
+        this.emit(
+          "message",
+          Buffer.from(
+            JSON.stringify({
+              id: msg.id,
+              ok: mockFakeWebSocket.subscriptionMode !== "error",
+              ...(mockFakeWebSocket.subscriptionMode === "error"
+                ? { error: { message: "unknown method: sessions.messages.subscribe" } }
+                : { result: { subscribed: true, key: canonicalKey } }),
+            }),
+          ),
+        );
+      };
+      if (Number(mockFakeWebSocket.subscriptionDelayMs) > 0) {
+        return setTimeout(respondToSubscription, Number(mockFakeWebSocket.subscriptionDelayMs));
+      }
+      return setImmediate(respondToSubscription);
+    }
+
+    if (msg.method === "sessions.messages.unsubscribe") {
+      mockFakeWebSocket.sessionMessageUnsubscriptions.push(msg.params);
+      const canonicalKey = mockFakeWebSocket.canonicalizeSessionKey(msg.params.key);
+      const registryKey = mockFakeWebSocket.sessionMessageSubscriptionRegistryKey(msg.params);
+      mockFakeWebSocket.sessionMessageSubscriptionRegistry.delete(registryKey);
+      return setImmediate(() => {
+        this.emit(
+          "message",
+          Buffer.from(
+            JSON.stringify({
+              id: msg.id,
+              ok: true,
+              result: { subscribed: false, key: canonicalKey },
+            }),
+          ),
+        );
+      });
+    }
+
     if (msg.method === "chat.send") {
-      if (mockFakeWebSocket.streamMode) {
-        return setImmediate(() => {
+      mockFakeWebSocket.chatSendRequests.push(msg.params);
+      const chatResponse = mockFakeWebSocket.chatResponses.shift() || {};
+      const streamMode = chatResponse.streamMode ?? mockFakeWebSocket.streamMode;
+      const chatRunId = Object.hasOwn(chatResponse, "runId")
+        ? chatResponse.runId
+        : mockFakeWebSocket.chatRunId;
+      const streamEvents = chatResponse.streamEvents || mockFakeWebSocket.streamEvents;
+      if (streamMode) {
+        const emitWireEvent = (nextEvent) => {
+          this.emit(
+            "message",
+            Buffer.from(
+              JSON.stringify({
+                type: "event",
+                event: nextEvent.event || "chat",
+                payload: nextEvent.payload,
+              }),
+            ),
+          );
+        };
+        const acknowledgeChat = () => {
+          for (const preAckEvent of chatResponse.preAckEvents || []) {
+            emitWireEvent(preAckEvent);
+          }
+          const ok = chatResponse.ok !== false;
+          const responseResult = Object.hasOwn(chatResponse, "result")
+            ? chatResponse.result
+            : { runId: chatRunId, status: "started" };
           this.emit(
             "message",
             Buffer.from(
               JSON.stringify({
                 id: msg.id,
-                ok: true,
-                result: { runId: "run-1", status: "started" },
+                ok,
+                ...(ok
+                  ? { result: responseResult }
+                  : { error: chatResponse.error || { message: "chat.send rejected" } }),
               }),
             ),
           );
-          setImmediate(() => {
-            this.emit(
-              "message",
-              Buffer.from(
-                JSON.stringify({
-                  type: "event",
-                  event: "chat",
-                  payload: {
-                    state: "final",
-                    model: "openai/gpt-5.5",
-                    provider: "openai",
-                    message: { role: "assistant" },
-                    usage: {
-                      input_tokens: 1000,
-                      output_tokens: 500,
-                      total_tokens: 1500,
-                    },
-                  },
-                }),
-              ),
-            );
-          });
-        });
+          const emitStreamEvent = (index) => {
+            const nextEvent = streamEvents[index];
+            if (!nextEvent) return;
+            const emitEvent = () => {
+              emitWireEvent(nextEvent);
+              emitStreamEvent(index + 1);
+            };
+            if (Number(nextEvent.delayMs) > 0) {
+              setTimeout(emitEvent, Number(nextEvent.delayMs));
+            } else {
+              setImmediate(emitEvent);
+            }
+          };
+          emitStreamEvent(0);
+        };
+        if (Number(chatResponse.ackDelayMs) > 0) {
+          return setTimeout(acknowledgeChat, Number(chatResponse.ackDelayMs));
+        }
+        return setImmediate(acknowledgeChat);
       }
       return setImmediate(() => {
         this.emit(
@@ -192,6 +264,26 @@ mockFakeWebSocket.toolsCatalogResult = { tools: [] };
 mockFakeWebSocket.connectParams = [];
 mockFakeWebSocket.instances = [];
 mockFakeWebSocket.streamMode = false;
+mockFakeWebSocket.chatRunId = "run-1";
+mockFakeWebSocket.subscriptionMode = "success";
+mockFakeWebSocket.subscriptionDelayMs = 0;
+mockFakeWebSocket.sessionMessageSubscriptions = [];
+mockFakeWebSocket.sessionMessageUnsubscriptions = [];
+mockFakeWebSocket.sessionMessageSubscriptionRegistry = new Set();
+mockFakeWebSocket.canonicalizeSessionKey = (key) =>
+  key === "main"
+    ? "agent:main:main"
+    : key === "global" || /^agent:[^:]+:global$/.test(key)
+      ? "global"
+      : key;
+mockFakeWebSocket.sessionMessageSubscriptionRegistryKey = (params) => {
+  const canonicalKey = mockFakeWebSocket.canonicalizeSessionKey(params.key);
+  return canonicalKey === "global" ? `agent:${params.agentId || "main"}:global` : canonicalKey;
+};
+mockFakeWebSocket.onSessionMessageSubscribe = null;
+mockFakeWebSocket.chatSendRequests = [];
+mockFakeWebSocket.chatResponses = [];
+mockFakeWebSocket.streamEvents = [];
 
 class mockFakeWebSocketServer {
   on() {}
@@ -220,6 +312,57 @@ describe("gateway proxy control-plane routes", () => {
   let app;
   const originalFetch = global.fetch;
 
+  function buildApp(routerOptions = {}) {
+    const nextApp = express();
+    nextApp.use(express.json());
+    nextApp.use((req, res, next) => {
+      req.user = { id: "user-1" };
+      next();
+    });
+    nextApp.use(createGatewayRouter(routerOptions));
+    return nextApp;
+  }
+
+  function mockRunningAgent(overrides = {}) {
+    mockDb.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: "agent-1",
+          user_id: "user-1",
+          status: "running",
+          host: "10.0.0.10",
+          gateway_token: "gateway-token",
+          gateway_host_port: null,
+          ...overrides,
+        },
+      ],
+    });
+  }
+
+  function postStreamingChat(body = {}) {
+    return request(app)
+      .post("/agents/agent-1/gateway/chat")
+      .buffer(true)
+      .parse((stream, callback) => {
+        let responseBody = "";
+        stream.setEncoding("utf8");
+        stream.on("data", (chunk) => {
+          responseBody += chunk;
+        });
+        stream.on("end", () => callback(null, responseBody));
+      })
+      .send({ message: "ping", stream: true, ...body });
+  }
+
+  function parseSsePayloads(body) {
+    return String(body)
+      .split(/\r?\n/)
+      .filter((line) => line.startsWith("data: "))
+      .map((line) => line.slice("data: ".length))
+      .filter((data) => data !== "[DONE]")
+      .map((data) => JSON.parse(data));
+  }
+
   beforeEach(() => {
     jest.resetModules();
     mockDb.query.mockReset();
@@ -232,18 +375,40 @@ describe("gateway proxy control-plane routes", () => {
     mockFakeWebSocket.connectParams = [];
     mockFakeWebSocket.instances = [];
     mockFakeWebSocket.streamMode = false;
+    mockFakeWebSocket.chatRunId = "run-1";
+    mockFakeWebSocket.subscriptionMode = "success";
+    mockFakeWebSocket.subscriptionDelayMs = 0;
+    mockFakeWebSocket.sessionMessageSubscriptions = [];
+    mockFakeWebSocket.sessionMessageUnsubscriptions = [];
+    mockFakeWebSocket.sessionMessageSubscriptionRegistry = new Set();
+    mockFakeWebSocket.onSessionMessageSubscribe = null;
+    mockFakeWebSocket.chatSendRequests = [];
+    mockFakeWebSocket.chatResponses = [];
+    mockFakeWebSocket.streamEvents = [
+      {
+        event: "chat",
+        payload: {
+          runId: "run-1",
+          sessionKey: "main",
+          seq: 1,
+          state: "final",
+          model: "openai/gpt-5.5",
+          provider: "openai",
+          message: { role: "assistant" },
+          usage: {
+            input_tokens: 1000,
+            output_tokens: 500,
+            total_tokens: 1500,
+          },
+        },
+      },
+    ];
     mockGetIntegrationsForSync.mockReset();
     mockBuildIntegrationToolCatalogEntries.mockReset();
 
     ({ createGatewayRouter, evictConnection } = require("../gatewayProxy"));
 
-    app = express();
-    app.use(express.json());
-    app.use((req, res, next) => {
-      req.user = { id: "user-1" };
-      next();
-    });
-    app.use(createGatewayRouter());
+    app = buildApp();
   });
 
   afterEach(() => {
@@ -449,31 +614,9 @@ describe("gateway proxy control-plane routes", () => {
 
   it("records model token metadata from streaming chat final events", async () => {
     mockFakeWebSocket.streamMode = true;
-    mockDb.query.mockResolvedValueOnce({
-      rows: [
-        {
-          id: "agent-1",
-          user_id: "user-1",
-          status: "running",
-          host: "10.0.0.10",
-          gateway_token: "gateway-token",
-          gateway_host_port: null,
-        },
-      ],
-    });
+    mockRunningAgent();
 
-    const res = await request(app)
-      .post("/agents/agent-1/gateway/chat")
-      .buffer(true)
-      .parse((stream, callback) => {
-        let body = "";
-        stream.setEncoding("utf8");
-        stream.on("data", (chunk) => {
-          body += chunk;
-        });
-        stream.on("end", () => callback(null, body));
-      })
-      .send({ message: "ping", stream: true });
+    const res = await postStreamingChat();
 
     expect(res.status).toBe(200);
     expect(res.body).toContain("[DONE]");
@@ -492,6 +635,646 @@ describe("gateway proxy control-plane routes", () => {
       }),
       expect.objectContaining({ source: "openclaw.gateway", sessionId: "main" }),
     );
+  });
+
+  it("subscribes to the requested session before streaming chat", async () => {
+    const sessionKey = "agent:main:session-42";
+    mockFakeWebSocket.streamMode = true;
+    mockFakeWebSocket.streamEvents = [
+      {
+        event: "chat",
+        payload: {
+          runId: "run-1",
+          sessionKey,
+          state: "final",
+          message: { role: "assistant", content: [{ type: "text", text: "done" }] },
+        },
+      },
+    ];
+    mockRunningAgent();
+
+    const res = await postStreamingChat({ session_id: sessionKey });
+    const payloads = parseSsePayloads(res.body);
+
+    expect(res.status).toBe(200);
+    expect(mockFakeWebSocket.sessionMessageSubscriptions).toEqual([{ key: sessionKey }]);
+    expect(payloads).toContainEqual({ type: "done", runId: "run-1", sessionKey });
+  });
+
+  it("shares one subscription lifetime across concurrent alias and canonical streams", async () => {
+    mockFakeWebSocket.streamMode = true;
+    mockFakeWebSocket.chatResponses = [
+      {
+        runId: "run-1",
+        streamEvents: [
+          {
+            delayMs: 30,
+            event: "chat",
+            payload: {
+              runId: "run-1",
+              sessionKey: "main",
+              state: "final",
+              message: { role: "assistant", content: [{ type: "text", text: "first" }] },
+            },
+          },
+        ],
+      },
+      {
+        runId: "run-2",
+        streamEvents: [
+          {
+            delayMs: 80,
+            event: "chat",
+            payload: {
+              runId: "run-2",
+              sessionKey: "main",
+              state: "final",
+              message: { role: "assistant", content: [{ type: "text", text: "second" }] },
+            },
+          },
+        ],
+      },
+    ];
+    mockDb.query.mockResolvedValue({
+      rows: [
+        {
+          id: "agent-1",
+          user_id: "user-1",
+          status: "running",
+          host: "10.0.0.10",
+          gateway_token: "gateway-token",
+          gateway_host_port: null,
+        },
+      ],
+    });
+    let markAliasSubscriptionStarted;
+    const aliasSubscriptionStarted = new Promise((resolve) => {
+      markAliasSubscriptionStarted = resolve;
+    });
+    mockFakeWebSocket.onSessionMessageSubscribe = markAliasSubscriptionStarted;
+
+    const firstRequest = Promise.resolve(postStreamingChat({ session_id: "main" }));
+    await aliasSubscriptionStarted;
+    const secondRequest = Promise.resolve(postStreamingChat({ session_id: "agent:main:main" }));
+    const firstCompleted = await firstRequest;
+
+    expect(firstCompleted.status).toBe(200);
+    expect(mockFakeWebSocket.sessionMessageSubscriptions).toEqual([{ key: "main" }]);
+    expect(mockFakeWebSocket.sessionMessageUnsubscriptions).toHaveLength(0);
+    expect(mockFakeWebSocket.sessionMessageSubscriptionRegistry).toEqual(
+      new Set(["agent:main:main"]),
+    );
+
+    const secondResponse = await secondRequest;
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(firstCompleted.body).toContain("[DONE]");
+    expect(secondResponse.body).toContain("[DONE]");
+    expect(mockFakeWebSocket.sessionMessageSubscriptions).toEqual([{ key: "main" }]);
+    expect(mockFakeWebSocket.sessionMessageUnsubscriptions).toEqual([{ key: "agent:main:main" }]);
+    expect(mockFakeWebSocket.sessionMessageSubscriptionRegistry).toEqual(new Set());
+  });
+
+  it("keeps scoped and bare global subscriptions independent", async () => {
+    mockFakeWebSocket.streamMode = true;
+    mockFakeWebSocket.chatResponses = [
+      {
+        runId: "run-scoped",
+        streamEvents: [
+          {
+            delayMs: 30,
+            event: "chat",
+            payload: {
+              runId: "run-scoped",
+              sessionKey: "agent:foo:global",
+              state: "final",
+              message: { role: "assistant", content: [{ type: "text", text: "scoped" }] },
+            },
+          },
+        ],
+      },
+      {
+        runId: "run-default",
+        streamEvents: [
+          {
+            delayMs: 80,
+            event: "chat",
+            payload: {
+              runId: "run-default",
+              sessionKey: "global",
+              state: "final",
+              message: { role: "assistant", content: [{ type: "text", text: "default" }] },
+            },
+          },
+        ],
+      },
+    ];
+    mockDb.query.mockResolvedValue({
+      rows: [
+        {
+          id: "agent-1",
+          user_id: "user-1",
+          status: "running",
+          host: "10.0.0.10",
+          gateway_token: "gateway-token",
+          gateway_host_port: null,
+        },
+      ],
+    });
+    let markScopedSubscriptionStarted;
+    const scopedSubscriptionStarted = new Promise((resolve) => {
+      markScopedSubscriptionStarted = resolve;
+    });
+    mockFakeWebSocket.onSessionMessageSubscribe = markScopedSubscriptionStarted;
+
+    const scopedRequest = Promise.resolve(postStreamingChat({ session_id: "agent:foo:global" }));
+    await scopedSubscriptionStarted;
+    const defaultRequest = Promise.resolve(postStreamingChat({ session_id: "global" }));
+    const scopedResponse = await scopedRequest;
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(scopedResponse.body).toContain("[DONE]");
+    expect(mockFakeWebSocket.sessionMessageSubscriptions).toEqual([
+      { key: "global", agentId: "foo" },
+      { key: "global", agentId: "main" },
+    ]);
+    expect(mockFakeWebSocket.sessionMessageUnsubscriptions).toEqual([
+      { key: "global", agentId: "foo" },
+    ]);
+    expect(mockFakeWebSocket.sessionMessageSubscriptionRegistry).toEqual(
+      new Set(["agent:main:global"]),
+    );
+
+    const defaultResponse = await defaultRequest;
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(defaultResponse.body).toContain("[DONE]");
+    expect(mockFakeWebSocket.sessionMessageUnsubscriptions).toEqual([
+      { key: "global", agentId: "foo" },
+      { key: "global", agentId: "main" },
+    ]);
+    expect(mockFakeWebSocket.sessionMessageSubscriptionRegistry).toEqual(new Set());
+  });
+
+  it("continues streaming when an older gateway rejects session subscriptions", async () => {
+    mockFakeWebSocket.streamMode = true;
+    mockFakeWebSocket.subscriptionMode = "error";
+    mockRunningAgent();
+
+    const res = await postStreamingChat();
+    const payloads = parseSsePayloads(res.body);
+
+    expect(res.status).toBe(200);
+    expect(mockFakeWebSocket.sessionMessageSubscriptions).toEqual([{ key: "main" }]);
+    expect(payloads).toContainEqual(expect.objectContaining({ state: "final", runId: "run-1" }));
+    expect(payloads).toContainEqual({ type: "done", runId: "run-1", sessionKey: "main" });
+    expect(mockFakeWebSocket.sessionMessageUnsubscriptions).toHaveLength(0);
+  });
+
+  it("stops promptly when the client closes during the subscription RPC", async () => {
+    app = buildApp({ chatTimeoutMs: 20 });
+    mockFakeWebSocket.streamMode = true;
+    mockFakeWebSocket.subscriptionDelayMs = 20;
+    mockFakeWebSocket.streamEvents = [];
+    mockRunningAgent();
+    let markSubscriptionStarted;
+    const subscriptionStarted = new Promise((resolve) => {
+      markSubscriptionStarted = resolve;
+    });
+    mockFakeWebSocket.onSessionMessageSubscribe = markSubscriptionStarted;
+
+    const pendingRequest = postStreamingChat();
+    const requestOutcome = pendingRequest.then(
+      () => null,
+      (error) => error,
+    );
+    await subscriptionStarted;
+    pendingRequest.abort();
+    await requestOutcome;
+    if (pendingRequest._server?.listening) {
+      await new Promise((resolve) => pendingRequest._server.close(resolve));
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(mockFakeWebSocket.chatSendRequests).toHaveLength(0);
+    expect(
+      mockRecordMetric.mock.calls.some(
+        (call) => call[2] === "error" && call[4]?.code === "CHAT_TIMEOUT",
+      ),
+    ).toBe(false);
+  });
+
+  it("filters pooled-socket events from a different acknowledged run", async () => {
+    mockFakeWebSocket.streamMode = true;
+    mockFakeWebSocket.streamEvents = [
+      {
+        event: "chat",
+        payload: {
+          runId: "run-stale",
+          sessionKey: "main",
+          state: "final",
+          message: { role: "assistant", content: [{ type: "text", text: "stale" }] },
+        },
+      },
+      {
+        event: "chat",
+        payload: {
+          runId: "run-1",
+          sessionKey: "main",
+          state: "final",
+          message: { role: "assistant", content: [{ type: "text", text: "current" }] },
+        },
+      },
+    ];
+    mockRunningAgent();
+
+    const res = await postStreamingChat();
+    const payloads = parseSsePayloads(res.body);
+
+    expect(res.body).not.toContain("run-stale");
+    expect(res.body).not.toContain("stale");
+    expect(payloads).toContainEqual(
+      expect.objectContaining({
+        runId: "run-1",
+        state: "final",
+        message: expect.objectContaining({
+          content: [{ type: "text", text: "current" }],
+        }),
+      }),
+    );
+  });
+
+  it("drops malformed pooled events that omit runId", async () => {
+    mockFakeWebSocket.streamMode = true;
+    mockFakeWebSocket.streamEvents = [
+      {
+        event: "chat",
+        payload: {
+          sessionKey: "main",
+          state: "final",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "runless pooled output" }],
+          },
+        },
+      },
+      {
+        event: "chat",
+        payload: {
+          runId: "run-1",
+          sessionKey: "main",
+          state: "final",
+          message: { role: "assistant", content: [{ type: "text", text: "current" }] },
+        },
+      },
+    ];
+    mockRunningAgent();
+
+    const res = await postStreamingChat();
+    const payloads = parseSsePayloads(res.body);
+
+    expect(res.body).not.toContain("runless pooled output");
+    expect(payloads).toContainEqual(
+      expect.objectContaining({
+        runId: "run-1",
+        state: "final",
+        message: expect.objectContaining({
+          content: [{ type: "text", text: "current" }],
+        }),
+      }),
+    );
+  });
+
+  it.each([
+    ["an RPC error", { ok: false, error: { message: "chat.send denied" } }, "chat.send denied"],
+    ["a missing runId", { result: { status: "started" } }, "no valid runId"],
+    ["a blank runId", { runId: "   " }, "no valid runId"],
+  ])("fails closed on %s without forwarding pooled events", async (_label, response, errorText) => {
+    const unrelatedEvent = {
+      event: "chat",
+      payload: {
+        runId: "run-unrelated",
+        sessionKey: "main",
+        state: "final",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "unrelated concurrent output" }],
+        },
+      },
+    };
+    mockFakeWebSocket.streamMode = true;
+    mockFakeWebSocket.chatResponses = [
+      {
+        ...response,
+        preAckEvents: [unrelatedEvent],
+        streamEvents: [unrelatedEvent],
+      },
+    ];
+    mockRunningAgent();
+
+    const res = await postStreamingChat();
+    const payloads = parseSsePayloads(res.body);
+
+    expect(res.status).toBe(200);
+    expect(payloads).toContainEqual(
+      expect.objectContaining({ type: "error", error: expect.stringContaining(errorText) }),
+    );
+    expect(res.body).not.toContain("run-unrelated");
+    expect(res.body).not.toContain("unrelated concurrent output");
+    expect(payloads.some((payload) => payload.type === "done")).toBe(false);
+    expect(mockRecordMetric).not.toHaveBeenCalledWith("agent-1", "user-1", "messages_sent", 1);
+  });
+
+  it("does not terminate on or accumulate text from a matching user-message echo", async () => {
+    mockFakeWebSocket.streamMode = true;
+    mockFakeWebSocket.streamEvents = [
+      {
+        event: "chat",
+        payload: {
+          runId: "run-1",
+          sessionKey: "main",
+          state: "final",
+          message: { role: "user", content: [{ type: "text", text: "ping" }] },
+        },
+      },
+      {
+        event: "chat",
+        payload: {
+          runId: "run-1",
+          sessionKey: "main",
+          state: "delta",
+          deltaText: "pong",
+        },
+      },
+      {
+        event: "chat",
+        payload: {
+          runId: "run-1",
+          sessionKey: "main",
+          state: "final",
+        },
+      },
+    ];
+    mockRunningAgent();
+
+    const res = await postStreamingChat();
+    const payloads = parseSsePayloads(res.body);
+
+    expect(payloads).toContainEqual(
+      expect.objectContaining({
+        state: "final",
+        message: expect.objectContaining({ role: "user" }),
+      }),
+    );
+    expect(payloads).toContainEqual(
+      expect.objectContaining({
+        state: "delta",
+        message: expect.objectContaining({
+          role: "assistant",
+          content: [{ type: "text", text: "pong" }],
+        }),
+      }),
+    );
+    expect(payloads).toContainEqual(
+      expect.objectContaining({
+        state: "final",
+        message: expect.objectContaining({
+          role: "assistant",
+          content: [{ type: "text", text: "pong" }],
+        }),
+      }),
+    );
+    expect(res.body).not.toContain("pingpong");
+    expect(payloads.at(-1)).toEqual({ type: "done", runId: "run-1", sessionKey: "main" });
+  });
+
+  it("accumulates protocol v4 deltaText and projects it onto an empty final event", async () => {
+    mockFakeWebSocket.streamMode = true;
+    mockFakeWebSocket.streamEvents = [
+      {
+        event: "chat",
+        payload: { runId: "run-1", sessionKey: "main", state: "delta", deltaText: "Hel" },
+      },
+      {
+        event: "chat",
+        payload: { runId: "run-1", sessionKey: "main", state: "delta", deltaText: "lo" },
+      },
+      {
+        event: "chat",
+        payload: { runId: "run-1", sessionKey: "main", state: "final" },
+      },
+    ];
+    mockRunningAgent();
+
+    const res = await postStreamingChat();
+    const chatPayloads = parseSsePayloads(res.body).filter((payload) => payload.runId === "run-1");
+
+    expect(chatPayloads.map((payload) => payload.message?.content?.[0]?.text)).toEqual([
+      "Hel",
+      "Hello",
+      "Hello",
+      undefined,
+    ]);
+    expect(chatPayloads.at(-1)).toEqual({ type: "done", runId: "run-1", sessionKey: "main" });
+  });
+
+  it.each(["error", "aborted"])(
+    "terminates on a chat %s event even when no assistant content preceded it",
+    async (state) => {
+      app = buildApp({ chatTimeoutMs: 100 });
+      mockFakeWebSocket.streamMode = true;
+      mockFakeWebSocket.streamEvents = [
+        {
+          event: "chat",
+          payload: {
+            runId: "run-1",
+            sessionKey: "main",
+            state,
+            errorMessage: state === "error" ? "provider failed" : undefined,
+          },
+        },
+      ];
+      mockRunningAgent();
+
+      const res = await postStreamingChat();
+      const payloads = parseSsePayloads(res.body);
+
+      expect(payloads).toContainEqual(expect.objectContaining({ runId: "run-1", state }));
+      expect(payloads).toContainEqual({ type: "done", runId: "run-1", sessionKey: "main" });
+      expect(res.body).not.toContain("CHAT_TIMEOUT");
+    },
+  );
+
+  it.each([
+    ["error", "error", "AGENT_LIFECYCLE_ERROR", true],
+    ["end", "final", undefined, undefined],
+  ])(
+    "uses an agent lifecycle %s event as a terminal fallback",
+    async (phase, expectedState, expectedCode, fallbackExhaustedFailure) => {
+      app = buildApp({
+        chatTimeoutMs: 100,
+        agentTerminalFallbackGraceMs: 1,
+        agentErrorFallbackGraceMs: 50,
+      });
+      mockFakeWebSocket.streamMode = true;
+      mockFakeWebSocket.streamEvents = [
+        {
+          event: "agent",
+          payload: {
+            runId: "run-1",
+            sessionKey: "main",
+            stream: "lifecycle",
+            data: {
+              phase,
+              error: phase === "error" ? "agent failed" : undefined,
+              fallbackExhaustedFailure,
+            },
+          },
+        },
+      ];
+      mockRunningAgent();
+
+      const res = await postStreamingChat();
+      const payloads = parseSsePayloads(res.body);
+      const terminalPayload = payloads.find((payload) => payload.state === expectedState);
+
+      expect(terminalPayload).toEqual(
+        expect.objectContaining({
+          runId: "run-1",
+          sessionKey: "main",
+          state: expectedState,
+          ...(expectedCode ? { code: expectedCode, error: "agent failed" } : {}),
+        }),
+      );
+      expect(payloads).toContainEqual({ type: "done", runId: "run-1", sessionKey: "main" });
+      expect(res.body).not.toContain("CHAT_TIMEOUT");
+    },
+  );
+
+  it("waits through the upstream retry grace and accepts recovered chat activity", async () => {
+    app = buildApp({
+      chatTimeoutMs: 100,
+      agentTerminalFallbackGraceMs: 1,
+      agentErrorFallbackGraceMs: 15,
+    });
+    mockFakeWebSocket.streamMode = true;
+    mockFakeWebSocket.streamEvents = [
+      {
+        event: "agent",
+        payload: {
+          runId: "run-1",
+          sessionKey: "main",
+          stream: "lifecycle",
+          data: { phase: "error", error: "first provider failed" },
+        },
+      },
+      {
+        event: "agent",
+        payload: {
+          runId: "run-1",
+          sessionKey: "main",
+          stream: "assistant",
+          data: { text: "retrying" },
+        },
+      },
+      {
+        event: "chat",
+        delayMs: 20,
+        payload: {
+          runId: "run-1",
+          sessionKey: "main",
+          state: "delta",
+          deltaText: "recovered",
+        },
+      },
+      {
+        event: "chat",
+        payload: {
+          runId: "run-1",
+          sessionKey: "main",
+          state: "final",
+          message: {
+            role: "assistant",
+            content: [{ type: "text", text: "recovered" }],
+          },
+        },
+      },
+    ];
+    mockRunningAgent();
+
+    const res = await postStreamingChat();
+    const payloads = parseSsePayloads(res.body);
+
+    expect(payloads).toContainEqual(
+      expect.objectContaining({
+        runId: "run-1",
+        state: "final",
+        message: expect.objectContaining({
+          content: [{ type: "text", text: "recovered" }],
+        }),
+      }),
+    );
+    expect(res.body).not.toContain("AGENT_LIFECYCLE_ERROR");
+    expect(res.body).not.toContain("CHAT_TIMEOUT");
+  });
+
+  it("falls back after the retry-aware lifecycle error grace expires", async () => {
+    app = buildApp({
+      chatTimeoutMs: 100,
+      agentTerminalFallbackGraceMs: 1,
+      agentErrorFallbackGraceMs: 5,
+    });
+    mockFakeWebSocket.streamMode = true;
+    mockFakeWebSocket.streamEvents = [
+      {
+        event: "agent",
+        payload: {
+          runId: "run-1",
+          sessionKey: "main",
+          stream: "lifecycle",
+          data: { phase: "error", error: "all retries stalled" },
+        },
+      },
+    ];
+    mockRunningAgent();
+
+    const res = await postStreamingChat();
+    const payloads = parseSsePayloads(res.body);
+
+    expect(payloads).toContainEqual(
+      expect.objectContaining({
+        state: "error",
+        code: "AGENT_LIFECYCLE_ERROR",
+        error: "all retries stalled",
+      }),
+    );
+    expect(res.body).not.toContain("CHAT_TIMEOUT");
+  });
+
+  it("emits an explicit error event and metric when the chat stream times out", async () => {
+    app = buildApp({ chatTimeoutMs: 10 });
+    mockFakeWebSocket.streamMode = true;
+    mockFakeWebSocket.streamEvents = [];
+    mockRunningAgent();
+
+    const res = await postStreamingChat();
+    const payloads = parseSsePayloads(res.body);
+
+    expect(payloads).toContainEqual(
+      expect.objectContaining({
+        type: "error",
+        state: "error",
+        code: "CHAT_TIMEOUT",
+        runId: "run-1",
+        sessionKey: "main",
+      }),
+    );
+    expect(payloads).toContainEqual({ type: "done", runId: "run-1", sessionKey: "main" });
+    expect(mockRecordMetric).toHaveBeenCalledWith("agent-1", "user-1", "error", 1, {
+      code: "CHAT_TIMEOUT",
+      error: "Chat stream timed out after 10ms",
+      runId: "run-1",
+    });
   });
 
   it("returns 502 when gateway health and status both fail", async () => {

--- a/backend-api/__tests__/provisioning.test.ts
+++ b/backend-api/__tests__/provisioning.test.ts
@@ -9,6 +9,7 @@ const {
   waitForAgentReadiness,
 } = require("../../workers/provisioner/healthChecks");
 const { waitForAgentReadiness: waitForBackendAgentReadiness } = require("../healthChecks");
+const { DEFAULT_OPENCLAW_PACKAGE_SPEC } = require("../../agent-runtime/lib/openclawDefaults");
 
 const mockReadNamespace = jest.fn();
 const mockCreateNamespace = jest.fn();
@@ -385,7 +386,7 @@ describe("provisioning runtime/gateway contracts", () => {
     const configMap = mockCreateNamespacedConfigMap.mock.calls[0][0].body;
     const container = deployment.spec.template.spec.containers[0];
 
-    expect(configMap.data["bootstrap.sh"]).toContain("openclaw@latest");
+    expect(configMap.data["bootstrap.sh"]).toContain(DEFAULT_OPENCLAW_PACKAGE_SPEC);
     expect(configMap.data["bootstrap.sh"]).toContain("__NORA_OPENCLAW_AUTH_SQLITE_IMPORT__");
     expect(configMap.data["bootstrap.sh"]).toContain("paste-api-key");
     expect(configMap.metadata.labels["nora.sandbox.profile"]).toBe("standard");

--- a/backend-api/gatewayProxy.ts
+++ b/backend-api/gatewayProxy.ts
@@ -28,6 +28,12 @@ const GATEWAY_PORT = OPENCLAW_GATEWAY_PORT;
 const CONNECT_TIMEOUT = 8000;
 const CALL_TIMEOUT = 30000;
 const CHAT_TIMEOUT = 120000;
+const SESSION_MESSAGE_SUBSCRIBE_TIMEOUT = 5000;
+const AGENT_TERMINAL_FALLBACK_GRACE_MS = 100;
+// OpenClaw 2026.6 keeps lifecycle errors retryable for 15 seconds while it
+// attempts provider/model fallback. Wait just beyond that upstream window
+// unless the gateway explicitly reports that fallback is exhausted.
+const AGENT_ERROR_FALLBACK_GRACE_MS = 16000;
 const RELAY_CONNECT_DELAY_MS = 750;
 const DOCKER_GATEWAY_HOST_PORT_MIN = 19000;
 const DOCKER_GATEWAY_HOST_PORT_MAX = 19999;
@@ -457,6 +463,9 @@ class GatewayConnection {
     this.connected = false;
     this.pending = new Map(); // id -> { resolve, reject, timer }
     this.eventListeners = new Map(); // event -> Set<callback>
+    this.sessionMessageSubscriptions = new Set(); // unique ref-counted subscription entries
+    this.sessionMessageSubscriptionAliases = new Map(); // requested/canonical key -> entry
+    this._sessionMessageSubscriptionOperation = Promise.resolve();
     this._reqId = 0;
     this._connectPromise = null;
     this._identity = deriveDeviceIdentity(token);
@@ -539,6 +548,7 @@ class GatewayConnection {
           if (msg.ok) {
             this.connected = true;
             resolve(this);
+            this._restoreSessionMessageSubscriptions();
           } else {
             reject(new Error(`Gateway handshake failed: ${msg.error?.message || "unknown"}`));
           }
@@ -572,6 +582,11 @@ class GatewayConnection {
         const wasConnected = this.connected;
         this.connected = false;
         this._connectPromise = null;
+        for (const entry of this.sessionMessageSubscriptions.values()) {
+          entry.subscribed = false;
+          entry.subscriptionAttempted = false;
+          entry.subscriptionSupported = null;
+        }
         // Reject all pending
         for (const [id, { reject: rej, timer: t }] of this.pending) {
           clearTimeout(t);
@@ -611,6 +626,191 @@ class GatewayConnection {
 
   off(event, callback) {
     this.eventListeners.get(event)?.delete(callback);
+  }
+
+  _sessionMessageSubscriptionTarget(key) {
+    const requestedKey = String(key || "").trim();
+    const scopedGlobal = requestedKey.match(/^agent:([^:]+):global$/);
+    if (scopedGlobal) {
+      const agentId = scopedGlobal[1];
+      return {
+        requestedKey,
+        subscriptionKey: "global",
+        agentId,
+        identityKey: `agent:${agentId}:global`,
+      };
+    }
+    if (requestedKey === "global") {
+      return {
+        requestedKey,
+        subscriptionKey: "global",
+        agentId: "main",
+        identityKey: "agent:main:global",
+      };
+    }
+    return {
+      requestedKey,
+      subscriptionKey: requestedKey,
+      agentId: null,
+      identityKey: requestedKey,
+    };
+  }
+
+  _sessionMessageSubscriptionIdentity(key, agentId) {
+    return key === "global" ? `agent:${agentId || "main"}:global` : key;
+  }
+
+  _queueSessionMessageSubscriptionOperation(operation) {
+    const next = this._sessionMessageSubscriptionOperation.then(operation, operation);
+    this._sessionMessageSubscriptionOperation = next.catch(() => {});
+    return next;
+  }
+
+  async _ensureSessionMessageSubscription(entry, timeout) {
+    if (
+      entry.refs <= 0 ||
+      entry.subscribed ||
+      entry.subscriptionSupported === false ||
+      !this.connected
+    ) {
+      return entry;
+    }
+    try {
+      entry.subscriptionAttempted = true;
+      const params = {
+        key: entry.subscriptionKey,
+        ...(entry.agentId ? { agentId: entry.agentId } : {}),
+      };
+      const msg = await this.call("sessions.messages.subscribe", params, timeout);
+      if (msg.ok === false) {
+        entry.subscriptionSupported = false;
+        return entry;
+      }
+      const result = msg.result ?? msg.payload ?? {};
+      entry.subscriptionSupported = true;
+      entry.subscribed = result.subscribed !== false;
+      if (typeof result.key === "string" && result.key.trim()) {
+        const canonicalKey = result.key.trim();
+        entry.subscriptionKey = canonicalKey;
+        const canonicalIdentity = this._sessionMessageSubscriptionIdentity(
+          canonicalKey,
+          entry.agentId,
+        );
+        const canonicalEntry = this.sessionMessageSubscriptionAliases.get(canonicalIdentity);
+        if (canonicalEntry && canonicalEntry !== entry) {
+          canonicalEntry.refs += entry.refs;
+          canonicalEntry.subscribed = canonicalEntry.subscribed || entry.subscribed;
+          canonicalEntry.subscriptionAttempted =
+            canonicalEntry.subscriptionAttempted || entry.subscriptionAttempted;
+          canonicalEntry.subscriptionSupported =
+            canonicalEntry.subscriptionSupported === true || entry.subscriptionSupported === true
+              ? true
+              : canonicalEntry.subscriptionSupported === false &&
+                  entry.subscriptionSupported === false
+                ? false
+                : null;
+          for (const alias of entry.aliases) {
+            canonicalEntry.aliases.add(alias);
+            this.sessionMessageSubscriptionAliases.set(alias, canonicalEntry);
+          }
+          canonicalEntry.aliases.add(canonicalIdentity);
+          this.sessionMessageSubscriptionAliases.set(canonicalIdentity, canonicalEntry);
+          this.sessionMessageSubscriptions.delete(entry);
+          entry = canonicalEntry;
+        } else {
+          entry.aliases.add(canonicalIdentity);
+          this.sessionMessageSubscriptionAliases.set(canonicalIdentity, entry);
+        }
+      }
+    } catch {
+      entry.subscribed = false;
+    }
+    return entry;
+  }
+
+  /** Acquire one pooled session-message subscription reference. */
+  acquireSessionMessageSubscription(key, timeout = SESSION_MESSAGE_SUBSCRIBE_TIMEOUT) {
+    const target = this._sessionMessageSubscriptionTarget(key);
+    const { requestedKey } = target;
+    if (!requestedKey) return Promise.resolve(false);
+    return this._queueSessionMessageSubscriptionOperation(async () => {
+      let entry =
+        this.sessionMessageSubscriptionAliases.get(requestedKey) ||
+        this.sessionMessageSubscriptionAliases.get(target.identityKey);
+      if (!entry) {
+        entry = {
+          refs: 0,
+          subscribed: false,
+          subscriptionAttempted: false,
+          subscriptionSupported: null,
+          subscriptionKey: target.subscriptionKey,
+          agentId: target.agentId,
+          aliases: new Set([requestedKey, target.identityKey]),
+          timeout,
+        };
+        this.sessionMessageSubscriptions.add(entry);
+        for (const alias of entry.aliases) {
+          this.sessionMessageSubscriptionAliases.set(alias, entry);
+        }
+      } else {
+        entry.aliases.add(requestedKey);
+        entry.aliases.add(target.identityKey);
+        this.sessionMessageSubscriptionAliases.set(requestedKey, entry);
+        this.sessionMessageSubscriptionAliases.set(target.identityKey, entry);
+      }
+      entry.refs += 1;
+      entry.timeout = timeout;
+      const canonicalEntry = await this._ensureSessionMessageSubscription(entry, timeout);
+      return canonicalEntry.subscribed;
+    });
+  }
+
+  /** Release one reference and unsubscribe after the final stream leaves. */
+  releaseSessionMessageSubscription(key, timeout = SESSION_MESSAGE_SUBSCRIBE_TIMEOUT) {
+    const requestedKey = String(key || "").trim();
+    if (!requestedKey) return Promise.resolve(false);
+    return this._queueSessionMessageSubscriptionOperation(async () => {
+      const entry = this.sessionMessageSubscriptionAliases.get(requestedKey);
+      if (!entry) return false;
+      entry.refs = Math.max(0, entry.refs - 1);
+      if (entry.refs > 0) return false;
+      const shouldUnsubscribe =
+        entry.subscribed || (entry.subscriptionAttempted && entry.subscriptionSupported !== false);
+      if (shouldUnsubscribe && this.connected) {
+        try {
+          await this.call(
+            "sessions.messages.unsubscribe",
+            {
+              key: entry.subscriptionKey,
+              ...(entry.agentId ? { agentId: entry.agentId } : {}),
+            },
+            timeout,
+          );
+        } catch {
+          // Best-effort cleanup; a closed socket drops its subscriptions too.
+        }
+      }
+      entry.subscribed = false;
+      entry.subscriptionAttempted = false;
+      if (entry.refs === 0) {
+        this.sessionMessageSubscriptions.delete(entry);
+        for (const alias of entry.aliases) {
+          if (this.sessionMessageSubscriptionAliases.get(alias) === entry) {
+            this.sessionMessageSubscriptionAliases.delete(alias);
+          }
+        }
+      }
+      return true;
+    });
+  }
+
+  _restoreSessionMessageSubscriptions() {
+    this._queueSessionMessageSubscriptionOperation(async () => {
+      for (const entry of [...this.sessionMessageSubscriptions]) {
+        if (entry.refs <= 0) continue;
+        await this._ensureSessionMessageSubscription(entry, entry.timeout);
+      }
+    });
   }
 
   /** Attempt reconnection with exponential backoff, respecting circuit breaker. */
@@ -691,6 +891,11 @@ class GatewayConnection {
   close() {
     this.connected = false;
     this._connectPromise = null;
+    for (const entry of this.sessionMessageSubscriptions.values()) {
+      entry.subscribed = false;
+      entry.subscriptionAttempted = false;
+      entry.subscriptionSupported = null;
+    }
     if (this.ws) {
       try {
         this.ws.close();
@@ -705,6 +910,8 @@ class GatewayConnection {
   retire() {
     this._retired = true;
     this.eventListeners.clear();
+    this.sessionMessageSubscriptions.clear();
+    this.sessionMessageSubscriptionAliases.clear();
     this.close();
   }
 
@@ -924,8 +1131,26 @@ function getToolName(tool, index) {
 
 // ─── HTTP Routes ─────────────────────────────────────────────────
 
-function createGatewayRouter() {
+function positiveTimeout(value, fallback) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback;
+}
+
+function createGatewayRouter(options = {}) {
   const router = require("express").Router();
+  const chatTimeoutMs = positiveTimeout(options.chatTimeoutMs, CHAT_TIMEOUT);
+  const sessionMessageSubscribeTimeoutMs = positiveTimeout(
+    options.sessionMessageSubscribeTimeoutMs,
+    SESSION_MESSAGE_SUBSCRIBE_TIMEOUT,
+  );
+  const agentTerminalFallbackGraceMs = positiveTimeout(
+    options.agentTerminalFallbackGraceMs,
+    AGENT_TERMINAL_FALLBACK_GRACE_MS,
+  );
+  const agentErrorFallbackGraceMs = positiveTimeout(
+    options.agentErrorFallbackGraceMs,
+    AGENT_ERROR_FALLBACK_GRACE_MS,
+  );
 
   function normalizeCronScheduleInput(schedule) {
     if (!schedule) return null;
@@ -1043,8 +1268,9 @@ function createGatewayRouter() {
         text = typeof last === "string" ? last : last.content || "";
       }
 
+      const sessionKey = session_id || "main";
       const params = {
-        sessionKey: session_id || "main",
+        sessionKey,
         idempotencyKey,
         message: text,
       };
@@ -1062,71 +1288,318 @@ function createGatewayRouter() {
         // The actual response streams via "chat" events (state: "delta", "final", "error").
         // We must keep listening for events AFTER the RPC resolves.
 
-        let streamDone = false;
-        let sawAssistantContent = false;
+        let runId = null;
+        let chatAcknowledged = false;
+        let streamCompletion = null;
+        let resolveStreamCompletion;
+        let streamSettled = false;
+        let chatTerminalPayload = null;
+        let agentTerminalFallback = null;
+        let accumulatedAssistantText = "";
         let finalTokenPayload = null;
-        const streamHandler = (evt) => {
-          const payload = evt.payload || evt;
-          const state = payload.state;
+        let streamTimeout = null;
+        let agentTerminalFallbackTimer = null;
+        let sessionMessageSubscriptionHeld = false;
+        const pendingEvents = [];
+
+        const completeStream = (reason) => {
+          if (streamSettled) return;
+          streamSettled = true;
+          resolveStreamCompletion(reason);
+        };
+
+        const releaseSessionMessageSubscription = () => {
+          if (!sessionMessageSubscriptionHeld) return;
+          sessionMessageSubscriptionHeld = false;
+          conn
+            .releaseSessionMessageSubscription(sessionKey, sessionMessageSubscribeTimeoutMs)
+            .catch(() => {});
+        };
+
+        const extractMessageText = (message) => {
+          if (!message) return "";
+          if (typeof message === "string") return message;
+          const content = message.content;
+          if (typeof content === "string") return content;
+          if (!Array.isArray(content)) return "";
+          return content
+            .map((part) => {
+              if (typeof part === "string") return part;
+              return typeof part?.text === "string" ? part.text : "";
+            })
+            .join("");
+        };
+
+        // OpenClaw 2026.6 added incremental `deltaText`; older gateways mainly
+        // exposed accumulated text through message.content. Preserve the raw
+        // fields and add the older accumulated message shape only when absent,
+        // so existing browser clients keep rendering while newer clients can
+        // consume deltaText directly.
+        const normalizeChatPayload = (payload) => {
+          const messageText = extractMessageText(payload.message);
           const role = payload.message?.role;
+          const isUserEcho = role === "user" || role === "human";
+          if (!isUserEcho && messageText) accumulatedAssistantText = messageText;
 
-          // Forward every event to the client as SSE
-          res.write(`data: ${JSON.stringify(payload)}\n\n`);
-
-          // Track when assistant content starts streaming
-          if (role === "assistant" || (!role && state === "delta" && sawAssistantContent)) {
-            sawAssistantContent = true;
+          if (!isUserEcho && payload.state === "delta" && typeof payload.deltaText === "string") {
+            accumulatedAssistantText = payload.replace
+              ? payload.deltaText
+              : messageText
+                ? messageText
+                : `${accumulatedAssistantText}${payload.deltaText}`;
           }
 
-          // Only mark done on the ASSISTANT's final/error — not the user message echo.
-          // The gateway sends a "final" for the user message before the assistant starts.
-          if (state === "final" || state === "error" || state === "aborted") {
-            if (role !== "user" && role !== "human" && sawAssistantContent) {
-              if (state === "final") finalTokenPayload = payload;
-              streamDone = true;
+          if (
+            (payload.state === "delta" || payload.state === "final") &&
+            !isUserEcho &&
+            !messageText &&
+            accumulatedAssistantText
+          ) {
+            const existingMessage =
+              payload.message &&
+              typeof payload.message === "object" &&
+              !Array.isArray(payload.message)
+                ? payload.message
+                : {};
+            return {
+              ...payload,
+              message: {
+                ...existingMessage,
+                role: existingMessage.role || "assistant",
+                content: [{ type: "text", text: accumulatedAssistantText }],
+              },
+            };
+          }
+
+          return payload;
+        };
+
+        const buildAgentTerminalFallback = (payload) => {
+          const phase = payload.data?.phase;
+          const errorMessage =
+            payload.data?.errorMessage ||
+            payload.data?.error ||
+            payload.errorMessage ||
+            payload.error;
+          if (phase === "error") {
+            return {
+              type: "error",
+              state: "error",
+              code: "AGENT_LIFECYCLE_ERROR",
+              runId: payload.runId || runId,
+              sessionKey: payload.sessionKey || sessionKey,
+              error: errorMessage || "Agent run failed",
+              errorMessage: errorMessage || "Agent run failed",
+            };
+          }
+          return {
+            state: "final",
+            runId: payload.runId || runId,
+            sessionKey: payload.sessionKey || sessionKey,
+            ...(accumulatedAssistantText
+              ? {
+                  message: {
+                    role: "assistant",
+                    content: [{ type: "text", text: accumulatedAssistantText }],
+                  },
+                }
+              : {}),
+          };
+        };
+
+        const cancelAgentTerminalFallback = () => {
+          if (agentTerminalFallbackTimer) clearTimeout(agentTerminalFallbackTimer);
+          agentTerminalFallbackTimer = null;
+          agentTerminalFallback = null;
+        };
+
+        const processStreamEvent = (eventName, evt) => {
+          const payload = evt.payload || evt;
+          const eventRunId =
+            typeof payload.runId === "string" && payload.runId.trim() ? payload.runId.trim() : null;
+
+          // Supported protocol-v3/v4 gateways require runId on chat and agent
+          // frames. Fail closed on malformed/runless events so pooled-socket
+          // traffic can never become a wildcard for this HTTP response.
+          if (!eventRunId || eventRunId !== runId) return;
+
+          if (res.writableEnded || res.destroyed) {
+            completeStream("client-close");
+            return;
+          }
+
+          // Any later matching activity means a pending lifecycle fallback is
+          // stale. Cancel it now; another terminal lifecycle event below will
+          // immediately schedule the appropriate short or retry-aware grace.
+          if (agentTerminalFallbackTimer) cancelAgentTerminalFallback();
+
+          if (eventName === "chat") {
+            const outboundPayload = normalizeChatPayload(payload);
+
+            // Forward matching events in their gateway-native shape (plus the
+            // additive message compatibility projection above).
+            res.write(`data: ${JSON.stringify(outboundPayload)}\n\n`);
+
+            const state = outboundPayload.state;
+            const role = outboundPayload.message?.role;
+            const isUserEcho = role === "user" || role === "human";
+            if (!isUserEcho && (state === "final" || state === "error" || state === "aborted")) {
+              chatTerminalPayload = outboundPayload;
+              if (state === "final") finalTokenPayload = outboundPayload;
+              completeStream("chat-terminal");
             }
+            return;
+          }
+
+          // Preserve agent sub-events for existing clients. A matching
+          // lifecycle end/error is also a terminal fallback because some
+          // gateway versions do not follow it with a chat terminal frame.
+          res.write(`data: ${JSON.stringify(payload)}\n\n`);
+          const lifecyclePhase = payload.stream === "lifecycle" ? payload.data?.phase : null;
+          if (lifecyclePhase === "error" || lifecyclePhase === "end") {
+            agentTerminalFallback = buildAgentTerminalFallback(payload);
+            const fallbackGraceMs =
+              lifecyclePhase === "error" && payload.data?.fallbackExhaustedFailure !== true
+                ? agentErrorFallbackGraceMs
+                : agentTerminalFallbackGraceMs;
+            agentTerminalFallbackTimer = setTimeout(
+              () => completeStream("agent-terminal"),
+              fallbackGraceMs,
+            );
           }
         };
 
-        conn.on("chat", streamHandler);
-        conn.on("agent", streamHandler);
+        const queueOrProcessStreamEvent = (eventName, evt) => {
+          if (!chatAcknowledged) {
+            // chat.send acknowledges before dispatching on current gateways;
+            // this small buffer also closes the theoretical ack/event race.
+            if (pendingEvents.length < 100) pendingEvents.push({ eventName, evt });
+            return;
+          }
+          processStreamEvent(eventName, evt);
+        };
+        const chatStreamHandler = (evt) => queueOrProcessStreamEvent("chat", evt);
+        const agentStreamHandler = (evt) => queueOrProcessStreamEvent("agent", evt);
+
+        streamCompletion = new Promise((resolve) => {
+          resolveStreamCompletion = resolve;
+        });
+        const handleClientClose = () => completeStream("client-close");
+        res.once("close", handleClientClose);
+        if (res.writableEnded || res.destroyed) completeStream("client-close");
+
+        // OpenClaw 2026.6 can scope live message events to explicit session
+        // subscribers. Older gateways reject this method, so it is deliberately
+        // best-effort and does not block chat when unsupported.
+        sessionMessageSubscriptionHeld = true;
+        const subscriptionAttempt = conn.acquireSessionMessageSubscription(
+          sessionKey,
+          sessionMessageSubscribeTimeoutMs,
+        );
+        await Promise.race([subscriptionAttempt, streamCompletion]);
+
+        // The response may have closed while the subscription RPC was in
+        // flight. Do not dispatch a new model turn for a client that is gone.
+        if (streamSettled) {
+          releaseSessionMessageSubscription();
+          res.off("close", handleClientClose);
+          return;
+        }
+
+        // Nothing for this request can stream before chat.send, so attach only
+        // after the best-effort subscription attempt. This avoids filling the
+        // pre-ack buffer with unrelated traffic from other pooled-socket runs.
+        conn.on("chat", chatStreamHandler);
+        conn.on("agent", agentStreamHandler);
 
         // Send the message — resolves immediately with { runId, status: "started" }
-        let runId = null;
         try {
           const result = await conn.call("chat.send", params, CALL_TIMEOUT);
-          runId = result.result?.runId || result.payload?.runId;
+          if (result?.ok === false) {
+            const rpcError = new Error(result.error?.message || "Gateway chat.send failed");
+            rpcError.code = result.error?.code || "GATEWAY_ERROR";
+            throw rpcError;
+          }
+          const acknowledgedRunId = result?.result?.runId ?? result?.payload?.runId;
+          if (typeof acknowledgedRunId !== "string" || !acknowledgedRunId.trim()) {
+            const acknowledgementError = new Error("Gateway chat.send returned no valid runId");
+            acknowledgementError.code = "INVALID_CHAT_ACK";
+            throw acknowledgementError;
+          }
+          runId = acknowledgedRunId.trim();
+          chatAcknowledged = true;
         } catch (err) {
-          res.write(`data: ${JSON.stringify({ type: "error", error: err.message })}\n\n`);
-          conn.off("chat", streamHandler);
-          conn.off("agent", streamHandler);
-          res.write("data: [DONE]\n\n");
-          res.end();
+          pendingEvents.length = 0;
+          conn.off("chat", chatStreamHandler);
+          conn.off("agent", agentStreamHandler);
+          releaseSessionMessageSubscription();
+          res.off("close", handleClientClose);
+          if (!res.writableEnded && !res.destroyed) {
+            res.write(`data: ${JSON.stringify({ type: "error", error: err.message })}\n\n`);
+            res.write("data: [DONE]\n\n");
+            res.end();
+          }
           metrics
             .recordMetric(req.agent.id, req.user.id, "error", 1, { error: err.message })
             .catch(() => {});
           return;
         }
 
-        // Wait for the stream to complete (chat:final / chat:error / timeout)
-        const streamTimeout = CHAT_TIMEOUT;
-        const startTime = Date.now();
-        await new Promise((resolve) => {
-          const check = setInterval(() => {
-            if (streamDone || Date.now() - startTime > streamTimeout) {
-              clearInterval(check);
-              resolve();
-            }
-          }, 200);
-          // Also resolve if the client disconnects
-          req.on("close", () => {
-            clearInterval(check);
-            resolve();
-          });
-        });
+        for (const pendingEvent of pendingEvents.splice(0)) {
+          processStreamEvent(pendingEvent.eventName, pendingEvent.evt);
+        }
 
-        conn.off("chat", streamHandler);
-        conn.off("agent", streamHandler);
+        streamTimeout = setTimeout(() => completeStream("timeout"), chatTimeoutMs);
+        // A disconnect can also race with chat.send acknowledgement; checking
+        // the state closes the tiny window between listener setup and now.
+        if (res.writableEnded || res.destroyed) completeStream("client-close");
+        const completionReason = await streamCompletion;
+        clearTimeout(streamTimeout);
+        if (agentTerminalFallbackTimer) {
+          clearTimeout(agentTerminalFallbackTimer);
+          agentTerminalFallbackTimer = null;
+        }
+        res.off("close", handleClientClose);
+
+        conn.off("chat", chatStreamHandler);
+        conn.off("agent", agentStreamHandler);
+        releaseSessionMessageSubscription();
+
+        if (
+          completionReason === "agent-terminal" &&
+          !chatTerminalPayload &&
+          agentTerminalFallback &&
+          !res.writableEnded &&
+          !res.destroyed
+        ) {
+          if (agentTerminalFallback.state === "final") {
+            finalTokenPayload = agentTerminalFallback;
+          }
+          res.write(`data: ${JSON.stringify(agentTerminalFallback)}\n\n`);
+        }
+
+        if (completionReason === "timeout") {
+          const timeoutMessage = `Chat stream timed out after ${chatTimeoutMs}ms`;
+          const timeoutPayload = {
+            type: "error",
+            state: "error",
+            code: "CHAT_TIMEOUT",
+            runId,
+            sessionKey,
+            error: timeoutMessage,
+            errorMessage: timeoutMessage,
+          };
+          if (!res.writableEnded && !res.destroyed) {
+            res.write(`data: ${JSON.stringify(timeoutPayload)}\n\n`);
+          }
+          metrics
+            .recordMetric(req.agent.id, req.user.id, "error", 1, {
+              code: "CHAT_TIMEOUT",
+              error: timeoutMessage,
+              runId,
+            })
+            .catch(() => {});
+        }
 
         // Record metrics
         metrics.recordMetric(req.agent.id, req.user.id, "messages_sent", 1).catch(() => {});
@@ -1140,9 +1613,11 @@ function createGatewayRouter() {
           .then(() => agentBudgets.checkAndEnforce(req.agent))
           .catch(() => {});
 
-        res.write(`data: ${JSON.stringify({ type: "done", runId })}\n\n`);
-        res.write("data: [DONE]\n\n");
-        if (!res.writableEnded) res.end();
+        if (completionReason !== "client-close" && !res.writableEnded && !res.destroyed) {
+          res.write(`data: ${JSON.stringify({ type: "done", runId, sessionKey })}\n\n`);
+          res.write("data: [DONE]\n\n");
+          res.end();
+        }
       } else {
         // Non-streaming: wait for final response
         const result = await rpcCall(req.agent, "chat.send", params, CHAT_TIMEOUT);

--- a/docs/configuration/environment-variables.mdx
+++ b/docs/configuration/environment-variables.mdx
@@ -292,57 +292,61 @@ Defaults allow OpenClaw's internal gateway port, Docker-published 19000-19999, a
 
 Proxmox is an opt-in experimental LXC target for standard OpenClaw and prepared Hermes images. Keep Docker enabled while validating it, use verified API TLS and pinned SSH host keys, and run the real-host smoke before production use. NemoClaw on Proxmox remains blocked.
 
-| Variable                                   | Required            | Default                                                    | Description                                                                                           |
-| ------------------------------------------ | ------------------- | ---------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `PROXMOX_API_URL`                          | With target         | —                                                          | HTTPS Proxmox API origin or URL ending in `/api2/json`.                                               |
-| `PROXMOX_TOKEN_ID`                         | With target         | —                                                          | API token ID in `user@realm!tokenname` format.                                                        |
-| `PROXMOX_TOKEN_SECRET`                     | With target         | —                                                          | Secret associated with the API token.                                                                 |
-| `PROXMOX_VERIFY_TLS`                       | No                  | `true`                                                     | Verifies the Proxmox API certificate. `false` is test-only.                                           |
-| `PROXMOX_CA_CERT` / `PROXMOX_CA_CERT_PATH` | No                  | —                                                          | Inline or mounted private CA certificate.                                                             |
-| `PROXMOX_ALLOW_INSECURE_HTTP`              | No                  | `false`                                                    | Test-only opt-in for an isolated HTTP fixture.                                                        |
-| `PROXMOX_NODE`                             | No                  | `pve`                                                      | Proxmox node where LXCs are created.                                                                  |
-| `PROXMOX_TEMPLATE`                         | No                  | `local:vztmpl/ubuntu-22.04-standard_22.04-1_amd64.tar.zst` | LXC template used for OpenClaw agents.                                                                |
-| `PROXMOX_HERMES_TEMPLATE`                  | For Hermes          | —                                                          | Prepared LXC template containing the Hermes executable and `hermes` user.                             |
-| `PROXMOX_ROOTFS_STORAGE`                   | No                  | `local-lvm`                                                | Storage pool used for the rootfs.                                                                     |
-| `PROXMOX_BRIDGE`                           | No                  | `vmbr0`                                                    | DHCP-capable network bridge attached to created LXCs.                                                 |
-| `PROXMOX_SSH_HOST` / `PROXMOX_SSH_USER`    | With target         | — / `root`                                                 | SSH endpoint used to run `pct`.                                                                       |
-| `PROXMOX_SSH_PORT`                         | No                  | `22`                                                       | SSH port.                                                                                             |
-| `PROXMOX_SSH_PRIVATE_KEY` / `_PATH`        | One SSH auth method | —                                                          | Inline or mounted SSH private key.                                                                    |
-| `PROXMOX_SSH_PRIVATE_KEY_PASSPHRASE`       | No                  | —                                                          | Passphrase for the configured private key.                                                            |
-| `PROXMOX_SSH_PASSWORD`                     | One SSH auth method | —                                                          | Password fallback when key auth is not configured.                                                    |
-| `PROXMOX_SSH_HOST_FINGERPRINT`             | With target         | —                                                          | Trusted OpenSSH SHA-256 host-key fingerprint.                                                         |
-| `PROXMOX_SSH_INSECURE_ACCEPT_HOST_KEY`     | No                  | `false`                                                    | Test-only bypass for pinned host verification.                                                        |
-| `PROXMOX_PCT_COMMAND` / `PROXMOX_SUDO`     | No                  | `pct` / auto                                               | Override the `pct` command or sudo prefix for a restricted SSH account.                               |
-| `PROXMOX_NODE_MAJOR`                       | No                  | `24`                                                       | Minimum Node.js major installed in stock OpenClaw templates.                                          |
-| `PROXMOX_OPENCLAW_PACKAGE`                 | No                  | `openclaw@latest`                                          | Package spec installed for OpenClaw. Pin for reproducible environments.                               |
-| `PROXMOX_HERMES_BIN`                       | No                  | `/opt/hermes/.venv/bin/hermes`                             | Hermes executable in the prepared template.                                                           |
-| `PROXMOX_HERMES_ENABLE_INSECURE_DASHBOARD` | No                  | `false`                                                    | Publishes the unauthenticated Hermes dashboard on `0.0.0.0`; leave false unless separately protected. |
+| Variable                                   | Required            | Default                                                    | Description                                                                                               |
+| ------------------------------------------ | ------------------- | ---------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `PROXMOX_API_URL`                          | With target         | —                                                          | HTTPS Proxmox API origin or URL ending in `/api2/json`.                                                   |
+| `PROXMOX_TOKEN_ID`                         | With target         | —                                                          | API token ID in `user@realm!tokenname` format.                                                            |
+| `PROXMOX_TOKEN_SECRET`                     | With target         | —                                                          | Secret associated with the API token.                                                                     |
+| `PROXMOX_VERIFY_TLS`                       | No                  | `true`                                                     | Verifies the Proxmox API certificate. `false` is test-only.                                               |
+| `PROXMOX_CA_CERT` / `PROXMOX_CA_CERT_PATH` | No                  | —                                                          | Inline or mounted private CA certificate.                                                                 |
+| `PROXMOX_ALLOW_INSECURE_HTTP`              | No                  | `false`                                                    | Test-only opt-in for an isolated HTTP fixture.                                                            |
+| `PROXMOX_NODE`                             | No                  | `pve`                                                      | Proxmox node where LXCs are created.                                                                      |
+| `PROXMOX_TEMPLATE`                         | No                  | `local:vztmpl/ubuntu-22.04-standard_22.04-1_amd64.tar.zst` | LXC template used for OpenClaw agents.                                                                    |
+| `PROXMOX_HERMES_TEMPLATE`                  | For Hermes          | —                                                          | Prepared LXC template containing the Hermes executable and `hermes` user.                                 |
+| `PROXMOX_ROOTFS_STORAGE`                   | No                  | `local-lvm`                                                | Storage pool used for the rootfs.                                                                         |
+| `PROXMOX_BRIDGE`                           | No                  | `vmbr0`                                                    | DHCP-capable network bridge attached to created LXCs.                                                     |
+| `PROXMOX_SSH_HOST` / `PROXMOX_SSH_USER`    | With target         | — / `root`                                                 | SSH endpoint used to run `pct`.                                                                           |
+| `PROXMOX_SSH_PORT`                         | No                  | `22`                                                       | SSH port.                                                                                                 |
+| `PROXMOX_SSH_PRIVATE_KEY` / `_PATH`        | One SSH auth method | —                                                          | Inline or mounted SSH private key.                                                                        |
+| `PROXMOX_SSH_PRIVATE_KEY_PASSPHRASE`       | No                  | —                                                          | Passphrase for the configured private key.                                                                |
+| `PROXMOX_SSH_PASSWORD`                     | One SSH auth method | —                                                          | Password fallback when key auth is not configured.                                                        |
+| `PROXMOX_SSH_HOST_FINGERPRINT`             | With target         | —                                                          | Trusted OpenSSH SHA-256 host-key fingerprint.                                                             |
+| `PROXMOX_SSH_INSECURE_ACCEPT_HOST_KEY`     | No                  | `false`                                                    | Test-only bypass for pinned host verification.                                                            |
+| `PROXMOX_PCT_COMMAND` / `PROXMOX_SUDO`     | No                  | `pct` / auto                                               | Override the `pct` command or sudo prefix for a restricted SSH account.                                   |
+| `PROXMOX_NODE_MAJOR`                       | No                  | `24`                                                       | Minimum Node.js major installed in stock OpenClaw templates.                                              |
+| `PROXMOX_OPENCLAW_PACKAGE`                 | No                  | `openclaw@2026.6.11`                                       | Package spec installed for OpenClaw. Override only after validating Gateway and activation compatibility. |
+| `PROXMOX_HERMES_BIN`                       | No                  | `/opt/hermes/.venv/bin/hermes`                             | Hermes executable in the prepared template.                                                               |
+| `PROXMOX_HERMES_ENABLE_INSECURE_DASHBOARD` | No                  | `false`                                                    | Publishes the unauthenticated Hermes dashboard on `0.0.0.0`; leave false unless separately protected.     |
 
 ## NemoClaw / NVIDIA
 
 Read when `ENABLED_SANDBOX_PROFILES` includes `nemoclaw`.
 
-| Variable                 | Required | Default                                          | Description                                                                                                                   |
-| ------------------------ | -------- | ------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------- |
-| `NVIDIA_API_KEY`         | No       | —                                                | API key from [build.nvidia.com](https://build.nvidia.com) for accessing NVIDIA-hosted Nemotron models.                        |
-| `NEMOCLAW_DEFAULT_MODEL` | No       | `nvidia/nemotron-3-super-120b-a12b`              | Default Nemotron model used by NemoClaw agents.                                                                               |
-| `NEMOCLAW_SANDBOX_IMAGE` | No       | `ghcr.io/solomon2773/nora-nemoclaw-agent:latest` | Container image for NemoClaw sandbox runtime. Use `nora-nemoclaw-agent:local` only when you build/preload the image yourself. |
+| Variable                 | Required | Default                                          | Description                                                                                                                                                                                                                        |
+| ------------------------ | -------- | ------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `NVIDIA_API_KEY`         | No       | —                                                | API key from [build.nvidia.com](https://build.nvidia.com) for accessing NVIDIA-hosted Nemotron models.                                                                                                                             |
+| `NEMOCLAW_DEFAULT_MODEL` | No       | `nvidia/nemotron-3-super-120b-a12b`              | Default Nemotron model used by NemoClaw agents.                                                                                                                                                                                    |
+| `NEMOCLAW_SANDBOX_IMAGE` | No       | `ghcr.io/solomon2773/nora-nemoclaw-agent:latest` | Container image for NemoClaw. Mutable registry tags refresh before Docker/Remote Docker create; normal local setup/deploy rebuilds Nora's exact local tag, while custom refs and remote/Kubernetes preloads remain operator-owned. |
 
 ## OpenClaw runtime
 
 These variables tune the OpenClaw runtime image and gateway. Most operators leave them at their defaults; override when running a forked OpenClaw build or pinning to a specific image.
 
-| Variable                   | Required | Default                  | Description                                                                              |
-| -------------------------- | -------- | ------------------------ | ---------------------------------------------------------------------------------------- |
-| `OPENCLAW_DOCKER_IMAGE`    | No       | OpenClaw default         | Container image used for OpenClaw agents.                                                |
-| `OPENCLAW_STANDARD_IMAGE`  | No       | OpenClaw default         | Image used specifically for the `standard` sandbox profile.                              |
-| `OPENCLAW_GATEWAY_PORT`    | No       | `18789`                  | Internal port the OpenClaw gateway listens on inside the agent container.                |
-| `OPENCLAW_GATEWAY_TOKEN`   | No       | auto-generated per agent | Static gateway token override. Most deployments rely on the per-agent token Nora issues. |
-| `OPENCLAW_DOCKER_PACKAGE`  | No       | OpenClaw default         | Override package name used when building images.                                         |
-| `OPENCLAW_TSX_BIN`         | No       | OpenClaw default         | Path to the `tsx` runner inside the OpenClaw image.                                      |
-| `OPENCLAW_TSX_PACKAGE`     | No       | OpenClaw default         | Override `tsx` package name.                                                             |
-| `OPENCLAW_CLI_PATH`        | No       | OpenClaw default         | Path to the OpenClaw CLI inside the image.                                               |
-| `OPENCLAW_DISABLE_BONJOUR` | No       | `false`                  | Disable Bonjour/mDNS inside OpenClaw containers when not needed.                         |
+| Variable                   | Required | Default                  | Description                                                                                |
+| -------------------------- | -------- | ------------------------ | ------------------------------------------------------------------------------------------ |
+| `OPENCLAW_DOCKER_IMAGE`    | No       | OpenClaw default         | Container image used for OpenClaw agents.                                                  |
+| `OPENCLAW_STANDARD_IMAGE`  | No       | OpenClaw default         | Image used specifically for the `standard` sandbox profile.                                |
+| `OPENCLAW_GATEWAY_PORT`    | No       | `18789`                  | Internal port the OpenClaw gateway listens on inside the agent container.                  |
+| `OPENCLAW_GATEWAY_TOKEN`   | No       | auto-generated per agent | Static gateway token override. Most deployments rely on the per-agent token Nora issues.   |
+| `OPENCLAW_DOCKER_PACKAGE`  | No       | `openclaw@2026.6.11`     | Validated package spec used across Docker, Kubernetes, and as the Proxmox fallback.        |
+| `OPENCLAW_TSX_BIN`         | No       | OpenClaw default         | Path to the `tsx` runner inside the OpenClaw image.                                        |
+| `OPENCLAW_TSX_PACKAGE`     | No       | OpenClaw default         | Override `tsx` package name.                                                               |
+| `OPENCLAW_CLI_PATH`        | No       | OpenClaw default         | Path to the OpenClaw CLI inside the image.                                                 |
+| `OPENCLAW_DISABLE_BONJOUR` | No       | `true`                   | Disable Bonjour/mDNS inside managed containers; set `0` only for deliberate LAN discovery. |
+
+When `OPENCLAW_DOCKER_PACKAGE` is overridden for NemoClaw, `NEMOCLAW_SANDBOX_IMAGE` must reference a
+prebuilt image containing the same exact OpenClaw version. The non-root NemoClaw runtime fails
+closed on a version mismatch instead of replacing the global package inside the sandbox.
 
 ## Hermes runtime
 

--- a/docs/guides/nemoclaw.mdx
+++ b/docs/guides/nemoclaw.mdx
@@ -49,9 +49,17 @@ NemoClaw runs as an OpenClaw sandbox profile on these deploy targets:
 | K3s / Kubernetes | Supported    | Uses the Kubernetes adapter with `sandbox_profile=nemoclaw`; API keys are injected through per-agent Kubernetes Secrets.          |
 | AKS / GKE / EKS  | Supported    | Same Kubernetes adapter as K3s; use LoadBalancer exposure or the cluster exposure mode configured in Admin.                       |
 
-The default sandbox image is `ghcr.io/solomon2773/nora-nemoclaw-agent:latest`. For air-gapped
-hosts or private clusters, build `nora-nemoclaw-agent:local`, preload it onto the target nodes, and
-set `NEMOCLAW_SANDBOX_IMAGE=nora-nemoclaw-agent:local`.
+The default sandbox image is `ghcr.io/solomon2773/nora-nemoclaw-agent:latest`. Nora refreshes that
+mutable registry tag before Docker or Remote Docker creates a sandbox. Normal local setup and the
+official single-host production deploy rebuild the exact `nora-nemoclaw-agent:local` tag when it is
+selected. For Remote Docker hosts, air-gapped hosts, or private Kubernetes clusters, build and
+preload the image on each target yourself. Custom local tags, versioned tags, and digest references
+remain operator-owned and must be refreshed deliberately after a Nora OpenClaw pin changes.
+
+If you override `OPENCLAW_DOCKER_PACKAGE`, build or preload a NemoClaw image containing that exact
+OpenClaw version and point `NEMOCLAW_SANDBOX_IMAGE` at the matching pinned reference. NemoClaw runs
+non-root and deliberately fails closed rather than replacing a mismatched global OpenClaw install
+inside the sandbox.
 
 ## Deploy a NemoClaw agent
 

--- a/docs/self-hosting.mdx
+++ b/docs/self-hosting.mdx
@@ -157,7 +157,7 @@ Run Nora itself on a Kubernetes cluster with the public OCI chart at `oci://ghcr
 
 ```bash
 helm install nora oci://ghcr.io/solomon2773/nora \
-  --version 0.7.2 \
+  --version 0.7.3 \
   --namespace nora --create-namespace \
   --set secrets.jwtSecret="$(openssl rand -hex 32)" \
   --set secrets.encryptionKey="$(openssl rand -hex 32)" \

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "nora",
   "description": "Operate self-hosted OpenClaw and Hermes agent fleets from Gemini CLI.",
-  "version": "1.16.2",
+  "version": "1.16.3",
   "settings": [
     {
       "name": "Nora API URL",

--- a/infra/cloudflare-launch.md
+++ b/infra/cloudflare-launch.md
@@ -90,6 +90,7 @@ first):
 - If **any** of:
   - URI Path starts with `/api/`
   - URI Path starts with `/app/`
+  - URI Path equals `/admin`
   - URI Path starts with `/admin/`
   - URI Path is in `/signup`, `/login`
   - Cookie contains your Nora session cookie name
@@ -99,6 +100,11 @@ This keeps the API (including the `/api/ws/` log/terminal sockets and the
 `/api/agents/*/gateway/chat` SSE stream), the operator app, the admin app, and every
 authenticated or cookie-setting response **off** the edge cache. Never cache a response
 that carries `Set-Cookie`.
+
+If you protect the Admin dashboard with **Cloudflare Access**, cover both the exact
+`/admin` path and `/admin/*`. The public nginx templates redirect `/admin` to `/admin/` as
+defense in depth, but the Access application should still include both paths so policy remains
+correct if routing changes or another origin serves the hostname.
 
 **Rule 2 — "Cache marketing" (priority 2):**
 
@@ -153,7 +159,10 @@ Run these against the live site **before** you post anywhere:
 - [ ] Sign up for a fresh account end-to-end (no cached/stale auth page; cookie sets).
 - [ ] `/api/auth/bootstrap-status` reports signup bot protection enabled and configured.
 - [ ] Log into `/app` and confirm the dashboard + a WebSocket log stream work.
-- [ ] Open an agent chat and confirm SSE streaming works (note the ~100s caveat).
+- [ ] When Cloudflare Access protects Admin, both `/admin` and `/admin/settings` enter the
+      Access login flow; `/admin` must not return a public shell whose `/_next` assets are blocked.
+- [ ] Open a freshly activated demo agent chat and confirm the first reply streams promptly over
+      SSE without an empty response, timeout, or loading stall.
 - [ ] OAuth login (Google/GitHub) round-trips (callbacks go through the marketing app).
 - [ ] `docker compose ... logs nginx` shows **real client IPs**, not Cloudflare IPs.
 - [ ] Trip the login rate limit intentionally and confirm a `429`/Block.

--- a/infra/helm/nora/Chart.yaml
+++ b/infra/helm/nora/Chart.yaml
@@ -5,8 +5,8 @@ description: >-
   (nginx edge, marketing/operator/admin frontends, backend API, provisioner and
   backup workers) plus optional in-chart PostgreSQL and Redis.
 type: application
-version: 0.7.2
-appVersion: "1.16.2"
+version: 0.7.3
+appVersion: "1.16.3"
 home: https://github.com/solomon2773/nora
 icon: https://raw.githubusercontent.com/solomon2773/nora/master/frontend-marketing/public/icon-512.png
 sources:

--- a/infra/nginx_public.conf.template
+++ b/infra/nginx_public.conf.template
@@ -182,6 +182,14 @@ http {
         }
 
         # 2. Admin Dashboard
+        # Normalize the bare entrypoint before proxying. Cloudflare Access path rules commonly
+        # protect /admin/*; without this redirect, /admin can serve an HTML shell whose assets are
+        # intercepted by Access, leaving anonymous visitors on a permanently loading page. Keep
+        # query arguments intact so canonicalization does not change the requested admin state.
+        location = /admin {
+            return 308 /admin/$is_args$args;
+        }
+
         location /admin {
             proxy_pass $admin_dashboard;
             proxy_set_header Host $host;

--- a/infra/nginx_tls.conf
+++ b/infra/nginx_tls.conf
@@ -210,6 +210,14 @@ http {
         }
 
         # 2. Admin Dashboard
+        # Normalize the bare entrypoint before proxying. Cloudflare Access path rules commonly
+        # protect /admin/*; without this redirect, /admin can serve an HTML shell whose assets are
+        # intercepted by Access, leaving anonymous visitors on a permanently loading page. Keep
+        # query arguments intact so canonicalization does not change the requested admin state.
+        location = /admin {
+            return 308 /admin/$is_args$args;
+        }
+
         location /admin {
             proxy_pass $admin_dashboard;
             proxy_set_header Host $host;

--- a/infra/run-release-upgrade.sh
+++ b/infra/run-release-upgrade.sh
@@ -314,6 +314,26 @@ run_upgrade() {
 
   build_compose_args "$env_file" "$compose_files" || return $?
   if [ ! -f setup.sh ] || [ "${NORA_UPGRADE_USE_SETUP:-true}" = "false" ]; then
+    echo "Rebuilding the pinned standard OpenClaw agent image..."
+    docker build \
+      -f agent-runtime/Dockerfile.openclaw-agent \
+      -t nora-openclaw-agent:local \
+      agent-runtime/
+    local enabled_sandbox_profiles nemoclaw_sandbox_image normalized_sandbox_profiles
+    enabled_sandbox_profiles="$(read_env_setting "$env_file" ENABLED_SANDBOX_PROFILES)"
+    nemoclaw_sandbox_image="$(read_env_setting "$env_file" NEMOCLAW_SANDBOX_IMAGE)"
+    normalized_sandbox_profiles="${enabled_sandbox_profiles//[[:space:]]/}"
+    case ",${normalized_sandbox_profiles}," in
+      *,nemoclaw,*)
+        if [ "$nemoclaw_sandbox_image" = "nora-nemoclaw-agent:local" ]; then
+          echo "Rebuilding the enabled local NemoClaw sandbox image..."
+          docker build \
+            -f agent-runtime/Dockerfile.nemoclaw-agent \
+            -t nora-nemoclaw-agent:local \
+            agent-runtime/
+        fi
+        ;;
+    esac
     echo "Pre-validating nginx configuration..."
     docker compose "${COMPOSE_ARGS[@]}" run --rm --no-deps --interactive=false -T nginx nginx -t
     docker compose "${COMPOSE_ARGS[@]}" up -d --build

--- a/scripts/infra-security.test.mjs
+++ b/scripts/infra-security.test.mjs
@@ -206,6 +206,11 @@ test("public nginx templates enforce marketing security and homepage cache heade
       source,
       /location = \/ \{[\s\S]*?proxy_hide_header Cache-Control;[\s\S]*?proxy_hide_header Strict-Transport-Security;/,
     );
+    assert.match(
+      source,
+      /location = \/admin \{\s*return 308 \/admin\/\$is_args\$args;\s*\}/,
+      `${file} must normalize the bare admin path without dropping query arguments`,
+    );
   }
 });
 
@@ -216,6 +221,98 @@ test("Next.js frontends suppress framework disclosure headers", () => {
     "admin-dashboard/next.config.ts",
   ]) {
     assert.match(read(file), /poweredByHeader:\s*false/, `${file} must hide X-Powered-By`);
+  }
+});
+
+test("validated OpenClaw defaults stay aligned across runtime, setup, and docs", () => {
+  const defaults = read("agent-runtime/lib/openclawDefaults.ts");
+  const match = defaults.match(/DEFAULT_OPENCLAW_VERSION\s*=\s*"([^"]+)"/);
+  assert.ok(match, "openclawDefaults.ts must expose an exact validated version");
+  const version = match[1];
+  const packageSpec = `openclaw@${version}`;
+
+  for (const file of [
+    "agent-runtime/Dockerfile.openclaw-agent",
+    "agent-runtime/Dockerfile.nemoclaw-agent",
+  ]) {
+    assert.match(
+      read(file),
+      new RegExp(`ARG OPENCLAW_VERSION=${version.replaceAll(".", "\\.")}(?:\\s|$)`),
+      `${file} must bake the validated OpenClaw version`,
+    );
+  }
+
+  for (const file of [
+    ".env.example",
+    "setup.sh",
+    "setup.ps1",
+    "docs/configuration/environment-variables.mdx",
+  ]) {
+    const source = read(file);
+    assert.ok(source.includes(packageSpec), `${file} must document ${packageSpec}`);
+  }
+  assert.doesNotMatch(read(".env.example"), /openclaw@latest/);
+  assert.doesNotMatch(read("docs/configuration/environment-variables.mdx"), /openclaw@latest/);
+  assert.doesNotMatch(
+    read("setup.sh"),
+    /read_env_value[^\n]+"openclaw@latest"\)/,
+    "setup.sh must not restore a floating package default",
+  );
+  assert.doesNotMatch(
+    read("setup.ps1"),
+    /Read-EnvValue[^\n]+-Default "openclaw@latest"/,
+    "setup.ps1 must not restore a floating package default",
+  );
+});
+
+test("NemoClaw image replaces inherited npm globals before reinstalling", () => {
+  const dockerfile = read("agent-runtime/Dockerfile.nemoclaw-agent");
+  const installCommand = shellLogicalLines(dockerfile)
+    .map((line) => line.replace(/\s+/g, " ").trim())
+    .find(
+      (line) =>
+        line.startsWith("RUN ") &&
+        line.includes('npm install -g "tsx@${TSX_VERSION}" "openclaw@${OPENCLAW_VERSION}"'),
+    );
+  assert.ok(installCommand, "NemoClaw Dockerfile must expose the global install command");
+
+  const treeRemoval = "rm -rf /usr/lib/node_modules/openclaw /usr/lib/node_modules/tsx";
+  const binRemoval = "rm -f /usr/bin/openclaw /usr/bin/tsx";
+  const install = 'npm install -g "tsx@${TSX_VERSION}" "openclaw@${OPENCLAW_VERSION}"';
+  const installIndex = installCommand.indexOf(install);
+
+  for (const removal of [treeRemoval, binRemoval]) {
+    const removalIndex = installCommand.indexOf(removal);
+    assert.notEqual(removalIndex, -1, `NemoClaw Dockerfile must run: ${removal}`);
+    assert.ok(removalIndex < installIndex, `${removal} must run before npm install -g`);
+  }
+
+  assert.equal(
+    (installCommand.match(/test "\$\(npm config get prefix\)" = "\/usr"/g) || []).length,
+    2,
+    "NemoClaw must verify the /usr npm prefix before and after installation",
+  );
+  assert.equal(
+    (installCommand.match(/test "\$\(npm root -g\)" = "\/usr\/lib\/node_modules"/g) || []).length,
+    2,
+    "NemoClaw must verify the /usr global root before and after installation",
+  );
+  assert.doesNotMatch(
+    installCommand,
+    /(?:NPM_CONFIG_PREFIX|npm config set prefix|npm install\b[^;&]*--prefix(?:=|\s))/,
+    "NemoClaw must replace the inherited /usr tree instead of leaving it beside a second prefix",
+  );
+  assert.match(
+    installCommand,
+    /test "\$\(node -p 'require\("\/usr\/lib\/node_modules\/openclaw\/package\.json"\)\.version'\)" = "\$\{OPENCLAW_VERSION\}"/,
+  );
+  assert.match(
+    installCommand,
+    /test "\$\(node -p 'require\("\/usr\/lib\/node_modules\/tsx\/package\.json"\)\.version'\)" = "\$\{TSX_VERSION\}"/,
+  );
+  for (const binary of ["openclaw", "tsx"]) {
+    assert.match(installCommand, new RegExp(`test -x /usr/bin/${binary}`));
+    assert.match(installCommand, new RegExp(`/usr/bin/${binary} --version`));
   }
 });
 
@@ -486,6 +583,129 @@ test("setup requires Compose 2.24.4+ and rejects standalone v1", () => {
   ]);
 });
 
+test("setup applies immutable-aware NemoClaw image policy", () => {
+  const bashSetup = read("setup.sh");
+  const powershellSetup = read("setup.ps1");
+
+  assert.match(bashSetup, /^nemoclaw_image_ref_is_mutable\(\)/m);
+  assert.match(bashSetup, /^csv_value_is_enabled\(\)/m);
+  assert.match(bashSetup, /\[Ll\]\[Aa\]\[Tt\]\[Ee\]\[Ss\]\[Tt\]/);
+  assert.doesNotMatch(bashSetup, /\$\{[^}]+,,\}/, "setup.sh must remain compatible with Bash 3.2");
+  assert.match(bashSetup, /^ensure_nemoclaw_sandbox_image\(\)/m);
+  assert.match(bashSetup, /docker image inspect "\$image"/);
+  assert.match(bashSetup, /ensure_nemoclaw_sandbox_image "\$NEMOCLAW_SANDBOX_IMAGE"/);
+  assert.match(bashSetup, /csv_value_is_enabled "\$\{ENABLED_SANDBOX_PROFILES:-\}" "nemoclaw"/);
+  assert.doesNotMatch(bashSetup, /grep -Eq '\^NEMOCLAW_SANDBOX_IMAGE=nora-nemoclaw-agent:local\$'/);
+  assert.match(powershellSetup, /function Test-NemoClawImageReferenceMutable/);
+  assert.match(powershellSetup, /function Test-CommaSeparatedValue/);
+  assert.match(powershellSetup, /function Ensure-NemoClawSandboxImage/);
+  assert.match(powershellSetup, /docker image inspect \$imageRef/);
+  assert.match(powershellSetup, /Ensure-NemoClawSandboxImage -Image \$NEMOCLAW_SANDBOX_IMAGE/);
+  assert.doesNotMatch(powershellSetup, /Select-String[^\n]+NEMOCLAW_SANDBOX_IMAGE/);
+
+  runChecked("bash", [
+    "-c",
+    `set -euo pipefail
+     info() { :; }
+     ok() { :; }
+     error() { :; }
+     source <(awk '/^nemoclaw_image_ref_is_mutable\\(\\)/,/^}/' setup.sh)
+     source <(awk '/^csv_value_is_enabled\\(\\)/,/^}/' setup.sh)
+     source <(awk '/^ensure_nemoclaw_sandbox_image\\(\\)/,/^}/' setup.sh)
+     fixture_dir="$(mktemp -d /tmp/nora-nemoclaw-image-policy.XXXXXX)"
+     docker_log="$fixture_dir/docker.log"
+     trap 'rm -rf "$fixture_dir"' EXIT
+     docker() {
+       printf '%s\n' "$*" >> "$docker_log"
+       case "$1" in
+         image)
+           case "$3" in
+             registry.example/missing:*|registry.example/unavailable:*) return 1 ;;
+             *) return 0 ;;
+           esac
+           ;;
+         pull)
+           [ "$2" != "registry.example/unavailable:1.0" ]
+           ;;
+         build) return 0 ;;
+       esac
+     }
+     reset_log() { : > "$docker_log"; }
+     assert_no_pull() { ! grep -q '^pull ' "$docker_log"; }
+
+     csv_value_is_enabled 'standard, nemoclaw' nemoclaw
+     csv_value_is_enabled ' standard ,  nemoclaw  ' nemoclaw
+     ! csv_value_is_enabled 'standard,strict' nemoclaw
+
+     reset_log
+     ensure_nemoclaw_sandbox_image nora-nemoclaw-agent:local
+     grep -Fq 'build -f agent-runtime/Dockerfile.nemoclaw-agent -t nora-nemoclaw-agent:local agent-runtime/' "$docker_log"
+     assert_no_pull
+
+     for immutable in registry.example/nemoclaw:local registry.example/nemoclaw:1.2.3 registry.example/nemoclaw@sha256:abc123; do
+       reset_log
+       ensure_nemoclaw_sandbox_image "$immutable"
+       grep -Fq "image inspect $immutable" "$docker_log"
+       assert_no_pull
+     done
+
+     for mutable in registry.example/nemoclaw registry.example/nemoclaw:latest; do
+       reset_log
+       ensure_nemoclaw_sandbox_image "$mutable"
+       grep -Fq "image inspect $mutable" "$docker_log"
+       grep -Fq "pull $mutable" "$docker_log"
+     done
+
+     reset_log
+     ensure_nemoclaw_sandbox_image registry.example/missing:2.0
+     grep -Fq 'image inspect registry.example/missing:2.0' "$docker_log"
+     grep -Fq 'pull registry.example/missing:2.0' "$docker_log"
+
+     reset_log
+     ! ensure_nemoclaw_sandbox_image registry.example/unavailable:1.0
+     grep -Fq 'pull registry.example/unavailable:1.0' "$docker_log"`,
+  ]);
+});
+
+test("production deploy reads NemoClaw settings without sourcing the env file", () => {
+  const workflow = read(".github/workflows/deploy-production.yml");
+  const functionMatch = workflow.match(/ {10}read_deploy_env_value\(\) \{\n[\s\S]*?\n {10}\}/);
+  assert.ok(functionMatch, "deploy workflow must expose the safe env reader");
+  const functionSource = functionMatch[0].replace(/^ {10}/gm, "");
+  assert.doesNotMatch(functionSource, /(?:^|\n)\s*(?:source|\.)\s+/);
+
+  const fixtureDir = mkdtempSync(path.join(tmpdir(), "nora-deploy-env-reader-"));
+  const envFile = path.join(fixtureDir, ".env");
+  try {
+    writeFileSync(
+      envFile,
+      [
+        'ENABLED_SANDBOX_PROFILES = "standard, nemoclaw"',
+        "NEMOCLAW_SANDBOX_IMAGE='nora-nemoclaw-agent:local'",
+        "JWT_SECRET=must-not-be-printed",
+      ].join("\n") + "\n",
+    );
+    const result = spawnSync(
+      "bash",
+      [
+        "-c",
+        `set -euo pipefail
+${functionSource}
+test "$(read_deploy_env_value "$1" ENABLED_SANDBOX_PROFILES "")" = "standard, nemoclaw"
+test "$(read_deploy_env_value "$1" NEMOCLAW_SANDBOX_IMAGE "")" = "nora-nemoclaw-agent:local"`,
+        "nora-deploy-env-reader",
+        envFile,
+      ],
+      { cwd: repoRoot, encoding: "utf8" },
+    );
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(result.stdout, "");
+    assert.equal(result.stderr, "");
+  } finally {
+    rmSync(fixtureDir, { recursive: true, force: true });
+  }
+});
+
 test("setup separates new API hash secrets while preserving migration fallbacks", () => {
   const bashSetup = read("setup.sh");
   const powershellSetup = read("setup.ps1");
@@ -536,6 +756,94 @@ const hasPowerShell =
   spawnSync("pwsh", ["-NoProfile", "-NonInteractive", "-Command", "exit 0"], {
     cwd: repoRoot,
   }).status === 0;
+
+test(
+  "PowerShell setup applies immutable-aware NemoClaw image policy",
+  { skip: !hasPowerShell },
+  () => {
+    runChecked("pwsh", ["-NoProfile", "-NonInteractive", "-Command", "-"], {
+      input: `$ErrorActionPreference = "Stop"
+$tokens = $null
+$parseErrors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile(
+  (Resolve-Path "setup.ps1"),
+  [ref]$tokens,
+  [ref]$parseErrors
+)
+if ($parseErrors.Count -gt 0) { throw ($parseErrors | Out-String) }
+foreach ($name in @("Test-NemoClawImageReferenceMutable", "Test-CommaSeparatedValue", "Ensure-NemoClawSandboxImage")) {
+  $definition = $ast.Find({
+    param($node)
+    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and $node.Name -eq $name
+  }, $true)
+  if (-not $definition) { throw "Missing function $name" }
+  Invoke-Expression $definition.Extent.Text
+}
+function Write-Info { param([string]$Message) }
+function Write-Ok { param([string]$Message) }
+function Write-Err { param([string]$Message) }
+$script:PresentImages = @(
+  "registry.example/nemoclaw:local",
+  "registry.example/nemoclaw:1.2.3",
+  "registry.example/nemoclaw@sha256:abc123",
+  "registry.example/nemoclaw",
+  "registry.example/nemoclaw:latest"
+)
+$script:DockerLog = New-Object System.Collections.Generic.List[string]
+function docker {
+  param([Parameter(ValueFromRemainingArguments = $true)][object[]]$DockerArgs)
+  $parts = @($DockerArgs | ForEach-Object { [string]$_ })
+  $script:DockerLog.Add(($parts -join " "))
+  if ($parts[0] -eq "image" -and $parts[1] -eq "inspect") {
+    $global:LASTEXITCODE = if ($script:PresentImages -contains $parts[2]) { 0 } else { 1 }
+    return
+  }
+  if ($parts[0] -eq "pull") {
+    $global:LASTEXITCODE = if ($parts[1] -eq "registry.example/unavailable:1.0") { 1 } else { 0 }
+    return
+  }
+  $global:LASTEXITCODE = 0
+}
+function Reset-DockerLog { $script:DockerLog.Clear() }
+function Assert-NoPull {
+  if ($script:DockerLog | Where-Object { $_ -like "pull *" }) { throw "Unexpected pull" }
+}
+
+if (-not (Test-NemoClawImageReferenceMutable -Image "registry.example/nemoclaw")) { throw "Untagged ref must be mutable" }
+if (-not (Test-NemoClawImageReferenceMutable -Image "registry.example/nemoclaw:latest")) { throw "latest must be mutable" }
+foreach ($immutable in @("registry.example/nemoclaw:local", "registry.example/nemoclaw:1.2.3", "registry.example/nemoclaw@sha256:abc123")) {
+  if (Test-NemoClawImageReferenceMutable -Image $immutable) { throw "$immutable must be immutable" }
+}
+if (-not (Test-CommaSeparatedValue -List "standard, nemoclaw" -Value "nemoclaw")) { throw "Whitespace profile was not enabled" }
+if (-not (Test-CommaSeparatedValue -List " standard ,  nemoclaw  " -Value "nemoclaw")) { throw "Trimmed profile was not enabled" }
+if (Test-CommaSeparatedValue -List "standard,strict" -Value "nemoclaw") { throw "Missing profile was enabled" }
+
+Reset-DockerLog
+Ensure-NemoClawSandboxImage -Image "nora-nemoclaw-agent:local"
+if (-not ($script:DockerLog | Where-Object { $_ -like "build *Dockerfile.nemoclaw-agent*" })) { throw "Exact local ref was not built" }
+Assert-NoPull
+
+foreach ($immutable in @("registry.example/nemoclaw:local", "registry.example/nemoclaw:1.2.3", "registry.example/nemoclaw@sha256:abc123")) {
+  Reset-DockerLog
+  Ensure-NemoClawSandboxImage -Image $immutable
+  Assert-NoPull
+}
+foreach ($mutable in @("registry.example/nemoclaw", "registry.example/nemoclaw:latest")) {
+  Reset-DockerLog
+  Ensure-NemoClawSandboxImage -Image $mutable
+  if (-not ($script:DockerLog -contains "pull $mutable")) { throw "$mutable was not refreshed" }
+}
+Reset-DockerLog
+Ensure-NemoClawSandboxImage -Image "registry.example/missing:2.0"
+if (-not ($script:DockerLog -contains "pull registry.example/missing:2.0")) { throw "Missing ref was not pulled" }
+Reset-DockerLog
+$failedClosed = $false
+try { Ensure-NemoClawSandboxImage -Image "registry.example/unavailable:1.0" } catch { $failedClosed = $true }
+if (-not $failedClosed) { throw "Unavailable ref did not fail closed" }
+`,
+    });
+  },
+);
 
 test(
   "PowerShell API hash migration preserves values and secures files",
@@ -737,6 +1045,31 @@ test("production update paths activate refreshed nginx config without touching c
   );
   assert.match(
     deployWorkflow,
+    /docker build \\\s*\n\s*-f agent-runtime\/Dockerfile\.openclaw-agent \\\s*\n\s*-t nora-openclaw-agent:local \\\s*\n\s*agent-runtime\//,
+    "production deploys must refresh the pinned standard OpenClaw image",
+  );
+  assert.match(deployWorkflow, /read_deploy_env_value\(\)/);
+  assert.match(
+    deployWorkflow,
+    /enabled_sandbox_profiles="\$\(read_deploy_env_value "\$DEPLOY_ENV_FILE" ENABLED_SANDBOX_PROFILES ""\)"/,
+  );
+  assert.match(
+    deployWorkflow,
+    /nemoclaw_sandbox_image="\$\(read_deploy_env_value "\$DEPLOY_ENV_FILE" NEMOCLAW_SANDBOX_IMAGE "ghcr\.io\/solomon2773\/nora-nemoclaw-agent:latest"\)"/,
+  );
+  assert.doesNotMatch(deployWorkflow, /(?:^|\n)\s*(?:source|\.)\s+"?\$DEPLOY_ENV_FILE"?/);
+  const deployNemoBuild = deployWorkflow.match(
+    /if \[ "\$nemoclaw_sandbox_image" = "nora-nemoclaw-agent:local" \]; then([\s\S]*?)\n\s*fi/,
+  );
+  assert.ok(deployNemoBuild, "production deploy must gate the local NemoClaw build exactly");
+  assert.match(deployNemoBuild[1], /agent-runtime\/Dockerfile\.nemoclaw-agent/);
+  assert.equal(
+    (deployWorkflow.match(/agent-runtime\/Dockerfile\.nemoclaw-agent/g) || []).length,
+    1,
+    "production deploy must not rebuild custom or pinned NemoClaw refs",
+  );
+  assert.match(
+    deployWorkflow,
     /docker compose "\$\{compose_args\[@\]\}" run --rm --no-deps --interactive=false -T nginx nginx -t[\s\S]*?docker compose "\$\{compose_args\[@\]\}" up -d --build[\s\S]*?docker compose "\$\{compose_args\[@\]\}" up -d --force-recreate --no-deps nginx[\s\S]*?docker compose "\$\{compose_args\[@\]\}" exec -T nginx nginx -t <\/dev\/null/,
   );
   assert.match(
@@ -770,6 +1103,22 @@ test("production update paths activate refreshed nginx config without touching c
   assert.match(
     releaseUpgrade,
     /docker compose "\$\{COMPOSE_ARGS\[@\]\}" run --rm --no-deps --interactive=false -T nginx nginx -t[\s\S]*?docker compose "\$\{COMPOSE_ARGS\[@\]\}" up -d --build[\s\S]*?docker compose "\$\{COMPOSE_ARGS\[@\]\}" up -d --force-recreate --no-deps nginx[\s\S]*?docker compose "\$\{COMPOSE_ARGS\[@\]\}" exec -T nginx nginx -t <\/dev\/null/,
+  );
+  const directUpgradeBlock = releaseUpgrade.match(
+    /if \[ ! -f setup\.sh \] \|\| \[ "\$\{NORA_UPGRADE_USE_SETUP:-true\}" = "false" \]; then([\s\S]*?)\n\s*fi/,
+  );
+  assert.ok(directUpgradeBlock, "direct upgrade fallback must remain explicit");
+  assert.match(directUpgradeBlock[1], /agent-runtime\/Dockerfile\.openclaw-agent/);
+  assert.match(directUpgradeBlock[1], /read_env_setting "\$env_file" ENABLED_SANDBOX_PROFILES/);
+  assert.match(directUpgradeBlock[1], /read_env_setting "\$env_file" NEMOCLAW_SANDBOX_IMAGE/);
+  assert.match(
+    directUpgradeBlock[1],
+    /if \[ "\$nemoclaw_sandbox_image" = "nora-nemoclaw-agent:local" \]; then[\s\S]*?agent-runtime\/Dockerfile\.nemoclaw-agent/,
+  );
+  assert.equal(
+    (releaseUpgrade.match(/agent-runtime\/Dockerfile\.nemoclaw-agent/g) || []).length,
+    1,
+    "direct upgrade must not rebuild custom or pinned NemoClaw refs",
   );
   assert.match(
     setupTls,

--- a/setup.ps1
+++ b/setup.ps1
@@ -925,6 +925,75 @@ function Read-EnvValueWithAlias {
     return $Default
 }
 
+function Test-NemoClawImageReferenceMutable {
+    param([string]$Image)
+
+    $reference = if ($null -eq $Image) { "" } else { $Image.Trim() }
+    if (-not $reference -or $reference.Contains("@")) {
+        return $false
+    }
+    $lastSlash = $reference.LastIndexOf("/")
+    $tagSeparator = $reference.LastIndexOf(":")
+    if ($tagSeparator -le $lastSlash) {
+        return $true
+    }
+    return $reference.Substring($tagSeparator + 1).ToLowerInvariant() -eq "latest"
+}
+
+function Test-CommaSeparatedValue {
+    param([string]$List, [string]$Value)
+
+    foreach ($item in ($List -split ',')) {
+        if ($item.Trim() -ieq $Value) {
+            return $true
+        }
+    }
+    return $false
+}
+
+function Ensure-NemoClawSandboxImage {
+    param([string]$Image)
+
+    $imageRef = if ($null -eq $Image) { "" } else { $Image.Trim() }
+    if (-not $imageRef) {
+        Write-Err "NEMOCLAW_SANDBOX_IMAGE must not be empty"
+        throw "NEMOCLAW_SANDBOX_IMAGE must not be empty"
+    }
+
+    if ($imageRef -eq "nora-nemoclaw-agent:local") {
+        Write-Host ""
+        Write-Info "Building nora-nemoclaw-agent:local (OpenShell sandbox + tsx)..."
+        Write-Host ""
+        docker build -f agent-runtime/Dockerfile.nemoclaw-agent -t nora-nemoclaw-agent:local agent-runtime/
+        if ($LASTEXITCODE -ne 0) {
+            Write-Err "Failed to build nora-nemoclaw-agent:local"
+            throw "Failed to build nora-nemoclaw-agent:local"
+        }
+        Write-Ok "NemoClaw sandbox image ready"
+        return
+    }
+
+    docker image inspect $imageRef *> $null
+    $imagePresent = $LASTEXITCODE -eq 0
+    if ($imagePresent -and -not (Test-NemoClawImageReferenceMutable -Image $imageRef)) {
+        Write-Info "Using existing immutable NemoClaw sandbox image"
+        Write-Ok "NemoClaw sandbox image ready"
+        return
+    }
+
+    if ($imagePresent) {
+        Write-Info "Refreshing mutable NemoClaw sandbox image..."
+    } else {
+        Write-Info "Pulling missing NemoClaw sandbox image..."
+    }
+    docker pull $imageRef
+    if ($LASTEXITCODE -ne 0) {
+        Write-Err "Failed to pull configured NemoClaw sandbox image"
+        throw "Failed to pull configured NemoClaw sandbox image"
+    }
+    Write-Ok "NemoClaw sandbox image ready"
+}
+
 function Update-SignupProtectionEnv {
     param([string]$EnvPath)
 
@@ -1539,7 +1608,11 @@ $PROXMOX_SSH_INSECURE_ACCEPT_HOST_KEY = Read-EnvValue -EnvPath $ENV_FILE -Name "
 $PROXMOX_PCT_COMMAND = Read-EnvValue -EnvPath $ENV_FILE -Name "PROXMOX_PCT_COMMAND" -Default "pct"
 $PROXMOX_SUDO = Read-EnvValue -EnvPath $ENV_FILE -Name "PROXMOX_SUDO" -Default ""
 $PROXMOX_NODE_MAJOR = Read-EnvValue -EnvPath $ENV_FILE -Name "PROXMOX_NODE_MAJOR" -Default "24"
-$PROXMOX_OPENCLAW_PACKAGE = Read-EnvValue -EnvPath $ENV_FILE -Name "PROXMOX_OPENCLAW_PACKAGE" -Default "openclaw@latest"
+$PROXMOX_OPENCLAW_PACKAGE = Read-EnvValue -EnvPath $ENV_FILE -Name "PROXMOX_OPENCLAW_PACKAGE" -Default "openclaw@2026.6.11"
+if ($PROXMOX_OPENCLAW_PACKAGE -eq "openclaw@latest") {
+    Write-Warn "Migrating legacy PROXMOX_OPENCLAW_PACKAGE=openclaw@latest to Nora's validated pin."
+    $PROXMOX_OPENCLAW_PACKAGE = "openclaw@2026.6.11"
+}
 $PROXMOX_HERMES_BIN = Read-EnvValue -EnvPath $ENV_FILE -Name "PROXMOX_HERMES_BIN" -Default "/opt/hermes/.venv/bin/hermes"
 $PROXMOX_HERMES_ENABLE_INSECURE_DASHBOARD = Read-EnvValue -EnvPath $ENV_FILE -Name "PROXMOX_HERMES_ENABLE_INSECURE_DASHBOARD" -Default "false"
 $NVIDIA_API_KEY = ""
@@ -1787,6 +1860,12 @@ $NORA_CURRENT_COMMIT = Resolve-CurrentReleaseCommit
 $DOCKER_GID = Get-DockerSocketGid
 $COMPOSE_PROJECT_NAME = Get-ComposeProjectName -EnvPath $ENV_FILE
 $DOCKER_AGENT_BIND_IP = Read-EnvValue -EnvPath $ENV_FILE -Name "DOCKER_AGENT_BIND_IP" -Default "127.0.0.1"
+$OPENCLAW_DOCKER_PACKAGE = Read-EnvValue -EnvPath $ENV_FILE -Name "OPENCLAW_DOCKER_PACKAGE" -Default "openclaw@2026.6.11"
+if ($OPENCLAW_DOCKER_PACKAGE -eq "openclaw@latest") {
+    Write-Warn "Migrating legacy OPENCLAW_DOCKER_PACKAGE=openclaw@latest to Nora's validated pin."
+    $OPENCLAW_DOCKER_PACKAGE = "openclaw@2026.6.11"
+}
+$NEMOCLAW_SANDBOX_IMAGE = Read-EnvValue -EnvPath $ENV_FILE -Name "NEMOCLAW_SANDBOX_IMAGE" -Default "ghcr.io/solomon2773/nora-nemoclaw-agent:latest"
 $DATABASE_URL = Read-EnvValue -EnvPath $ENV_FILE -Name "DATABASE_URL" -Default ""
 $DB_SSL_MODE = Read-EnvValue -EnvPath $ENV_FILE -Name "DB_SSL_MODE" -Default ""
 $DB_SSL_CA = Read-EnvValue -EnvPath $ENV_FILE -Name "DB_SSL_CA" -Default ""
@@ -2004,6 +2083,7 @@ ENABLED_RUNTIME_FAMILIES=$ENABLED_RUNTIME_FAMILIES
 ENABLED_BACKENDS=$ENABLED_BACKENDS
 ENABLED_SANDBOX_PROFILES=$ENABLED_SANDBOX_PROFILES
 DOCKER_AGENT_BIND_IP=$DOCKER_AGENT_BIND_IP
+OPENCLAW_DOCKER_PACKAGE=$OPENCLAW_DOCKER_PACKAGE
 
 # ── Proxmox LXC (experimental; secure configuration required) ──────────
 PROXMOX_API_URL=$PROXMOX_API_URL
@@ -2039,7 +2119,7 @@ NVIDIA_API_KEY=$NVIDIA_API_KEY
 NEMOCLAW_DEFAULT_MODEL=nvidia/nemotron-3-super-120b-a12b
 # Defaults to the Nora-published GHCR image. For offline hosts or private
 # clusters, build/preload nora-nemoclaw-agent:local and override this value.
-NEMOCLAW_SANDBOX_IMAGE=ghcr.io/solomon2773/nora-nemoclaw-agent:latest
+NEMOCLAW_SANDBOX_IMAGE=$NEMOCLAW_SANDBOX_IMAGE
 
 # ── Security ─────────────────────────────────────────────────
 CORS_ORIGINS=$CORS_ORIGINS
@@ -2143,20 +2223,10 @@ docker build -f agent-runtime/Dockerfile.openclaw-agent -t nora-openclaw-agent:l
 if ($LASTEXITCODE -ne 0) { Write-Err "Failed to build nora-openclaw-agent:local"; exit 1 }
 Write-Ok "OpenClaw agent image ready"
 
-# Only build the NemoClaw fallback image when the operator enables the sandbox
-# and explicitly points NEMOCLAW_SANDBOX_IMAGE at the local tag.
-if (($ENABLED_SANDBOX_PROFILES -split ',') -contains 'nemoclaw') {
-    $nemoclawImageLine = Select-String -Path $ENV_FILE -Pattern '^NEMOCLAW_SANDBOX_IMAGE=nora-nemoclaw-agent:local$' -Quiet
-    if ($nemoclawImageLine) {
-        Write-Host ""
-        Write-Info "Building nora-nemoclaw-agent:local (OpenShell sandbox + tsx)..."
-        Write-Host ""
-        docker build -f agent-runtime/Dockerfile.nemoclaw-agent -t nora-nemoclaw-agent:local agent-runtime/
-        if ($LASTEXITCODE -ne 0) { Write-Err "Failed to build nora-nemoclaw-agent:local"; exit 1 }
-        Write-Ok "NemoClaw sandbox image ready"
-    } else {
-        Write-Info "Using GHCR NemoClaw sandbox image from NEMOCLAW_SANDBOX_IMAGE"
-    }
+# Build Nora's exact local NemoClaw tag. Other refs follow provisioner policy:
+# refresh mutable refs, reuse present immutable refs, and pull any missing ref.
+if (Test-CommaSeparatedValue -List $ENABLED_SANDBOX_PROFILES -Value "nemoclaw") {
+    Ensure-NemoClawSandboxImage -Image $NEMOCLAW_SANDBOX_IMAGE
 }
 Start-NoraComposeStack
 

--- a/setup.sh
+++ b/setup.sh
@@ -645,6 +645,78 @@ read_env_value_with_alias() {
   printf '%s\n' "${value:-$default_value}"
 }
 
+nemoclaw_image_ref_is_mutable() {
+  local reference="$1" last_component tag
+  reference="${reference#"${reference%%[![:space:]]*}"}"
+  reference="${reference%"${reference##*[![:space:]]}"}"
+  [ -n "$reference" ] || return 1
+  [[ "$reference" == *"@"* ]] && return 1
+  last_component="${reference##*/}"
+  [[ "$last_component" != *":"* ]] && return 0
+  tag="${last_component##*:}"
+  case "$tag" in
+    [Ll][Aa][Tt][Ee][Ss][Tt]) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+csv_value_is_enabled() {
+  local csv="$1" expected="$2" item
+  local -a items=()
+  IFS=',' read -r -a items <<< "$csv"
+  for item in "${items[@]}"; do
+    item="${item#"${item%%[![:space:]]*}"}"
+    item="${item%"${item##*[![:space:]]}"}"
+    [ "$item" = "$expected" ] && return 0
+  done
+  return 1
+}
+
+ensure_nemoclaw_sandbox_image() {
+  local image="$1" image_present="false"
+  image="${image#"${image%%[![:space:]]*}"}"
+  image="${image%"${image##*[![:space:]]}"}"
+  if [ -z "$image" ]; then
+    error "NEMOCLAW_SANDBOX_IMAGE must not be empty"
+    return 1
+  fi
+
+  if [ "$image" = "nora-nemoclaw-agent:local" ]; then
+    echo ""
+    info "Building nora-nemoclaw-agent:local (OpenShell sandbox + tsx)..."
+    echo ""
+    if ! docker build \
+      -f agent-runtime/Dockerfile.nemoclaw-agent \
+      -t nora-nemoclaw-agent:local \
+      agent-runtime/; then
+      error "Failed to build nora-nemoclaw-agent:local"
+      return 1
+    fi
+    ok "NemoClaw sandbox image ready"
+    return 0
+  fi
+
+  if docker image inspect "$image" >/dev/null 2>&1; then
+    image_present="true"
+  fi
+  if [ "$image_present" = "true" ] && ! nemoclaw_image_ref_is_mutable "$image"; then
+    info "Using existing immutable NemoClaw sandbox image"
+    ok "NemoClaw sandbox image ready"
+    return 0
+  fi
+
+  if [ "$image_present" = "true" ]; then
+    info "Refreshing mutable NemoClaw sandbox image..."
+  else
+    info "Pulling missing NemoClaw sandbox image..."
+  fi
+  if ! docker pull "$image"; then
+    error "Failed to pull configured NemoClaw sandbox image"
+    return 1
+  fi
+  ok "NemoClaw sandbox image ready"
+}
+
 ensure_signup_protection_env() {
   local env_path="$1"
   local burst_max burst_window daily_max daily_window provider turnstile_site_key
@@ -1441,7 +1513,11 @@ PROXMOX_SSH_INSECURE_ACCEPT_HOST_KEY="$(read_env_value "$ENV_FILE" "PROXMOX_SSH_
 PROXMOX_PCT_COMMAND="$(read_env_value "$ENV_FILE" "PROXMOX_PCT_COMMAND" "pct")"
 PROXMOX_SUDO="$(read_env_value "$ENV_FILE" "PROXMOX_SUDO" "")"
 PROXMOX_NODE_MAJOR="$(read_env_value "$ENV_FILE" "PROXMOX_NODE_MAJOR" "24")"
-PROXMOX_OPENCLAW_PACKAGE="$(read_env_value "$ENV_FILE" "PROXMOX_OPENCLAW_PACKAGE" "openclaw@latest")"
+PROXMOX_OPENCLAW_PACKAGE="$(read_env_value "$ENV_FILE" "PROXMOX_OPENCLAW_PACKAGE" "openclaw@2026.6.11")"
+if [ "$PROXMOX_OPENCLAW_PACKAGE" = "openclaw@latest" ]; then
+  warn "Migrating legacy PROXMOX_OPENCLAW_PACKAGE=openclaw@latest to Nora's validated pin."
+  PROXMOX_OPENCLAW_PACKAGE="openclaw@2026.6.11"
+fi
 PROXMOX_HERMES_BIN="$(read_env_value "$ENV_FILE" "PROXMOX_HERMES_BIN" "/opt/hermes/.venv/bin/hermes")"
 PROXMOX_HERMES_ENABLE_INSECURE_DASHBOARD="$(read_env_value "$ENV_FILE" "PROXMOX_HERMES_ENABLE_INSECURE_DASHBOARD" "false")"
 NVIDIA_API_KEY=""
@@ -1702,6 +1778,12 @@ NORA_CURRENT_COMMIT="$(resolve_current_release_commit)"
 DOCKER_GID="$(resolve_docker_gid)"
 COMPOSE_PROJECT_NAME="$(resolve_compose_project_name "$ENV_FILE")"
 DOCKER_AGENT_BIND_IP="$(read_env_value "$ENV_FILE" "DOCKER_AGENT_BIND_IP" "127.0.0.1")"
+OPENCLAW_DOCKER_PACKAGE="$(read_env_value "$ENV_FILE" "OPENCLAW_DOCKER_PACKAGE" "openclaw@2026.6.11")"
+if [ "$OPENCLAW_DOCKER_PACKAGE" = "openclaw@latest" ]; then
+  warn "Migrating legacy OPENCLAW_DOCKER_PACKAGE=openclaw@latest to Nora's validated pin."
+  OPENCLAW_DOCKER_PACKAGE="openclaw@2026.6.11"
+fi
+NEMOCLAW_SANDBOX_IMAGE="$(read_env_value "$ENV_FILE" "NEMOCLAW_SANDBOX_IMAGE" "ghcr.io/solomon2773/nora-nemoclaw-agent:latest")"
 DATABASE_URL="$(read_env_value "$ENV_FILE" "DATABASE_URL" "")"
 DB_SSL_MODE="$(read_env_value "$ENV_FILE" "DB_SSL_MODE" "")"
 DB_SSL_CA="$(read_env_value "$ENV_FILE" "DB_SSL_CA" "")"
@@ -1918,6 +2000,7 @@ ENABLED_RUNTIME_FAMILIES=${ENABLED_RUNTIME_FAMILIES}
 ENABLED_BACKENDS=${ENABLED_BACKENDS}
 ENABLED_SANDBOX_PROFILES=${ENABLED_SANDBOX_PROFILES}
 DOCKER_AGENT_BIND_IP=${DOCKER_AGENT_BIND_IP}
+OPENCLAW_DOCKER_PACKAGE=${OPENCLAW_DOCKER_PACKAGE}
 
 # ── Proxmox LXC (experimental; secure configuration required) ──────────
 PROXMOX_API_URL=${PROXMOX_API_URL}
@@ -1953,7 +2036,7 @@ NVIDIA_API_KEY=${NVIDIA_API_KEY}
 NEMOCLAW_DEFAULT_MODEL=nvidia/nemotron-3-super-120b-a12b
 # Defaults to the Nora-published GHCR image. For offline hosts or private
 # clusters, build/preload nora-nemoclaw-agent:local and override this value.
-NEMOCLAW_SANDBOX_IMAGE=ghcr.io/solomon2773/nora-nemoclaw-agent:latest
+NEMOCLAW_SANDBOX_IMAGE=${NEMOCLAW_SANDBOX_IMAGE}
 
 # ── Security ─────────────────────────────────────────────────
 CORS_ORIGINS=${CORS_ORIGINS}
@@ -2057,24 +2140,11 @@ docker build \
   agent-runtime/
 ok "OpenClaw agent image ready"
 
-# Only build the NemoClaw fallback image when the operator enables the sandbox
-# and explicitly points NEMOCLAW_SANDBOX_IMAGE at the local tag.
-case ",${ENABLED_SANDBOX_PROFILES:-}," in
-  *,nemoclaw,*)
-    if grep -Eq '^NEMOCLAW_SANDBOX_IMAGE=nora-nemoclaw-agent:local$' "$ENV_FILE"; then
-      echo ""
-      info "Building nora-nemoclaw-agent:local (OpenShell sandbox + tsx)..."
-      echo ""
-      docker build \
-        -f agent-runtime/Dockerfile.nemoclaw-agent \
-        -t nora-nemoclaw-agent:local \
-        agent-runtime/
-      ok "NemoClaw sandbox image ready"
-    else
-      info "Using GHCR NemoClaw sandbox image from NEMOCLAW_SANDBOX_IMAGE"
-    fi
-    ;;
-esac
+# Build Nora's exact local NemoClaw tag. Other refs follow provisioner policy:
+# refresh mutable refs, reuse present immutable refs, and pull any missing ref.
+if csv_value_is_enabled "${ENABLED_SANDBOX_PROFILES:-}" "nemoclaw"; then
+  ensure_nemoclaw_sandbox_image "$NEMOCLAW_SANDBOX_IMAGE"
+fi
 
 start_compose_stack
 

--- a/workers/provisioner/backends/docker.ts
+++ b/workers/provisioner/backends/docker.ts
@@ -1,5 +1,6 @@
 // @ts-nocheck
 const ProvisionerBackend = require("./interface");
+const { demuxDockerExecStream } = require("./dockerExecStream");
 const crypto = require("crypto");
 const path = require("path");
 const {
@@ -976,20 +977,26 @@ class DockerBackend extends ProvisionerBackend {
 
   async exec(containerId, opts = {}) {
     const container = this.docker.getContainer(containerId);
+    const tty = opts.tty !== false;
     const execInstance = await container.exec({
       Cmd: opts.cmd || ["/bin/sh", "-c", "command -v bash >/dev/null 2>&1 && exec bash || exec sh"],
       AttachStdin: true,
       AttachStdout: true,
       AttachStderr: true,
-      Tty: opts.tty !== false,
+      Tty: tty,
       Env: opts.env || ["TERM=xterm-256color"],
     });
-    const stream = await execInstance.start({
+    const rawStream = await execInstance.start({
       hijack: true,
       stdin: true,
-      Tty: opts.tty !== false,
+      Tty: tty,
     });
-    return { exec: execInstance, stream };
+    if (tty) return { exec: execInstance, stream: rawStream };
+
+    // Docker multiplexes stdout/stderr behind 8-byte frame headers whenever
+    // TTY is disabled. Demux at the adapter boundary so command consumers see
+    // the same plain byte stream as Kubernetes and Proxmox adapters.
+    return { exec: execInstance, stream: demuxDockerExecStream(this.docker, rawStream) };
   }
 }
 

--- a/workers/provisioner/backends/dockerExecStream.ts
+++ b/workers/provisioner/backends/dockerExecStream.ts
@@ -1,0 +1,50 @@
+// @ts-nocheck
+const { PassThrough } = require("node:stream");
+
+function demuxDockerExecStream(docker, rawStream) {
+  if (!docker?.modem?.demuxStream || !rawStream) {
+    throw new Error("Docker exec stream demultiplexer is unavailable");
+  }
+
+  const stdout = new PassThrough();
+  const stderr = new PassThrough();
+  const stream = new PassThrough();
+  let finished = false;
+
+  const finish = () => {
+    if (finished) return;
+    finished = true;
+    stdout.end();
+    stderr.end();
+    if (!stream.destroyed) stream.end();
+  };
+  const fail = (error) => {
+    if (finished) return;
+    finished = true;
+    stdout.destroy();
+    stderr.destroy();
+    stream.destroy(error);
+  };
+
+  stdout.on("data", (chunk) => stream.write(chunk));
+  stderr.on("data", (chunk) => stream.write(chunk));
+  stdout.on("error", fail);
+  stderr.on("error", fail);
+  rawStream.once("end", finish);
+  rawStream.once("close", finish);
+  rawStream.once("error", fail);
+  docker.modem.demuxStream(rawStream, stdout, stderr);
+
+  const destroy = stream.destroy.bind(stream);
+  stream.destroy = (...args) => {
+    finished = true;
+    stdout.destroy();
+    stderr.destroy();
+    rawStream.destroy();
+    return destroy(...args);
+  };
+
+  return stream;
+}
+
+module.exports = { demuxDockerExecStream };

--- a/workers/provisioner/backends/nemoclaw.ts
+++ b/workers/provisioner/backends/nemoclaw.ts
@@ -5,6 +5,8 @@
 
 const Docker = require("dockerode");
 const ProvisionerBackend = require("./interface");
+const { demuxDockerExecStream } = require("./dockerExecStream");
+const { ensureNemoClawImage } = require("./nemoclawImage");
 const crypto = require("crypto");
 const path = require("path");
 const {
@@ -23,6 +25,7 @@ const {
   getNemoClawDefaultModel,
   getNemoClawSandboxImage,
 } = require("../../../agent-runtime/lib/nemoclawDefaults");
+const { getStandardDockerPackageSpec } = require("../../../agent-runtime/lib/agentImages");
 const {
   buildDockerTelemetry,
   buildUnavailableTelemetry,
@@ -36,6 +39,7 @@ const {
 const SANDBOX_IMAGE = getNemoClawSandboxImage(process.env);
 
 const DEFAULT_MODEL = getNemoClawDefaultModel(process.env);
+const sandboxImageRefreshStates = new Map();
 
 // Baseline network policy — only these endpoints are allowed.
 // Matches NemoClaw's openclaw-sandbox.yaml spec.
@@ -91,6 +95,28 @@ class NemoClawBackend extends ProvisionerBackend {
     super();
     this.docker = new Docker({ socketPath: "/var/run/docker.sock" });
     this._composeNetwork = null;
+  }
+
+  _sandboxImageRefreshKey() {
+    const target = this.executionTargetId
+      ? [this.executionTargetId, this.profile?.sshHost || "", this.profile?.sshPort || ""].join(":")
+      : "local";
+    return `${target}\0${SANDBOX_IMAGE}`;
+  }
+
+  async _ensureSandboxImage() {
+    const key = this._sandboxImageRefreshKey();
+    let state = sandboxImageRefreshStates.get(key);
+    if (!state) {
+      state = { pending: null, refreshed: false };
+      sandboxImageRefreshStates.set(key, state);
+    }
+    await ensureNemoClawImage({
+      docker: this.docker,
+      image: SANDBOX_IMAGE,
+      state,
+      log: (message) => console.log(`[nemoclaw] ${message}`),
+    });
   }
 
   async _findComposeNetwork() {
@@ -163,7 +189,10 @@ class NemoClawBackend extends ProvisionerBackend {
     const startupScript = [
       "#!/bin/sh",
       "set -eu",
-      buildOpenClawInstallCommand(["openclaw@latest", "nemoclaw@latest"]),
+      buildOpenClawInstallCommand([
+        getStandardDockerPackageSpec(),
+        process.env.NEMOCLAW_PACKAGE || "nemoclaw@latest",
+      ]),
       "mkdir -p ~/.openclaw/devices",
       "cat <<'__NORA_GATEWAY_CONFIG__' > ~/.openclaw/openclaw.json",
       JSON.stringify({ gateway: { port: OPENCLAW_GATEWAY_PORT, bind: "lan", mode: "local" } }),
@@ -268,23 +297,7 @@ class NemoClawBackend extends ProvisionerBackend {
 
     console.log(`[nemoclaw] Creating sandbox ${containerName} from ${SANDBOX_IMAGE}`);
 
-    // Pull the sandbox image
-    try {
-      await this.docker.getImage(SANDBOX_IMAGE).inspect();
-      console.log(`[nemoclaw] Image ${SANDBOX_IMAGE} already present`);
-    } catch {
-      console.log(`[nemoclaw] Pulling image ${SANDBOX_IMAGE}...`);
-      await new Promise((resolve, reject) => {
-        this.docker.pull(SANDBOX_IMAGE, (err, stream) => {
-          if (err) return reject(err);
-          this.docker.modem.followProgress(stream, (err) => {
-            if (err) return reject(err);
-            console.log(`[nemoclaw] Image ${SANDBOX_IMAGE} pulled successfully`);
-            resolve();
-          });
-        });
-      });
-    }
+    await this._ensureSandboxImage();
 
     // Remove orphaned containers
     try {
@@ -648,20 +661,24 @@ class NemoClawBackend extends ProvisionerBackend {
 
   async exec(containerId, opts = {}) {
     const container = this.docker.getContainer(containerId);
+    const tty = opts.tty !== false;
     const execInstance = await container.exec({
       Cmd: opts.cmd || ["/bin/sh", "-c", "command -v bash >/dev/null 2>&1 && exec bash || exec sh"],
       AttachStdin: true,
       AttachStdout: true,
       AttachStderr: true,
-      Tty: opts.tty !== false,
+      Tty: tty,
       Env: opts.env || ["TERM=xterm-256color"],
     });
-    const stream = await execInstance.start({
+    const rawStream = await execInstance.start({
       hijack: true,
       stdin: true,
-      Tty: opts.tty !== false,
+      Tty: tty,
     });
-    return { exec: execInstance, stream };
+    return {
+      exec: execInstance,
+      stream: tty ? rawStream : demuxDockerExecStream(this.docker, rawStream),
+    };
   }
 
   /**
@@ -678,7 +695,8 @@ class NemoClawBackend extends ProvisionerBackend {
         AttachStdout: true,
         AttachStderr: true,
       });
-      const stream = await exec.start();
+      const rawStream = await exec.start();
+      const stream = demuxDockerExecStream(this.docker, rawStream);
       return new Promise((resolve) => {
         let output = "";
         stream.on("data", (chunk) => (output += chunk.toString()));

--- a/workers/provisioner/backends/nemoclawImage.ts
+++ b/workers/provisioner/backends/nemoclawImage.ts
@@ -1,0 +1,60 @@
+// @ts-nocheck
+
+function isMutableNemoClawImageReference(image) {
+  const reference = String(image || "").trim();
+  if (!reference || reference.includes("@")) return false;
+  const lastSlash = reference.lastIndexOf("/");
+  const tagSeparator = reference.lastIndexOf(":");
+  if (tagSeparator <= lastSlash) return true;
+  return reference.slice(tagSeparator + 1).toLowerCase() === "latest";
+}
+
+async function pullNemoClawImage(docker, image, log) {
+  log(`Pulling image ${image}...`);
+  await new Promise((resolve, reject) => {
+    docker.pull(image, (error, stream) => {
+      if (error) return reject(error);
+      docker.modem.followProgress(stream, (progressError) => {
+        if (progressError) return reject(progressError);
+        log(`Image ${image} pulled successfully`);
+        resolve();
+      });
+    });
+  });
+}
+
+async function ensureNemoClawImage({ docker, image, state, log = () => {} } = {}) {
+  if (!docker || !state) throw new Error("docker and state are required");
+  if (state.pending) return state.pending;
+
+  state.pending = (async () => {
+    let imagePresent = false;
+    try {
+      await docker.getImage(image).inspect();
+      imagePresent = true;
+    } catch {
+      // Pull below when the configured image is not present.
+    }
+
+    if (imagePresent && (!isMutableNemoClawImageReference(image) || state.refreshed)) {
+      log(`Image ${image} already present`);
+      return;
+    }
+
+    await pullNemoClawImage(docker, image, log);
+    state.refreshed = true;
+  })();
+
+  try {
+    await state.pending;
+  } catch (error) {
+    state.pending = null;
+    throw error;
+  }
+  state.pending = null;
+}
+
+module.exports = {
+  ensureNemoClawImage,
+  isMutableNemoClawImageReference,
+};

--- a/workers/provisioner/backends/proxmox.ts
+++ b/workers/provisioner/backends/proxmox.ts
@@ -28,6 +28,7 @@ const {
   getProxmoxConfigIssue,
   getProxmoxProductionSecurityIssue,
 } = require("../../../agent-runtime/lib/backendCatalog");
+const { getStandardDockerPackageSpec } = require("../../../agent-runtime/lib/agentImages");
 const {
   HERMES_MANAGED_ENV_ENV,
   buildHermesManagedEnvBlock,
@@ -1069,10 +1070,7 @@ class ProxmoxBackend extends ProvisionerBackend {
       "0600",
       { signal },
     );
-    const openClawPackage =
-      process.env.PROXMOX_OPENCLAW_PACKAGE ||
-      process.env.OPENCLAW_DOCKER_PACKAGE ||
-      "openclaw@latest";
+    const openClawPackage = process.env.PROXMOX_OPENCLAW_PACKAGE || getStandardDockerPackageSpec();
     const customProviders = buildOpenClawCustomProviders(env || {});
     if (Object.keys(customProviders).length > 0) {
       await this._writeFile(

--- a/workers/provisioner/demoActivationCanary.test.js
+++ b/workers/provisioner/demoActivationCanary.test.js
@@ -1,0 +1,202 @@
+const assert = require("node:assert/strict");
+const { spawnSync } = require("node:child_process");
+const test = require("node:test");
+
+const { shellSingleQuote } = require("../../agent-runtime/lib/containerCommand.ts");
+const {
+  DEFAULT_DEMO_ACTIVATION_CANARY_TIMEOUT_MS,
+  DEMO_ACTIVATION_CANARY_MAX_OUTPUT_BYTES,
+  DEMO_ACTIVATION_CANARY_MARKER,
+  buildDemoActivationCanaryCleanupCommand,
+  buildDemoActivationCanaryCommand,
+  resolveDemoActivationCanaryTimeoutMs,
+  runDemoActivationCanary,
+  verifyDemoActivationCanaryOutput,
+} = require("./demoActivationCanary.ts");
+
+function gatewayReply(text = `ready ${DEMO_ACTIVATION_CANARY_MARKER}`) {
+  return JSON.stringify({
+    runId: "run-canary-1",
+    status: "ok",
+    result: {
+      payloads: [{ text }],
+      meta: { durationMs: 42 },
+    },
+  });
+}
+
+test("canary timeout defaults to five minutes and clamps operator overrides", () => {
+  assert.equal(resolveDemoActivationCanaryTimeoutMs(), DEFAULT_DEMO_ACTIVATION_CANARY_TIMEOUT_MS);
+  assert.equal(resolveDemoActivationCanaryTimeoutMs("invalid"), 300000);
+  assert.equal(resolveDemoActivationCanaryTimeoutMs("1000"), 60000);
+  assert.equal(resolveDemoActivationCanaryTimeoutMs("900000"), 600000);
+  assert.equal(resolveDemoActivationCanaryTimeoutMs("120000"), 120000);
+});
+
+test("canary commands use a non-main session, JSON mode, bounded timeout, and safe quoting", () => {
+  const sessionKey = "agent:main:canary'; touch /tmp/should-not-run; #";
+  const command = buildDemoActivationCanaryCommand({ sessionKey, timeoutMs: 300000 });
+  const cleanup = buildDemoActivationCanaryCleanupCommand({ sessionKey });
+
+  assert.match(command, /agent --agent 'main'/);
+  assert.ok(command.includes(`--session-key ${shellSingleQuote(sessionKey)}`));
+  assert.ok(
+    command.includes(
+      `--message ${shellSingleQuote(`Activation check: reply with a message containing ${DEMO_ACTIVATION_CANARY_MARKER}.`)}`,
+    ),
+  );
+  assert.match(command, /--thinking 'off' --json --timeout '255'/);
+  assert.match(command, /timeout -k 5s 300s/);
+  assert.match(command, /Container timeout utility unavailable for activation canary/);
+  assert.match(cleanup, /sessions --agent main --json/);
+  assert.match(cleanup, /sessions cleanup --agent main --fix-missing --enforce --json/);
+  assert.ok(cleanup.includes(shellSingleQuote(sessionKey)));
+  assert.doesNotMatch(cleanup, /gateway call|sessions\.delete/);
+  assert.match(cleanup, /Activation canary session cleanup did not remove the session/);
+  assert.equal(spawnSync("sh", ["-n"], { input: command }).status, 0);
+  assert.equal(spawnSync("sh", ["-n"], { input: cleanup }).status, 0);
+});
+
+test("canary command builders reject the OpenClaw main session", () => {
+  assert.throws(
+    () => buildDemoActivationCanaryCommand({ sessionKey: "agent:main:main" }),
+    /requires a non-main OpenClaw session key/,
+  );
+  assert.throws(
+    () => buildDemoActivationCanaryCleanupCommand({ sessionKey: "main" }),
+    /requires a non-main OpenClaw session key/,
+  );
+});
+
+test("canary verification accepts only a completed Gateway JSON reply containing the marker", () => {
+  assert.deepEqual(verifyDemoActivationCanaryOutput(gatewayReply()), {
+    status: "ready",
+    runId: "run-canary-1",
+    payloadCount: 1,
+  });
+
+  assert.throws(
+    () =>
+      verifyDemoActivationCanaryOutput(
+        JSON.stringify({
+          runId: "run-canary-2",
+          status: "ok",
+          result: { payloads: [{ text: "reply without marker" }] },
+          note: DEMO_ACTIVATION_CANARY_MARKER,
+        }),
+      ),
+    (error) => error.code === "DEMO_ACTIVATION_CANARY_MARKER_MISSING",
+  );
+});
+
+test("canary verification rejects direct embedded and explicit fallback results", () => {
+  assert.throws(
+    () =>
+      verifyDemoActivationCanaryOutput(
+        JSON.stringify({
+          payloads: [{ text: DEMO_ACTIVATION_CANARY_MARKER }],
+          meta: { transport: "embedded", fallbackFrom: "gateway" },
+        }),
+      ),
+    (error) => error.code === "DEMO_ACTIVATION_CANARY_EMBEDDED_FALLBACK",
+  );
+
+  assert.throws(
+    () =>
+      verifyDemoActivationCanaryOutput(
+        JSON.stringify({
+          runId: "run-canary-fallback",
+          status: "ok",
+          result: {
+            payloads: [{ text: DEMO_ACTIVATION_CANARY_MARKER }],
+            meta: { fallbackReason: "gateway_timeout" },
+          },
+        }),
+      ),
+    (error) => error.code === "DEMO_ACTIVATION_CANARY_EMBEDDED_FALLBACK",
+  );
+});
+
+test("canary verification fails closed on malformed or non-Gateway JSON", () => {
+  assert.throws(
+    () => verifyDemoActivationCanaryOutput("not json"),
+    (error) => error.code === "DEMO_ACTIVATION_CANARY_INVALID_JSON",
+  );
+  assert.throws(
+    () =>
+      verifyDemoActivationCanaryOutput(
+        JSON.stringify({
+          payloads: [{ text: DEMO_ACTIVATION_CANARY_MARKER }],
+          meta: { durationMs: 1 },
+        }),
+      ),
+    (error) => error.code === "DEMO_ACTIVATION_CANARY_INVALID_GATEWAY_REPLY",
+  );
+});
+
+test("canary execution verifies the reply before deleting its isolated session", async () => {
+  const calls = [];
+  const result = await runDemoActivationCanary({
+    agentId: "agent-1",
+    sessionKey: "agent:main:nora-activation-canary-test",
+    timeoutMs: 300000,
+    execute: async (command, options) => {
+      calls.push({ command, options });
+      return calls.length === 1 ? { output: gatewayReply() } : { output: "" };
+    },
+  });
+
+  assert.deepEqual(result, { status: "ready", runId: "run-canary-1", payloadCount: 1 });
+  assert.equal(calls.length, 2);
+  assert.match(calls[0].command, / agent /);
+  assert.equal(calls[0].options.timeout, 310000);
+  assert.equal(calls[0].options.maxOutputBytes, DEMO_ACTIVATION_CANARY_MAX_OUTPUT_BYTES);
+  assert.equal(calls[0].options.agentId, "agent-1");
+  assert.match(calls[1].command, /sessions cleanup/);
+  assert.equal(calls[1].options.timeout, 20000);
+});
+
+test("canary cleanup is attempted after verification failure and remains best effort", async () => {
+  const calls = [];
+  const cleanupFailures = [];
+
+  await assert.rejects(
+    runDemoActivationCanary({
+      agentId: "agent-1",
+      sessionKey: "agent:main:nora-activation-canary-test",
+      execute: async (command) => {
+        calls.push(command);
+        if (calls.length === 1) return { output: gatewayReply("missing marker") };
+        throw new Error("cleanup unavailable");
+      },
+      onCleanupFailure: async (failure) => cleanupFailures.push(failure),
+    }),
+    (error) => error.code === "DEMO_ACTIVATION_CANARY_MARKER_MISSING",
+  );
+
+  assert.equal(calls.length, 2);
+  assert.match(calls[1], /sessions cleanup/);
+  assert.equal(cleanupFailures.length, 1);
+  assert.equal(cleanupFailures[0].agentId, "agent-1");
+});
+
+test("canary wraps exec failures without exposing command output and still cleans up", async () => {
+  const calls = [];
+  await assert.rejects(
+    runDemoActivationCanary({
+      agentId: "agent-1",
+      sessionKey: "agent:main:nora-activation-canary-test",
+      execute: async (command) => {
+        calls.push(command);
+        if (calls.length === 1) throw new Error("sensitive transport output");
+        return { output: "" };
+      },
+    }),
+    (error) => {
+      assert.equal(error.code, "DEMO_ACTIVATION_CANARY_EXEC_FAILED");
+      assert.doesNotMatch(error.message, /sensitive transport output/);
+      return true;
+    },
+  );
+  assert.equal(calls.length, 2);
+});

--- a/workers/provisioner/demoActivationCanary.ts
+++ b/workers/provisioner/demoActivationCanary.ts
@@ -1,0 +1,274 @@
+// @ts-nocheck
+const crypto = require("crypto");
+const { shellSingleQuote } = require("../../agent-runtime/lib/containerCommand.ts");
+
+const DEMO_ACTIVATION_CANARY_MARKER = "NORA_ACTIVATION_READY";
+const DEMO_ACTIVATION_CANARY_PROMPT = `Activation check: reply with a message containing ${DEMO_ACTIVATION_CANARY_MARKER}.`;
+const DEFAULT_DEMO_ACTIVATION_CANARY_TIMEOUT_MS = 5 * 60 * 1000;
+const MIN_DEMO_ACTIVATION_CANARY_TIMEOUT_MS = 60 * 1000;
+const MAX_DEMO_ACTIVATION_CANARY_TIMEOUT_MS = 10 * 60 * 1000;
+const DEMO_ACTIVATION_CANARY_EXEC_GRACE_MS = 10 * 1000;
+const DEMO_ACTIVATION_CANARY_CLEANUP_TIMEOUT_MS = 15 * 1000;
+const DEMO_ACTIVATION_CANARY_MAX_OUTPUT_BYTES = 1024 * 1024;
+
+function createCanaryError(code, message, cause) {
+  const error = new Error(message);
+  error.code = code;
+  if (cause) error.cause = cause;
+  return error;
+}
+
+function resolveDemoActivationCanaryTimeoutMs(
+  rawValue = process.env.DEMO_ACTIVATION_CANARY_TIMEOUT_MS,
+) {
+  const normalized = String(rawValue ?? "").trim();
+  const parsed = /^\d+$/.test(normalized) ? Number(normalized) : NaN;
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    return DEFAULT_DEMO_ACTIVATION_CANARY_TIMEOUT_MS;
+  }
+  return Math.max(
+    MIN_DEMO_ACTIVATION_CANARY_TIMEOUT_MS,
+    Math.min(MAX_DEMO_ACTIVATION_CANARY_TIMEOUT_MS, parsed),
+  );
+}
+
+function normalizeCanaryTimeoutMs(timeoutMs) {
+  if (timeoutMs == null) return resolveDemoActivationCanaryTimeoutMs();
+  const parsed = Number(timeoutMs);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return DEFAULT_DEMO_ACTIVATION_CANARY_TIMEOUT_MS;
+  }
+  return Math.max(
+    MIN_DEMO_ACTIVATION_CANARY_TIMEOUT_MS,
+    Math.min(MAX_DEMO_ACTIVATION_CANARY_TIMEOUT_MS, Math.floor(parsed)),
+  );
+}
+
+function buildOpenClawBinResolution() {
+  return [
+    'OPENCLAW_BIN="${OPENCLAW_CLI_PATH:-/usr/local/bin/openclaw}";',
+    'if [ ! -x "$OPENCLAW_BIN" ]; then OPENCLAW_BIN="$(command -v openclaw 2>/dev/null || true)"; fi;',
+    '[ -n "$OPENCLAW_BIN" ] && [ -x "$OPENCLAW_BIN" ] || { echo "OpenClaw CLI unavailable for activation canary" >&2; exit 127; };',
+  ];
+}
+
+function assertNonMainSessionKey(sessionKey) {
+  const normalized = String(sessionKey || "").trim();
+  if (!normalized || normalized === "main" || normalized === "agent:main:main") {
+    throw new Error("Demo activation canary requires a non-main OpenClaw session key");
+  }
+  return normalized;
+}
+
+function buildDemoActivationCanaryCommand({ sessionKey, timeoutMs } = {}) {
+  const normalizedSessionKey = assertNonMainSessionKey(sessionKey);
+  const resolvedTimeoutMs = normalizeCanaryTimeoutMs(timeoutMs);
+  const commandTimeoutSeconds = Math.max(1, Math.floor(resolvedTimeoutMs / 1000));
+  // OpenClaw adds a 30-second transport allowance to --timeout. Leave another
+  // 15 seconds for JSON serialization and orderly process teardown before the
+  // outer container timeout fires.
+  const agentTimeoutSeconds = Math.max(1, Math.floor((resolvedTimeoutMs - 45_000) / 1000));
+
+  return [
+    ...buildOpenClawBinResolution(),
+    `set -- "$OPENCLAW_BIN" agent --agent ${shellSingleQuote("main")} --session-key ${shellSingleQuote(normalizedSessionKey)} --message ${shellSingleQuote(DEMO_ACTIVATION_CANARY_PROMPT)} --thinking ${shellSingleQuote("off")} --json --timeout ${shellSingleQuote(String(agentTimeoutSeconds))};`,
+    'command -v timeout >/dev/null 2>&1 || { echo "Container timeout utility unavailable for activation canary" >&2; exit 127; };',
+    `if ! CANARY_OUTPUT="$(timeout -k 5s ${commandTimeoutSeconds}s "$@" 2>/dev/null)"; then`,
+    '  echo "OpenClaw Gateway activation canary command failed" >&2;',
+    "  exit 1;",
+    "fi;",
+    'printf "%s\\n" "$CANARY_OUTPUT";',
+  ].join("\n");
+}
+
+function buildDemoActivationCanaryCleanupCommand({ sessionKey } = {}) {
+  const normalizedSessionKey = assertNonMainSessionKey(sessionKey);
+  return [
+    ...buildOpenClawBinResolution(),
+    'CANARY_SESSIONS_FILE="$(mktemp /tmp/nora-activation-canary-sessions.XXXXXX.json)";',
+    'cleanup_canary_sessions_file() { rm -f "$CANARY_SESSIONS_FILE"; };',
+    "trap cleanup_canary_sessions_file EXIT;",
+    '"$OPENCLAW_BIN" sessions --agent main --json > "$CANARY_SESSIONS_FILE";',
+    `node - "$CANARY_SESSIONS_FILE" ${shellSingleQuote(normalizedSessionKey)} <<'__NORA_REMOVE_ACTIVATION_CANARY_FILES__'`,
+    'const fs = require("fs");',
+    'const path = require("path");',
+    "const [, , file, key] = process.argv;",
+    'const data = JSON.parse(fs.readFileSync(file, "utf8"));',
+    "const entry = Array.isArray(data.sessions) ? data.sessions.find((item) => item?.key === key) : null;",
+    "if (!entry) process.exit(0);",
+    'const sessionId = String(entry.sessionId || "");',
+    "if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(sessionId)) {",
+    '  throw new Error("Invalid activation canary session id");',
+    "}",
+    'const storePath = path.resolve(String(data.path || ""));',
+    'if (path.basename(storePath) !== "sessions.json") {',
+    '  throw new Error("Invalid OpenClaw session store path");',
+    "}",
+    "const directory = path.dirname(storePath);",
+    'for (const suffix of [".jsonl", ".trajectory.jsonl", ".trajectory-path.json"]) {',
+    "  fs.rmSync(path.join(directory, `${sessionId}${suffix}`), { force: true });",
+    "}",
+    "__NORA_REMOVE_ACTIVATION_CANARY_FILES__",
+    '"$OPENCLAW_BIN" sessions cleanup --agent main --fix-missing --enforce --json >/dev/null;',
+    '"$OPENCLAW_BIN" sessions --agent main --json > "$CANARY_SESSIONS_FILE";',
+    `node - "$CANARY_SESSIONS_FILE" ${shellSingleQuote(normalizedSessionKey)} <<'__NORA_VERIFY_ACTIVATION_CANARY_REMOVED__'`,
+    'const fs = require("fs");',
+    "const [, , file, key] = process.argv;",
+    'const data = JSON.parse(fs.readFileSync(file, "utf8"));',
+    "if (Array.isArray(data.sessions) && data.sessions.some((item) => item?.key === key)) {",
+    '  throw new Error("Activation canary session cleanup did not remove the session");',
+    "}",
+    "__NORA_VERIFY_ACTIVATION_CANARY_REMOVED__",
+  ].join("\n");
+}
+
+function findExplicitEmbeddedFallback(value, seen = new Set()) {
+  if (!value || typeof value !== "object" || seen.has(value)) return null;
+  seen.add(value);
+
+  for (const [key, entry] of Object.entries(value)) {
+    const normalizedKey = key.toLowerCase();
+    if (normalizedKey === "transport" && String(entry || "").toLowerCase() === "embedded") {
+      return "transport=embedded";
+    }
+    if (
+      ["fallbackfrom", "fallbackreason", "fallbacksessionid", "fallbacksessionkey"].includes(
+        normalizedKey,
+      ) &&
+      entry != null &&
+      String(entry) !== ""
+    ) {
+      return key;
+    }
+    const nested = findExplicitEmbeddedFallback(entry, seen);
+    if (nested) return nested;
+  }
+  return null;
+}
+
+function verifyDemoActivationCanaryOutput(output) {
+  const serialized = String(output || "").trim();
+  if (!serialized) {
+    throw createCanaryError(
+      "DEMO_ACTIVATION_CANARY_EMPTY_REPLY",
+      "Demo activation Gateway canary returned no JSON reply",
+    );
+  }
+
+  let response;
+  try {
+    response = JSON.parse(serialized);
+  } catch (error) {
+    throw createCanaryError(
+      "DEMO_ACTIVATION_CANARY_INVALID_JSON",
+      "Demo activation Gateway canary returned invalid JSON",
+      error,
+    );
+  }
+
+  const fallbackMarker = findExplicitEmbeddedFallback(response);
+  if (fallbackMarker) {
+    throw createCanaryError(
+      "DEMO_ACTIVATION_CANARY_EMBEDDED_FALLBACK",
+      "Demo activation canary used OpenClaw embedded fallback instead of the Gateway",
+    );
+  }
+
+  if (
+    response?.status !== "ok" ||
+    typeof response?.runId !== "string" ||
+    !response.runId.trim() ||
+    !response?.result ||
+    typeof response.result !== "object" ||
+    !Array.isArray(response.result.payloads)
+  ) {
+    throw createCanaryError(
+      "DEMO_ACTIVATION_CANARY_INVALID_GATEWAY_REPLY",
+      "Demo activation canary did not return a completed OpenClaw Gateway result",
+    );
+  }
+
+  const replyTexts = response.result.payloads
+    .map((payload) => (typeof payload?.text === "string" ? payload.text : ""))
+    .filter(Boolean);
+  if (!replyTexts.some((text) => text.includes(DEMO_ACTIVATION_CANARY_MARKER))) {
+    throw createCanaryError(
+      "DEMO_ACTIVATION_CANARY_MARKER_MISSING",
+      `Demo activation Gateway reply did not contain ${DEMO_ACTIVATION_CANARY_MARKER}`,
+    );
+  }
+
+  return {
+    status: "ready",
+    runId: response.runId,
+    payloadCount: replyTexts.length,
+  };
+}
+
+function createDemoActivationCanarySessionKey() {
+  return `agent:main:nora-activation-canary-${crypto.randomUUID()}`;
+}
+
+async function runDemoActivationCanary({
+  execute,
+  agentId,
+  timeoutMs,
+  sessionKey = createDemoActivationCanarySessionKey(),
+  onCleanupFailure,
+} = {}) {
+  if (typeof execute !== "function") {
+    throw new Error("execute is required");
+  }
+  const normalizedSessionKey = assertNonMainSessionKey(sessionKey);
+  const resolvedTimeoutMs = normalizeCanaryTimeoutMs(timeoutMs);
+
+  try {
+    let result;
+    try {
+      result = await execute(
+        buildDemoActivationCanaryCommand({
+          sessionKey: normalizedSessionKey,
+          timeoutMs: resolvedTimeoutMs,
+        }),
+        {
+          timeout: resolvedTimeoutMs + DEMO_ACTIVATION_CANARY_EXEC_GRACE_MS,
+          maxOutputBytes: DEMO_ACTIVATION_CANARY_MAX_OUTPUT_BYTES,
+          agentId,
+        },
+      );
+    } catch (error) {
+      throw createCanaryError(
+        "DEMO_ACTIVATION_CANARY_EXEC_FAILED",
+        "Demo activation Gateway canary command did not complete successfully",
+        error,
+      );
+    }
+    return verifyDemoActivationCanaryOutput(result?.output);
+  } finally {
+    try {
+      await execute(buildDemoActivationCanaryCleanupCommand({ sessionKey: normalizedSessionKey }), {
+        timeout: DEMO_ACTIVATION_CANARY_CLEANUP_TIMEOUT_MS + 5000,
+        maxOutputBytes: 8192,
+        agentId,
+      });
+    } catch (error) {
+      try {
+        await onCleanupFailure?.({ agentId, sessionKey: normalizedSessionKey, error });
+      } catch {
+        // Cleanup and its observer are deliberately best effort.
+      }
+    }
+  }
+}
+
+module.exports = {
+  DEFAULT_DEMO_ACTIVATION_CANARY_TIMEOUT_MS,
+  DEMO_ACTIVATION_CANARY_MAX_OUTPUT_BYTES,
+  DEMO_ACTIVATION_CANARY_MARKER,
+  buildDemoActivationCanaryCleanupCommand,
+  buildDemoActivationCanaryCommand,
+  createDemoActivationCanarySessionKey,
+  resolveDemoActivationCanaryTimeoutMs,
+  runDemoActivationCanary,
+  verifyDemoActivationCanaryOutput,
+};

--- a/workers/provisioner/deploymentLifecycle.test.js
+++ b/workers/provisioner/deploymentLifecycle.test.js
@@ -382,6 +382,9 @@ test("provider finalization retries drift and commits only while mutation state 
         providerFingerprint: reconcilePass === 1 ? "provider-v1" : "provider-v2",
       };
     },
+    verify: async ({ pass, providerFingerprint }) => {
+      order.push(`canary:${pass}:${providerFingerprint}`);
+    },
     readFingerprint: async () => {
       const fingerprint = fingerprints.shift();
       order.push(`verify:${fingerprint}`);
@@ -405,15 +408,50 @@ test("provider finalization retries drift and commits only while mutation state 
   assert.equal(result.finalization.finalized, true);
   assert.deepEqual(order, [
     "reconcile:provider-v1",
+    "canary:1:provider-v1",
     "lock",
     "verify:provider-v2",
     "unlock",
     "reconcile:provider-v1",
+    "canary:2:provider-v2",
     "lock",
     "verify:provider-v2",
     "finalize",
     "unlock",
   ]);
+});
+
+test("provider verification failure prevents mutation locking and finalization", async () => {
+  const order = [];
+
+  await assert.rejects(
+    reconcileProviderStateUntilStable({
+      bootstrappedFingerprint: "provider-v1",
+      reconcile: async () => {
+        order.push("reconcile");
+        return { status: "skipped", providerFingerprint: "provider-v1" };
+      },
+      verify: async () => {
+        order.push("canary");
+        throw new Error("activation reply missing");
+      },
+      readFingerprint: async () => {
+        order.push("fingerprint");
+        return "provider-v1";
+      },
+      withMutationLock: async (operation) => {
+        order.push("lock");
+        return operation();
+      },
+      finalize: async () => {
+        order.push("finalize");
+        return { finalized: true };
+      },
+    }),
+    /activation reply missing/,
+  );
+
+  assert.deepEqual(order, ["reconcile", "canary"]);
 });
 
 test("provider finalization fails closed when mutations never settle", async () => {

--- a/workers/provisioner/deploymentLifecycle.ts
+++ b/workers/provisioner/deploymentLifecycle.ts
@@ -315,6 +315,7 @@ async function runProvisioningReadinessBarrier({
 async function reconcileProviderStateUntilStable({
   bootstrappedFingerprint,
   reconcile,
+  verify,
   readFingerprint,
   withMutationLock,
   finalize,
@@ -322,6 +323,9 @@ async function reconcileProviderStateUntilStable({
 } = {}) {
   if (typeof reconcile !== "function") {
     throw new Error("reconcile is required");
+  }
+  if (verify != null && typeof verify !== "function") {
+    throw new Error("verify must be a function");
   }
   if (typeof readFingerprint !== "function") {
     throw new Error("readFingerprint is required");
@@ -346,6 +350,14 @@ async function reconcileProviderStateUntilStable({
       throw new Error("provider reconciliation did not return a provider fingerprint");
     }
     appliedFingerprint = reconciledFingerprint;
+
+    if (typeof verify === "function") {
+      await verify({
+        pass,
+        providerFingerprint: appliedFingerprint,
+        reconciliation,
+      });
+    }
 
     const verification = await withMutationLock(async () => {
       const currentFingerprint = await readFingerprint();

--- a/workers/provisioner/nemoclawImage.test.js
+++ b/workers/provisioner/nemoclawImage.test.js
@@ -1,0 +1,103 @@
+const assert = require("node:assert/strict");
+const { PassThrough } = require("node:stream");
+const test = require("node:test");
+const Docker = require("dockerode");
+
+const { demuxDockerExecStream } = require("./backends/dockerExecStream.ts");
+const {
+  ensureNemoClawImage,
+  isMutableNemoClawImageReference,
+} = require("./backends/nemoclawImage.ts");
+
+test("NemoClaw image references distinguish mutable tags from immutable releases", () => {
+  assert.equal(
+    isMutableNemoClawImageReference("ghcr.io/solomon2773/nora-nemoclaw-agent:latest"),
+    true,
+  );
+  assert.equal(isMutableNemoClawImageReference("ghcr.io/solomon2773/nora-nemoclaw-agent"), true);
+  assert.equal(isMutableNemoClawImageReference("nora-nemoclaw-agent:local"), false);
+  assert.equal(
+    isMutableNemoClawImageReference("ghcr.io/solomon2773/nora-nemoclaw-agent:v1.16.3"),
+    false,
+  );
+  assert.equal(
+    isMutableNemoClawImageReference("ghcr.io/solomon2773/nora-nemoclaw-agent:latest@sha256:abc123"),
+    false,
+  );
+});
+
+test("NemoClaw refreshes a cached mutable image once per adapter", async () => {
+  let inspectCalls = 0;
+  let pullCalls = 0;
+  const state = { pending: null, refreshed: false };
+  const docker = {
+    getImage: () => ({
+      inspect: async () => {
+        inspectCalls += 1;
+        return { Id: "cached-image" };
+      },
+    }),
+    pull: (_image, callback) => {
+      pullCalls += 1;
+      callback(null, {});
+    },
+    modem: {
+      followProgress: (_stream, callback) => callback(null),
+    },
+  };
+
+  const ensure = () =>
+    ensureNemoClawImage({
+      docker,
+      image: "ghcr.io/solomon2773/nora-nemoclaw-agent:latest",
+      state,
+    });
+  await Promise.all([ensure(), ensure()]);
+  await ensure();
+
+  assert.equal(inspectCalls, 2);
+  assert.equal(pullCalls, 1);
+});
+
+test("NemoClaw retries a failed mutable image refresh", async () => {
+  let pullCalls = 0;
+  const state = { pending: null, refreshed: false };
+  const docker = {
+    getImage: () => ({ inspect: async () => ({ Id: "cached-image" }) }),
+    pull: (_image, callback) => {
+      pullCalls += 1;
+      if (pullCalls === 1) return callback(new Error("registry unavailable"));
+      callback(null, {});
+    },
+    modem: {
+      followProgress: (_stream, callback) => callback(null),
+    },
+  };
+
+  const ensure = () =>
+    ensureNemoClawImage({
+      docker,
+      image: "ghcr.io/solomon2773/nora-nemoclaw-agent:latest",
+      state,
+    });
+  await assert.rejects(ensure(), /registry unavailable/);
+  await ensure();
+
+  assert.equal(pullCalls, 2);
+});
+
+test("NemoClaw demuxes non-TTY Docker exec output", async () => {
+  const rawStream = new PassThrough();
+  const payload = Buffer.from(`${'{"status":"ok"}'.padEnd(67, " ")}\n`);
+  const frame = Buffer.alloc(8 + payload.length);
+  frame[0] = 1;
+  frame.writeUInt32BE(payload.length, 4);
+  payload.copy(frame, 8);
+  const docker = new Docker({ socketPath: "/var/run/docker.sock" });
+  const stream = demuxDockerExecStream(docker, rawStream);
+  setImmediate(() => rawStream.end(frame));
+  const chunks = [];
+  for await (const chunk of stream) chunks.push(chunk);
+
+  assert.equal(Buffer.concat(chunks).toString("utf8"), payload.toString("utf8"));
+});

--- a/workers/provisioner/worker.ts
+++ b/workers/provisioner/worker.ts
@@ -79,6 +79,7 @@ const {
 } = require("../../agent-runtime/lib/hermesRuntimeBootstrap");
 const { waitForAgentReadiness } = require("./healthChecks");
 const { buildReadinessWarningDetail, persistReadinessWarning } = require("./readinessWarning");
+const { runDemoActivationCanary } = require("./demoActivationCanary");
 const {
   acquireDedicatedSessionLock,
   finalizeProvisionedDeployment,
@@ -3185,6 +3186,23 @@ const worker = new Worker(
                       gatewayToken,
                       bootstrappedProviderFingerprint: appliedFingerprint,
                     }),
+                  verify: builtInDemoActivation
+                    ? async () => {
+                        await runDemoActivationCanary({
+                          agentId: id,
+                          execute: (command, options) =>
+                            runProvisionerExecCommand(provisioner, containerId, command, options),
+                          onCleanupFailure: ({ error }) => {
+                            console.warn(
+                              `[provisioner] Demo activation canary session cleanup failed for agent ${id}: ${error?.message || "unknown error"}`,
+                            );
+                          },
+                        });
+                        console.log(
+                          `[provisioner] Demo activation Gateway canary passed for agent ${id}`,
+                        );
+                      }
+                    : null,
                   readFingerprint: async () =>
                     (await fetchEffectiveProviderState(userId, llmProviderId)).fingerprint,
                   withMutationLock: (operation) => withProviderMutationLock(userId, operation),


### PR DESCRIPTION
## Summary

- require built-in demo activation to complete a real isolated OpenClaw Gateway turn before publishing `running`
- make streaming chat fail closed on invalid acknowledgements, runless/mismatched pooled events, terminal errors, and timeouts while supporting current `deltaText` payloads and ref-counted session subscriptions
- pin Nora's validated OpenClaw package to `2026.6.11` across Docker, Kubernetes, NemoClaw, and Proxmox, including setup/deploy/upgrade image preparation
- demultiplex non-TTY Docker and Remote Docker exec streams before command parsing
- normalize exact `/admin` to `/admin/` for Cloudflare Access compatibility
- prepare Nora `v1.16.3`, Gemini `1.16.3`, and Helm `0.7.3` release metadata

## Scope and risk

- Affected subsystems: backend Gateway proxy, demo activation lifecycle, shared runtime bootstrap, Docker/Remote Docker/NemoClaw/Proxmox adapters, setup/update scripts, production deployment, nginx, Helm, and public docs
- Security: streaming events require the acknowledged run id; inherited vulnerable NemoClaw OpenClaw globals are removed before installing the validated pin; immutable/custom image references remain operator-controlled
- Compatibility: session subscription RPCs remain best-effort for older supported gateways; Proxmox stays Experimental and NemoClaw on Proxmox stays blocked
- Rollback: revert this commit and redeploy; existing provisioned agent instances are intentionally preserved

## Validation

- `/root/.codex/skills/nora-ci-checks/scripts/run-nora-ci-checks.sh --repo /home/projects/nora`
  - 1,630 backend tests passed; 1 environment-dependent test skipped
  - 26 agent-runtime tests passed
  - 23 infrastructure checks passed/skipped as expected (21 passed, 2 PowerShell-only checks skipped because `pwsh` is unavailable)
  - all package lint, formatting, typechecks, secret scans, dependency audits, license checks, Helm/kubeconform validation, production Docker builds, and compose-backed Playwright passed
  - Playwright: 30 passed, 65 private real-credential tests skipped as designed
- clean no-cache `nora-nemoclaw-agent:local` build completed in 306 seconds
  - `OpenClaw 2026.6.11 (e085fa1)`
  - package version `2026.6.11`, tsx `4.21.0`, no retired legacy package directories
- focused Gateway suite: 31/31 passed
- focused activation proof: fresh zero-key activation, Gateway canary, first chat, deletion, and cleanup passed locally

## Proof

- Before: fresh demo activation could publish `running` before the first Gateway model turn and streaming chat could end with an empty success-looking response.
- After: activation waits for `NORA_ACTIVATION_READY`; first chat streams a real reply, invalid/runless pooled events are dropped, and terminal failures/timeouts are explicit.
- Remote Docker documentation was verified present in Mintlify navigation and live at HTTP 200; no duplicate page was added.

## Checklist

- [x] This PR is focused and does not include unrelated refactors.
- [x] Tests or checks cover the changed behavior, or the reason they do not is documented above.
- [x] Public docs were updated if setup, APIs, architecture, deployment, or user-visible behavior changed.
- [x] No secrets, credentials, private data, or unsafe example values are included.
