### PR TITLE
fix(worker): resolve backend adapters from /app/backends in prod image

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,7 @@ Two consequences that routinely confuse agents:
 
 - **The mount shadows the host `backend-api/backends/` directory at runtime.** Inside the backend-api container, `/app/backends/*` resolves to the worker's copy, _not_ the host files under `backend-api/backends/`. A change to a host file that the mount shadows has **no runtime effect** in the container.
 - **`backend-api/backends/hermes.ts` and `nemoclaw.ts` are re-export shims** (`module.exports = require("../../workers/provisioner/backends/<name>")`) — edit the worker source, never the shim. The one genuinely backend-owned file there is `telemetry.ts` (backend telemetry normalization), which is distinct from the worker's `telemetry.ts`.
+- **`containerManager.resolveBackendPath` loads adapters from `/app/backends` first.** That directory holds the worker's real adapters in every layout (backend-api prod `COPY`, worker-provisioner prod image, and the dev bind mount), so lifecycle/destroy calls resolve correctly even in the worker-provisioner prod image, where `containerManager` runs from `/backend-api` and the shims' `../../workers/...` path is dead (there is no `/workers` dir). Don't reintroduce reliance on the shim path for prod resolution.
 
 Treat `workers/provisioner/backends/` and `agent-runtime/` as **shared-blast-radius zones**: an edit there changes both backend-api and the worker, so verify both consumers.
 

--- a/backend-api/__tests__/backendPathResolution.test.ts
+++ b/backend-api/__tests__/backendPathResolution.test.ts
@@ -1,0 +1,103 @@
+// @ts-nocheck
+// Regression coverage for the production-only backend module-resolution bug:
+// in the worker-provisioner prod image, containerManager runs from /backend-api
+// while the worker's real adapters live at /app/backends and there is no
+// /workers directory. The resolver must find the real adapter at /app/backends
+// instead of returning the re-export shim (whose ../../workers/... path is dead
+// there) or the dead /workers fallback. See resolveBackendPath in containerManager.
+
+const { resolveBackendPath, backendPathCandidates } = require("../containerManager");
+
+// Build a fake require.resolve that "resolves" only the paths present in the
+// given set and throws MODULE_NOT_FOUND for everything else, mirroring a
+// specific on-disk container layout.
+function fakeResolver(existingPaths) {
+  const set = new Set(existingPaths);
+  return (p) => {
+    if (set.has(p)) return p;
+    const err = new Error(`Cannot find module '${p}'`);
+    err.code = "MODULE_NOT_FOUND";
+    throw err;
+  };
+}
+
+describe("backendPathCandidates", () => {
+  it("tries the canonical /app/backends location first", () => {
+    const candidates = backendPathCandidates("hermes", {
+      appBackendsDir: "/app/backends",
+      dirname: "/backend-api",
+    });
+    expect(candidates[0]).toBe("/app/backends/hermes");
+    // The dead worker-relative path must not be the only fallback.
+    expect(candidates).toContain("/backend-api/backends/hermes");
+  });
+});
+
+describe("resolveBackendPath — worker-provisioner prod image layout", () => {
+  // Worker image: containerManager at /backend-api, real adapters at /app/backends,
+  // the re-export shim present at /backend-api/backends/{hermes,nemoclaw}, no /workers.
+  const dirname = "/backend-api";
+  const appBackendsDir = "/app/backends";
+
+  it("resolves a shimmed backend (hermes) to the real /app/backends adapter, not the shim", () => {
+    const resolve = fakeResolver([
+      "/app/backends/hermes", // real worker adapter (COPY workers/provisioner/ -> /app)
+      "/backend-api/backends/hermes", // the re-export shim (its ../../workers path is dead)
+    ]);
+    expect(resolveBackendPath("hermes", { resolve, dirname, appBackendsDir })).toBe(
+      "/app/backends/hermes",
+    );
+  });
+
+  it("resolves a shimmed backend (nemoclaw) to the real /app/backends adapter", () => {
+    const resolve = fakeResolver([
+      "/app/backends/nemoclaw",
+      "/backend-api/backends/nemoclaw",
+    ]);
+    expect(resolveBackendPath("nemoclaw", { resolve, dirname, appBackendsDir })).toBe(
+      "/app/backends/nemoclaw",
+    );
+  });
+
+  it("resolves a non-shim backend (docker) to /app/backends when no /workers dir exists", () => {
+    // Only the real adapter exists; /backend-api/backends/docker and
+    // /workers/provisioner/backends/docker are both absent in this image.
+    const resolve = fakeResolver(["/app/backends/docker"]);
+    expect(resolveBackendPath("docker", { resolve, dirname, appBackendsDir })).toBe(
+      "/app/backends/docker",
+    );
+  });
+});
+
+describe("resolveBackendPath — backend-api image + dev layouts (no regression)", () => {
+  it("resolves to /app/backends when containerManager runs from /app", () => {
+    const resolve = fakeResolver(["/app/backends/hermes"]);
+    expect(
+      resolveBackendPath("hermes", { resolve, dirname: "/app", appBackendsDir: "/app/backends" }),
+    ).toBe("/app/backends/hermes");
+  });
+
+  it("falls back to the dev sibling path when /app/backends is absent", () => {
+    // Local dev / running tests off a checkout: no /app dir; the worker-sibling
+    // copy is what exists.
+    const resolve = fakeResolver(["/repo/workers/provisioner/backends/docker"]);
+    expect(
+      resolveBackendPath("docker", {
+        resolve,
+        dirname: "/repo/backend-api",
+        appBackendsDir: "/app/backends",
+      }),
+    ).toBe("/repo/workers/provisioner/backends/docker");
+  });
+
+  it("returns the dev-sibling path as a last resort so failures name a real path", () => {
+    const resolve = fakeResolver([]); // nothing resolves
+    expect(
+      resolveBackendPath("docker", {
+        resolve,
+        dirname: "/repo/backend-api",
+        appBackendsDir: "/app/backends",
+      }),
+    ).toBe("/repo/workers/provisioner/backends/docker");
+  });
+});

