### PR TITLE
feat(hermes): surface dashboard login credentials on the Connect card (stacked on #305 + #300)

### DIFF
--- a/backend-api/__tests__/agents.test.ts
+++ b/backend-api/__tests__/agents.test.ts
@@ -5,6 +5,10 @@
 const request = require("supertest");
 const jwt = require("jsonwebtoken");
 const { getDefaultAgentImage } = require("../../agent-runtime/lib/agentImages");
+const { deriveHermesDashboardBasicAuth } = require("../../agent-runtime/lib/hermesDashboardAuth");
+// The connect block derives dashboard basic-auth from the API key (seed).
+const HERMES_CONNECT_TOKEN = "hermes-token";
+const HERMES_CONNECT_DASHBOARD = deriveHermesDashboardBasicAuth(HERMES_CONNECT_TOKEN);
 
 const JWT_SECRET = process.env.JWT_SECRET || "secret";
 process.env.JWT_SECRET = JWT_SECRET;
@@ -1160,6 +1164,8 @@ describe("Hermes WebUI routes", () => {
       runtimeApiUrl: "http://100.71.115.105:19500",
       dashboardUrl: "http://100.71.115.105:19044",
       apiKey: "hermes-token",
+      dashboardUsername: "nora",
+      dashboardPassword: HERMES_CONNECT_DASHBOARD.password,
     });
   });
 
@@ -1316,6 +1322,8 @@ describe("Hermes WebUI routes", () => {
       runtimeApiUrl: "http://100.71.115.105:19500",
       dashboardUrl: "http://100.71.115.105:19044",
       apiKey: "hermes-token",
+      dashboardUsername: "nora",
+      dashboardPassword: HERMES_CONNECT_DASHBOARD.password,
     });
   });
 
@@ -1378,6 +1386,8 @@ describe("Hermes WebUI routes", () => {
       runtimeApiUrl: "http://nora.internal.example:19500",
       dashboardUrl: "http://nora.internal.example:19044",
       apiKey: "hermes-token",
+      dashboardUsername: "nora",
+      dashboardPassword: HERMES_CONNECT_DASHBOARD.password,
     });
   });
 

--- a/backend-api/routes/agents.ts
+++ b/backend-api/routes/agents.ts
@@ -687,11 +687,18 @@ async function resolveHermesConnectInfo(agent, req) {
     ? formatHostForUrl(runtimeHostIp)
     : resolvePublishedGatewayHost(req);
   const apiKey = await resolveHermesApiToken(agent);
+  // The dashboard's basic-auth password is derived from the API key (the same
+  // seed the worker injects into the container), so we can surface it without
+  // storing it. Username is always "nora". The derived `secret` is not needed
+  // by the client and is deliberately not returned.
+  const dashboardAuth = apiKey ? deriveHermesDashboardBasicAuth(apiKey) : null;
 
   return {
     runtimeApiUrl: `${proto}://${host}:${runtimeApiHostPort}`,
     dashboardUrl: dashboardHostPort ? `${proto}://${host}:${dashboardHostPort}` : null,
     apiKey: apiKey || null,
+    dashboardUsername: dashboardAuth?.username ?? null,
+    dashboardPassword: dashboardAuth?.password ?? null,
   };
 }
 

