### PR TITLE
fix: Hermes Docker deploy fails after readiness probe times out (#297)

### DIFF
--- a/backend-api/__tests__/provisioning.test.ts
+++ b/backend-api/__tests__/provisioning.test.ts
@@ -1827,20 +1827,28 @@ describe("Hermes dashboard provisioning", () => {
     expect(config.Env).toEqual(
       expect.arrayContaining(["GATEWAY_HEALTH_URL=http://127.0.0.1:8642"]),
     );
+    // Bug #2 (#297): the gateway API key must be baked into the container env so
+    // the s6-supervised gateway (which reads /run/s6/container_environment, not
+    // the sourced managed-env file) inherits it on every boot, including
+    // auth-reconcile restarts. It must match the token returned to the control plane.
+    const apiServerKeyEnv = config.Env.find((entry) => entry.startsWith("API_SERVER_KEY="));
+    expect(apiServerKeyEnv).toBe(`API_SERVER_KEY=${result.gatewayToken}`);
     expect(config.Entrypoint).toBeUndefined();
     expect(config.Cmd).toEqual([
       "bash",
       "-lc",
       expect.stringContaining('HERMES_BIN="/opt/hermes/.venv/bin/hermes"'),
     ]);
-    expect(config.Cmd[2]).toContain("exec /init bash -lc");
+    // Bug #1 (#297): the CMD must NOT re-exec /init. The image's PID-1 /init
+    // (s6-overlay) supervises this command directly; a nested /init fatals with
+    // "s6-overlay-suexec: can only run as pid 1" and exits before port 8642 binds.
+    expect(config.Cmd[2]).not.toContain("/init");
     expect(config.Cmd[2]).toContain(
       'nohup "$HERMES_BIN" dashboard --host 0.0.0.0 --insecure --no-open',
     );
     expect(config.Cmd[2]).toContain(">> /opt/data/hermes-dashboard.log 2>&1");
     expect(config.Cmd[2]).not.toContain("/proc/1/fd");
     expect(config.Cmd[2]).toContain('exec "$HERMES_BIN" gateway run');
-    expect(config.Cmd[2].match(/\/init/g)).toHaveLength(1);
     expect(config.Cmd.join(" ")).not.toContain("/opt/hermes/docker/entrypoint.sh");
     expect(config.ExposedPorts).toEqual({
       "8642/tcp": {},

--- a/workers/provisioner/backends/hermes.ts
+++ b/workers/provisioner/backends/hermes.ts
@@ -11,7 +11,6 @@ const { getHermesDockerAgentImage } = require("../../../agent-runtime/lib/agentI
 const { HERMES_DASHBOARD_PORT } = require("../../../agent-runtime/lib/contracts");
 const {
   buildContainerBootstrap,
-  shellSingleQuote,
 } = require("../../../agent-runtime/lib/containerCommand");
 const {
   buildHermesRuntimeConfigBootstrapCommand,
@@ -21,7 +20,6 @@ const HERMES_RUNTIME_PORT = 8642;
 const HERMES_HOME = "/opt/data";
 const HERMES_WORKSPACE = `${HERMES_HOME}/workspace`;
 const HERMES_DASHBOARD_LOG = `${HERMES_HOME}/hermes-dashboard.log`;
-const HERMES_ENTRYPOINT = "/init";
 const HERMES_BIN = "/opt/hermes/.venv/bin/hermes";
 const DEFAULT_AGENT_PIDS_LIMIT = 512;
 // The official Hermes image starts s6 as root, repairs mounted-state
@@ -48,7 +46,13 @@ function isMutableImageReference(imgName) {
 }
 
 function buildHermesStartCommand() {
-  const hermesRuntimeCommand = [
+  // This runs as the container CMD, supervised directly by the image's PID-1
+  // /init (s6-overlay). Do NOT re-exec /init here: a second s6 init launched as
+  // a non-PID-1 child fatals with "s6-overlay-suexec: can only run as pid 1"
+  // and exits the container within seconds, before the gateway can bind
+  // port 8642 for the readiness probe (#297). Returning the runtime command
+  // directly lets the image's PID-1 /init supervise it naturally.
+  return [
     "set -eu",
     "if [ -r /opt/nora-managed-env/apply.sh ]; then . /opt/nora-managed-env/apply.sh; fi",
     buildHermesRuntimeConfigBootstrapCommand(),
@@ -56,13 +60,6 @@ function buildHermesStartCommand() {
     '[ -x "$HERMES_BIN" ] || HERMES_BIN="$(command -v hermes)"',
     `nohup "$HERMES_BIN" dashboard --host 0.0.0.0 --insecure --no-open >> ${HERMES_DASHBOARD_LOG} 2>&1 &`,
     'exec "$HERMES_BIN" gateway run',
-  ].join("\n");
-
-  return [
-    "set -eu",
-    // Bootstrap the mounted Hermes home once, then fork dashboard and gateway
-    // from that initialized session so first-run file seeding cannot race.
-    `exec ${HERMES_ENTRYPOINT} bash -lc ${shellSingleQuote(hermesRuntimeCommand)}`,
   ].join("\n");
 }
 
@@ -213,6 +210,12 @@ class HermesBackend extends DockerBackend {
       API_SERVER_ENABLED: "true",
       API_SERVER_HOST: "0.0.0.0",
       API_SERVER_PORT: String(HERMES_RUNTIME_PORT),
+      // Bake the gateway API key into the container environment so the
+      // s6-supervised gateway service — which reads /run/s6/container_environment,
+      // not the sourced managed-env file — inherits it on every boot, including
+      // auth-reconcile restarts. Without this the gateway refuses to start with
+      // "Refusing to start: API_SERVER_KEY is required" (#297).
+      API_SERVER_KEY: apiServerKey,
       GATEWAY_HEALTH_URL: `http://127.0.0.1:${HERMES_RUNTIME_PORT}`,
       MESSAGING_CWD: HERMES_WORKSPACE,
       TERMINAL_CWD: HERMES_WORKSPACE,


### PR DESCRIPTION
Fixes #297.

Two bugs caused Hermes agent deploys on the Docker backend to time out on the `/health` readiness probe and land in the DLQ after 5 retries.

## Bug #1 — nested `/init`
`buildHermesStartCommand()` wrapped the runtime command with `exec /init …`, but the image ENTRYPOINT is already `/init` (s6-overlay, PID 1) supervising the container CMD. The nested `/init` ran as a non-PID-1 child and fataled with `s6-overlay-suexec: fatal: can only run as pid 1`, exiting the container within ~3s before port 8642 could bind.

**Fix:** return the runtime command directly so the image's PID-1 `/init` supervises it. Removes the now-unused `HERMES_ENTRYPOINT` constant and `shellSingleQuote` import.

## Bug #2 — `API_SERVER_KEY` delivery
`API_SERVER_KEY` was only written to the sourced managed-env file (`/opt/nora-managed-env/apply.sh`), but the s6-supervised gateway reads `/run/s6/container_environment`, so it refused to start on supervised/auth-reconcile restarts with `Refusing to start: API_SERVER_KEY is required`.

**Fix:** bake `API_SERVER_KEY` into the container `Env` array alongside the other `API_SERVER_*` variables so the gateway inherits it on every boot.

## Scope & tests
- Change is confined to `workers/provisioner/backends/hermes.ts` (the Docker Hermes backend); `RemoteHermesBackend` inherits both fixes via `super.create()`.
- `backend-api/__tests__/provisioning.test.ts` updated to assert the corrected behavior: the CMD contains no nested `/init`, and `Env` carries `API_SERVER_KEY` matching the returned gateway token.
- Related suites pass locally (`provisioning`, `remoteHermes`, `hermesUi`): 74 passed.

## Note (not included here)
The Kubernetes Hermes backend (`workers/provisioner/backends/k8s.ts`) has the same nested-`/init` pattern and is likely affected by Bug #1 as well; it already delivers `API_SERVER_KEY` via its pod env (so Bug #2 does not apply there). Left out of this PR to keep it scoped to the Docker issue reported in #297.
