### PR TITLE
feat(hermes): skills reconciliation contracts + agents.hermes_skills schema

### DIFF
--- a/agent-runtime/lib/hermesSkillsReconciliation.js
+++ b/agent-runtime/lib/hermesSkillsReconciliation.js
@@ -1,0 +1,213 @@
+// Desired-vs-actual reconciliation contracts for Hermes runtime skills.
+//
+// Deliberately a parallel module to clawhubReconciliation.js rather than a
+// shared engine: both live in the mounted agent-runtime blast-radius zone, and
+// the two families differ in identity (ClawHub keys on author+slug from its
+// own lockfile; Hermes keys on the skill NAME from the Hermes hub lockfile at
+// ~/.hermes/skills/.hub/lock.json, whose entries may nest under category
+// folders via install_path). The status vocabulary and row shape are kept
+// IDENTICAL to the ClawHub module so the dashboard's shared skill components
+// render both families: healthy / missing_runtime / orphaned_runtime /
+// pending_install / pending_delete.
+
+// Container-absolute paths for the Hermes skills tree (HOME=/opt/data/home).
+const HERMES_SKILLS_DIR = "/opt/data/home/.hermes/skills";
+const HERMES_SKILLS_LOCK_FILE = `${HERMES_SKILLS_DIR}/.hub/lock.json`;
+
+// Skill directories Nora itself manages. These are written by the integrations
+// reconciler as plain folders (never hub-lock entries, so they cannot surface
+// as orphaned_runtime), but install/delete requests naming them must still be
+// refused everywhere: deleting one would race the integrations reconciler.
+const NORA_MANAGED_HERMES_SKILL_DIRS = ["nora-integrations"];
+
+// The lockfile skill name doubles as the `hermes skills uninstall <name>`
+// argument and appears in shell commands, so it is validated at this single
+// choke point. Leading alphanumeric excludes "." / ".." and hidden names; the
+// charset excludes path separators and whitespace.
+const HERMES_SKILL_NAME_RE = /^[a-z0-9][a-z0-9._-]{0,63}$/i;
+
+function isValidHermesSkillName(name) {
+  return HERMES_SKILL_NAME_RE.test(String(name || ""));
+}
+
+function isReservedHermesSkillName(name) {
+  return NORA_MANAGED_HERMES_SKILL_DIRS.includes(
+    String(name || "")
+      .trim()
+      .toLowerCase(),
+  );
+}
+
+function normalizeSavedHermesSkillEntry(name, entry = {}) {
+  const skillName = String(entry?.name || name || "").trim();
+  if (!isValidHermesSkillName(skillName) || isReservedHermesSkillName(skillName)) {
+    return null;
+  }
+
+  const ref = String(entry?.ref || "").trim();
+  const source = entry?.source === "hermes-bundle" ? "hermes-bundle" : "hermes-hub";
+  const installMode = entry?.installMode === "files" ? "files" : "cli";
+  const installedAtRaw = String(entry?.installedAt || "").trim();
+  const installedAt =
+    installedAtRaw && !Number.isNaN(new Date(installedAtRaw).getTime())
+      ? new Date(installedAtRaw).toISOString()
+      : new Date().toISOString();
+
+  return {
+    source,
+    ref,
+    name: skillName,
+    installMode,
+    installedAt,
+  };
+}
+
+function normalizeSavedHermesSkillEntries(entries = []) {
+  const deduped = new Map();
+  for (const entry of Array.isArray(entries) ? entries : []) {
+    const normalized = normalizeSavedHermesSkillEntry(entry?.name, entry);
+    if (!normalized) continue;
+    if (!deduped.has(normalized.name)) {
+      deduped.set(normalized.name, normalized);
+    }
+  }
+  return [...deduped.values()];
+}
+
+function normalizeInstalledHermesSkillEntries(entries = []) {
+  return (Array.isArray(entries) ? entries : [])
+    .map((entry) => ({
+      name: String(entry?.name || "").trim(),
+      version: String(entry?.version || "").trim(),
+      installPath: String(entry?.installPath || entry?.install_path || "").trim(),
+    }))
+    .filter((entry) => isValidHermesSkillName(entry.name));
+}
+
+// Parse the Hermes hub lockfile ({"installed": {<name>: {...entry}}}) into
+// installed-entry rows. Shared by the worker (provisioner exec read) and the
+// backend route (runContainerCommand read) so both interpret the runtime's
+// actual state identically. Malformed content yields [] rather than throwing —
+// callers treat an unreadable lockfile as "nothing installed" plus a warning.
+function installedEntriesFromHermesLockData(data) {
+  const installed = data && typeof data === "object" ? data.installed : null;
+  if (!installed || typeof installed !== "object" || Array.isArray(installed)) {
+    return [];
+  }
+  return normalizeInstalledHermesSkillEntries(
+    Object.entries(installed).map(([name, entry]) => ({
+      name,
+      version: entry?.version,
+      installPath: entry?.install_path,
+    })),
+  );
+}
+
+function computeMissingSavedHermesSkills(savedSkills = [], installedSkills = []) {
+  const normalizedSaved = normalizeSavedHermesSkillEntries(savedSkills);
+  const installedNames = new Set(
+    normalizeInstalledHermesSkillEntries(installedSkills).map((entry) => entry.name),
+  );
+  return normalizedSaved.filter((entry) => !installedNames.has(entry.name));
+}
+
+function computeOrphanedInstalledHermesSkills(savedSkills = [], installedSkills = []) {
+  const normalizedSaved = normalizeSavedHermesSkillEntries(savedSkills);
+  const savedNames = new Set(normalizedSaved.map((entry) => entry.name));
+  return normalizeInstalledHermesSkillEntries(installedSkills).filter(
+    (entry) => !savedNames.has(entry.name),
+  );
+}
+
+function removeSavedHermesSkillEntry(entries = [], name) {
+  const normalizedName = String(name || "").trim();
+  if (!normalizedName) {
+    return normalizeSavedHermesSkillEntries(entries);
+  }
+  return normalizeSavedHermesSkillEntries(entries).filter((entry) => entry.name !== normalizedName);
+}
+
+/**
+ * Merge Nora's saved Hermes skill entries, the runtime hub-lockfile view, and
+ * any in-flight jobs into one operator-facing skill list.
+ *
+ * Drift is surfaced, never hidden: `healthy` means saved+installed match,
+ * `missing_runtime` means Nora expects the skill but the runtime lacks it
+ * (e.g. a Docker redeploy rebuilt /opt/data), and `orphaned_runtime` means the
+ * runtime has a hub-installed skill Nora is not tracking (e.g. installed via
+ * the agent's own TUI). Pending install/delete jobs win over steady-state
+ * statuses so the UI can show transitional state.
+ *
+ * @param {Array<object>} [savedSkills=[]] Saved entries from `agents.hermes_skills`.
+ * @param {Array<object>} [installedSkills=[]] Hub-lockfile entries currently installed.
+ * @param {Array<object>} [pendingJobs=[]] In-flight skill jobs keyed by `name`.
+ * @returns {Array<object>} Sorted merged rows with a derived `status`.
+ */
+function mergeHermesSkillState(savedSkills = [], installedSkills = [], pendingJobs = []) {
+  const normalizedSaved = normalizeSavedHermesSkillEntries(savedSkills);
+  const normalizedInstalled = normalizeInstalledHermesSkillEntries(installedSkills);
+  const installedByName = new Map(normalizedInstalled.map((entry) => [entry.name, entry]));
+  const pendingByName = new Map(
+    (Array.isArray(pendingJobs) ? pendingJobs : [])
+      .map((job) => [String(job?.name || "").trim(), job])
+      .filter(([name]) => name),
+  );
+  const merged = [];
+
+  for (const saved of normalizedSaved) {
+    const installed = installedByName.get(saved.name);
+    const pending = pendingByName.get(saved.name);
+    merged.push({
+      name: saved.name,
+      version: installed?.version || "",
+      saved: true,
+      installed: Boolean(installed),
+      source: saved.source,
+      ref: saved.ref,
+      installMode: saved.installMode,
+      installedAt: saved.installedAt || null,
+      status:
+        pending?.operation === "delete"
+          ? "pending_delete"
+          : pending?.operation === "install"
+            ? "pending_install"
+            : installed
+              ? "healthy"
+              : "missing_runtime",
+    });
+    installedByName.delete(saved.name);
+  }
+
+  for (const installed of installedByName.values()) {
+    const pending = pendingByName.get(installed.name);
+    merged.push({
+      name: installed.name,
+      version: installed.version || "",
+      saved: false,
+      installed: true,
+      source: "hermes-hub",
+      ref: "",
+      installMode: "cli",
+      installedAt: null,
+      status: pending?.operation === "delete" ? "pending_delete" : "orphaned_runtime",
+    });
+  }
+
+  return merged.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+module.exports = {
+  HERMES_SKILLS_DIR,
+  HERMES_SKILLS_LOCK_FILE,
+  NORA_MANAGED_HERMES_SKILL_DIRS,
+  computeMissingSavedHermesSkills,
+  computeOrphanedInstalledHermesSkills,
+  installedEntriesFromHermesLockData,
+  isReservedHermesSkillName,
+  isValidHermesSkillName,
+  mergeHermesSkillState,
+  normalizeInstalledHermesSkillEntries,
+  normalizeSavedHermesSkillEntries,
+  normalizeSavedHermesSkillEntry,
+  removeSavedHermesSkillEntry,
+};

--- a/backend-api/__tests__/hermesSkillsReconciliation.test.ts
+++ b/backend-api/__tests__/hermesSkillsReconciliation.test.ts
@@ -1,0 +1,176 @@
+// @ts-nocheck
+const {
+  HERMES_SKILLS_LOCK_FILE,
+  computeMissingSavedHermesSkills,
+  computeOrphanedInstalledHermesSkills,
+  installedEntriesFromHermesLockData,
+  isReservedHermesSkillName,
+  isValidHermesSkillName,
+  mergeHermesSkillState,
+  normalizeSavedHermesSkillEntries,
+  removeSavedHermesSkillEntry,
+} = require("../../agent-runtime/lib/hermesSkillsReconciliation");
+
+describe("hermes skill name validation", () => {
+  it("accepts lockfile-style names", () => {
+    for (const name of ["1password", "3-statement-model", "K8s", "a.b_c-d"]) {
+      expect(isValidHermesSkillName(name)).toBe(true);
+    }
+  });
+
+  it("rejects path-unsafe and empty names", () => {
+    for (const name of ["", ".", "..", ".hidden", "a/b", "a b", "-lead", "a".repeat(65), null]) {
+      expect(isValidHermesSkillName(name)).toBe(false);
+    }
+  });
+
+  it("treats Nora-managed skill dirs as reserved, case-insensitively", () => {
+    expect(isReservedHermesSkillName("nora-integrations")).toBe(true);
+    expect(isReservedHermesSkillName("Nora-Integrations")).toBe(true);
+    expect(isReservedHermesSkillName("github")).toBe(false);
+  });
+});
+
+describe("saved-entry normalization", () => {
+  it("deduplicates by name, drops invalid, reserved, and null entries", () => {
+    const normalized = normalizeSavedHermesSkillEntries([
+      { name: "github", ref: "official/dev/github" },
+      { name: "github", ref: "duplicate/ref" },
+      { name: "nora-integrations", ref: "sneaky/reserved" },
+      { name: "bad/name", ref: "x" },
+      { name: "", ref: "x" },
+      null,
+      { name: "notion", ref: "skills-sh/productivity/notion", source: "hermes-bundle" },
+    ]);
+
+    expect(normalized).toHaveLength(2);
+    expect(normalized[0]).toEqual(
+      expect.objectContaining({
+        name: "github",
+        ref: "official/dev/github",
+        source: "hermes-hub",
+        installMode: "cli",
+      }),
+    );
+    expect(normalized[1]).toEqual(
+      expect.objectContaining({ name: "notion", source: "hermes-bundle" }),
+    );
+  });
+
+  it("defaults unknown installMode/source values to cli/hermes-hub", () => {
+    const [entry] = normalizeSavedHermesSkillEntries([
+      { name: "github", ref: "r", installMode: "wat", source: "wat" },
+    ]);
+    expect(entry.installMode).toBe("cli");
+    expect(entry.source).toBe("hermes-hub");
+  });
+
+  it("preserves a valid installedAt and replaces an invalid one", () => {
+    const [kept] = normalizeSavedHermesSkillEntries([
+      { name: "a1", installedAt: "2026-04-12T12:00:00.000Z" },
+    ]);
+    expect(kept.installedAt).toBe("2026-04-12T12:00:00.000Z");
+    const [replaced] = normalizeSavedHermesSkillEntries([
+      { name: "a2", installedAt: "not-a-date" },
+    ]);
+    expect(Number.isNaN(new Date(replaced.installedAt).getTime())).toBe(false);
+  });
+});
+
+describe("lockfile parsing", () => {
+  it("parses the hub lockfile installed map into entries", () => {
+    const entries = installedEntriesFromHermesLockData({
+      installed: {
+        github: { version: "1.2.0", install_path: "dev/github" },
+        "1password": { version: "0.9.1" },
+      },
+    });
+    expect(entries).toEqual([
+      { name: "github", version: "1.2.0", installPath: "dev/github" },
+      { name: "1password", version: "0.9.1", installPath: "" },
+    ]);
+  });
+
+  it("returns [] for malformed lock data and filters invalid names", () => {
+    expect(installedEntriesFromHermesLockData(null)).toEqual([]);
+    expect(installedEntriesFromHermesLockData({})).toEqual([]);
+    expect(installedEntriesFromHermesLockData({ installed: [] })).toEqual([]);
+    expect(installedEntriesFromHermesLockData({ installed: { "../evil": {} } })).toEqual([]);
+  });
+
+  it("exports the lockfile path under the skills dir", () => {
+    expect(HERMES_SKILLS_LOCK_FILE).toBe("/opt/data/home/.hermes/skills/.hub/lock.json");
+  });
+});
+
+describe("drift computation", () => {
+  const saved = [
+    { name: "github", ref: "official/dev/github" },
+    { name: "notion", ref: "skills-sh/productivity/notion" },
+  ];
+
+  it("finds saved skills missing from the runtime", () => {
+    const missing = computeMissingSavedHermesSkills(saved, [{ name: "github" }]);
+    expect(missing).toEqual([expect.objectContaining({ name: "notion" })]);
+  });
+
+  it("finds runtime skills Nora is not tracking", () => {
+    const orphaned = computeOrphanedInstalledHermesSkills(saved, [
+      { name: "github" },
+      { name: "manual-tui-install", version: "2.0" },
+    ]);
+    expect(orphaned).toEqual([expect.objectContaining({ name: "manual-tui-install" })]);
+  });
+
+  it("removes a saved entry by name", () => {
+    expect(removeSavedHermesSkillEntry(saved, "github")).toEqual([
+      expect.objectContaining({ name: "notion" }),
+    ]);
+    expect(removeSavedHermesSkillEntry(saved, "")).toHaveLength(2);
+  });
+});
+
+describe("mergeHermesSkillState", () => {
+  it("derives healthy / missing_runtime / orphaned_runtime and sorts by name", () => {
+    const merged = mergeHermesSkillState(
+      [
+        { name: "github", ref: "official/dev/github" },
+        { name: "notion", ref: "skills-sh/productivity/notion" },
+      ],
+      [
+        { name: "github", version: "1.2.0" },
+        { name: "zulip", version: "0.1.0" },
+      ],
+    );
+
+    expect(merged.map((row) => [row.name, row.status])).toEqual([
+      ["github", "healthy"],
+      ["notion", "missing_runtime"],
+      ["zulip", "orphaned_runtime"],
+    ]);
+    expect(merged[0]).toEqual(
+      expect.objectContaining({ saved: true, installed: true, version: "1.2.0" }),
+    );
+    expect(merged[2]).toEqual(expect.objectContaining({ saved: false, installed: true }));
+  });
+
+  it("lets pending jobs win over steady-state statuses", () => {
+    const merged = mergeHermesSkillState(
+      [{ name: "github", ref: "official/dev/github" }],
+      [{ name: "zulip" }],
+      [
+        { name: "github", operation: "install" },
+        { name: "zulip", operation: "delete" },
+      ],
+    );
+    expect(merged.map((row) => [row.name, row.status])).toEqual([
+      ["github", "pending_install"],
+      ["zulip", "pending_delete"],
+    ]);
+  });
+
+  it("never surfaces reserved Nora-managed skills from saved state", () => {
+    const merged = mergeHermesSkillState([{ name: "nora-integrations", ref: "x" }], []);
+    expect(merged).toEqual([]);
+  });
+});

--- a/backend-api/db_schema.sql
+++ b/backend-api/db_schema.sql
@@ -44,6 +44,7 @@ CREATE TABLE IF NOT EXISTS agents (
   image TEXT,
   template_payload JSONB DEFAULT '{}',
   clawhub_skills JSONB DEFAULT '[]',
+  hermes_skills JSONB DEFAULT '[]',
   vcpu INTEGER DEFAULT 1,
   ram_mb INTEGER DEFAULT 1024,
   disk_gb INTEGER DEFAULT 10,

--- a/backend-api/server.ts
+++ b/backend-api/server.ts
@@ -1867,6 +1867,8 @@ async function migrateDB(database = db, env = process.env) {
     `UPDATE agents SET template_payload = '{}'::jsonb WHERE template_payload IS NULL`,
     `DO $$ BEGIN ALTER TABLE agents ADD COLUMN clawhub_skills JSONB DEFAULT '[]'; EXCEPTION WHEN duplicate_column THEN NULL; END $$`,
     `UPDATE agents SET clawhub_skills = '[]'::jsonb WHERE clawhub_skills IS NULL`,
+    `DO $$ BEGIN ALTER TABLE agents ADD COLUMN hermes_skills JSONB DEFAULT '[]'; EXCEPTION WHEN duplicate_column THEN NULL; END $$`,
+    `UPDATE agents SET hermes_skills = '[]'::jsonb WHERE hermes_skills IS NULL`,
     `CREATE TABLE IF NOT EXISTS agent_migrations (
        id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
        user_id UUID REFERENCES users(id) ON DELETE CASCADE,

--- a/infra/helm/nora/files/db_schema.sql
+++ b/infra/helm/nora/files/db_schema.sql
@@ -44,6 +44,7 @@ CREATE TABLE IF NOT EXISTS agents (
   image TEXT,
   template_payload JSONB DEFAULT '{}',
   clawhub_skills JSONB DEFAULT '[]',
+  hermes_skills JSONB DEFAULT '[]',
   vcpu INTEGER DEFAULT 1,
   ram_mb INTEGER DEFAULT 1024,
   disk_gb INTEGER DEFAULT 10,


### PR DESCRIPTION
PR 1 of the **Hermes Skills + Agent Hub Hermes bundles** epic (planned from community feedback: skill pre-install for Hermes agents mirroring ClawHub, then Agent Hub Hermes templates).

## Background (from the implementation spike)
Hermes skills are the Agent Skills open standard (`SKILL.md` folders). The `nousresearch/hermes-agent` image ships a full `hermes skills` CLI (`install <identifier> --yes`, `uninstall <name>`, search/browse/audit) with a built-in security scanner, tracks hub installs in a lockfile at `~/.hermes/skills/.hub/lock.json` keyed by skill **name**, and aggregates a 90k-skill index at `hermes-agent.nousresearch.com/docs/api/skills-index.json`. Later PRs exec the CLI from the provisioner (ClawHub-style verify-then-persist jobs + reconcile-at-boot) and add browse/install routes + UI.

## This PR (inert foundation)
- **`agent-runtime/lib/hermesSkillsReconciliation.js`** — desired-vs-actual contracts keyed on the lockfile skill name, with the exact ClawHub status vocabulary (`healthy/missing_runtime/orphaned_runtime/pending_install/pending_delete`) so the dashboard's shared skill components render both families. A deliberate parallel module to `clawhubReconciliation.js` (rule of three — no shared engine at n=2), including a shared lockfile parser used later by both backend-api and the worker.
- **Name validation choke point**: the skill name reaches shell commands (`hermes skills uninstall <name>`), so one regex gate rejects path-unsafe names; Nora-managed skill dirs (`nora-integrations`) are reserved and can never normalize into saved state.
- **Schema**: `agents.hermes_skills JSONB DEFAULT '[]'` in `db_schema.sql` + the Helm mirror + the `server.ts` boot-migration array (same idiom as `clawhub_skills`).
- Tests: 15-case jest suite (validation, dedup/normalization, lockfile parsing, drift computation, merge statuses, reserved exclusion).

No routes, worker handlers, or UI in this PR — nothing changes behavior until PR 2/3 land.

Validated locally: new suite + full backend-api jest (2203 passing), typecheck, prettier.