### PR TITLE
feat(hermes): Skills sub-tab + smoke-test fixes (skills path, uninstall confirmation)

### DIFF
--- a/agent-runtime/lib/hermesSkillsReconciliation.js
+++ b/agent-runtime/lib/hermesSkillsReconciliation.js
@@ -4,14 +4,18 @@
 // shared engine: both live in the mounted agent-runtime blast-radius zone, and
 // the two families differ in identity (ClawHub keys on author+slug from its
 // own lockfile; Hermes keys on the skill NAME from the Hermes hub lockfile at
-// ~/.hermes/skills/.hub/lock.json, whose entries may nest under category
+// $HERMES_HOME/skills/.hub/lock.json, whose entries may nest under category
 // folders via install_path). The status vocabulary and row shape are kept
 // IDENTICAL to the ClawHub module so the dashboard's shared skill components
 // render both families: healthy / missing_runtime / orphaned_runtime /
 // pending_install / pending_delete.
 
-// Container-absolute paths for the Hermes skills tree (HOME=/opt/data/home).
-const HERMES_SKILLS_DIR = "/opt/data/home/.hermes/skills";
+// Container-absolute paths for the Hermes hub skills tree. get_hermes_home()
+// honors HERMES_HOME (=/opt/data in Nora containers and the stock image), so
+// hub skills live at /opt/data/skills — NOT under $HOME/.hermes (that is the
+// separate "local" tier where Nora's generated nora-integrations skill lives).
+// Verified against nousresearch/hermes-agent:latest (2026-07-30 smoke).
+const HERMES_SKILLS_DIR = "/opt/data/skills";
 const HERMES_SKILLS_LOCK_FILE = `${HERMES_SKILLS_DIR}/.hub/lock.json`;
 
 // Skill directories Nora itself manages. These are written by the integrations

