### PR TITLE
feat(hermes): deploy-time skill selection (Phase B)

### DIFF
--- a/backend-api/__tests__/agents.test.ts
+++ b/backend-api/__tests__/agents.test.ts
@@ -4545,6 +4545,180 @@ describe("POST /agents/deploy", () => {
     );
   });
 
+  it("persists normalized hermes skills for Hermes deploys and drops invalid entries", async () => {
+    process.env.ENABLED_RUNTIME_FAMILIES = "openclaw,hermes";
+    process.env.ENABLED_BACKENDS = "docker";
+
+    mockDb.query
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: "a-hermes-skills",
+            name: "Hermes Skills Agent",
+            status: "queued",
+            user_id: "user-1",
+            runtime_family: "hermes",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const res = await auth(
+      request(app)
+        .post("/agents/deploy")
+        .send({
+          name: "Hermes Skills Agent",
+          runtime_family: "hermes",
+          hermes_skills: [
+            {
+              source: "hermes-hub",
+              ref: "official/security/1password",
+              name: "1password",
+              installMode: "cli",
+              installedAt: "2026-07-30T00:00:00.000Z",
+              description: "Should not persist",
+            },
+            {
+              // Duplicate name (the reconciliation identity) — first wins.
+              source: "hermes-hub",
+              ref: "clawhub/other/1password",
+              name: "1password",
+              installMode: "cli",
+              installedAt: "2026-07-30T00:05:00.000Z",
+            },
+            {
+              // Missing ref — deploy-time saves are CLI installs from a ref.
+              source: "hermes-hub",
+              name: "no-ref",
+              installMode: "cli",
+              installedAt: "2026-07-30T00:00:00.000Z",
+            },
+            {
+              // Invalid charset in the shell-reaching name.
+              source: "hermes-hub",
+              ref: "x/y",
+              name: "../escape",
+              installedAt: "2026-07-30T00:00:00.000Z",
+            },
+            {
+              // Nora-managed reserved skill.
+              source: "hermes-hub",
+              ref: "x/z",
+              name: "nora-integrations",
+              installedAt: "2026-07-30T00:00:00.000Z",
+            },
+          ],
+        }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockDb.query.mock.calls[0][0]).toEqual(expect.stringContaining("hermes_skills"));
+    const insertParams = mockDb.query.mock.calls[0][1];
+    expect(JSON.parse(insertParams[12])).toEqual([
+      {
+        source: "hermes-hub",
+        ref: "official/security/1password",
+        name: "1password",
+        installMode: "cli",
+        installedAt: "2026-07-30T00:00:00.000Z",
+      },
+    ]);
+    expect(mockAddDeploymentJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "a-hermes-skills",
+        hermes_skills: [
+          expect.objectContaining({
+            name: "1password",
+            ref: "official/security/1password",
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("stores an empty hermes skill list when the resolved runtime family is not hermes", async () => {
+    mockDb.query
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: "a-openclaw-hermes-skills",
+            name: "OpenClaw Agent",
+            status: "queued",
+            user_id: "user-1",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const res = await auth(
+      request(app)
+        .post("/agents/deploy")
+        .send({
+          name: "OpenClaw Agent",
+          hermes_skills: [
+            {
+              source: "hermes-hub",
+              ref: "official/security/1password",
+              name: "1password",
+              installMode: "cli",
+              installedAt: "2026-07-30T00:00:00.000Z",
+            },
+          ],
+        }),
+    );
+
+    expect(res.status).toBe(200);
+    const insertParams = mockDb.query.mock.calls[0][1];
+    expect(JSON.parse(insertParams[12])).toEqual([]);
+    expect(mockAddDeploymentJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "a-openclaw-hermes-skills",
+        hermes_skills: [],
+      }),
+    );
+  });
+
+  it("truncates hermes skill pre-selection to twenty entries", async () => {
+    process.env.ENABLED_RUNTIME_FAMILIES = "openclaw,hermes";
+    process.env.ENABLED_BACKENDS = "docker";
+
+    mockDb.query
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: "a-hermes-cap",
+            name: "Capped Hermes Agent",
+            status: "queued",
+            user_id: "user-1",
+            runtime_family: "hermes",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const res = await auth(
+      request(app)
+        .post("/agents/deploy")
+        .send({
+          name: "Capped Hermes Agent",
+          runtime_family: "hermes",
+          hermes_skills: Array.from({ length: 25 }, (_, index) => ({
+            source: "hermes-hub",
+            ref: `official/tools/skill-${index}`,
+            name: `skill-${index}`,
+            installMode: "cli",
+            installedAt: "2026-07-30T00:00:00.000Z",
+          })),
+        }),
+    );
+
+    expect(res.status).toBe(200);
+    const persisted = JSON.parse(mockDb.query.mock.calls[0][1][12]);
+    expect(persisted).toHaveLength(20);
+    expect(persisted[0].name).toBe("skill-0");
+    expect(persisted[19].name).toBe("skill-19");
+  });
+
   it("uses operator-managed deployment defaults in PaaS mode", async () => {
     const billing = require("../billing");
     billing.IS_PAAS = true;

--- a/backend-api/routes/agents.ts
+++ b/backend-api/routes/agents.ts
@@ -53,6 +53,9 @@ const {
 const { getDefaultAgentImage } = require("../../agent-runtime/lib/agentImages");
 const { deriveHermesDashboardBasicAuth } = require("../../agent-runtime/lib/hermesDashboardAuth");
 const {
+  normalizeSavedHermesSkillEntries,
+} = require("../../agent-runtime/lib/hermesSkillsReconciliation");
+const {
   DEFAULT_RUNTIME_FAMILY,
   KNOWN_RUNTIME_FAMILIES,
   getRuntimeSelectionStatus,
@@ -249,6 +252,7 @@ function buildDemoDeploymentJob(agent, userId, demoProviderId, plan = "selfhoste
     model: null,
     migration_draft_id: null,
     clawhub_skills: [],
+    hermes_skills: [],
     llm_provider_id: demoProviderId,
   };
 }
@@ -761,6 +765,26 @@ function normalizeClawhubSkills(entries) {
   }
 
   return normalized;
+}
+
+// Deploy requests may pre-select at most this many Hermes skills; extra
+// entries are silently truncated after validation/dedup.
+const MAX_HERMES_SKILLS_PER_DEPLOY = 20;
+
+/**
+ * Normalize the Hermes skill entries a deploy request may save on an agent
+ * row. Validation, dedup-by-name, and reserved-name filtering are delegated
+ * to the shared agent-runtime normalizer; deploy-time saves are always CLI
+ * installs resolved from a registry ref, so ref-less entries are dropped, and
+ * the list is capped at MAX_HERMES_SKILLS_PER_DEPLOY.
+ *
+ * @param {Array} entries - Raw skill entries from the request body.
+ * @returns {Array} Stable list of normalized Hermes skill descriptors.
+ */
+function normalizeHermesSkills(entries) {
+  return normalizeSavedHermesSkillEntries(Array.isArray(entries) ? entries : [])
+    .filter((entry) => entry.ref)
+    .slice(0, MAX_HERMES_SKILLS_PER_DEPLOY);
 }
 
 router.get(
@@ -1972,9 +1996,9 @@ router.post("/activate-demo", requireSession, async (req, res) => {
     const result = await client.query(
       `INSERT INTO agents(
          user_id, name, status, node, backend_type, sandbox_type, vcpu, ram_mb, disk_gb,
-         container_name, image, template_payload, clawhub_skills, runtime_family, deploy_target,
-         execution_target_id, sandbox_profile
-       ) VALUES($1, $2, 'queued', $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb, '[]'::jsonb, $12, $13, $14, $15)
+         container_name, image, template_payload, clawhub_skills, hermes_skills, runtime_family,
+         deploy_target, execution_target_id, sandbox_profile
+       ) VALUES($1, $2, 'queued', $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb, '[]'::jsonb, '[]'::jsonb, $12, $13, $14, $15)
        RETURNING *`,
       [
         userId,
@@ -2072,6 +2096,7 @@ router.post("/deploy", async (req, res) => {
   try {
     const requestBody = req.body || {};
     const clawhubSkills = normalizeClawhubSkills(requestBody.clawhub_skills);
+    const requestedHermesSkills = normalizeHermesSkills(requestBody.hermes_skills);
     let migrationDraft = null;
     if (requestBody.migration_draft_id) {
       if (req.apiKey) {
@@ -2109,6 +2134,10 @@ router.post("/deploy", async (req, res) => {
         runtime_family: runtimeFamily || DEFAULT_RUNTIME_FAMILY,
       },
     });
+    // Hermes skill pre-selection only applies to Hermes runtimes; the gate
+    // uses the RESOLVED family (unlike clawhub_skills, which is normalized
+    // before the family is known) so non-Hermes agents always store [].
+    const hermesSkills = runtimeFields.runtime_family === "hermes" ? requestedHermesSkills : [];
     if (!requireSessionForRemoteDockerPlacement(req, res, runtimeFields)) return;
     // Enforce billing only after authorization has rejected session-only
     // Remote Docker placement for workspace API keys.
@@ -2187,9 +2216,9 @@ router.post("/deploy", async (req, res) => {
       req,
       `INSERT INTO agents(
          user_id, name, status, node, backend_type, sandbox_type, vcpu, ram_mb, disk_gb,
-         container_name, image, template_payload, clawhub_skills, runtime_family, deploy_target,
-         execution_target_id, sandbox_profile
-       ) VALUES($1, $2, 'queued', $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb, $13, $14, $15, $16) RETURNING *`,
+         container_name, image, template_payload, clawhub_skills, hermes_skills, runtime_family,
+         deploy_target, execution_target_id, sandbox_profile
+       ) VALUES($1, $2, 'queued', $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb, $13::jsonb, $14, $15, $16, $17) RETURNING *`,
       [
         req.user.id,
         name,
@@ -2203,6 +2232,7 @@ router.post("/deploy", async (req, res) => {
         image,
         JSON.stringify(templatePayload),
         JSON.stringify(clawhubSkills),
+        JSON.stringify(hermesSkills),
         runtimeFields.runtime_family,
         runtimeFields.deploy_target,
         runtimeFields.execution_target_id,
@@ -2253,6 +2283,7 @@ router.post("/deploy", async (req, res) => {
       model: runtimeFields.sandbox_profile === "nemoclaw" ? req.body.model || null : null,
       migration_draft_id: migrationDraft?.id || null,
       clawhub_skills: clawhubSkills,
+      hermes_skills: hermesSkills,
     });
 
     const deployType = `${runtimeSelectionStatus.runtimeFamily}/${runtimeSelectionStatus.deployTarget}/${runtimeSelectionStatus.sandboxProfile}`;

--- a/docs/guides/deploy-agent.mdx
+++ b/docs/guides/deploy-agent.mdx
@@ -68,8 +68,20 @@ Make sure you have at least one LLM provider key saved in **Settings** before de
   before deploying.
 </Step>
 
+  <Step title="Choose deploy-time skills">
+    Blank deploys include a per-family skills step: the primary button reads **Next: Choose
+    Skills** and opens the skills picker for the selected runtime family. OpenClaw agents pick
+    from **ClawHub**. Hermes agents pick from the **Hermes Skills Hub**, with your instance's
+    curated **Skills Library** shown first for one-click selection — any operator can pin a skill
+    to the shared library from the picker's detail panel or from a running Hermes agent's Skills
+    tab. Selected skills are saved on the agent record and installed automatically once the
+    runtime is ready. Adopting an external runtime skips this step, and you can always continue
+    without selecting any skills.
+
+  </Step>
+
   <Step title="Confirm and deploy">
-    Click **Confirm & Deploy Agent**. Nora creates the agent record with a `queued` status and adds a deployment job to the queue.
+    Click **Deploy Agent & Open Validation** on the skills page. Nora creates the agent record with a `queued` status and adds a deployment job to the queue.
 
     ![Deploy wizard — final confirm step before submission](/images/guides/deploy/wizard-confirm.png)
 
@@ -97,7 +109,7 @@ invented silently.
 
 ## What happens during deployment
 
-After you click **Confirm & Deploy Agent**, the deployment moves through three stages:
+After you submit the deploy, the deployment moves through three stages:
 
 1. **Queued** — The agent record is created and a deployment job is queued. The status is set to `queued` immediately so you can track progress.
 2. **Deploying** — A provisioner worker is creating the workload on the execution target and waiting for readiness.

--- a/frontend-dashboard/components/agents/hermes/SkillDetailCard.tsx
+++ b/frontend-dashboard/components/agents/hermes/SkillDetailCard.tsx
@@ -1,0 +1,134 @@
+import { BookMarked, ChevronLeft, CircleAlert, FileText } from "lucide-react";
+import { formatHermesTrustLevel } from "../../../lib/hermesSkillsView";
+
+function MetaChip({ label, value }) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2">
+      <p className="text-[10px] font-bold uppercase tracking-wide text-slate-400">{label}</p>
+      <p className="mt-1 break-all text-xs font-medium text-slate-700">{value || "Not listed"}</p>
+    </div>
+  );
+}
+
+// Local stand-in for the shared openclaw SkillDetailPanel: Hermes index
+// entries carry no readme, download counts, or requirements metadata, so the
+// ClawHub-shaped panel would render misleading zero-count and empty-README
+// sections. This card shows the metadata the Hermes registry actually
+// provides (source, trust level, repo/path, tags) plus the library action.
+export default function SkillDetailCard({
+  skill,
+  detail,
+  loading,
+  error,
+  inLibrary,
+  libraryBusy,
+  onAddToLibrary,
+  onClose,
+}) {
+  const activeSkill = detail || skill;
+
+  return (
+    <aside className="lg:sticky lg:top-5">
+      <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-sky-600">
+              Skill Detail
+            </p>
+            <h4 className="mt-1 text-lg font-black text-slate-900">
+              {activeSkill?.name || "Select a skill to inspect"}
+            </h4>
+          </div>
+          {activeSkill ? (
+            <button
+              type="button"
+              onClick={onClose}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs font-bold text-slate-600 transition hover:bg-slate-100"
+            >
+              <ChevronLeft size={12} />
+              Close
+            </button>
+          ) : null}
+        </div>
+
+        {!activeSkill ? (
+          <div className="mt-5 rounded-2xl border border-dashed border-slate-200 bg-slate-50 p-6 text-center">
+            <FileText size={24} className="mx-auto text-slate-300" />
+            <p className="mt-3 text-sm font-bold text-slate-700">
+              Pick a card to see the skill&apos;s registry metadata.
+            </p>
+            <p className="mt-1 text-xs leading-5 text-slate-500">
+              This panel is read-only and focused on the skill&apos;s details.
+            </p>
+          </div>
+        ) : (
+          <div className="mt-5 space-y-5">
+            <div className="space-y-3">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-bold uppercase tracking-wide text-slate-600">
+                  {activeSkill.ref}
+                </span>
+              </div>
+              <p className="text-sm leading-6 text-slate-600">
+                {activeSkill.description || "No description provided."}
+              </p>
+            </div>
+
+            {error ? (
+              <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+                <div className="flex items-start gap-2">
+                  <CircleAlert size={16} className="mt-0.5 shrink-0 text-red-500" />
+                  <div>
+                    <p className="font-bold text-red-800">Could not load skill details.</p>
+                    <p className="mt-1 text-xs leading-5 text-red-700">{error}</p>
+                  </div>
+                </div>
+              </div>
+            ) : null}
+
+            {loading && !detail ? (
+              <div className="space-y-3 rounded-2xl border border-slate-200 bg-slate-50 p-4">
+                <div className="h-4 w-1/2 animate-pulse rounded-full bg-slate-200" />
+                <div className="h-4 w-full animate-pulse rounded-full bg-slate-200" />
+                <div className="h-4 w-3/4 animate-pulse rounded-full bg-slate-200" />
+              </div>
+            ) : (
+              <div className="grid gap-2 sm:grid-cols-2">
+                <MetaChip label="Source" value={activeSkill.source} />
+                <MetaChip
+                  label="Trust level"
+                  value={formatHermesTrustLevel(activeSkill.trustLevel)}
+                />
+                <MetaChip label="Repository" value={detail?.repo} />
+                <MetaChip label="Path" value={detail?.path} />
+              </div>
+            )}
+
+            {detail?.tags?.length ? (
+              <div className="flex flex-wrap gap-2">
+                {detail.tags.map((tag) => (
+                  <span
+                    key={tag}
+                    className="rounded-full bg-slate-50 px-2.5 py-1 text-[11px] font-medium text-slate-600 ring-1 ring-slate-200"
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            ) : null}
+
+            <button
+              type="button"
+              onClick={() => onAddToLibrary(activeSkill)}
+              disabled={inLibrary || libraryBusy}
+              className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-bold text-slate-700 transition-colors hover:bg-slate-50 disabled:opacity-60"
+            >
+              <BookMarked size={14} />
+              {inLibrary ? "In library" : libraryBusy ? "Adding..." : "Add to library"}
+            </button>
+          </div>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/frontend-dashboard/components/agents/hermes/SkillsPanel.tsx
+++ b/frontend-dashboard/components/agents/hermes/SkillsPanel.tsx
@@ -1,21 +1,11 @@
 import { useEffect, useMemo, useRef, useState } from "react";
-import {
-  BookMarked,
-  Bot,
-  Boxes,
-  ChevronLeft,
-  CircleAlert,
-  FileText,
-  RefreshCw,
-  Rocket,
-  Trash2,
-  X,
-} from "lucide-react";
+import { BookMarked, Bot, Boxes, RefreshCw, Rocket, Trash2, X } from "lucide-react";
 import { useToast } from "../../Toast";
 import { fetchWithAuth } from "../../../lib/api";
 import InstalledSkillsPanel from "../openclaw/InstalledSkillsPanel";
 import SkillGrid from "../openclaw/SkillGrid";
 import SkillSearchBar from "../openclaw/SkillSearchBar";
+import SkillDetailCard from "./SkillDetailCard";
 import {
   agentSkillRowToInstalledRow,
   applyPendingJobOverlay,
@@ -23,145 +13,12 @@ import {
   computeInstalledNames,
   computeInstalledRefs,
   computeLibraryRefs,
-  formatHermesTrustLevel,
   installedSectionRows,
   isJobActive,
 } from "../../../lib/hermesSkillsView";
 
 const REGISTRY_UNAVAILABLE_MESSAGE =
   "Could not load skills. The Hermes skills registry may be unavailable.";
-
-function MetaChip({ label, value }) {
-  return (
-    <div className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2">
-      <p className="text-[10px] font-bold uppercase tracking-wide text-slate-400">{label}</p>
-      <p className="mt-1 break-all text-xs font-medium text-slate-700">{value || "Not listed"}</p>
-    </div>
-  );
-}
-
-// Local stand-in for the shared openclaw SkillDetailPanel: Hermes index
-// entries carry no readme, download counts, or requirements metadata, so the
-// ClawHub-shaped panel would render misleading zero-count and empty-README
-// sections. This card shows the metadata the Hermes registry actually
-// provides (source, trust level, repo/path, tags) plus the library action.
-function SkillDetailCard({
-  skill,
-  detail,
-  loading,
-  error,
-  inLibrary,
-  libraryBusy,
-  onAddToLibrary,
-  onClose,
-}) {
-  const activeSkill = detail || skill;
-
-  return (
-    <aside className="lg:sticky lg:top-5">
-      <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-        <div className="flex items-center justify-between gap-3">
-          <div>
-            <p className="text-[11px] font-bold uppercase tracking-[0.22em] text-sky-600">
-              Skill Detail
-            </p>
-            <h4 className="mt-1 text-lg font-black text-slate-900">
-              {activeSkill?.name || "Select a skill to inspect"}
-            </h4>
-          </div>
-          {activeSkill ? (
-            <button
-              type="button"
-              onClick={onClose}
-              className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-slate-50 px-3 py-1.5 text-xs font-bold text-slate-600 transition hover:bg-slate-100"
-            >
-              <ChevronLeft size={12} />
-              Close
-            </button>
-          ) : null}
-        </div>
-
-        {!activeSkill ? (
-          <div className="mt-5 rounded-2xl border border-dashed border-slate-200 bg-slate-50 p-6 text-center">
-            <FileText size={24} className="mx-auto text-slate-300" />
-            <p className="mt-3 text-sm font-bold text-slate-700">
-              Pick a card to see the skill&apos;s registry metadata.
-            </p>
-            <p className="mt-1 text-xs leading-5 text-slate-500">
-              This panel is read-only and focused on the skill&apos;s details.
-            </p>
-          </div>
-        ) : (
-          <div className="mt-5 space-y-5">
-            <div className="space-y-3">
-              <div className="flex flex-wrap items-center gap-2">
-                <span className="rounded-full bg-slate-100 px-2.5 py-1 text-[11px] font-bold uppercase tracking-wide text-slate-600">
-                  {activeSkill.ref}
-                </span>
-              </div>
-              <p className="text-sm leading-6 text-slate-600">
-                {activeSkill.description || "No description provided."}
-              </p>
-            </div>
-
-            {error ? (
-              <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
-                <div className="flex items-start gap-2">
-                  <CircleAlert size={16} className="mt-0.5 shrink-0 text-red-500" />
-                  <div>
-                    <p className="font-bold text-red-800">Could not load skill details.</p>
-                    <p className="mt-1 text-xs leading-5 text-red-700">{error}</p>
-                  </div>
-                </div>
-              </div>
-            ) : null}
-
-            {loading && !detail ? (
-              <div className="space-y-3 rounded-2xl border border-slate-200 bg-slate-50 p-4">
-                <div className="h-4 w-1/2 animate-pulse rounded-full bg-slate-200" />
-                <div className="h-4 w-full animate-pulse rounded-full bg-slate-200" />
-                <div className="h-4 w-3/4 animate-pulse rounded-full bg-slate-200" />
-              </div>
-            ) : (
-              <div className="grid gap-2 sm:grid-cols-2">
-                <MetaChip label="Source" value={activeSkill.source} />
-                <MetaChip
-                  label="Trust level"
-                  value={formatHermesTrustLevel(activeSkill.trustLevel)}
-                />
-                <MetaChip label="Repository" value={detail?.repo} />
-                <MetaChip label="Path" value={detail?.path} />
-              </div>
-            )}
-
-            {detail?.tags?.length ? (
-              <div className="flex flex-wrap gap-2">
-                {detail.tags.map((tag) => (
-                  <span
-                    key={tag}
-                    className="rounded-full bg-slate-50 px-2.5 py-1 text-[11px] font-medium text-slate-600 ring-1 ring-slate-200"
-                  >
-                    {tag}
-                  </span>
-                ))}
-              </div>
-            ) : null}
-
-            <button
-              type="button"
-              onClick={() => onAddToLibrary(activeSkill)}
-              disabled={inLibrary || libraryBusy}
-              className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-bold text-slate-700 transition-colors hover:bg-slate-50 disabled:opacity-60"
-            >
-              <BookMarked size={14} />
-              {inLibrary ? "In library" : libraryBusy ? "Adding..." : "Add to library"}
-            </button>
-          </div>
-        )}
-      </div>
-    </aside>
-  );
-}
 
 export default function HermesSkillsPanel({ agentId, agentStatus }) {
   const toast = useToast();

--- a/frontend-dashboard/components/agents/openclaw/SkillSelectionTray.tsx
+++ b/frontend-dashboard/components/agents/openclaw/SkillSelectionTray.tsx
@@ -8,6 +8,7 @@ type SkillSelectionTrayProps = {
   installLabel?: string;
   installDisabled?: boolean;
   installError?: string | null;
+  emptyMessage?: string;
   onBack?: () => void;
   onDeploy?: () => void;
   onInstall?: () => void;
@@ -22,6 +23,7 @@ export default function SkillSelectionTray({
   installLabel,
   installDisabled = false,
   installError = null,
+  emptyMessage,
   onBack,
   onDeploy,
   onInstall,
@@ -95,11 +97,12 @@ export default function SkillSelectionTray({
             </div>
           ) : (
             <p className="text-sm text-slate-500">
-              {isDeployMode
-                ? "No ClawHub skills selected. You can still continue and deploy the agent without any."
-                : isDeleteMode
-                  ? "No ClawHub skills selected for delete yet. Pick one or more installed skills above."
-                  : "No ClawHub skills selected yet. Pick one or more cards to queue installs."}
+              {emptyMessage ||
+                (isDeployMode
+                  ? "No ClawHub skills selected. You can still continue and deploy the agent without any."
+                  : isDeleteMode
+                    ? "No ClawHub skills selected for delete yet. Pick one or more installed skills above."
+                    : "No ClawHub skills selected yet. Pick one or more cards to queue installs.")}
             </p>
           )}
           {installError ? <p className="text-sm font-medium text-red-600">{installError}</p> : null}

--- a/frontend-dashboard/lib/clawhubDeploy.test.ts
+++ b/frontend-dashboard/lib/clawhubDeploy.test.ts
@@ -7,6 +7,7 @@ import {
   loadDeployDraft,
   saveDeployDraft,
   type DeployDraft,
+  type DeployHermesSkill,
 } from "./clawhubDeploy";
 
 function createDraft(overrides: Partial<DeployDraft> = {}): DeployDraft {
@@ -355,6 +356,107 @@ test("deploy draft storage keeps only the versioned schema and whitelisted skill
       },
     ]);
     assert.doesNotMatch(JSON.stringify(stored), /TOP-LEVEL-LEAK|NESTED-LEAK|SKILL-LEAK/);
+  } finally {
+    storage.restore();
+  }
+});
+
+test("hermes deploy skills round-trip only the whitelisted entry fields", () => {
+  const storage = installSessionStorage();
+
+  try {
+    saveDeployDraft({
+      ...createDraft({ runtimeFamily: "hermes" }),
+      hermesSkills: [
+        {
+          source: "hermes-hub",
+          ref: "official/security/1password",
+          name: "1password",
+          installMode: "cli",
+          installedAt: "2026-07-30T00:00:00.000Z",
+          description: "Secrets tooling",
+          accessToken: "HERMES-SKILL-LEAK",
+        },
+      ],
+    } as unknown as DeployDraft);
+
+    const stored = storage.readDraft();
+    assert.deepEqual(stored.hermesSkills, [
+      {
+        source: "hermes-hub",
+        ref: "official/security/1password",
+        name: "1password",
+        installMode: "cli",
+        installedAt: "2026-07-30T00:00:00.000Z",
+        description: "Secrets tooling",
+      },
+    ]);
+    assert.doesNotMatch(JSON.stringify(stored), /HERMES-SKILL-LEAK/);
+
+    const loaded = loadDeployDraft();
+    assert.deepEqual(loaded?.hermesSkills, stored.hermesSkills);
+  } finally {
+    storage.restore();
+  }
+});
+
+test("hermes skill sanitizer drops invalid, ref-less, reserved, and duplicate entries", () => {
+  const storage = installSessionStorage();
+
+  try {
+    saveDeployDraft(
+      createDraft({
+        runtimeFamily: "hermes",
+        hermesSkills: [
+          {
+            source: "hermes-hub",
+            ref: "official/tools/k8s",
+            name: "k8s",
+            installMode: "cli",
+            installedAt: "2026-07-30T00:00:00.000Z",
+          },
+          {
+            // Duplicate name (the reconciliation identity) — first entry wins.
+            source: "hermes-hub",
+            ref: "clawhub/other/k8s",
+            name: "k8s",
+            installMode: "cli",
+            installedAt: "2026-07-30T00:05:00.000Z",
+          },
+          {
+            // Missing ref — deploy-time saves are CLI installs resolved from a ref.
+            source: "hermes-hub",
+            ref: "",
+            name: "no-ref",
+            installMode: "cli",
+            installedAt: "2026-07-30T00:00:00.000Z",
+          },
+          {
+            // Invalid charset (path traversal) in the shell-reaching name.
+            source: "hermes-hub",
+            ref: "x/y",
+            name: "../escape",
+            installMode: "cli",
+            installedAt: "2026-07-30T00:00:00.000Z",
+          },
+          {
+            // Nora-managed reserved skill.
+            source: "hermes-hub",
+            ref: "x/z",
+            name: "nora-integrations",
+            installMode: "cli",
+            installedAt: "2026-07-30T00:00:00.000Z",
+          },
+        ],
+      }),
+    );
+
+    const stored = storage.readDraft();
+    assert.deepEqual(
+      stored.hermesSkills.map((skill: DeployHermesSkill) => skill.name),
+      ["k8s"],
+    );
+    assert.equal(stored.hermesSkills[0].ref, "official/tools/k8s");
   } finally {
     storage.restore();
   }

--- a/frontend-dashboard/lib/clawhubDeploy.ts
+++ b/frontend-dashboard/lib/clawhubDeploy.ts
@@ -10,6 +10,15 @@ export type DeployClawHubSkill = {
   description?: string;
 };
 
+export type DeployHermesSkill = {
+  source: "hermes-hub";
+  ref: string;
+  name: string;
+  installMode: "cli";
+  installedAt: string;
+  description?: string;
+};
+
 export type DeployDraft = {
   name: string;
   containerName: string;
@@ -25,6 +34,7 @@ export type DeployDraft = {
   ramMb: number;
   diskGb: number;
   clawhubSkills: DeployClawHubSkill[];
+  hermesSkills?: DeployHermesSkill[];
 };
 
 type DraftResourceOptions = {
@@ -169,6 +179,43 @@ function sanitizeClawHubSkills(value: unknown): DeployClawHubSkill[] {
   });
 }
 
+// Mirrors the agent-runtime hermesSkillsReconciliation validation: the skill
+// name is the Hermes reconciliation identity (and later reaches shell commands
+// in the worker), so the same charset and reserved-name rules apply at this
+// choke point. "nora-integrations" is written by Nora's integrations
+// reconciler and must never ride in as an operator-selected skill.
+const HERMES_SKILL_NAME_RE = /^[a-z0-9][a-z0-9._-]{0,63}$/i;
+const RESERVED_HERMES_SKILL_NAMES = ["nora-integrations"];
+
+function sanitizeHermesSkills(value: unknown): DeployHermesSkill[] {
+  if (!Array.isArray(value)) return [];
+
+  const seenNames = new Set<string>();
+  return value.flatMap((entry) => {
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) return [];
+    const candidate = entry as Record<string, unknown>;
+    const ref = stringValue(candidate.ref).trim();
+    const name = stringValue(candidate.name).trim();
+    if (!ref || !HERMES_SKILL_NAME_RE.test(name)) return [];
+    if (RESERVED_HERMES_SKILL_NAMES.includes(name.toLowerCase())) return [];
+    if (seenNames.has(name)) return [];
+    seenNames.add(name);
+
+    return [
+      {
+        source: "hermes-hub" as const,
+        ref,
+        name,
+        installMode: "cli" as const,
+        installedAt: stringValue(candidate.installedAt),
+        ...(stringValue(candidate.description)
+          ? { description: stringValue(candidate.description) }
+          : {}),
+      },
+    ];
+  });
+}
+
 function sanitizeDeployDraft(draft: unknown): DeployDraft | null {
   if (!draft || typeof draft !== "object" || Array.isArray(draft)) return null;
 
@@ -214,6 +261,7 @@ function sanitizeDeployDraft(draft: unknown): DeployDraft | null {
     ramMb: numberValue(candidate.ramMb),
     diskGb: numberValue(candidate.diskGb),
     clawhubSkills: sanitizeClawHubSkills(candidate.clawhubSkills),
+    hermesSkills: sanitizeHermesSkills(candidate.hermesSkills),
   };
 }
 

--- a/frontend-dashboard/pages/deploy/index.tsx
+++ b/frontend-dashboard/pages/deploy/index.tsx
@@ -410,7 +410,7 @@ export default function Deploy() {
   const canDeployExecutionTarget = Boolean(activeSandboxOption?.available);
   // Adopt mode registers an already-running external runtime by URL + token — it
   // skips provisioning, so the execution-target / sandbox / resource selectors and
-  // the ClawHub step don't apply.
+  // the per-family skills step don't apply.
   const isAdopt = deploymentMode === "adopt";
   const canAdopt = Boolean(name.trim() && adoptUrl.trim() && adoptGatewayToken.trim());
   const isNemoClaw = activeSandboxOption?.id === "nemoclaw";
@@ -421,6 +421,7 @@ export default function Deploy() {
     defaultRuntimeFamily?.id ||
     "openclaw";
   const usesClawHubStep = effectiveRuntimeFamily === "openclaw";
+  const usesHermesSkillsStep = effectiveRuntimeFamily === "hermes";
   const isHermes = effectiveRuntimeFamily === "hermes";
   const showSandboxSelection = visibleSandboxOptions.length > 1;
   const showRuntimeFamilySelection = visibleRuntimeFamilies.length > 1;
@@ -557,6 +558,7 @@ export default function Deploy() {
       ramMb: isSelfHosted ? normalizedResources.ramMb : 0,
       diskGb: isSelfHosted ? normalizedResources.diskGb : 0,
       clawhubSkills: usesClawHubStep ? loadDeployDraft()?.clawhubSkills || [] : [],
+      hermesSkills: usesHermesSkillsStep ? loadDeployDraft()?.hermesSkills || [] : [],
     };
 
     deployDraftRef.current = nextDraft;
@@ -595,6 +597,14 @@ export default function Deploy() {
           ...(nextDraft.ramMb ? { ram_mb: normalizedResources.ramMb } : {}),
           ...(nextDraft.diskGb ? { disk_gb: normalizedResources.diskGb } : {}),
           clawhub_skills: [],
+          hermes_skills:
+            nextDraft.hermesSkills?.map((skill) => ({
+              source: "hermes-hub",
+              ref: skill.ref,
+              name: skill.name,
+              installMode: "cli",
+              installedAt: skill.installedAt,
+            })) || [],
         }),
       });
       const data = await res.json().catch(() => ({}));
@@ -670,6 +680,11 @@ export default function Deploy() {
 
     if (usesClawHubStep) {
       router.push("/clawhub");
+      return;
+    }
+
+    if (usesHermesSkillsStep) {
+      router.push("/hermes-skills-select");
       return;
     }
 
@@ -1725,7 +1740,7 @@ export default function Deploy() {
                     ? "Prepare Migration Draft First"
                     : !canDeployExecutionTarget
                       ? "Selected Runtime Path Unavailable"
-                      : usesClawHubStep
+                      : usesClawHubStep || usesHermesSkillsStep
                         ? "Next: Choose Skills"
                         : "Deploy Agent"}
             </button>

--- a/frontend-dashboard/pages/hermes-skills-select/index.tsx
+++ b/frontend-dashboard/pages/hermes-skills-select/index.tsx
@@ -1,0 +1,614 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/router";
+import { BookMarked, Boxes, Plus, RefreshCw, Trash2 } from "lucide-react";
+import Layout from "../../components/layout/Layout";
+import { useToast } from "../../components/Toast";
+import { fetchWithAuth } from "../../lib/api";
+import {
+  clearDeployDraft,
+  DeployDraft,
+  DeployHermesSkill,
+  loadDeployDraft,
+  normalizeDeployDraftResources,
+  saveDeployDraft,
+} from "../../lib/clawhubDeploy";
+import SkillDetailCard from "../../components/agents/hermes/SkillDetailCard";
+import SkillGrid from "../../components/agents/openclaw/SkillGrid";
+import SkillSearchBar from "../../components/agents/openclaw/SkillSearchBar";
+import SkillSelectionTray from "../../components/agents/openclaw/SkillSelectionTray";
+import { SkillSummary } from "../../components/agents/openclaw/SkillCard";
+import {
+  browseSummaryToCardSkill,
+  computeLibraryRefs,
+  HermesLibraryEntry,
+  HermesSkillSummary,
+} from "../../lib/hermesSkillsView";
+
+const REGISTRY_UNAVAILABLE_MESSAGE =
+  "Could not load skills. The Hermes skills registry may be unavailable.";
+
+type HermesSkillDetail = HermesSkillSummary & {
+  repo?: string;
+  path?: string;
+};
+
+type SkillListResponse = {
+  skills?: HermesSkillSummary[];
+  error?: string;
+  message?: string;
+};
+
+function buildSelectedSkill(detail: HermesSkillDetail): DeployHermesSkill {
+  return {
+    source: "hermes-hub",
+    ref: detail.ref,
+    name: detail.name || detail.ref,
+    installMode: "cli",
+    installedAt: new Date().toISOString(),
+    ...(detail.description ? { description: detail.description } : {}),
+  };
+}
+
+export default function HermesSkillsSelectPage() {
+  const router = useRouter();
+  const toast = useToast();
+  const [draft, setDraft] = useState<DeployDraft | null>(null);
+  const [query, setQuery] = useState("");
+  const [skills, setSkills] = useState<HermesSkillSummary[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedSkill, setSelectedSkill] = useState<HermesSkillSummary | null>(null);
+  const [selectedSkillDetail, setSelectedSkillDetail] = useState<HermesSkillDetail | null>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [detailError, setDetailError] = useState<string | null>(null);
+  const [selectedSkills, setSelectedSkills] = useState<DeployHermesSkill[]>([]);
+  const [selectionBusyRef, setSelectionBusyRef] = useState<string | null>(null);
+  const [deploying, setDeploying] = useState(false);
+  const [library, setLibrary] = useState<HermesLibraryEntry[]>([]);
+  const [libraryError, setLibraryError] = useState<string | null>(null);
+  const [libraryBusyId, setLibraryBusyId] = useState<string | null>(null);
+  const [libraryAddBusyRef, setLibraryAddBusyRef] = useState<string | null>(null);
+  const requestIdRef = useRef(0);
+  const detailCacheRef = useRef<Record<string, HermesSkillDetail>>({});
+
+  const showingDefaultBrowseEmptyState = !query.trim() && !loading && !error && skills.length === 0;
+  const browseCards = useMemo(() => skills.map(browseSummaryToCardSkill), [skills]);
+  // The skill name is the Hermes install identity (dedup key); browse cards
+  // are keyed by registry ref, so the grid's selection badges need the refs.
+  const selectedSkillNames = useMemo(
+    () => new Set(selectedSkills.map((skill) => skill.name)),
+    [selectedSkills],
+  );
+  const selectedSkillRefs = useMemo(
+    () => new Set(selectedSkills.map((skill) => skill.ref)),
+    [selectedSkills],
+  );
+  const libraryRefs = useMemo(() => computeLibraryRefs(library), [library]);
+  // The shared tray renders ClawHub-shaped rows; map the Hermes entries at
+  // this boundary (name doubles as the slug identity, the registry ref shows
+  // as the pagePath) so the openclaw component renders them unmodified.
+  const traySkills = useMemo(
+    () =>
+      selectedSkills.map((skill) => ({
+        source: "clawhub" as const,
+        installSlug: skill.name,
+        author: "",
+        pagePath: skill.ref,
+        installedAt: skill.installedAt,
+        name: skill.name,
+        ...(skill.description ? { description: skill.description } : {}),
+      })),
+    [selectedSkills],
+  );
+
+  useEffect(() => {
+    const nextDraft = loadDeployDraft();
+    if (!nextDraft) {
+      toast.error("Start from the deploy page before choosing Hermes skills.");
+      router.replace("/deploy");
+      return;
+    }
+
+    const draftRuntimeFamily = String(nextDraft.runtimeFamily || "openclaw")
+      .trim()
+      .toLowerCase();
+    if (draftRuntimeFamily !== "hermes") {
+      toast.error("Hermes skills are only available for Hermes agents.");
+      router.replace("/deploy");
+      return;
+    }
+
+    const normalizedDraft = {
+      ...nextDraft,
+      runtimeFamily: draftRuntimeFamily,
+    };
+
+    setDraft(normalizedDraft);
+    setSelectedSkills(
+      Array.isArray(normalizedDraft.hermesSkills) ? normalizedDraft.hermesSkills : [],
+    );
+  }, [router, toast]);
+
+  useEffect(() => {
+    if (!draft) return;
+    saveDeployDraft({
+      ...draft,
+      hermesSkills: selectedSkills,
+    });
+  }, [draft, selectedSkills]);
+
+  async function loadBrowseResults() {
+    const requestId = ++requestIdRef.current;
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetchWithAuth("/api/hermes-skills/skills");
+      const data: SkillListResponse = await res.json();
+      if (requestId !== requestIdRef.current) return;
+
+      if (!res.ok) {
+        throw new Error(data.message || data.error || REGISTRY_UNAVAILABLE_MESSAGE);
+      }
+
+      setSkills(Array.isArray(data.skills) ? data.skills : []);
+    } catch (err: any) {
+      if (requestId !== requestIdRef.current) return;
+      setSkills([]);
+      setError(err?.message || REGISTRY_UNAVAILABLE_MESSAGE);
+    } finally {
+      if (requestId === requestIdRef.current) {
+        setLoading(false);
+      }
+    }
+  }
+
+  async function searchSkills() {
+    const trimmed = query.trim();
+    if (!trimmed) {
+      loadBrowseResults();
+      return;
+    }
+
+    const requestId = ++requestIdRef.current;
+    setLoading(true);
+    setError(null);
+
+    try {
+      const res = await fetchWithAuth(
+        `/api/hermes-skills/skills/search?q=${encodeURIComponent(trimmed)}`,
+      );
+      const data: SkillListResponse = await res.json();
+      if (requestId !== requestIdRef.current) return;
+
+      if (!res.ok) {
+        throw new Error(data.message || data.error || REGISTRY_UNAVAILABLE_MESSAGE);
+      }
+
+      setSkills(Array.isArray(data.skills) ? data.skills : []);
+    } catch (err: any) {
+      if (requestId !== requestIdRef.current) return;
+      setSkills([]);
+      setError(err?.message || REGISTRY_UNAVAILABLE_MESSAGE);
+    } finally {
+      if (requestId === requestIdRef.current) {
+        setLoading(false);
+      }
+    }
+  }
+
+  async function loadLibrary() {
+    setLibraryError(null);
+    try {
+      const res = await fetchWithAuth("/api/hermes-skills/library");
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data.message || data.error || "Could not load the skills library.");
+      }
+      setLibrary(Array.isArray(data.skills) ? data.skills : []);
+    } catch (err: any) {
+      setLibraryError(err?.message || "Could not load the skills library.");
+    }
+  }
+
+  async function fetchSkillDetail(ref: string) {
+    const cached = detailCacheRef.current[ref];
+    if (cached) {
+      return cached;
+    }
+
+    const res = await fetchWithAuth(
+      `/api/hermes-skills/skills/detail?ref=${encodeURIComponent(ref)}`,
+    );
+    const data = await res.json();
+
+    if (!res.ok) {
+      throw new Error(data.message || data.error || "Could not load skill details.");
+    }
+
+    detailCacheRef.current[ref] = data;
+    return data as HermesSkillDetail;
+  }
+
+  // The grid hands back card objects keyed by slug; the slug IS the registry
+  // ref for Hermes browse cards.
+  async function loadSkillDetail(card: SkillSummary) {
+    setSelectedSkill({ ref: card.slug, name: card.name, description: card.description });
+    setSelectedSkillDetail(detailCacheRef.current[card.slug] || null);
+    setDetailError(null);
+    setDetailLoading(true);
+
+    try {
+      const detail = await fetchSkillDetail(card.slug);
+      setSelectedSkill(detail);
+      setSelectedSkillDetail(detail);
+    } catch (err: any) {
+      setDetailError(err?.message || "Could not load skill details.");
+    } finally {
+      setDetailLoading(false);
+    }
+  }
+
+  function addSelectedSkill(nextSkill: DeployHermesSkill) {
+    setSelectedSkills((current) => {
+      if (current.some((entry) => entry.name === nextSkill.name)) {
+        return current;
+      }
+      return [...current, nextSkill];
+    });
+  }
+
+  function removeSelectedSkillByName(name: string) {
+    setSelectedSkills((current) => current.filter((entry) => entry.name !== name));
+  }
+
+  function removeSelectedSkillByRef(ref: string) {
+    setSelectedSkills((current) => current.filter((entry) => entry.ref !== ref));
+  }
+
+  function clearSelectedSkills() {
+    setSelectedSkills([]);
+  }
+
+  async function toggleSkillSelection(card: SkillSummary) {
+    const ref = card.slug;
+    if (selectedSkillRefs.has(ref)) {
+      removeSelectedSkillByRef(ref);
+      return;
+    }
+
+    setSelectionBusyRef(ref);
+    try {
+      const detail = detailCacheRef.current[ref] || (await fetchSkillDetail(ref));
+      addSelectedSkill(buildSelectedSkill(detail));
+    } catch (err: any) {
+      toast.error(err?.message || "Could not select that skill.");
+    } finally {
+      setSelectionBusyRef(null);
+    }
+  }
+
+  function handleSelectLibraryEntry(entry: HermesLibraryEntry) {
+    addSelectedSkill(
+      buildSelectedSkill({
+        ref: entry.ref,
+        name: entry.name || entry.ref,
+        description: entry.description,
+      }),
+    );
+  }
+
+  async function handleAddToLibrary(skill: HermesSkillSummary) {
+    if (!skill?.ref || libraryRefs.has(skill.ref)) return;
+    setLibraryAddBusyRef(skill.ref);
+    try {
+      const res = await fetchWithAuth("/api/hermes-skills/library", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          ref: skill.ref,
+          name: skill.name || skill.ref,
+          description: skill.description || "",
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(data.message || data.error || "Could not add that skill to the library.");
+      }
+      toast.success(`${data.name || skill.name || skill.ref} added to the library.`);
+      await loadLibrary();
+    } catch (err: any) {
+      toast.error(err?.message || "Could not add that skill to the library.");
+    } finally {
+      setLibraryAddBusyRef(null);
+    }
+  }
+
+  async function handleRemoveLibraryEntry(entry: HermesLibraryEntry) {
+    setLibraryBusyId(entry.id || null);
+    try {
+      const res = await fetchWithAuth(
+        `/api/hermes-skills/library/${encodeURIComponent(entry.id || "")}`,
+        { method: "DELETE" },
+      );
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(
+          data.message || data.error || "Could not remove that skill from the library.",
+        );
+      }
+      setLibrary((current) => current.filter((row) => row.id !== entry.id));
+    } catch (err: any) {
+      toast.error(err?.message || "Could not remove that skill from the library.");
+    } finally {
+      setLibraryBusyId(null);
+    }
+  }
+
+  function handleQueryChange(value: string) {
+    setQuery(value);
+    if (!value.trim()) {
+      setSelectedSkill(null);
+      setSelectedSkillDetail(null);
+      setDetailError(null);
+      loadBrowseResults();
+    }
+  }
+
+  function handleClearSearch() {
+    setQuery("");
+    setSelectedSkill(null);
+    setSelectedSkillDetail(null);
+    setDetailError(null);
+    loadBrowseResults();
+  }
+
+  async function handleDeploy() {
+    if (!draft) return;
+
+    const normalizedResources = normalizeDeployDraftResources(draft);
+
+    setDeploying(true);
+    try {
+      const res = await fetchWithAuth("/api/agents/deploy", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: draft.name,
+          runtime_family: draft.runtimeFamily,
+          deploy_target: draft.deployTarget,
+          execution_target_id: draft.deployTarget,
+          sandbox_profile: draft.sandboxProfile || "standard",
+          ...(draft.containerName.trim() ? { container_name: draft.containerName.trim() } : {}),
+          ...(draft.model ? { model: draft.model } : {}),
+          ...(draft.deploymentMode === "migrate" && draft.migrationDraft?.id
+            ? { migration_draft_id: draft.migrationDraft.id }
+            : {}),
+          ...(draft.vcpu ? { vcpu: normalizedResources.vcpu } : {}),
+          ...(draft.ramMb ? { ram_mb: normalizedResources.ramMb } : {}),
+          ...(draft.diskGb ? { disk_gb: normalizedResources.diskGb } : {}),
+          hermes_skills: selectedSkills.map((skill) => ({
+            source: "hermes-hub",
+            ref: skill.ref,
+            name: skill.name,
+            installMode: "cli",
+            installedAt: skill.installedAt,
+          })),
+        }),
+      });
+
+      if (res.ok) {
+        const data = await res.json();
+        clearDeployDraft();
+        window.location.href = data?.id ? `/app/agents/${data.id}` : "/app/agents";
+        return;
+      }
+
+      if (res.status === 402) {
+        toast.error("You've reached your plan's agent limit. Please upgrade.");
+      } else {
+        const data = await res.json().catch(() => ({}));
+        toast.error(data.error || "Deployment failed. Please try again.");
+      }
+    } catch (err) {
+      console.error(err);
+      toast.error("Network error during deployment.");
+    } finally {
+      setDeploying(false);
+    }
+  }
+
+  function handleBack() {
+    if (!draft) {
+      router.push("/deploy");
+      return;
+    }
+
+    saveDeployDraft({
+      ...draft,
+      hermesSkills: selectedSkills,
+    });
+    router.push("/deploy");
+  }
+
+  useEffect(() => {
+    if (!draft) return;
+    loadBrowseResults();
+    loadLibrary();
+  }, [draft]);
+
+  return (
+    <Layout>
+      <div className="space-y-6">
+        <div className="rounded-[2rem] border border-slate-200 bg-gradient-to-r from-white via-slate-50 to-blue-50 p-6 shadow-sm">
+          <div className="flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
+            <div className="space-y-2">
+              <div className="inline-flex items-center gap-2 rounded-full border border-blue-200 bg-white px-3 py-1 text-[11px] font-black uppercase tracking-[0.18em] text-blue-700">
+                <Boxes size={12} />
+                Hermes Skills Selection
+              </div>
+              <h1 className="text-3xl font-black text-slate-900">
+                Choose skills for this Hermes agent
+              </h1>
+              <p className="max-w-3xl text-sm leading-6 text-slate-600">
+                Pick from your instance&apos;s Skills Library or search the Hermes Skills Hub, then
+                attach only the skills you want saved on this Hermes agent at deploy time. Nora
+                installs them once the runtime is ready.
+              </p>
+            </div>
+
+            <button
+              type="button"
+              onClick={() => {
+                loadBrowseResults();
+                loadLibrary();
+              }}
+              disabled={loading}
+              className="inline-flex items-center gap-2 self-start rounded-xl border border-slate-200 bg-white px-4 py-2 text-sm font-bold text-slate-700 transition-colors hover:bg-slate-50 disabled:opacity-60"
+            >
+              <RefreshCw size={14} className={loading ? "animate-spin" : ""} />
+              Refresh
+            </button>
+          </div>
+        </div>
+
+        <SkillSelectionTray
+          skills={traySkills}
+          deploying={deploying}
+          emptyMessage="No Hermes skills selected. You can still continue and deploy the agent without any."
+          onBack={handleBack}
+          onDeploy={handleDeploy}
+          onRemoveSkill={(skill) => removeSelectedSkillByName(skill.installSlug)}
+          onClearAll={clearSelectedSkills}
+        />
+
+        <div className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
+          <div className="space-y-3">
+            <div className="text-xs font-black uppercase tracking-[0.18em] text-slate-500">
+              Skills Library
+            </div>
+            <div className="flex items-center gap-2 text-2xl font-black text-slate-900">
+              <BookMarked size={20} className="text-blue-500" />
+              {library.length} saved
+            </div>
+            <p className="text-sm text-slate-600">
+              Skills curated for this Nora instance. Add one to this deploy&apos;s selection, or
+              remove it from the shared library.
+            </p>
+            {libraryError ? (
+              <p className="text-sm font-medium text-red-600">{libraryError}</p>
+            ) : null}
+          </div>
+
+          {library.length ? (
+            <div className="mt-5 grid grid-cols-1 gap-3 xl:grid-cols-2">
+              {library.map((entry) => {
+                const selected = selectedSkillNames.has(entry.name || entry.ref);
+                return (
+                  <div
+                    key={entry.id || entry.ref}
+                    className="flex h-full flex-col justify-between gap-3 rounded-2xl border border-slate-200 bg-slate-50 p-4"
+                  >
+                    <div className="min-w-0">
+                      <div className="text-sm font-black text-slate-900">{entry.name}</div>
+                      <div className="truncate text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                        {entry.ref}
+                      </div>
+                      {entry.description ? (
+                        <p className="mt-2 line-clamp-2 text-sm leading-6 text-slate-600">
+                          {entry.description}
+                        </p>
+                      ) : null}
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => handleSelectLibraryEntry(entry)}
+                        disabled={selected}
+                        className="inline-flex items-center gap-2 rounded-xl bg-emerald-600 px-3 py-2 text-xs font-black text-white transition-colors hover:bg-emerald-700 disabled:opacity-60"
+                      >
+                        <Plus size={12} />
+                        {selected ? "Selected" : "Add to selection"}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() => handleRemoveLibraryEntry(entry)}
+                        disabled={libraryBusyId === entry.id}
+                        className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-xs font-black text-slate-600 transition-colors hover:bg-slate-100 hover:text-rose-700 disabled:opacity-60"
+                      >
+                        <Trash2 size={12} />
+                        Remove
+                      </button>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ) : (
+            <div className="mt-5 rounded-2xl border border-dashed border-slate-300 bg-slate-50 px-5 py-6 text-center">
+              <p className="text-sm font-bold text-slate-700">No skills in the library yet.</p>
+              <p className="mt-1 text-xs text-slate-500">
+                Open a skill below and choose &quot;Add to library&quot; to pin it for every
+                operator on this instance.
+              </p>
+            </div>
+          )}
+        </div>
+
+        <SkillSearchBar
+          placeholder="Search Hermes skills and press Enter"
+          query={query}
+          loading={loading}
+          onQueryChange={handleQueryChange}
+          onSubmit={searchSkills}
+          onClear={handleClearSearch}
+        />
+
+        <div className="grid grid-cols-1 gap-4 2xl:grid-cols-[minmax(0,1.4fr)_minmax(360px,0.9fr)]">
+          <div className="min-w-0">
+            <SkillGrid
+              loadingLabel="Loading Hermes skills..."
+              skills={browseCards}
+              loading={loading}
+              error={error}
+              query={query}
+              selectedSlug={selectedSkill?.ref || null}
+              selectedSkillSlugs={selectedSkillRefs}
+              selectionBusySlug={selectionBusyRef}
+              onSelect={loadSkillDetail}
+              onToggleSelection={toggleSkillSelection}
+              emptyTitle={
+                showingDefaultBrowseEmptyState
+                  ? "Search the Hermes Skills Hub to discover skills."
+                  : "No skills found."
+              }
+              emptyMessage={
+                showingDefaultBrowseEmptyState
+                  ? "The registry returned an empty default browse list. Enter a search and press Enter to find skills."
+                  : undefined
+              }
+            />
+          </div>
+
+          <div className="min-w-0">
+            <SkillDetailCard
+              skill={selectedSkill}
+              detail={selectedSkillDetail}
+              loading={detailLoading}
+              error={detailError}
+              inLibrary={selectedSkill ? libraryRefs.has(selectedSkill.ref) : false}
+              libraryBusy={selectedSkill ? libraryAddBusyRef === selectedSkill.ref : false}
+              onAddToLibrary={handleAddToLibrary}
+              onClose={() => {
+                setSelectedSkill(null);
+                setSelectedSkillDetail(null);
+                setDetailError(null);
+                setDetailLoading(false);
+              }}
+            />
+          </div>
+        </div>
+      </div>
+    </Layout>
+  );
+}


### PR DESCRIPTION
PR 5 of the Hermes Skills epic (follows #318–#321). Completes the deploy-side story from the feature request: pick skills while deploying a Hermes agent, with the instance Skills Library front and center.

- **Deploy wizard**: `usesHermesSkillsStep` mirrors `usesClawHubStep` — hermes deploys route through a new `/hermes-skills-select` picker (draft-guarded; adopt exempt; migrate follows the family lock exactly like OpenClaw's flow).
- **Picker page**: Skills Library first (add-to-selection / remove / add-from-detail), then browse/search over the cached 90k index; selection dedups on the lockfile name, persists to the deploy draft, and deploys with `hermes_skills` in the POST.
- **Backend**: `normalizeHermesSkills` delegates to the shared agent-runtime normalizer (ref required, reserved names dropped, capped at 20, truncation asserted in tests), family-gated to `[]` after runtime-field resolution; both INSERT sites + job payload carry the column. First-boot install is the existing `reconcileHermesSkills` — no new worker logic.
- **Shared components**: `SkillDetailCard` extracted for reuse; `SkillSelectionTray` gains only an optional `emptyMessage` (all ClawHub copy preserved; hermes rows adapt at the call site to avoid type churn).
- Docs: deploy guide now describes the per-family skills step.

Validation: backend 219 targeted + full suite 2263 green; frontend 36 tests + typecheck; eslint/prettier clean; OpenClaw e2e selectors untouched.