### PR TITLE
fix(agent-runtime): bump postcss to 8.5.22 (GHSA-6g55-p6wh-862q)

### DIFF
--- a/agent-runtime/package-lock.json
+++ b/agent-runtime/package-lock.json
@@ -1263,9 +1263,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -1319,9 +1319,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.22",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
+      "integrity": "sha512-KBDEIpLrvpv16pp3K0Fw+UCoZfopFjjgeB+0tA/aaThfEE74kKDLrgg603YvOWJyg3+WYtyq3xYsQWsIyZlPqQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -1337,7 +1337,7 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Problem

`npm audit --omit=dev --audit-level=high` fails for **agent-runtime**, which cascades into the CI **Security gate** on master and every open PR (e.g. #309).

## Root cause

agent-runtime pulls postcss as a **production** dependency via `sanitize-html@2.17.4 -> postcss@8.5.10`. The newly published advisory **GHSA-6g55-p6wh-862q** flags `postcss <=8.5.11` (high: arbitrary file read / info disclosure via attacker-controlled `sourceMappingURL` in CSS comments). Because `npm audit` queries the live advisory DB, the unchanged lockfile passed before publication and fails after — so this is a time-based, repo-wide regression, not caused by any recent PR.

## Fix

Bump the nested postcss to **8.5.22** (within sanitize-html's `^8.3.11` range; also lifts its `nanoid` pin 3.3.11 -> 3.3.16). **Lockfile-only**, no `package.json` change.

## Verification

`npm ci && npm audit --omit=dev --audit-level=high` in `agent-runtime/` now reports **`found 0 vulnerabilities`** (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)