--- a/backend-api/__tests__/hermesSkills.test.ts
+++ b/backend-api/__tests__/hermesSkills.test.ts
@@ -450,7 +450,7 @@ describe("hermes skills routes", () => {
     expect(res.statusCode).toBe(200);
     expect(runContainerCommand).toHaveBeenCalledWith(
       expect.objectContaining({ id: "agent-1" }),
-      expect.stringContaining(".hermes/skills/.hub/lock.json"),
+      expect.stringContaining("/opt/data/skills/.hub/lock.json"),
     );
     expect(res.body).toEqual({
       skills: [

--- a/backend-api/__tests__/hermesSkillsReconciliation.test.ts
+++ b/backend-api/__tests__/hermesSkillsReconciliation.test.ts
@@ -99,7 +99,7 @@ describe("lockfile parsing", () => {
   });
 
   it("exports the lockfile path under the skills dir", () => {
-    expect(HERMES_SKILLS_LOCK_FILE).toBe("/opt/data/home/.hermes/skills/.hub/lock.json");
+    expect(HERMES_SKILLS_LOCK_FILE).toBe("/opt/data/skills/.hub/lock.json");
   });
 });
 

--- a/frontend-dashboard/components/agents/HermesWebUITab.tsx
+++ b/frontend-dashboard/components/agents/HermesWebUITab.tsx
@@ -14,6 +14,7 @@ import HermesChannelsPanel from "./hermes/ChannelsPanel";
 import HermesChatPanel from "./hermes/ChatPanel";
 import HermesCronPanel from "./hermes/CronPanel";
 import OfficialDashboardPanel from "./hermes/OfficialDashboardPanel";
+import HermesSkillsPanel from "./hermes/SkillsPanel";
 import HermesStatusPanel from "./hermes/StatusPanel";
 
 const STATUS_POLL_MS = 5000;
@@ -23,6 +24,7 @@ const subTabs = [
   { id: "status", label: "Status", icon: Radio },
   { id: "chat", label: "Chat", icon: MessageSquare },
   { id: "integrations", label: "Integrations", icon: Puzzle },
+  { id: "skills", label: "Skills", icon: Puzzle },
   { id: "cron", label: "Cron", icon: CalendarClock },
   { id: "channels", label: "Channels", icon: MessagesSquare },
 ];
@@ -199,6 +201,9 @@ export default function HermesWebUITab({ agentId, agentStatus }) {
           />
         )}
         {activeSubTab === "integrations" && <HermesIntegrationsPanel agentId={agentId} />}
+        {activeSubTab === "skills" && (
+          <HermesSkillsPanel agentId={agentId} agentStatus={agentStatus} />
+        )}
         {activeSubTab === "cron" && <HermesCronPanel agentId={agentId} />}
         {activeSubTab === "channels" && <HermesChannelsPanel agentId={agentId} />}
       </div>

--- a/frontend-dashboard/components/agents/hermes/SkillsPanel.tsx
+++ b/frontend-dashboard/components/agents/hermes/SkillsPanel.tsx
@@ -1,0 +1,917 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  BookMarked,
+  Bot,
+  Boxes,
+  ChevronLeft,
+  CircleAlert,
+  FileText,
+  RefreshCw,
+  Rocket,
+  Trash2,
+  X,
+} from "lucide-react";
+import { useToast } from "../../Toast";
+import { fetchWithAuth } from "../../../lib/api";
+import InstalledSkillsPanel from "../openclaw/InstalledSkillsPanel";
+import SkillGrid from "../openclaw/SkillGrid";
+import SkillSearchBar from "../openclaw/SkillSearchBar";
+import {
+  agentSkillRowToInstalledRow,
+  applyPendingJobOverlay,
+  browseSummaryToCardSkill,
+  computeInstalledNames,
+  computeInstalledRefs,
+  computeLibraryRefs,
+  formatHermesTrustLevel,
+  installedSectionRows,
+  isJobActive,
+} from "../../../lib/hermesSkillsView";
+
+const REGISTRY_UNAVAILABLE_MESSAGE =
+  "Could not load skills. The Hermes skills registry may be unavailable.";
+
+function MetaChip({ label, value }) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2">
+      <p className="text-[10px] font-bold uppercase tracking-wide text-slate-400">{label}</p>
+      <p className="mt-1 break-all text-xs font-medium text-slate-700">{value || "Not listed"}</p>
+    </div>
+  );
+}
+
+// Local stand-in for the shared openclaw SkillDetailPanel: Hermes index
+// entries carry no readme, download counts, or requirements metadata, so the
+// ClawHub-shaped panel would render misleading zero-count and empty-README
+// sections. This card shows the metadata the Hermes registry actually
+// provides (source, trust level, repo/path, tags) plus the library action.
+function SkillDetailCard({
+  skill,
+  detail,
+  loading,
+  error,
+  inLibrary,
+  libraryBusy,
+  onAddToLibrary,
+  onClose,
+}) {
+  const activeSkill = detail || skill;
+
+  return (
+    <aside className="lg:sticky lg:top-5">
+      <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-sky-600">
+              Skill Detail
+            </p>
+            <h4 className="mt-1 text-lg font-black text-slate-900">
+              {activeSkill?.name || "Select a skill to inspect"}
+            </h4>
+          </div>
+          {activeSkill ? (
+            <button
+              type="button"
+              onClick={onClose}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs font-bold text-slate-600 transition hover:bg-slate-100"
+            >
+              <ChevronLeft size={12} />
+              Close
+            </button>
+          ) : null}
+        </div>
+
+        {!activeSkill ? (
+          <div className="mt-5 rounded-2xl border border-dashed border-slate-200 bg-slate-50 p-6 text-center">
+            <FileText size={24} className="mx-auto text-slate-300" />
+            <p className="mt-3 text-sm font-bold text-slate-700">
+              Pick a card to see the skill&apos;s registry metadata.
+            </p>
+            <p className="mt-1 text-xs leading-5 text-slate-500">
+              This panel is read-only and focused on the skill&apos;s details.
+            </p>
+          </div>
+        ) : (
+          <div className="mt-5 space-y-5">
+            <div className="space-y-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-bold uppercase tracking-wide text-slate-600">
+                  {activeSkill.ref}
+                </span>
+              </div>
+              <p className="text-sm leading-6 text-slate-600">
+                {activeSkill.description || "No description provided."}
+              </p>
+            </div>
+
+            {error ? (
+              <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+                <div className="flex items-start gap-2">
+                  <CircleAlert size={16} className="mt-0.5 shrink-0 text-red-500" />
+                  <div>
+                    <p className="font-bold text-red-800">Could not load skill details.</p>
+                    <p className="mt-1 text-xs leading-5 text-red-700">{error}</p>
+                  </div>
+                </div>
+              </div>
+            ) : null}
+
+            {loading && !detail ? (
+              <div className="space-y-3 rounded-2xl border border-slate-200 bg-slate-50 p-4">
+                <div className="h-4 w-1/2 animate-pulse rounded-full bg-slate-200" />
+                <div className="h-4 w-full animate-pulse rounded-full bg-slate-200" />
+                <div className="h-4 w-3/4 animate-pulse rounded-full bg-slate-200" />
+              </div>
+            ) : (
+              <div className="grid gap-2 sm:grid-cols-2">
+                <MetaChip label="Source" value={activeSkill.source} />
+                <MetaChip
+                  label="Trust level"
+                  value={formatHermesTrustLevel(activeSkill.trustLevel)}
+                />
+                <MetaChip label="Repository" value={detail?.repo} />
+                <MetaChip label="Path" value={detail?.path} />
+              </div>
+            )}
+
+            {detail?.tags?.length ? (
+              <div className="flex flex-wrap gap-2">
+                {detail.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="rounded-full bg-slate-50 px-2.5 py-1 text-[11px] font-medium text-slate-600 ring-1 ring-slate-200"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            ) : null}
+
+            <button
+              type="button"
+              onClick={() => onAddToLibrary(activeSkill)}
+              disabled={inLibrary || libraryBusy}
+              className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-bold text-slate-700 transition-colors hover:bg-slate-50 disabled:opacity-60"
+            >
+              <BookMarked size={14} />
+              {inLibrary ? "In library" : libraryBusy ? "Adding..." : "Add to library"}
+            </button>
+          </div>
+        )}
+      </div>
+    </aside>
+  );
+}
+
+export default function HermesSkillsPanel({ agentId, agentStatus }) {
+  const toast = useToast();
+  const agentActive = agentStatus === "running" || agentStatus === "warning";
+  const [query, setQuery] = useState("");
+  const [skills, setSkills] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [selectedSkill, setSelectedSkill] = useState(null);
+  const [selectedSkillDetail, setSelectedSkillDetail] = useState(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [detailError, setDetailError] = useState(null);
+  const [selectedInstallSkills, setSelectedInstallSkills] = useState([]);
+  const [pendingInstallSelectionRefs, setPendingInstallSelectionRefs] = useState([]);
+  const [selectedDeleteSkills, setSelectedDeleteSkills] = useState([]);
+  const [selectionBusyRef, setSelectionBusyRef] = useState(null);
+  const [jobStatuses, setJobStatuses] = useState<Record<string, any>>({});
+  const [installError, setInstallError] = useState(null);
+  const [deleteError, setDeleteError] = useState(null);
+  const [agentSkills, setAgentSkills] = useState([]);
+  const [library, setLibrary] = useState([]);
+  const [libraryError, setLibraryError] = useState(null);
+  const [libraryBusyId, setLibraryBusyId] = useState(null);
+  const [libraryAddBusyRef, setLibraryAddBusyRef] = useState(null);
+  const requestIdRef = useRef(0);
+  const detailCacheRef = useRef({});
+
+  const showingDefaultBrowseEmptyState = !query.trim() && !loading && !error && skills.length === 0;
+  const browseCards = useMemo(() => skills.map(browseSummaryToCardSkill), [skills]);
+  const displayedAgentSkills = useMemo(
+    () => applyPendingJobOverlay(agentSkills, jobStatuses),
+    [agentSkills, jobStatuses],
+  );
+  const installedSectionSkills = useMemo(
+    () => installedSectionRows(displayedAgentSkills).map(agentSkillRowToInstalledRow),
+    [displayedAgentSkills],
+  );
+  const installedNames = useMemo(() => computeInstalledNames(agentSkills), [agentSkills]);
+  const installedRefs = useMemo(() => computeInstalledRefs(agentSkills), [agentSkills]);
+  const libraryRefs = useMemo(() => computeLibraryRefs(library), [library]);
+  const displayedSelectedInstallRefs = useMemo(
+    () =>
+      new Set([...pendingInstallSelectionRefs, ...selectedInstallSkills.map((skill) => skill.ref)]),
+    [pendingInstallSelectionRefs, selectedInstallSkills],
+  );
+  const selectedDeleteNames = useMemo(
+    () => new Set(selectedDeleteSkills.map((skill) => skill.slug)),
+    [selectedDeleteSkills],
+  );
+  const activeInstallCount = useMemo(
+    () =>
+      Object.values(jobStatuses).filter(
+        (status) => status.operation === "install" && isJobActive(status),
+      ).length,
+    [jobStatuses],
+  );
+  const activeDeleteCount = useMemo(
+    () =>
+      Object.values(jobStatuses).filter(
+        (status) => status.operation === "delete" && isJobActive(status),
+      ).length,
+    [jobStatuses],
+  );
+
+  async function loadInstalledSkills() {
+    try {
+      const res = await fetchWithAuth(`/api/hermes-skills/agents/${agentId}/skills`);
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data.message || data.error || "Could not load installed skills.");
+      }
+      setAgentSkills(Array.isArray(data.skills) ? data.skills : []);
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  async function loadLibrary() {
+    setLibraryError(null);
+    try {
+      const res = await fetchWithAuth("/api/hermes-skills/library");
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data.message || data.error || "Could not load the skills library.");
+      }
+      setLibrary(Array.isArray(data.skills) ? data.skills : []);
+    } catch (err) {
+      setLibraryError(err?.message || "Could not load the skills library.");
+    }
+  }
+
+  async function loadBrowseResults() {
+    const requestId = ++requestIdRef.current;
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetchWithAuth("/api/hermes-skills/skills");
+      const data = await res.json();
+      if (requestId !== requestIdRef.current) return;
+
+      if (!res.ok) {
+        throw new Error(data.message || data.error || REGISTRY_UNAVAILABLE_MESSAGE);
+      }
+
+      setSkills(Array.isArray(data.skills) ? data.skills : []);
+    } catch (err) {
+      if (requestId !== requestIdRef.current) return;
+      setSkills([]);
+      setError(err?.message || REGISTRY_UNAVAILABLE_MESSAGE);
+    } finally {
+      if (requestId === requestIdRef.current) {
+        setLoading(false);
+      }
+    }
+  }
+
+  async function searchSkills() {
+    const trimmed = query.trim();
+    if (!trimmed) {
+      loadBrowseResults();
+      return;
+    }
+
+    const requestId = ++requestIdRef.current;
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetchWithAuth(
+        `/api/hermes-skills/skills/search?q=${encodeURIComponent(trimmed)}`,
+      );
+      const data = await res.json();
+      if (requestId !== requestIdRef.current) return;
+
+      if (!res.ok) {
+        throw new Error(data.message || data.error || REGISTRY_UNAVAILABLE_MESSAGE);
+      }
+
+      setSkills(Array.isArray(data.skills) ? data.skills : []);
+    } catch (err) {
+      if (requestId !== requestIdRef.current) return;
+      setSkills([]);
+      setError(err?.message || REGISTRY_UNAVAILABLE_MESSAGE);
+    } finally {
+      if (requestId === requestIdRef.current) {
+        setLoading(false);
+      }
+    }
+  }
+
+  async function fetchSkillDetail(ref) {
+    const cached = detailCacheRef.current[ref];
+    if (cached) {
+      return cached;
+    }
+
+    const res = await fetchWithAuth(
+      `/api/hermes-skills/skills/detail?ref=${encodeURIComponent(ref)}`,
+    );
+    const data = await res.json();
+
+    if (!res.ok) {
+      throw new Error(data.message || data.error || "Could not load skill details.");
+    }
+
+    detailCacheRef.current[ref] = data;
+    return data;
+  }
+
+  // The grid hands back card objects keyed by slug; the slug IS the registry
+  // ref for Hermes browse cards.
+  async function loadSkillDetail(card) {
+    setSelectedSkill({ ref: card.slug, name: card.name, description: card.description });
+    setSelectedSkillDetail(detailCacheRef.current[card.slug] || null);
+    setDetailError(null);
+    setDetailLoading(true);
+
+    try {
+      const detail = await fetchSkillDetail(card.slug);
+      setSelectedSkill(detail);
+      setSelectedSkillDetail(detail);
+    } catch (err) {
+      setDetailError(err?.message || "Could not load skill details.");
+    } finally {
+      setDetailLoading(false);
+    }
+  }
+
+  function addSelectedInstallSkill(detail) {
+    setPendingInstallSelectionRefs((current) => current.filter((ref) => ref !== detail.ref));
+    setSelectedInstallSkills((current) => {
+      if (current.some((entry) => entry.ref === detail.ref)) return current;
+      return [...current, detail];
+    });
+  }
+
+  // Removal is matched on ref (browse identity) or name (install identity):
+  // job completions only know the skill name.
+  function removeSelectedInstallSkill(skill) {
+    setPendingInstallSelectionRefs((current) => current.filter((ref) => ref !== skill.ref));
+    setSelectedInstallSkills((current) =>
+      current.filter((entry) => entry.ref !== skill.ref && entry.name !== skill.name),
+    );
+  }
+
+  function clearSelectedInstallSkills() {
+    setPendingInstallSelectionRefs([]);
+    setSelectedInstallSkills([]);
+  }
+
+  function removeSelectedDeleteSkill(skill) {
+    setSelectedDeleteSkills((current) => current.filter((entry) => entry.slug !== skill.slug));
+  }
+
+  function clearSelectedDeleteSkills() {
+    setSelectedDeleteSkills([]);
+  }
+
+  function toggleInstalledSkillSelection(skill) {
+    if (selectedDeleteNames.has(skill.slug)) {
+      removeSelectedDeleteSkill(skill);
+    } else {
+      setSelectedDeleteSkills((current) => {
+        if (current.some((entry) => entry.slug === skill.slug)) return current;
+        return [...current, skill];
+      });
+    }
+  }
+
+  async function toggleSkillSelection(card) {
+    const ref = card.slug;
+    const cached = detailCacheRef.current[ref];
+    if (displayedSelectedInstallRefs.has(ref)) {
+      setPendingInstallSelectionRefs((current) => current.filter((entry) => entry !== ref));
+      setSelectedInstallSkills((current) => current.filter((entry) => entry.ref !== ref));
+      return;
+    }
+
+    setPendingInstallSelectionRefs((current) =>
+      current.includes(ref) ? current : [...current, ref],
+    );
+    setSelectionBusyRef(ref);
+    try {
+      const detail = cached || (await fetchSkillDetail(ref));
+      addSelectedInstallSkill(detail);
+      setSelectedSkill(detail);
+      setSelectedSkillDetail(detail);
+      setDetailError(null);
+    } catch (err) {
+      setPendingInstallSelectionRefs((current) => current.filter((entry) => entry !== ref));
+      toast.error(err?.message || "Could not update that selection.");
+    } finally {
+      setSelectionBusyRef(null);
+    }
+  }
+
+  async function queueInstall(skill) {
+    if (installedNames.has(skill.name)) {
+      return;
+    }
+    const res = await fetchWithAuth(`/api/hermes-skills/agents/${agentId}/skills/install`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ ref: skill.ref, name: skill.name }),
+    });
+    const data = await res.json();
+    if (!res.ok) {
+      throw new Error(data.message || data.error || "Could not queue install.");
+    }
+
+    const name = data.name || skill.name;
+    setJobStatuses((current) => ({
+      ...current,
+      [name]: {
+        jobId: data.jobId,
+        agentId: data.agentId,
+        name,
+        operation: "install",
+        status: data.status || "pending",
+        error: null,
+        completedAt: null,
+      },
+    }));
+  }
+
+  async function handleInstallSelected() {
+    const installable = selectedInstallSkills.filter((skill) => !installedNames.has(skill.name));
+    if (!installable.length) {
+      setInstallError("All selected skills are already installed.");
+      return;
+    }
+
+    setInstallError(null);
+
+    for (const skill of installable) {
+      try {
+        await queueInstall(skill);
+      } catch (err) {
+        setJobStatuses((current) => ({
+          ...current,
+          [skill.name]: {
+            jobId: current[skill.name]?.jobId || `${skill.name}-failed`,
+            agentId,
+            name: skill.name,
+            operation: "install",
+            status: "failed",
+            error: err?.message || "Could not queue install.",
+            completedAt: null,
+          },
+        }));
+      }
+    }
+  }
+
+  async function handleDeleteSelected() {
+    if (!selectedDeleteSkills.length) {
+      setDeleteError("No installed skills selected for delete.");
+      return;
+    }
+
+    setDeleteError(null);
+
+    for (const skill of selectedDeleteSkills) {
+      try {
+        const res = await fetchWithAuth(`/api/hermes-skills/agents/${agentId}/skills/delete`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ name: skill.slug }),
+        });
+        const data = await res.json();
+        if (!res.ok) {
+          throw new Error(data.message || data.error || "Could not queue delete.");
+        }
+
+        setJobStatuses((current) => ({
+          ...current,
+          [data.name || skill.slug]: {
+            jobId: data.jobId,
+            agentId: data.agentId,
+            name: data.name || skill.slug,
+            operation: "delete",
+            status: data.status || "pending",
+            error: null,
+            completedAt: null,
+          },
+        }));
+      } catch (err) {
+        setJobStatuses((current) => ({
+          ...current,
+          [skill.slug]: {
+            jobId: current[skill.slug]?.jobId || `${skill.slug}-delete-failed`,
+            agentId,
+            name: skill.slug,
+            operation: "delete",
+            status: "failed",
+            error: err?.message || "Could not queue delete.",
+            completedAt: null,
+          },
+        }));
+      }
+    }
+  }
+
+  async function handleInstallLibraryEntry(entry) {
+    try {
+      await queueInstall(entry);
+    } catch (err) {
+      toast.error(err?.message || "Could not queue install.");
+    }
+  }
+
+  async function handleAddToLibrary(skill) {
+    if (!skill?.ref || libraryRefs.has(skill.ref)) return;
+    setLibraryAddBusyRef(skill.ref);
+    try {
+      const res = await fetchWithAuth("/api/hermes-skills/library", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ref: skill.ref,
+          name: skill.name || skill.ref,
+          description: skill.description || "",
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data.message || data.error || "Could not add that skill to the library.");
+      }
+      toast.success(`${data.name || skill.name || skill.ref} added to the library.`);
+      await loadLibrary();
+    } catch (err) {
+      toast.error(err?.message || "Could not add that skill to the library.");
+    } finally {
+      setLibraryAddBusyRef(null);
+    }
+  }
+
+  async function handleRemoveLibraryEntry(entry) {
+    setLibraryBusyId(entry.id);
+    try {
+      const res = await fetchWithAuth(
+        `/api/hermes-skills/library/${encodeURIComponent(entry.id)}`,
+        { method: "DELETE" },
+      );
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(
+          data.message || data.error || "Could not remove that skill from the library.",
+        );
+      }
+      setLibrary((current) => current.filter((row) => row.id !== entry.id));
+    } catch (err) {
+      toast.error(err?.message || "Could not remove that skill from the library.");
+    } finally {
+      setLibraryBusyId(null);
+    }
+  }
+
+  function handleQueryChange(value) {
+    setQuery(value);
+    if (!value.trim()) {
+      setSelectedSkill(null);
+      setSelectedSkillDetail(null);
+      setDetailError(null);
+      loadBrowseResults();
+    }
+  }
+
+  function handleClearSearch() {
+    setQuery("");
+    setSelectedSkill(null);
+    setSelectedSkillDetail(null);
+    setDetailError(null);
+    loadBrowseResults();
+  }
+
+  useEffect(() => {
+    if (!agentId || !agentActive) return;
+    loadBrowseResults();
+    loadLibrary();
+  }, [agentId, agentActive]);
+
+  useEffect(() => {
+    if (!agentId || !agentActive) return;
+    loadInstalledSkills();
+  }, [agentId, agentActive]);
+
+  useEffect(() => {
+    const activeJobs = Object.values(jobStatuses).filter((status) => isJobActive(status));
+    if (!activeJobs.length) return;
+
+    const intervalId = window.setInterval(async () => {
+      for (const job of activeJobs) {
+        try {
+          const res = await fetchWithAuth(
+            `/api/hermes-skills/jobs/${encodeURIComponent(job.jobId)}`,
+          );
+          const data = await res.json();
+          if (!res.ok) {
+            continue;
+          }
+
+          setJobStatuses((current) => ({
+            ...current,
+            [data.name]: data,
+          }));
+
+          if (data.status === "success") {
+            await loadInstalledSkills();
+            if (data.operation === "install") {
+              removeSelectedInstallSkill({ name: data.name });
+              toast.success(`${data.name} installed.`);
+            } else {
+              removeSelectedDeleteSkill({ slug: data.name });
+              toast.success(`${data.name} deleted.`);
+            }
+          }
+
+          if (data.status === "failed" && data.error) {
+            toast.error(data.error);
+          }
+        } catch (err) {
+          console.error(err);
+        }
+      }
+    }, 2000);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [agentId, jobStatuses, toast]);
+
+  if (!agentActive) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-3 rounded-2xl border border-slate-200 bg-slate-50 p-12">
+        <Bot size={32} className="text-slate-400" />
+        <p className="text-sm font-medium text-slate-500">
+          Hermes skills available when agent is{" "}
+          <span className="font-bold text-green-500">running</span>
+        </p>
+        <p className="text-xs text-slate-400">
+          Agent is currently <span className="font-bold">{agentStatus}</span>
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-3xl border border-slate-200 bg-gradient-to-r from-white via-slate-50 to-blue-50 p-5 shadow-sm">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+          <div className="space-y-2">
+            <div className="inline-flex items-center gap-2 rounded-full border border-blue-200 bg-white px-3 py-1 text-[11px] font-black uppercase tracking-[0.18em] text-blue-700">
+              <Boxes size={12} />
+              Hermes Skills Hub
+            </div>
+            <h3 className="text-2xl font-black text-slate-900">Manage skills on this agent</h3>
+            <p className="max-w-2xl text-sm leading-6 text-slate-600">
+              Review installed Hermes skills, remove skills from the running agent, and browse the
+              Hermes Skills Hub to queue new installs.
+            </p>
+          </div>
+
+          <button
+            type="button"
+            onClick={() => {
+              loadBrowseResults();
+              loadInstalledSkills();
+              loadLibrary();
+            }}
+            disabled={loading}
+            className="inline-flex items-center gap-2 self-start rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-bold text-slate-700 transition-colors hover:bg-slate-50 disabled:opacity-60"
+          >
+            <RefreshCw size={14} className={loading ? "animate-spin" : ""} />
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      <div className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
+        <div className="space-y-3">
+          <div className="text-xs font-black uppercase tracking-[0.18em] text-slate-500">
+            Skills Library
+          </div>
+          <div className="flex items-center gap-2 text-2xl font-black text-slate-900">
+            <BookMarked size={20} className="text-blue-500" />
+            {library.length} saved
+          </div>
+          <p className="text-sm text-slate-600">
+            Skills curated for this Nora instance. Install one on this agent, or remove it from the
+            shared library.
+          </p>
+          {libraryError ? <p className="text-sm font-medium text-red-600">{libraryError}</p> : null}
+        </div>
+
+        {library.length ? (
+          <div className="mt-5 grid grid-cols-1 gap-3 xl:grid-cols-2">
+            {library.map((entry) => {
+              const installed = installedNames.has(entry.name);
+              const busy = isJobActive(jobStatuses[entry.name]);
+              return (
+                <div
+                  key={entry.id}
+                  className="flex h-full flex-col justify-between gap-3 rounded-2xl border border-slate-200 bg-slate-50 p-4"
+                >
+                  <div className="min-w-0">
+                    <div className="text-sm font-black text-slate-900">{entry.name}</div>
+                    <div className="truncate text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                      {entry.ref}
+                    </div>
+                    {entry.description ? (
+                      <p className="mt-2 line-clamp-2 text-sm leading-6 text-slate-600">
+                        {entry.description}
+                      </p>
+                    ) : null}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => handleInstallLibraryEntry(entry)}
+                      disabled={installed || busy}
+                      className="inline-flex items-center gap-2 rounded-xl bg-emerald-600 px-3 py-2 text-xs font-black text-white transition-colors hover:bg-emerald-700 disabled:opacity-60"
+                    >
+                      <Rocket size={12} />
+                      {installed ? "Installed" : busy ? "Working..." : "Install"}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => handleRemoveLibraryEntry(entry)}
+                      disabled={libraryBusyId === entry.id}
+                      className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-xs font-black text-slate-600 transition-colors hover:bg-slate-100 hover:text-rose-700 disabled:opacity-60"
+                    >
+                      <Trash2 size={12} />
+                      Remove
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        ) : (
+          <div className="mt-5 rounded-2xl border border-dashed border-slate-300 bg-slate-50 px-5 py-6 text-center">
+            <p className="text-sm font-bold text-slate-700">No skills in the library yet.</p>
+            <p className="mt-1 text-xs text-slate-500">
+              Open a skill below and choose &quot;Add to library&quot; to pin it for every operator
+              on this instance.
+            </p>
+          </div>
+        )}
+      </div>
+
+      <div className="space-y-3">
+        {installedSectionSkills.length ? (
+          // Hermes rows satisfy everything the shared panel renders (slug,
+          // status, version, pagePath); the AgentClawhubSkill type's
+          // clawhub-literal `source` field is the only mismatch, so the cast
+          // stays contained to this boundary.
+          <InstalledSkillsPanel
+            skills={installedSectionSkills as any}
+            selectedDeleteSlugs={selectedDeleteNames}
+            deleting={activeDeleteCount > 0}
+            deleteError={deleteError}
+            onToggleDelete={toggleInstalledSkillSelection}
+            onDeleteSelected={handleDeleteSelected}
+            onClearSelection={clearSelectedDeleteSkills}
+          />
+        ) : (
+          // The shared panel's empty state is ClawHub-branded, so the Hermes
+          // panel renders its own copy of the same empty-state block.
+          <div className="rounded-3xl border border-dashed border-slate-300 bg-slate-50 px-5 py-8 text-center">
+            <p className="text-sm font-bold text-slate-700">
+              No Hermes skills currently installed.
+            </p>
+          </div>
+        )}
+      </div>
+
+      <SkillSearchBar
+        placeholder="Search Hermes skills and press Enter"
+        query={query}
+        loading={loading}
+        onQueryChange={handleQueryChange}
+        onSubmit={searchSkills}
+        onClear={handleClearSearch}
+      />
+
+      {selectedInstallSkills.length ? (
+        <div className="rounded-3xl border border-slate-200 bg-white p-4 shadow-sm">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+            <div className="space-y-2">
+              <div className="text-xs font-black uppercase tracking-[0.18em] text-slate-500">
+                Selected Skills
+              </div>
+              <p className="text-sm font-semibold text-slate-900">
+                {selectedInstallSkills.length} skill{selectedInstallSkills.length === 1 ? "" : "s"}{" "}
+                selected for install.
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {selectedInstallSkills.map((skill) => (
+                  <span
+                    key={skill.ref}
+                    className="inline-flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-bold text-slate-800"
+                  >
+                    {skill.name || skill.ref}
+                    <button
+                      type="button"
+                      onClick={() => removeSelectedInstallSkill(skill)}
+                      className="inline-flex h-4 w-4 items-center justify-center rounded-full text-slate-500 transition-colors hover:bg-slate-200 hover:text-slate-800"
+                      aria-label={`Remove ${skill.name || skill.ref} from install selection`}
+                    >
+                      <X size={12} />
+                    </button>
+                  </span>
+                ))}
+              </div>
+              {installError ? (
+                <p className="text-sm font-medium text-red-600">{installError}</p>
+              ) : null}
+            </div>
+
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <button
+                type="button"
+                onClick={clearSelectedInstallSkills}
+                className="inline-flex items-center justify-center gap-2 rounded-2xl border border-slate-200 bg-white px-4 py-3 text-sm font-black text-slate-700 transition-colors hover:bg-slate-50"
+              >
+                Clear
+              </button>
+              <button
+                type="button"
+                onClick={handleInstallSelected}
+                disabled={activeInstallCount > 0}
+                className="inline-flex items-center justify-center gap-2 rounded-2xl bg-emerald-600 px-5 py-3 text-sm font-black text-white transition-colors hover:bg-emerald-700 disabled:opacity-60"
+              >
+                <Rocket size={16} />
+                {activeInstallCount
+                  ? `Installing ${activeInstallCount} skill${activeInstallCount === 1 ? "" : "s"}...`
+                  : `Install Selected (${selectedInstallSkills.length})`}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+
+      <div className="grid grid-cols-1 gap-4 2xl:grid-cols-[minmax(0,1.4fr)_minmax(360px,0.9fr)]">
+        <div className="min-w-0">
+          <SkillGrid
+            loadingLabel="Loading Hermes skills..."
+            skills={browseCards}
+            loading={loading}
+            error={error}
+            query={query}
+            selectedSlug={null}
+            installedSlugs={installedRefs}
+            selectedSkillSlugs={displayedSelectedInstallRefs}
+            selectionBusySlug={selectionBusyRef}
+            onSelect={loadSkillDetail}
+            onToggleSelection={toggleSkillSelection}
+            emptyTitle={
+              showingDefaultBrowseEmptyState
+                ? "Search the Hermes Skills Hub to discover skills."
+                : "No skills found."
+            }
+            emptyMessage={
+              showingDefaultBrowseEmptyState
+                ? "The registry returned an empty default browse list. Enter a search and press Enter to find skills."
+                : undefined
+            }
+          />
+        </div>
+
+        <div className="min-w-0">
+          <SkillDetailCard
+            skill={selectedSkill}
+            detail={selectedSkillDetail}
+            loading={detailLoading}
+            error={detailError}
+            inLibrary={selectedSkill ? libraryRefs.has(selectedSkill.ref) : false}
+            libraryBusy={selectedSkill ? libraryAddBusyRef === selectedSkill.ref : false}
+            onAddToLibrary={handleAddToLibrary}
+            onClose={() => {
+              setSelectedSkill(null);
+              setSelectedSkillDetail(null);
+              setDetailError(null);
+              setDetailLoading(false);
+            }}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend-dashboard/components/agents/openclaw/SkillGrid.tsx
+++ b/frontend-dashboard/components/agents/openclaw/SkillGrid.tsx
@@ -14,6 +14,7 @@ type SkillGridProps = {
   onToggleSelection?: (skill: SkillSummary) => void;
   emptyTitle?: string;
   emptyMessage?: string;
+  loadingLabel?: string;
 };
 
 function LoadingSkeleton() {
@@ -41,13 +42,14 @@ export default function SkillGrid({
   onToggleSelection,
   emptyTitle = "No skills found.",
   emptyMessage,
+  loadingLabel = "Loading ClawHub skills...",
 }: SkillGridProps) {
   if (loading) {
     return (
       <div className="space-y-4">
         <div className="flex items-center gap-2 text-sm font-semibold text-slate-500">
           <Loader2 size={16} className="animate-spin text-blue-500" />
-          Loading ClawHub skills...
+          {loadingLabel}
         </div>
         <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
           {Array.from({ length: 6 }).map((_, index) => (

--- a/frontend-dashboard/components/agents/openclaw/SkillSearchBar.tsx
+++ b/frontend-dashboard/components/agents/openclaw/SkillSearchBar.tsx
@@ -4,6 +4,7 @@ import { Search, X } from "lucide-react";
 type SkillSearchBarProps = {
   query: string;
   loading?: boolean;
+  placeholder?: string;
   onQueryChange: (value: string) => void;
   onSubmit: () => void;
   onClear: () => void;
@@ -12,6 +13,7 @@ type SkillSearchBarProps = {
 export default function SkillSearchBar({
   query,
   loading = false,
+  placeholder = "Search ClawHub skills and press Enter",
   onQueryChange,
   onSubmit,
   onClear,
@@ -36,7 +38,7 @@ export default function SkillSearchBar({
             type="text"
             value={query}
             onChange={(event) => onQueryChange(event.target.value)}
-            placeholder="Search ClawHub skills and press Enter"
+            placeholder={placeholder}
             className="w-full rounded-xl border border-slate-200 bg-slate-50 py-2.5 pl-10 pr-10 text-sm text-slate-900 outline-none transition-all focus:border-blue-400 focus:bg-white focus:ring-2 focus:ring-blue-100"
           />
           {query && (

--- a/frontend-dashboard/lib/hermesSkillsView.test.ts
+++ b/frontend-dashboard/lib/hermesSkillsView.test.ts
@@ -1,0 +1,151 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  agentSkillRowToInstalledRow,
+  applyPendingJobOverlay,
+  browseSummaryToCardSkill,
+  computeInstalledNames,
+  computeInstalledRefs,
+  computeLibraryRefs,
+  formatHermesTrustLevel,
+  installedSectionRows,
+  isJobActive,
+  type HermesAgentSkillRow,
+} from "./hermesSkillsView";
+
+function row(overrides: Partial<HermesAgentSkillRow> = {}): HermesAgentSkillRow {
+  return {
+    name: "1password",
+    version: "1.0.0",
+    saved: true,
+    installed: true,
+    source: "hermes-hub",
+    ref: "official/security/1password",
+    installMode: "cli",
+    installedAt: "2026-07-01T00:00:00.000Z",
+    status: "healthy",
+    ...overrides,
+  };
+}
+
+test("browse summaries map ref to slug with null counts so SkillCard hides stats", () => {
+  const card = browseSummaryToCardSkill({
+    ref: "official/security/1password",
+    name: "1password",
+    description: "Manage 1Password items.",
+    source: "official",
+    trustLevel: "builtin",
+    tags: ["security"],
+  });
+
+  assert.deepEqual(card, {
+    slug: "official/security/1password",
+    name: "1password",
+    description: "Manage 1Password items.",
+    downloads: null,
+    stars: null,
+    updatedAt: null,
+  });
+});
+
+test("browse summaries fall back to the ref as name and a neutral description", () => {
+  const card = browseSummaryToCardSkill({ ref: "community/foo/bar" });
+  assert.equal(card.name, "community/foo/bar");
+  assert.equal(card.description, "No description provided.");
+});
+
+test("agent skill rows gain slug=name and surface the ref as pagePath", () => {
+  const mapped = agentSkillRowToInstalledRow(row());
+  assert.equal(mapped.slug, "1password");
+  assert.equal(mapped.author, "");
+  assert.equal(mapped.pagePath, "official/security/1password");
+  assert.equal(mapped.status, "healthy");
+  assert.equal(mapped.version, "1.0.0");
+});
+
+test("orphaned rows without a ref map to an empty pagePath (panel falls back to slug)", () => {
+  const mapped = agentSkillRowToInstalledRow(
+    row({ name: "mystery", ref: "", saved: false, status: "orphaned_runtime", version: "" }),
+  );
+  assert.equal(mapped.slug, "mystery");
+  assert.equal(mapped.pagePath, "");
+  assert.equal(mapped.version, "");
+});
+
+test("active install jobs overlay pending_install; delete jobs overlay pending_delete", () => {
+  const rows = [row(), row({ name: "k8s", ref: "openai/skills/k8s" })];
+  const overlaid = applyPendingJobOverlay(rows, {
+    "1password": { operation: "delete", status: "running" },
+    k8s: { operation: "install", status: "pending" },
+  });
+
+  assert.equal(overlaid[0].status, "pending_delete");
+  assert.equal(overlaid[1].status, "pending_install");
+});
+
+test("finished or unknown jobs leave row status untouched", () => {
+  const rows = [row(), row({ name: "k8s", ref: "openai/skills/k8s", status: "missing_runtime" })];
+  const overlaid = applyPendingJobOverlay(rows, {
+    "1password": { operation: "install", status: "success" },
+    other: { operation: "install", status: "running" },
+  });
+
+  assert.equal(overlaid[0].status, "healthy");
+  assert.equal(overlaid[1].status, "missing_runtime");
+});
+
+test("isJobActive is true only for pending/running jobs", () => {
+  assert.equal(isJobActive({ operation: "install", status: "pending" }), true);
+  assert.equal(isJobActive({ operation: "delete", status: "running" }), true);
+  assert.equal(isJobActive({ operation: "install", status: "success" }), false);
+  assert.equal(isJobActive({ operation: "install", status: "failed" }), false);
+  assert.equal(isJobActive(null), false);
+  assert.equal(isJobActive(undefined), false);
+});
+
+test("installed names include only rows present on the runtime", () => {
+  const names = computeInstalledNames([
+    row(),
+    row({ name: "gone", installed: false, status: "missing_runtime" }),
+  ]);
+  assert.deepEqual([...names], ["1password"]);
+});
+
+test("installed refs badge browse cards and skip ref-less orphans", () => {
+  const refs = computeInstalledRefs([
+    row(),
+    row({ name: "orphan", ref: "", saved: false, status: "orphaned_runtime" }),
+    row({ name: "gone", ref: "openai/skills/gone", installed: false, status: "missing_runtime" }),
+  ]);
+  assert.deepEqual([...refs], ["official/security/1password"]);
+});
+
+test("library refs collect the pinned registry identifiers", () => {
+  const refs = computeLibraryRefs([
+    { id: "a", ref: "official/security/1password", name: "1password" },
+    { id: "b", ref: "openai/skills/k8s", name: "k8s" },
+    { id: "c", ref: "" },
+  ]);
+  assert.deepEqual([...refs], ["official/security/1password", "openai/skills/k8s"]);
+});
+
+test("installed section keeps installed, orphaned, and pending-delete rows only", () => {
+  const rows = [
+    row(),
+    row({ name: "orphan", ref: "", saved: false, status: "orphaned_runtime", installed: true }),
+    row({ name: "deleting", status: "pending_delete", installed: false }),
+    row({ name: "gone", installed: false, status: "missing_runtime" }),
+  ];
+  assert.deepEqual(
+    installedSectionRows(rows).map((entry) => entry.name),
+    ["1password", "orphan", "deleting"],
+  );
+});
+
+test("trust levels display capitalized and tolerate missing values", () => {
+  assert.equal(formatHermesTrustLevel("community"), "Community");
+  assert.equal(formatHermesTrustLevel("builtin"), "Builtin");
+  assert.equal(formatHermesTrustLevel(""), "");
+  assert.equal(formatHermesTrustLevel(undefined), "");
+});

--- a/frontend-dashboard/lib/hermesSkillsView.ts
+++ b/frontend-dashboard/lib/hermesSkillsView.ts
@@ -1,0 +1,154 @@
+// Pure display logic for the Hermes Skills panel. Kept out of the React
+// component so it can be unit-tested with the repo's lightweight
+// `tsx --test lib/*.test.ts` runner (there is no component-test harness).
+//
+// The Hermes skills API keys browse entries by registry ref (a
+// slash-containing identifier like "official/security/1password") and
+// installed rows by skill name, while the shared openclaw skill components
+// (SkillCard/SkillGrid/InstalledSkillsPanel) key everything by `slug`. These
+// helpers translate at that boundary so the shared components render Hermes
+// data unmodified.
+
+export type HermesSkillStatus =
+  | "healthy"
+  | "missing_runtime"
+  | "orphaned_runtime"
+  | "pending_install"
+  | "pending_delete";
+
+export type HermesSkillSummary = {
+  ref: string;
+  name?: string;
+  description?: string;
+  source?: string;
+  trustLevel?: string;
+  tags?: string[];
+};
+
+export type HermesBrowseCardSkill = {
+  slug: string;
+  name: string;
+  description: string;
+  downloads: null;
+  stars: null;
+  updatedAt: null;
+};
+
+export type HermesAgentSkillRow = {
+  name: string;
+  version?: string;
+  saved?: boolean;
+  installed?: boolean;
+  source?: string;
+  ref?: string;
+  installMode?: string;
+  installedAt?: string | null;
+  status: HermesSkillStatus;
+};
+
+export type HermesInstalledCardRow = HermesAgentSkillRow & {
+  slug: string;
+  author: string;
+  pagePath: string;
+  version: string;
+  installedAt: string | null;
+};
+
+export type HermesSkillJobStatus = {
+  operation?: string;
+  status?: string;
+};
+
+export type HermesLibraryEntry = {
+  id?: string;
+  ref: string;
+  name?: string;
+  description?: string;
+};
+
+// Map a registry browse summary onto the shared SkillCard shape. The Hermes
+// index has no download/star counts or update timestamps: `null` (never 0)
+// keeps SkillCard from rendering a stats row at all, because it only renders
+// counts when `typeof value === "number"`. The description fallback lives
+// here so SkillCard's ClawHub-branded fallback copy never shows.
+export function browseSummaryToCardSkill(summary: HermesSkillSummary): HermesBrowseCardSkill {
+  return {
+    slug: summary.ref,
+    name: summary.name || summary.ref,
+    description: summary.description || "No description provided.",
+    downloads: null,
+    stars: null,
+    updatedAt: null,
+  };
+}
+
+// Map a merged agent skill row (name-keyed, ClawHub status vocabulary) onto
+// the shared InstalledSkillsPanel row shape. The panel's subtitle renders
+// `pagePath || slug`, so the registry ref becomes the subtitle when the entry
+// has one and orphaned runtime installs (no ref) fall back to their name.
+export function agentSkillRowToInstalledRow(row: HermesAgentSkillRow): HermesInstalledCardRow {
+  return {
+    ...row,
+    slug: row.name,
+    author: "",
+    pagePath: row.ref || "",
+    version: row.version || "",
+    installedAt: row.installedAt || null,
+  };
+}
+
+export function isJobActive(job?: HermesSkillJobStatus | null): boolean {
+  return Boolean(job && (job.status === "pending" || job.status === "running"));
+}
+
+// Overlay in-flight job state (keyed by skill name) onto merged rows so the
+// UI shows pending_install / pending_delete immediately instead of waiting
+// for the next installed-state reload.
+export function applyPendingJobOverlay(
+  rows: HermesAgentSkillRow[],
+  jobs: Record<string, HermesSkillJobStatus>,
+): HermesAgentSkillRow[] {
+  return rows.map((row) => {
+    const job = jobs[row.name];
+    if (!isJobActive(job)) return row;
+    return {
+      ...row,
+      status: job?.operation === "delete" ? "pending_delete" : "pending_install",
+    };
+  });
+}
+
+// Names currently installed on the agent — the install identity, used to
+// guard duplicate install requests.
+export function computeInstalledNames(rows: HermesAgentSkillRow[]): Set<string> {
+  return new Set(rows.filter((row) => row.installed).map((row) => row.name));
+}
+
+// Browse cards are keyed by registry ref, so the "Installed" badge needs the
+// refs of installed rows. Orphaned runtime installs carry no ref and cannot
+// be badged in the browse grid.
+export function computeInstalledRefs(rows: HermesAgentSkillRow[]): Set<string> {
+  return new Set(rows.filter((row) => row.installed && row.ref).map((row) => String(row.ref)));
+}
+
+// Library membership, keyed by registry ref (the library's unique key).
+export function computeLibraryRefs(entries: HermesLibraryEntry[]): Set<string> {
+  return new Set(entries.map((entry) => entry.ref).filter(Boolean));
+}
+
+// Rows shown in the installed section: mirrors ClawHubTab's filter — present
+// on the runtime, orphaned there, or mid-delete. Saved-but-missing rows stay
+// out of the installed panel (its status pills have no missing_runtime case).
+export function installedSectionRows<T extends HermesAgentSkillRow>(rows: T[]): T[] {
+  return rows.filter(
+    (row) => row.installed || row.status === "orphaned_runtime" || row.status === "pending_delete",
+  );
+}
+
+// Trust levels arrive as lowercase registry identifiers ("builtin",
+// "trusted", "community"); capitalize for display.
+export function formatHermesTrustLevel(value?: string): string {
+  const normalized = String(value || "").trim();
+  if (!normalized) return "";
+  return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+}

--- a/workers/provisioner/worker.ts
+++ b/workers/provisioner/worker.ts
@@ -3564,7 +3564,7 @@ async function runClawhubDeleteJob({
 
 // ── Hermes skills: job + reconciliation helpers ─────────────────
 // Mirrors the ClawHub block above with the Hermes hub CLI (`hermes skills`)
-// and its lockfile (~/.hermes/skills/.hub/lock.json, keyed by skill name).
+// and its lockfile ($HERMES_HOME/skills/.hub/lock.json, keyed by skill name).
 
 const HERMES_CLI_BIN = "/opt/hermes/.venv/bin/hermes";
 const HERMES_CONTAINER_HOME = "/opt/data/home";
@@ -3702,7 +3702,10 @@ async function uninstallHermesSkill(provisioner, containerId, name, agentId) {
   await runProvisionerExecCommand(
     provisioner,
     containerId,
-    buildHermesSkillsCliPrefix() + `"$HERMES_BIN" skills uninstall ${shellSingleQuote(name)}`,
+    // `skills uninstall` has no --yes flag and prompts; pipe the confirmation
+    // (verified: non-interactive runs otherwise cancel and leave the skill).
+    buildHermesSkillsCliPrefix() +
+      `printf 'y\\n' | "$HERMES_BIN" skills uninstall ${shellSingleQuote(name)}`,
     {
       timeout: HERMES_SKILLS_INSTALL_TIMEOUT_MS + 10000,
       maxOutputBytes: 32768,


### PR DESCRIPTION
PR 4 of the Hermes Skills epic (follows #318/#319/#320). Two commits:

## 1. Live-smoke fixes to the merged plumbing (first commit)
Ran the worker's exact commands against a throwaway `nousresearch/hermes-agent:latest` container and caught two defects:
- **Hub skills live at `$HERMES_HOME/skills` = `/opt/data/skills`**, not `~/.hermes/skills` — `get_hermes_home()` honors the image-baked `HERMES_HOME=/opt/data`; `~/.hermes` is the separate *local* tier where Nora's generated `nora-integrations` skill correctly lives. With the old constants every lockfile read saw an empty tree and install verification could never pass.
- **`hermes skills uninstall` prompts** ("Confirm [y/N]") and cancels non-interactively — the worker now pipes the confirmation (verified: lock empties).
Smoke also confirmed the design live: the CLI's security scanner ran on our install (DANGEROUS verdict allowed only because the source is builtin — we never pass `--force`), and the lock is name-keyed with nested `install_path` exactly as modeled.

## 2. The Skills sub-tab (second commit)
- New **Skills** sub-tab on the Hermes agent view, mirroring the ClawHub tab: browse/search the cached 90k-skill index, **Skills Library section first** (install, remove, add-to-library from the detail card), installed panel with drift statuses, multi-select install tray, 2s job polling with optimistic pending overlays.
- Reuses `SkillGrid/SkillCard/SkillSearchBar/InstalledSkillsPanel` unmodified (name→slug prop mapping at the call site; `null` counts hide the stats row since the index has none). `SkillDetailPanel` is deliberately not reused — it hard-renders counts/requirements/README that would mislead for index entries; a local detail card shows description + source/trust/repo/path/tags instead.
- `SkillGrid`/`SkillSearchBar` gain optional `loadingLabel`/`placeholder` props (ClawHub defaults, zero change for OpenClaw) so the Hermes tab doesn't display ClawHub copy.
- Pure mapping helpers in `lib/hermesSkillsView.ts` + 12 node:test cases.

Validated: frontend tests 34 green, typecheck, eslint, prettier; backend suites re-run for the path fix (reconciliation + routes).