### PR TITLE
chore(hermes): connect-card follow-ups from the #308 review

### DIFF
--- a/backend-api/__tests__/agents.test.ts
+++ b/backend-api/__tests__/agents.test.ts
@@ -1169,6 +1169,75 @@ describe("Hermes WebUI routes", () => {
     });
   });
 
+  it("returns null connect credentials when the runtime token is unresolvable", async () => {
+    // No stored gateway_token and a container env without API_SERVER_KEY: the
+    // connect block must degrade to null credentials — the `apiKey ? derive :
+    // null` guard is load-bearing because deriveHermesDashboardBasicAuth
+    // throws on an empty seed, which would 500 the whole hermes-ui route.
+    mockReadHermesRuntimeSnapshot.mockResolvedValueOnce({
+      runtimeStatus: {
+        gateway_state: "running",
+        active_agents: 1,
+        updated_at: "2026-04-12T12:00:00.000Z",
+        platforms: {},
+      },
+      directory: {
+        updated_at: "2026-04-12T12:00:00.000Z",
+        platforms: {},
+      },
+      platformDetails: {},
+      jobsCount: 0,
+      modelConfig: {
+        defaultModel: "gpt-5.5",
+        provider: "custom",
+        baseUrl: "https://api.openai.com/v1",
+      },
+    });
+    mockDb.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: "a-hermes-tokenless",
+          user_id: "user-1",
+          status: "running",
+          runtime_family: "hermes",
+          backend_type: "docker",
+          container_id: "hermes-container",
+          runtime_host: "10.0.0.43",
+          runtime_port: 8642,
+          gateway_token: null,
+        },
+      ],
+    });
+    global.fetch = jest.fn().mockResolvedValue(createMockFetchResponse({ body: {} }));
+    // Every inspect (the token fallback re-inspects per resolution attempt plus
+    // the published-port lookup) sees the same container: ports published, no
+    // API_SERVER_KEY in the environment.
+    mockDockerInspect.mockResolvedValue({
+      Config: { Env: ["HERMES_HOME=/opt/hermes"] },
+      NetworkSettings: {
+        Ports: {
+          "8642/tcp": [{ HostIp: "100.71.115.105", HostPort: "19500" }],
+          "9119/tcp": [{ HostIp: "100.71.115.105", HostPort: "19044" }],
+        },
+      },
+    });
+
+    const res = await auth(
+      request(app)
+        .get("/agents/a-hermes-tokenless/hermes-ui")
+        .set("X-Forwarded-Host", "100.71.115.105"),
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.body.connect).toEqual({
+      runtimeApiUrl: "http://100.71.115.105:19500",
+      dashboardUrl: "http://100.71.115.105:19044",
+      apiKey: null,
+      dashboardUsername: null,
+      dashboardPassword: null,
+    });
+  });
+
   it.each(["viewer", "editor", "admin"])(
     "omits Hermes connect credentials for workspace %s members",
     async (role) => {

--- a/frontend-dashboard/components/agents/hermes/StatusPanel.tsx
+++ b/frontend-dashboard/components/agents/hermes/StatusPanel.tsx
@@ -135,11 +135,53 @@ function resolveDefaultChoiceKey(savedProviders, options) {
   return providerMatch?.key || options[0]?.key || "";
 }
 
-// A single "Connect Hermes Desktop" field: selectable readonly value + Copy.
-// Secret fields (API key, dashboard password) are masked by default behind a
-// reveal toggle; each owns its reveal state (revealing one never reveals another)
-// and Copy always copies the REAL value, even while masked.
-function ConnectField({ label, value, Icon, mono = false, secret = false, onCopy, toast }) {
+// Legacy execCommand copy for non-secure contexts. navigator.clipboard is only
+// defined in a secure context (HTTPS, http://localhost / 127.0.0.1); over a
+// plain-HTTP non-localhost origin (e.g. http://<tailscale-ip>:8080) it is
+// undefined, so the native path throws.
+function legacyCopy(text) {
+  try {
+    const ta = document.createElement("textarea");
+    ta.value = text;
+    ta.setAttribute("readonly", "");
+    ta.style.position = "fixed";
+    ta.style.top = "-1000px";
+    ta.style.opacity = "0";
+    document.body.appendChild(ta);
+    ta.select();
+    const ok = document.execCommand("copy");
+    document.body.removeChild(ta);
+    return ok;
+  } catch {
+    return false;
+  }
+}
+
+// Copy `value` to the clipboard, returning whether it succeeded. Uses the
+// async Clipboard API in a secure context and falls back to the legacy
+// execCommand path on plain-HTTP non-localhost origins. Success/failure
+// messaging (and the "reveal a masked secret so you can copy it" fallback) is
+// left to the caller, which knows whether the value is a masked secret.
+async function copyValue(value) {
+  if (!value) return false;
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(value);
+      return true;
+    }
+    return legacyCopy(value);
+  } catch {
+    return legacyCopy(value);
+  }
+}
+
+// A single "Connect Hermes Desktop" field: readonly value + Copy, selectable
+// while the real value is visible. Secret fields (API key, dashboard password)
+// are masked by default behind a reveal toggle; each owns its reveal state
+// (revealing one never reveals another) and Copy always copies the REAL value,
+// even while masked.
+function ConnectField({ label, value, Icon, mono = false, secret = false }) {
+  const toast = useToast();
   // Track the exact value the field was revealed for (not a bare boolean), so a
   // rotated credential re-masks automatically — see isSecretRevealed.
   const [revealedFor, setRevealedFor] = useState(null);
@@ -147,8 +189,8 @@ function ConnectField({ label, value, Icon, mono = false, secret = false, onCopy
   const displayValue = connectFieldDisplay(value, { secret, revealed });
 
   const handleCopy = async () => {
-    // onCopy copies the REAL value regardless of masking, and reports success.
-    const copied = await onCopy(value);
+    // copyValue copies the REAL value regardless of masking, and reports success.
+    const copied = await copyValue(value);
     if (copied) {
       toast.success(`${label} copied`);
       return;
@@ -185,21 +227,26 @@ function ConnectField({ label, value, Icon, mono = false, secret = false, onCopy
             <button
               type="button"
               onClick={handleCopy}
+              aria-label={`Copy ${label}`}
               className="text-xs font-bold text-blue-600 hover:text-blue-700"
             >
               Copy
             </button>
           </div>
         </div>
+        {/* Select-on-click only while the real value is visible: selecting a
+            masked field would put literal mask bullets on the clipboard, so a
+            masked field offers Copy / reveal instead of select-all. */}
         <input
           type="text"
           readOnly
+          aria-label={label}
           value={displayValue}
-          onFocus={(e) => e.currentTarget.select()}
-          onClick={(e) => e.currentTarget.select()}
-          className={`mt-1 block w-full select-all break-all rounded-md border border-slate-200 bg-white px-2 py-1 text-sm font-medium text-slate-800 ${
-            mono ? "font-mono" : ""
-          }`}
+          onFocus={(e) => revealed && e.currentTarget.select()}
+          onClick={(e) => revealed && e.currentTarget.select()}
+          className={`mt-1 block w-full break-all rounded-md border border-slate-200 bg-white px-2 py-1 text-sm font-medium text-slate-800 ${
+            revealed ? "select-all" : ""
+          } ${mono ? "font-mono" : ""}`}
         />
       </div>
     </div>
@@ -282,46 +329,8 @@ export default function HermesStatusPanel({ agentId, runtimeInfo, loading, error
 
   const runtimeReady = Boolean(runtimeInfo?.health?.ok);
   const connect = runtimeInfo?.connect || null;
-  // Legacy execCommand copy for non-secure contexts. navigator.clipboard is only
-  // defined in a secure context (HTTPS, http://localhost / 127.0.0.1); over a
-  // plain-HTTP non-localhost origin (e.g. http://<tailscale-ip>:8080) it is
-  // undefined, so the native path throws.
-  const legacyCopy = (text) => {
-    try {
-      const ta = document.createElement("textarea");
-      ta.value = text;
-      ta.setAttribute("readonly", "");
-      ta.style.position = "fixed";
-      ta.style.top = "-1000px";
-      ta.style.opacity = "0";
-      document.body.appendChild(ta);
-      ta.select();
-      const ok = document.execCommand("copy");
-      document.body.removeChild(ta);
-      return ok;
-    } catch {
-      return false;
-    }
-  };
-  // Copy `value` to the clipboard, returning whether it succeeded. Uses the
-  // async Clipboard API in a secure context and falls back to the legacy
-  // execCommand path on plain-HTTP non-localhost origins. Success/failure
-  // messaging (and the "reveal a masked secret so you can copy it" fallback) is
-  // left to the caller, which knows whether the value is a masked secret.
-  const copyValue = async (value) => {
-    if (!value) return false;
-    try {
-      if (navigator.clipboard?.writeText) {
-        await navigator.clipboard.writeText(value);
-        return true;
-      }
-      return legacyCopy(value);
-    } catch {
-      return legacyCopy(value);
-    }
-  };
-  // Connect fields render via the module-level <ConnectField> component (below),
-  // which owns its own reveal state for secret values. copyValue is passed in.
+  // Connect fields render via the module-level <ConnectField> component (above),
+  // which owns its own reveal state and copy/toast handling.
   const models = Array.isArray(runtimeInfo?.models) ? runtimeInfo.models : [];
   const gateway: any = runtimeInfo?.gateway || {};
   const platformStates =
@@ -796,56 +805,38 @@ export default function HermesStatusPanel({ agentId, runtimeInfo, loading, error
               </p>
             </div>
             <div className="space-y-3 p-4">
-              <ConnectField
-                label="Runtime API"
-                value={connect.runtimeApiUrl}
-                Icon={Server}
-                onCopy={copyValue}
-                toast={toast}
-              />
+              <ConnectField label="Runtime API" value={connect.runtimeApiUrl} Icon={Server} />
               {connect.dashboardUrl ? (
-                <ConnectField
-                  label="Dashboard"
-                  value={connect.dashboardUrl}
-                  Icon={Workflow}
-                  onCopy={copyValue}
-                  toast={toast}
-                />
+                <ConnectField label="Dashboard" value={connect.dashboardUrl} Icon={Workflow} />
               ) : null}
-              {connect.dashboardUsername || connect.dashboardPassword ? (
+              {/* Dashboard login credentials are shown only alongside a dashboard
+                  URL to log into. With the 9119 port unpublished there is no
+                  direct dashboard to reach — the dashboard embedded in Nora
+                  authenticates itself — so credentials would only confuse. */}
+              {connect.dashboardUrl && connect.dashboardUsername ? (
                 <ConnectField
                   label="Dashboard Username"
-                  value={connect.dashboardUsername || "nora"}
+                  value={connect.dashboardUsername}
                   Icon={Bot}
-                  onCopy={copyValue}
-                  toast={toast}
                 />
               ) : null}
-              {connect.dashboardPassword ? (
+              {connect.dashboardUrl && connect.dashboardPassword ? (
                 <ConnectField
                   label="Dashboard Password"
                   value={connect.dashboardPassword}
                   Icon={Key}
-                  onCopy={copyValue}
-                  toast={toast}
                   mono
                   secret
                 />
               ) : null}
               {connect.apiKey ? (
-                <ConnectField
-                  label="API Key"
-                  value={connect.apiKey}
-                  Icon={Key}
-                  onCopy={copyValue}
-                  toast={toast}
-                  mono
-                  secret
-                />
+                <ConnectField label="API Key" value={connect.apiKey} Icon={Key} mono secret />
               ) : null}
               <p className="text-xs text-slate-500">
                 These credentials rotate when the agent is redeployed — the API key and dashboard
-                password are regenerated on each deploy.
+                password are regenerated on each deploy. The URLs above are plain HTTP unless you
+                have put TLS in front of them, so use them over a trusted network; the dashboard
+                embedded in Nora stays behind your Nora origin instead.
               </p>
             </div>
           </section>


### PR DESCRIPTION
Lands the Medium/Low findings from the [#308 review](https://github.com/solomon2773/nora/pull/308#pullrequestreview-4793440132) that weren't blocking the merge.

## Frontend (`ConnectField` / Connect card)
- **Masked select-copy trap (the Medium):** clicking a masked secret no longer select-alls — selecting put literal `••••••••••••` on the clipboard and pasting it into the Hermes login failed silently. Select-on-click (and the `select-all` class) now apply only while the real value is visible; Copy and the reveal toggle are the affordances while masked.
- **a11y:** the value input gets `aria-label={label}` and each Copy button `aria-label={\`Copy \${label}\`}`, so the five fields no longer announce identically (two of them render identical bullets when masked).
- **Credential gating:** Dashboard Username/Password render only when there is a `dashboardUrl` to log into — with the 9119 port unpublished the embedded dashboard authenticates itself and showing credentials only confuses. The unreachable `|| "nora"` fallback (duplicating the server-side username constant) is gone.
- **Convention:** `copyValue`/`legacyCopy` moved to module scope and `ConnectField` calls `useToast()` itself, dropping the only `toast={...}` prop instances in the codebase.
- **Copy:** the rotation note now also mentions plain-HTTP transport; the stale "(below)" comment pointer fixed.

## Backend test
- Pins the null-token connect branch: no stored `gateway_token` + container env without `API_SERVER_KEY` must yield `200` with `apiKey/dashboardUsername/dashboardPassword: null` — the `apiKey ? derive : null` guard is load-bearing because `deriveHermesDashboardBasicAuth` throws on an empty seed, which would 500 the whole `hermes-ui` route if a refactor dropped the ternary.

No behavior change for the normal path (token resolvable, dashboard port published): same fields, same values, same copy flow.