### PR TITLE
fix(nginx): restore agent terminal + log WebSocket routing

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -80,9 +80,16 @@ http {
         set $admin_dashboard http://admin-dashboard:3000;
         set $marketing_site http://frontend-marketing:3000;
 
-        # 1a. WebSocket streams: logs & terminal (must be above /api/)
-        location /api/ws/ {
-            proxy_pass $backend_api/ws/;
+        # 1a. WebSocket streams: logs & terminal (must be above /api/).
+        # Regex + $1 capture, NOT a bare `proxy_pass $backend_api/ws/;`. $backend_api
+        # is a variable (so nginx re-resolves the upstream via the Docker resolver per
+        # request); a variable proxy_pass that carries a URI does not append the matched
+        # location remainder. `proxy_pass $backend_api/ws/;` therefore forwards a bare
+        # /ws/ and drops the /exec/{id} (or /logs/{id}) tail, so no backend upgrade
+        # handler matches and the socket hangs (499, never 101). Reconstruct the full
+        # /ws/... path with $1, mirroring infra/nginx_public.conf.template.
+        location ~ ^/api/ws/(.*)$ {
+            proxy_pass $backend_api/ws/$1$is_args$args;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";

--- a/nginx.e2e.conf
+++ b/nginx.e2e.conf
@@ -32,8 +32,15 @@ http {
         set $admin_dashboard http://admin-dashboard:3000;
         set $marketing_site http://frontend-marketing:3000;
 
-        location /api/ws/ {
-            proxy_pass $backend_api/ws/;
+        # WebSocket streams: logs & terminal (must be above /api/).
+        # Regex + $1 capture, NOT a bare `proxy_pass $backend_api/ws/;`. $backend_api
+        # is a variable (so nginx re-resolves the upstream via the Docker resolver per
+        # request); a variable proxy_pass that carries a URI does not append the matched
+        # location remainder, so a bare /ws/ would be forwarded and the /exec/{id} (or
+        # /logs/{id}) tail dropped — no backend upgrade handler matches, the socket
+        # hangs (499, never 101). Reconstruct the full /ws/... path with $1.
+        location ~ ^/api/ws/(.*)$ {
+            proxy_pass $backend_api/ws/$1$is_args$args;
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";


### PR DESCRIPTION
## Problem

Opening an agent's **Terminal** tab immediately shows `--- Session ended ---` and Reconnect does nothing; the **Logs** WebSocket stream is dead too. It affects **every agent** — it looked Hermes-specific only because those were the only agents present in the reporting environment.

## Root cause

The nginx `/api/ws/` block used a **variable** `proxy_pass` carrying a URI part:

```nginx
location /api/ws/ {
    proxy_pass $backend_api/ws/;
}
```

When `proxy_pass` uses a variable *and* specifies a URI, nginx forwards that URI as-is and does **not** append the matched location remainder. So `/api/ws/exec/{id}` reached backend-api as a bare `/ws/`, which matches no upgrade handler (`^/ws/exec/(.+)$` in `execStream.ts`, `^/ws/logs/…` in `logStream.ts`). The upgrade hung → client aborted (**499, never 101**), so the handler never ran.

Regression from `2acc0feed`, which switched this block from the static `proxy_pass http://backend_api/ws/;` (which *does* append the remainder) to the variable form — presumably to force per-request DNS re-resolution via the Docker resolver.

## Fix

Reconstruct the full path with a regex `$1` capture, matching the already-correct `infra/nginx_public.conf.template`:

```nginx
location ~ ^/api/ws/(.*)$ {
    proxy_pass $backend_api/ws/$1$is_args$args;
}
```

Keeps the resolver-friendly variable upstream **and** preserves the full `/ws/exec/{id}` path plus the `?token=` query the terminal sends. Applied to both `nginx.conf` and `nginx.e2e.conf`.

## Verification

Probe against a running stack — `/api/ws/exec/<id>` with no token:

| Check | Before | After |
|---|---|---|
| status / time | `000`, ~6–8s hang | `401`, 0.002s |
| Terminal tab | `--- Session ended ---` | Connects, shell prompt |

`nginx -t` passes for both configs.

> Ops note: reloading a single-file bind-mounted nginx config needs `docker compose restart nginx`, not `nginx -s reload` — an edit changes the file inode and the container keeps reading the old inode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)