### PR TITLE
ci(security): move npm audit to a scheduled sweep, off the per-PR blocking gate

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -30,36 +30,13 @@ jobs:
       - run: npm ci
       - run: npm run ci:secret-scan
 
-  dependency-audit:
-    name: "npm audit (${{ matrix.package }})"
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        package:
-          - admin-dashboard
-          - frontend-dashboard
-          - frontend-marketing
-          - backend-api
-          - agent-runtime
-          - workers/backup
-          - workers/provisioner
-          - e2e
-          - mcp-server
-          - cli
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
-        with:
-          node-version-file: .nvmrc
-          cache: npm
-          cache-dependency-path: ${{ matrix.package }}/package-lock.json
-      - run: npm ci
-        working-directory: ${{ matrix.package }}
-      - run: npm audit --omit=dev --audit-level=high
-        working-directory: ${{ matrix.package }}
+  # NOTE: npm advisory auditing runs on a schedule (see
+  # .github/workflows/dependency-audit.yml), not as a per-PR blocking gate.
+  # `npm audit` queries the live GitHub advisory DB, so an unchanged lockfile
+  # flips red the moment an unrelated advisory is published — which would block
+  # every open PR on advisory-publication timing rather than on anything the PR
+  # changed. Dependabot security updates remediate; the scheduled job surfaces
+  # regressions daily. Keep only deterministic checks in this blocking gate.
 
   license-compliance:
     name: "license policy (${{ matrix.package }})"
@@ -133,7 +110,6 @@ jobs:
     if: ${{ always() }}
     needs:
       - secret-scan
-      - dependency-audit
       - license-compliance
       - infra-validation
     runs-on: ubuntu-latest
@@ -143,7 +119,6 @@ jobs:
         env:
           SECURITY_RESULTS: >-
             secret-scan=${{ needs.secret-scan.result }}
-            dependency-audit=${{ needs.dependency-audit.result }}
             license-compliance=${{ needs.license-compliance.result }}
             infra-validation=${{ needs.infra-validation.result }}
         run: |

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -1,0 +1,72 @@
+name: Dependency Audit (scheduled)
+
+# npm advisory auditing is intentionally NOT a per-PR blocking gate. `npm audit`
+# queries the live GitHub advisory DB, so an unchanged lockfile flips red the
+# moment an unrelated advisory is published — which would block every open PR on
+# advisory-publication timing rather than on anything the PR changed. Instead we
+# sweep daily here (and on demand), rely on Dependabot security updates to open
+# remediation PRs, and open a tracking issue when the sweep finds something.
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 7 * * *" # daily 07:00 UTC
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-audit:
+    name: "npm audit (${{ matrix.package }})"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - admin-dashboard
+          - frontend-dashboard
+          - frontend-marketing
+          - backend-api
+          - agent-runtime
+          - workers/backup
+          - workers/provisioner
+          - e2e
+          - mcp-server
+          - cli
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: ${{ matrix.package }}/package-lock.json
+      - run: npm ci
+        working-directory: ${{ matrix.package }}
+      - run: npm audit --omit=dev --audit-level=high
+        working-directory: ${{ matrix.package }}
+
+  report:
+    name: Open tracking issue on failure
+    needs: dependency-audit
+    if: ${{ failure() && github.event_name == 'schedule' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Open or update the advisory tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          title="Scheduled dependency audit found high-severity advisories"
+          body="The daily \`npm audit --omit=dev --audit-level=high\` sweep failed — one or more packages have high-severity advisories. Dependabot security updates should open remediation PRs; otherwise bump the flagged package(s) manually. Failing run: ${RUN_URL}"
+          existing="$(gh issue list --repo "${REPO}" --state open --search "${title} in:title" --json number --jq '.[0].number // empty' || true)"
+          if [ -n "${existing}" ]; then
+            gh issue comment "${existing}" --repo "${REPO}" --body "${body}"
+          else
+            gh issue create --repo "${REPO}" --title "${title}" --body "${body}"
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ cd e2e && npm run smoke:runtime-path        # Runtime resolution
 cd e2e && npm run capture:operator-readme   # Regenerate README screenshots
 ```
 
-CI is split across `.github/workflows/ci-quality.yml`, `.github/workflows/ci-security.yml`, `.github/workflows/ci-compose.yml`, and `.github/workflows/ci-codeql.yml` on pull requests and pushes to `master` under Node 24.
+CI is split across `.github/workflows/ci-quality.yml`, `.github/workflows/ci-security.yml`, `.github/workflows/ci-compose.yml`, and `.github/workflows/ci-codeql.yml` on pull requests and pushes to `master` under Node 24. npm advisory auditing is deliberately **not** a per-PR blocking check — `npm audit` queries the live advisory DB, so an unchanged lockfile would flip red whenever an unrelated advisory is published. It runs instead on a schedule in `.github/workflows/dependency-audit.yml` (daily + `workflow_dispatch`), with Dependabot security updates handling remediation; the blocking `Security gate` in `ci-security.yml` covers only the deterministic checks (secret scan, license policy, infra validation).
 
 ## Architecture
 


### PR DESCRIPTION
## Problem

`npm audit --omit=dev --audit-level=high` runs as a **required, per-PR** check (aggregated into `Security gate`). But `npm audit` queries the **live** GitHub advisory DB, so the same unchanged lockfile passes one hour and fails the next the moment an unrelated advisory is published — blocking **every open PR** on advisory-publication *timing*, not on anything the PR changed. We hit this repeatedly in a single afternoon: postcss (twice), body-parser, js-yaml, protobufjs.

## Change

- Remove the `dependency-audit` job from `ci-security.yml` and from the required `Security gate`'s aggregation. The blocking gate now covers only **deterministic** checks: secret scan, license policy, infra validation.
- Add `.github/workflows/dependency-audit.yml` — the same audit matrix on a **daily schedule** + `workflow_dispatch`, opening a tracking issue on failure.
- **Dependabot** security updates remain the remediation engine.

## Why this is safe

- **No ruleset change.** `Security gate` stays the required check; it just no longer depends on the live audit. Fully reversible via this workflow file alone.
- Advisories are still caught within a day (scheduled sweep) and auto-remediated (Dependabot), so posture stays strong.
- **Trade-off (named):** a PR could merge introducing a newly-vulnerable dep, caught within ~a day rather than at merge time — the right balance versus randomly blocking every contributor's unrelated PR.

See also the follow-up bump PR clearing today's advisory wave so the first scheduled sweep is green.