--- a/backend-api/__tests__/backendPathResolution.test.ts
+++ b/backend-api/__tests__/backendPathResolution.test.ts
@@ -50,10 +50,7 @@ describe("resolveBackendPath — worker-provisioner prod image layout", () => {
   });
 
   it("resolves a shimmed backend (nemoclaw) to the real /app/backends adapter", () => {
-    const resolve = fakeResolver([
-      "/app/backends/nemoclaw",
-      "/backend-api/backends/nemoclaw",
-    ]);
+    const resolve = fakeResolver(["/app/backends/nemoclaw", "/backend-api/backends/nemoclaw"]);
     expect(resolveBackendPath("nemoclaw", { resolve, dirname, appBackendsDir })).toBe(
       "/app/backends/nemoclaw",
     );

--- a/backend-api/containerManager.ts
+++ b/backend-api/containerManager.ts
@@ -203,7 +203,10 @@ const APP_BACKENDS_DIR = "/app/backends";
  * /workers/provisioner/backends path. Trying /app/backends first loads the real
  * adapter directly and never touches the shims.
  */
-function backendPathCandidates(name, { appBackendsDir = APP_BACKENDS_DIR, dirname = __dirname } = {}) {
+function backendPathCandidates(
+  name,
+  { appBackendsDir = APP_BACKENDS_DIR, dirname = __dirname } = {},
+) {
   return [
     path.join(appBackendsDir, name),
     path.resolve(dirname, "backends", name),

--- a/backend-api/containerManager.ts
+++ b/backend-api/containerManager.ts
@@ -184,20 +184,56 @@ function isIgnorableStopError(error) {
   return /already stopped|not running/i.test(String(error?.message || ""));
 }
 
+// Canonical in-container location of the worker's real backend adapters. They
+// live here in EVERY layout: the backend-api prod image COPYs them to
+// /app/backends, the worker-provisioner prod image has the worker itself at
+// /app (so /app/backends is the worker's own backends), and dev compose bind-
+// mounts ./workers/provisioner/backends to /app/backends in both services.
+const APP_BACKENDS_DIR = "/app/backends";
+
 /**
- * Resolve the path to a backend module.
- * In Docker: backends are mounted at /app/backends/ via docker-compose.
- * In dev/local: fall back to ../workers/provisioner/backends/ relative path.
+ * Ordered candidate paths for a backend adapter module, most-canonical first.
+ *
+ * /app/backends is tried FIRST because it always points at the worker's real
+ * adapters (see APP_BACKENDS_DIR). This is essential in the worker-provisioner
+ * prod image, where containerManager runs from /backend-api: there the
+ * __dirname-relative candidates resolve either to the re-export shims
+ * (backend-api/backends/{hermes,nemoclaw}, whose ../../workers/... require is
+ * dead — there is no /workers dir in that image) or to a nonexistent
+ * /workers/provisioner/backends path. Trying /app/backends first loads the real
+ * adapter directly and never touches the shims.
  */
-function resolveBackendPath(name) {
-  const localPath = path.resolve(__dirname, "backends", name);
-  const workerPath = path.resolve(__dirname, "../workers/provisioner/backends", name);
-  try {
-    require.resolve(localPath);
-    return localPath;
-  } catch {
-    return workerPath;
+function backendPathCandidates(name, { appBackendsDir = APP_BACKENDS_DIR, dirname = __dirname } = {}) {
+  return [
+    path.join(appBackendsDir, name),
+    path.resolve(dirname, "backends", name),
+    path.resolve(dirname, "../workers/provisioner/backends", name),
+  ];
+}
+
+/**
+ * Resolve the path to a backend module across the backend-api image, the
+ * worker-provisioner image, and dev bind-mount layouts. Returns the first
+ * candidate that resolves; if none do, returns the dev-sibling path so a
+ * downstream require failure names a real, meaningful location.
+ *
+ * @param {string} name Backend adapter name (e.g. "docker", "hermes").
+ * @param {Object} [opts]
+ * @param {(p: string) => string} [opts.resolve] Resolver (injectable for tests).
+ * @param {string} [opts.appBackendsDir] Override the canonical /app/backends dir.
+ * @param {string} [opts.dirname] Override __dirname (for tests).
+ */
+function resolveBackendPath(name, { resolve = require.resolve, appBackendsDir, dirname } = {}) {
+  const candidates = backendPathCandidates(name, { appBackendsDir, dirname });
+  for (const candidate of candidates) {
+    try {
+      resolve(candidate);
+      return candidate;
+    } catch {
+      // Try the next candidate layout.
+    }
   }
+  return candidates[candidates.length - 1];
 }
 
 /**
@@ -357,6 +393,9 @@ async function backendForCleanup(agent) {
 module.exports = {
   NoContainerError,
   ensureContainerId,
+  // Exported for layout-resolution regression tests (backendPathResolution.test.ts).
+  resolveBackendPath,
+  backendPathCandidates,
 
   /**
    * Start an agent's runtime through its backend adapter.


### PR DESCRIPTION
> **Draft.** Pre-existing production-only bug — independent of the Hermes external-connect feature PR. Cherry-picked cleanly onto `master`.

## Bug

Redeploying (or destroying) an agent on the `docker` deploy target fails in the **worker-provisioner prod image** with:

```
Cannot find module '../../workers/provisioner/backends/hermes'
Require stack:
- /backend-api/backends/hermes.ts
- /backend-api/containerManager.ts
- /backend-api/agentMigrations.ts
- /app/worker.ts
```

Fresh creation works (it uses the worker's own `./backends`); only the redeploy/destroy path — which routes through backend-api's `containerManager` — breaks.

## Root cause

`containerManager.resolveBackendPath` runs from `/backend-api` in the worker-provisioner prod image and resolves the re-export **shims** at `/backend-api/backends/{hermes,nemoclaw}`, whose `../../workers/...` require is dead there (the image has no `/workers` dir), and its fallback `/workers/provisioner/backends/...` is dead too. Neither reaches the worker's real adapters at `/app/backends`. This affects **all** Docker backends on the destroy path — Hermes just surfaces first via the shim.

Verified by reproducing the exact `MODULE_NOT_FOUND` inside the built prod image.

## Fix

`resolveBackendPath` now tries **`/app/backends/<name>` first** — the one location holding the worker's real adapters in every layout (backend-api prod `COPY`, the worker-provisioner prod image, and the dev bind mount). Resolution no longer touches the brittle shims. The resolver is made injectable and a candidate-list helper is extracted, both exported for tests.

- No Dockerfile/image-layout change; no shim change.
- No-op (identical result) in the backend-api image and dev, where it already worked.

## Testing

- New `backendPathResolution.test.ts` (7 cases) simulating the worker-prod, backend-api, and dev layouts — all green.
- Reproduced-then-fixed inside the actual worker-provisioner prod image: `resolveBackendPath` now returns `/app/backends/{hermes,nemoclaw,docker}` and each requires successfully.
- Full backend-api suite otherwise unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