--- a/frontend-dashboard/components/agents/hermes/StatusPanel.tsx
+++ b/frontend-dashboard/components/agents/hermes/StatusPanel.tsx
@@ -3,6 +3,8 @@ import {
   AlertTriangle,
   Bot,
   CheckCircle2,
+  Eye,
+  EyeOff,
   Key,
   Loader2,
   RefreshCw,
@@ -10,6 +12,7 @@ import {
   Workflow,
 } from "lucide-react";
 import { fetchWithAuth } from "../../../lib/api";
+import { connectFieldDisplay, isSecretRevealed } from "../../../lib/connectField";
 import { useToast } from "../../Toast";
 import { formatModelLabel, getProviderMeta, ProviderLogo } from "../providerLogos";
 
@@ -132,6 +135,75 @@ function resolveDefaultChoiceKey(savedProviders, options) {
   return providerMatch?.key || options[0]?.key || "";
 }
 
+// A single "Connect Hermes Desktop" field: selectable readonly value + Copy.
+// Secret fields (API key, dashboard password) are masked by default behind a
+// reveal toggle; each owns its reveal state (revealing one never reveals another)
+// and Copy always copies the REAL value, even while masked.
+function ConnectField({ label, value, Icon, mono = false, secret = false, onCopy, toast }) {
+  // Track the exact value the field was revealed for (not a bare boolean), so a
+  // rotated credential re-masks automatically — see isSecretRevealed.
+  const [revealedFor, setRevealedFor] = useState(null);
+  const revealed = secret ? isSecretRevealed(revealedFor, value) : true;
+  const displayValue = connectFieldDisplay(value, { secret, revealed });
+
+  const handleCopy = async () => {
+    // onCopy copies the REAL value regardless of masking, and reports success.
+    const copied = await onCopy(value);
+    if (copied) {
+      toast.success(`${label} copied`);
+      return;
+    }
+    if (secret && !revealed) {
+      // Programmatic copy failed and the value is masked — selecting the field
+      // would copy the mask, so reveal it and let the user copy it manually.
+      setRevealedFor(value);
+      toast.error(`Couldn't copy ${label} automatically — revealed it so you can select and copy it.`);
+    } else {
+      toast.error(`Couldn't copy ${label} — select the text to copy it manually.`);
+    }
+  };
+
+  return (
+    <div className="flex items-start gap-3 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
+      <Icon size={16} className="mt-0.5 shrink-0 text-slate-500" />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center justify-between gap-2">
+          <p className="text-xs font-bold uppercase tracking-[0.2em] text-slate-400">{label}</p>
+          <div className="flex shrink-0 items-center gap-3">
+            {secret ? (
+              <button
+                type="button"
+                onClick={() => setRevealedFor(revealed ? null : value)}
+                aria-label={revealed ? `Hide ${label}` : `Reveal ${label}`}
+                className="text-slate-400 hover:text-slate-600"
+              >
+                {revealed ? <EyeOff size={14} /> : <Eye size={14} />}
+              </button>
+            ) : null}
+            <button
+              type="button"
+              onClick={handleCopy}
+              className="text-xs font-bold text-blue-600 hover:text-blue-700"
+            >
+              Copy
+            </button>
+          </div>
+        </div>
+        <input
+          type="text"
+          readOnly
+          value={displayValue}
+          onFocus={(e) => e.currentTarget.select()}
+          onClick={(e) => e.currentTarget.select()}
+          className={`mt-1 block w-full select-all break-all rounded-md border border-slate-200 bg-white px-2 py-1 text-sm font-medium text-slate-800 ${
+            mono ? "font-mono" : ""
+          }`}
+        />
+      </div>
+    </div>
+  );
+}
+
 export default function HermesStatusPanel({ agentId, runtimeInfo, loading, error, onRefresh }) {
   const [providers, setProviders] = useState(null);
   const [availableProviders, setAvailableProviders] = useState([]);
@@ -229,53 +301,25 @@ export default function HermesStatusPanel({ agentId, runtimeInfo, loading, error
       return false;
     }
   };
-  const copyValue = async (label, value) => {
-    if (!value) return;
+  // Copy `value` to the clipboard, returning whether it succeeded. Uses the
+  // async Clipboard API in a secure context and falls back to the legacy
+  // execCommand path on plain-HTTP non-localhost origins. Success/failure
+  // messaging (and the "reveal a masked secret so you can copy it" fallback) is
+  // left to the caller, which knows whether the value is a masked secret.
+  const copyValue = async (value) => {
+    if (!value) return false;
     try {
       if (navigator.clipboard?.writeText) {
         await navigator.clipboard.writeText(value);
-      } else if (!legacyCopy(value)) {
-        throw new Error("clipboard unavailable");
+        return true;
       }
-      toast.success(`${label} copied`);
+      return legacyCopy(value);
     } catch {
-      // Native path failed (unavailable or permission) — try the legacy path.
-      if (legacyCopy(value)) {
-        toast.success(`${label} copied`);
-      } else {
-        toast.error(`Could not copy ${label} — select the text to copy it manually`);
-      }
+      return legacyCopy(value);
     }
   };
-  // Render a connect field as SELECTABLE text (readonly input) plus a Copy button,
-  // so the operator can always copy manually even if programmatic copy is blocked.
-  const renderConnectField = (label, value, Icon, { mono = false } = {}) => (
-    <div className="flex items-start gap-3 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
-      <Icon size={16} className="mt-0.5 shrink-0 text-slate-500" />
-      <div className="min-w-0 flex-1">
-        <div className="flex items-center justify-between gap-2">
-          <p className="text-xs font-bold uppercase tracking-[0.2em] text-slate-400">{label}</p>
-          <button
-            type="button"
-            onClick={() => copyValue(label, value)}
-            className="shrink-0 text-xs font-bold text-blue-600 hover:text-blue-700"
-          >
-            Copy
-          </button>
-        </div>
-        <input
-          type="text"
-          readOnly
-          value={value}
-          onFocus={(e) => e.currentTarget.select()}
-          onClick={(e) => e.currentTarget.select()}
-          className={`mt-1 block w-full select-all break-all rounded-md border border-slate-200 bg-white px-2 py-1 text-sm font-medium text-slate-800 ${
-            mono ? "font-mono" : ""
-          }`}
-        />
-      </div>
-    </div>
-  );
+  // Connect fields render via the module-level <ConnectField> component (below),
+  // which owns its own reveal state for secret values. copyValue is passed in.
   const models = Array.isArray(runtimeInfo?.models) ? runtimeInfo.models : [];
   const gateway: any = runtimeInfo?.gateway || {};
   const platformStates =
@@ -750,13 +794,57 @@ export default function HermesStatusPanel({ agentId, runtimeInfo, loading, error
               </p>
             </div>
             <div className="space-y-3 p-4">
-              {renderConnectField("Runtime API", connect.runtimeApiUrl, Server)}
-              {connect.dashboardUrl
-                ? renderConnectField("Dashboard", connect.dashboardUrl, Workflow)
-                : null}
-              {connect.apiKey
-                ? renderConnectField("API Key", connect.apiKey, Key, { mono: true })
-                : null}
+              <ConnectField
+                label="Runtime API"
+                value={connect.runtimeApiUrl}
+                Icon={Server}
+                onCopy={copyValue}
+                toast={toast}
+              />
+              {connect.dashboardUrl ? (
+                <ConnectField
+                  label="Dashboard"
+                  value={connect.dashboardUrl}
+                  Icon={Workflow}
+                  onCopy={copyValue}
+                  toast={toast}
+                />
+              ) : null}
+              {connect.dashboardUsername || connect.dashboardPassword ? (
+                <ConnectField
+                  label="Dashboard Username"
+                  value={connect.dashboardUsername || "nora"}
+                  Icon={Bot}
+                  onCopy={copyValue}
+                  toast={toast}
+                />
+              ) : null}
+              {connect.dashboardPassword ? (
+                <ConnectField
+                  label="Desktop Password"
+                  value={connect.dashboardPassword}
+                  Icon={Key}
+                  onCopy={copyValue}
+                  toast={toast}
+                  mono
+                  secret
+                />
+              ) : null}
+              {connect.apiKey ? (
+                <ConnectField
+                  label="API Key"
+                  value={connect.apiKey}
+                  Icon={Key}
+                  onCopy={copyValue}
+                  toast={toast}
+                  mono
+                  secret
+                />
+              ) : null}
+              <p className="text-xs text-slate-500">
+                These credentials rotate when the agent is redeployed — the API key and dashboard
+                password are regenerated on each deploy.
+              </p>
             </div>
           </section>
         ) : null}

--- a/frontend-dashboard/components/agents/hermes/StatusPanel.tsx
+++ b/frontend-dashboard/components/agents/hermes/StatusPanel.tsx
@@ -157,7 +157,9 @@ function ConnectField({ label, value, Icon, mono = false, secret = false, onCopy
       // Programmatic copy failed and the value is masked — selecting the field
       // would copy the mask, so reveal it and let the user copy it manually.
       setRevealedFor(value);
-      toast.error(`Couldn't copy ${label} automatically — revealed it so you can select and copy it.`);
+      toast.error(
+        `Couldn't copy ${label} automatically — revealed it so you can select and copy it.`,
+      );
     } else {
       toast.error(`Couldn't copy ${label} — select the text to copy it manually.`);
     }
@@ -821,7 +823,7 @@ export default function HermesStatusPanel({ agentId, runtimeInfo, loading, error
               ) : null}
               {connect.dashboardPassword ? (
                 <ConnectField
-                  label="Desktop Password"
+                  label="Dashboard Password"
                   value={connect.dashboardPassword}
                   Icon={Key}
                   onCopy={copyValue}

--- a/frontend-dashboard/lib/connectField.test.ts
+++ b/frontend-dashboard/lib/connectField.test.ts
@@ -4,15 +4,24 @@ import test from "node:test";
 import { CONNECT_FIELD_MASK, connectFieldDisplay, isSecretRevealed } from "./connectField";
 
 test("secret fields are masked by default (not revealed)", () => {
-  assert.equal(connectFieldDisplay("s3cret-password", { secret: true, revealed: false }), CONNECT_FIELD_MASK);
+  assert.equal(
+    connectFieldDisplay("s3cret-password", { secret: true, revealed: false }),
+    CONNECT_FIELD_MASK,
+  );
 });
 
 test("revealing a secret shows its real value", () => {
-  assert.equal(connectFieldDisplay("s3cret-password", { secret: true, revealed: true }), "s3cret-password");
+  assert.equal(
+    connectFieldDisplay("s3cret-password", { secret: true, revealed: true }),
+    "s3cret-password",
+  );
 });
 
 test("non-secret fields always show the real value", () => {
-  assert.equal(connectFieldDisplay("http://100.71.115.105:19500", { secret: false }), "http://100.71.115.105:19500");
+  assert.equal(
+    connectFieldDisplay("http://100.71.115.105:19500", { secret: false }),
+    "http://100.71.115.105:19500",
+  );
   assert.equal(connectFieldDisplay("nora", {}), "nora");
 });
 

--- a/frontend-dashboard/lib/connectField.test.ts
+++ b/frontend-dashboard/lib/connectField.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { CONNECT_FIELD_MASK, connectFieldDisplay, isSecretRevealed } from "./connectField";
+
+test("secret fields are masked by default (not revealed)", () => {
+  assert.equal(connectFieldDisplay("s3cret-password", { secret: true, revealed: false }), CONNECT_FIELD_MASK);
+});
+
+test("revealing a secret shows its real value", () => {
+  assert.equal(connectFieldDisplay("s3cret-password", { secret: true, revealed: true }), "s3cret-password");
+});
+
+test("non-secret fields always show the real value", () => {
+  assert.equal(connectFieldDisplay("http://100.71.115.105:19500", { secret: false }), "http://100.71.115.105:19500");
+  assert.equal(connectFieldDisplay("nora", {}), "nora");
+});
+
+test("the mask is fixed-width and does not leak the secret's length", () => {
+  assert.equal(
+    connectFieldDisplay("short", { secret: true }),
+    connectFieldDisplay("a-considerably-longer-secret-value", { secret: true }),
+  );
+});
+
+test("a secret is revealed only for the exact value it was revealed for", () => {
+  assert.equal(isSecretRevealed("v1", "v1"), true);
+  assert.equal(isSecretRevealed(null, "v1"), false);
+  assert.equal(isSecretRevealed("v1", "v2"), false);
+});
+
+test("rotating a revealed secret re-masks it (redeploy regenerates credentials)", () => {
+  // The field was revealed for the old password; after rotation the value the
+  // component holds differs, so it must be treated as not-revealed and re-masked.
+  const revealed = isSecretRevealed("old-password", "new-password");
+  assert.equal(revealed, false);
+  assert.equal(connectFieldDisplay("new-password", { secret: true, revealed }), CONNECT_FIELD_MASK);
+});
+
+test("independent fields: revealing one value does not reveal a different one", () => {
+  // Each field tracks its own "revealed-for" value; a value revealed in one
+  // field is not revealed in a field holding a different value.
+  const revealedForApiKey = "api-key-abc";
+  assert.equal(isSecretRevealed(revealedForApiKey, "api-key-abc"), true);
+  assert.equal(isSecretRevealed(revealedForApiKey, "dashboard-password-xyz"), false);
+});

--- a/frontend-dashboard/lib/connectField.ts
+++ b/frontend-dashboard/lib/connectField.ts
@@ -1,0 +1,26 @@
+// Pure display/reveal logic for the "Connect Hermes Desktop" card's fields.
+// Kept out of the React component so it can be unit-tested with the repo's
+// lightweight `tsx --test lib/*.test.ts` runner (there is no component-test
+// harness). The component is a thin shell over these helpers.
+
+// Fixed-width mask: the same regardless of the secret's real length, so the
+// masked rendering never leaks how long the credential is.
+export const CONNECT_FIELD_MASK = "••••••••••••";
+
+// What a field should render: the real value, or the mask for a secret that is
+// not currently revealed.
+export function connectFieldDisplay(
+  value: string,
+  { secret = false, revealed = false }: { secret?: boolean; revealed?: boolean } = {},
+): string {
+  return secret && !revealed ? CONNECT_FIELD_MASK : value;
+}
+
+// A secret is revealed only while the reveal toggle was set for the EXACT
+// value currently shown. Storing "the value we revealed for" (rather than a
+// bare boolean) means a rotated credential — e.g. the agent is redeployed and
+// the API key / dashboard password regenerate — is never shown unmasked: the
+// stored value no longer matches, so the new value re-masks automatically.
+export function isSecretRevealed(revealedForValue: string | null, value: string): boolean {
+  return revealedForValue !== null && revealedForValue === value;
+}


### PR DESCRIPTION
> 🚧 **DRAFT — do not merge yet. Blocked on two PRs (see Dependencies).**

## What this does
Surfaces the Hermes **dashboard login credentials** on the operator's "Connect Hermes Desktop" card so users can actually sign in to an agent's dashboard from Hermes Desktop.

- **Backend** (`resolveHermesConnectInfo`): derives the dashboard basic-auth from the agent's API key — the same seed the worker injects into the container — via `deriveHermesDashboardBasicAuth(apiKey)`, and returns `dashboardUsername` (always `"nora"`) + `dashboardPassword`. The derived `secret` is deliberately not returned.
- **Frontend** (`StatusPanel` Connect card): renders **Dashboard Username** in the clear, and **Desktop Password** + **API Key** as secret fields — masked by default behind a per-field reveal toggle (Eye/EyeOff). Copy always copies the real value (including the non-secure-context clipboard fallback added earlier). A note explains the credentials rotate on redeploy.
- Backend test asserts `dashboardPassword === deriveHermesDashboardBasicAuth(apiKey).password` and `dashboardUsername === "nora"`.

## Dependencies — merge these first
This change sits at the **intersection of two independent feature lines** and cannot build on `master` until both land:

1. **#305 — external connect for local Docker Hermes** (the Connect card + `resolveHermesConnectInfo` this edits). This branch is **stacked on #305**, so #305's commits currently appear in this diff; they'll drop out once #305 merges to `master`.
2. **#300 — authenticate the Hermes dashboard (basic-auth)** — provides `agent-runtime/lib/hermesDashboardAuth.ts` / `deriveHermesDashboardBasicAuth`, which this imports. That module is **not** on this branch, so **CI will fail** (`Cannot find module '../../agent-runtime/lib/hermesDashboardAuth'`) until #300 is on `master`. (#301, stacked on #300, also carries this module.)

Without the dashboard-auth feature the Hermes dashboard runs unauthenticated (`--insecure`) and there are no credentials to surface — so this only makes sense on top of #300.

## After the dependencies merge
Once **#305** and **#300** (and #301) are on `master`, this branch will be **rebased onto `master`** and reduce to a single commit — the "surface dashboard credentials" change — at which point CI should pass and it's ready for review.

## Status
Already merged and green on our integration branch, where both feature lines are present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
