### PR TITLE
feat(agent-hub): runtime_family on listings + snapshot defaults (C1)

### DIFF
--- a/backend-api/__tests__/agentHubRuntimeFamily.test.ts
+++ b/backend-api/__tests__/agentHubRuntimeFamily.test.ts
@@ -1,0 +1,189 @@
+// @ts-nocheck
+const mockDb = { query: jest.fn() };
+jest.mock("../db", () => mockDb);
+
+const agentHubStore = require("../agentHubStore");
+
+function existingListingRow(overrides = {}) {
+  return {
+    id: "listing-1",
+    snapshot_id: "snapshot-1",
+    owner_user_id: "user-1",
+    name: "Existing Listing",
+    description: "Existing description",
+    price: "Free",
+    category: "General",
+    built_in: false,
+    source_type: "community",
+    runtime_family: "openclaw",
+    status: "published",
+    visibility: "public",
+    share_target: "internal",
+    local_visibility: "internal",
+    central_share_status: "not_shared",
+    central_listing_id: null,
+    central_last_synced_at: null,
+    central_error: null,
+    slug: "existing-listing",
+    current_version: 1,
+    review_notes: null,
+    ...overrides,
+  };
+}
+
+function primeQueries({ existing = null, returnedRow = {} } = {}) {
+  mockDb.query.mockImplementation(async (sql) => {
+    const text = String(sql);
+    if (text.includes("WHERE snapshot_id = $1 ORDER BY created_at")) {
+      return { rows: existing ? [existing] : [] };
+    }
+    if (text.includes("WHERE slug = $1")) {
+      return { rows: [] };
+    }
+    if (text.includes("SELECT * FROM agent_hub_listings WHERE id = $1")) {
+      return { rows: existing ? [existing] : [] };
+    }
+    if (text.includes("agent_hub_listing_versions")) {
+      return { rows: [] };
+    }
+    if (text.includes("INSERT INTO agent_hub_listings")) {
+      return { rows: [returnedRow] };
+    }
+    if (text.includes("UPDATE agent_hub_listings")) {
+      return { rows: [returnedRow] };
+    }
+    return { rows: [] };
+  });
+}
+
+function findQueryCall(pattern) {
+  return mockDb.query.mock.calls.find(([sql]) => String(sql).includes(pattern));
+}
+
+function insertParamIndexFor(sql, column) {
+  const columnsMatch = String(sql).match(/INSERT INTO agent_hub_listings\(([\s\S]*?)\)\s*VALUES/i);
+  expect(columnsMatch).not.toBeNull();
+  const columns = columnsMatch[1].split(",").map((entry) => entry.trim());
+  const index = columns.indexOf(column);
+  expect(index).toBeGreaterThanOrEqual(0);
+  return index;
+}
+
+function updateParamIndexFor(sql, column) {
+  const match = String(sql).match(new RegExp(`${column}\\s*=\\s*\\$(\\d+)`));
+  expect(match).not.toBeNull();
+  return Number(match[1]) - 1;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("agentHubStore runtime family persistence", () => {
+  it("round-trips a known runtimeFamily through insert and returns the stored row", async () => {
+    const stored = existingListingRow({ runtime_family: "hermes" });
+    primeQueries({ returnedRow: stored });
+
+    const listing = await agentHubStore.upsertListing({
+      snapshotId: "snapshot-1",
+      name: "Hermes Listing",
+      runtimeFamily: "hermes",
+    });
+
+    const insertCall = findQueryCall("INSERT INTO agent_hub_listings");
+    expect(insertCall).toBeDefined();
+    const [insertSql, insertParams] = insertCall;
+    expect(insertParams[insertParamIndexFor(insertSql, "runtime_family")]).toBe("hermes");
+    expect(listing.runtime_family).toBe("hermes");
+  });
+
+  it("defaults runtime_family to openclaw when runtimeFamily is absent", async () => {
+    primeQueries({ returnedRow: existingListingRow() });
+
+    await agentHubStore.upsertListing({
+      snapshotId: "snapshot-1",
+      name: "Plain Listing",
+    });
+
+    const [insertSql, insertParams] = findQueryCall("INSERT INTO agent_hub_listings");
+    expect(insertParams[insertParamIndexFor(insertSql, "runtime_family")]).toBe("openclaw");
+  });
+
+  it("normalizes runtimeFamily case and whitespace", async () => {
+    primeQueries({ returnedRow: existingListingRow({ runtime_family: "hermes" }) });
+
+    await agentHubStore.upsertListing({
+      snapshotId: "snapshot-1",
+      name: "Hermes Listing",
+      runtimeFamily: "  HeRmEs  ",
+    });
+
+    const [insertSql, insertParams] = findQueryCall("INSERT INTO agent_hub_listings");
+    expect(insertParams[insertParamIndexFor(insertSql, "runtime_family")]).toBe("hermes");
+  });
+
+  it("collapses unknown runtime families to openclaw instead of persisting free text", async () => {
+    primeQueries({ returnedRow: existingListingRow() });
+
+    await agentHubStore.upsertListing({
+      snapshotId: "snapshot-1",
+      name: "Odd Listing",
+      runtimeFamily: "quantum-claw",
+    });
+
+    const [insertSql, insertParams] = findQueryCall("INSERT INTO agent_hub_listings");
+    expect(insertParams[insertParamIndexFor(insertSql, "runtime_family")]).toBe("openclaw");
+  });
+
+  it("preserves the existing listing family on update when runtimeFamily is not provided", async () => {
+    const existing = existingListingRow({ runtime_family: "hermes" });
+    primeQueries({ existing, returnedRow: existing });
+
+    await agentHubStore.upsertListing({
+      listingId: existing.id,
+      snapshotId: existing.snapshot_id,
+      name: "Renamed Listing",
+    });
+
+    const updateCall = findQueryCall("UPDATE agent_hub_listings");
+    expect(updateCall).toBeDefined();
+    const [updateSql, updateParams] = updateCall;
+    expect(updateParams[updateParamIndexFor(updateSql, "runtime_family")]).toBe("hermes");
+  });
+
+  it("persists an explicit runtimeFamily change on update", async () => {
+    const existing = existingListingRow({ runtime_family: "openclaw" });
+    primeQueries({ existing, returnedRow: existing });
+
+    await agentHubStore.upsertListing({
+      listingId: existing.id,
+      snapshotId: existing.snapshot_id,
+      name: "Now Hermes",
+      runtimeFamily: "hermes",
+    });
+
+    const [updateSql, updateParams] = findQueryCall("UPDATE agent_hub_listings");
+    expect(updateParams[updateParamIndexFor(updateSql, "runtime_family")]).toBe("hermes");
+  });
+});
+
+describe("agentHubStore listing queries include runtime_family", () => {
+  it.each([
+    ["getListing", () => agentHubStore.getListing("listing-1")],
+    ["listAgentHubLocalListings", () => agentHubStore.listAgentHubLocalListings()],
+    ["listUserListings", () => agentHubStore.listUserListings("user-1")],
+    ["listCommunityCatalog", () => agentHubStore.listCommunityCatalog()],
+    ["listAdminListings", () => agentHubStore.listAdminListings()],
+    ["getPlatformListingByTemplateKey", () => agentHubStore.getPlatformListingByTemplateKey("key")],
+  ])("selects ml.runtime_family in %s", async (_name, run) => {
+    mockDb.query.mockResolvedValue({ rows: [] });
+
+    await run();
+
+    const listingSelect = mockDb.query.mock.calls.find(([sql]) =>
+      String(sql).includes("FROM agent_hub_listings ml"),
+    );
+    expect(listingSelect).toBeDefined();
+    expect(String(listingSelect[0])).toContain("ml.runtime_family");
+  });
+});

--- a/backend-api/__tests__/agentPayloads.test.ts
+++ b/backend-api/__tests__/agentPayloads.test.ts
@@ -171,6 +171,62 @@ describe("Agent Hub template deploy targets", () => {
   });
 });
 
+describe("Agent Hub template runtime family", () => {
+  it("defaults runtimeFamily to openclaw for snapshots captured before the field existed", () => {
+    expect(
+      extractTemplateDefaultsFromSnapshot({
+        config: {
+          defaults: {
+            deploy_target: "docker",
+          },
+        },
+      }),
+    ).toEqual(expect.objectContaining({ runtimeFamily: "openclaw" }));
+  });
+
+  it("defaults runtimeFamily to openclaw when the snapshot has no defaults at all", () => {
+    expect(extractTemplateDefaultsFromSnapshot({ config: {} })).toEqual(
+      expect.objectContaining({ runtimeFamily: "openclaw" }),
+    );
+  });
+
+  it("surfaces a stored runtime_family from snapshot defaults", () => {
+    expect(
+      extractTemplateDefaultsFromSnapshot({
+        config: {
+          defaults: {
+            runtime_family: "hermes",
+          },
+        },
+      }),
+    ).toEqual(expect.objectContaining({ runtimeFamily: "hermes" }));
+  });
+
+  it("accepts the camelCase runtimeFamily alias", () => {
+    expect(
+      extractTemplateDefaultsFromSnapshot({
+        config: {
+          defaults: {
+            runtimeFamily: "hermes",
+          },
+        },
+      }),
+    ).toEqual(expect.objectContaining({ runtimeFamily: "hermes" }));
+  });
+
+  it("collapses unknown runtime families to openclaw", () => {
+    expect(
+      extractTemplateDefaultsFromSnapshot({
+        config: {
+          defaults: {
+            runtime_family: "quantumclaw",
+          },
+        },
+      }),
+    ).toEqual(expect.objectContaining({ runtimeFamily: "openclaw" }));
+  });
+});
+
 describe("buildTemplatePayloadFromAgent capture authorization", () => {
   it.each([
     "REMOTE_HOST_ACCESS_REVOKED",

--- a/backend-api/agentHubStore.ts
+++ b/backend-api/agentHubStore.ts
@@ -2,6 +2,10 @@
 // Agent Hub registry backed by PostgreSQL.
 
 const db = require("./db");
+const {
+  DEFAULT_RUNTIME_FAMILY,
+  normalizeRuntimeFamilyName,
+} = require("../agent-runtime/lib/backendCatalog");
 
 const LISTING_SOURCE_PLATFORM = "platform";
 const LISTING_SOURCE_COMMUNITY = "community";
@@ -43,6 +47,7 @@ const LISTING_SELECT = `
     ml.downloads,
     ml.built_in,
     ml.source_type,
+    ml.runtime_family,
     ml.status,
     ml.visibility,
     ml.share_target,
@@ -121,6 +126,19 @@ function normalizeLocalVisibility(value, fallback = LISTING_LOCAL_VISIBILITY_OWN
   if (value === LISTING_LOCAL_VISIBILITY_INTERNAL) return LISTING_LOCAL_VISIBILITY_INTERNAL;
   if (value === LISTING_LOCAL_VISIBILITY_OWNER) return LISTING_LOCAL_VISIBILITY_OWNER;
   return fallback;
+}
+
+/**
+ * Normalize a listing runtime family: lower/trim, absent values fall back to
+ * the provided fallback, and unknown families collapse to the platform default
+ * (`openclaw`) via the shared runtime catalog rather than persisting free text.
+ */
+function normalizeRuntimeFamily(value, fallback = DEFAULT_RUNTIME_FAMILY) {
+  const normalized = String(value ?? "")
+    .trim()
+    .toLowerCase();
+  if (!normalized) return normalizeRuntimeFamilyName(fallback);
+  return normalizeRuntimeFamilyName(normalized);
 }
 
 function normalizeCentralShareStatus(value, fallback = CENTRAL_SHARE_STATUS_NOT_SHARED) {
@@ -214,6 +232,7 @@ async function upsertListing({
   category = "General",
   builtIn = false,
   sourceType = builtIn ? LISTING_SOURCE_PLATFORM : LISTING_SOURCE_COMMUNITY,
+  runtimeFamily = null,
   ownerUserId = null,
   status = null,
   visibility = LISTING_VISIBILITY_PUBLIC,
@@ -276,6 +295,10 @@ async function upsertListing({
       ? CENTRAL_SHARE_STATUS_QUEUED
       : CENTRAL_SHARE_STATUS_NOT_SHARED,
   );
+  const normalizedRuntimeFamily = normalizeRuntimeFamily(
+    runtimeFamily,
+    existing?.runtime_family || DEFAULT_RUNTIME_FAMILY,
+  );
   const normalizedName = normalizeText(name, existing?.name || "Untitled Listing").slice(0, 100);
   const normalizedDescription = normalizeDescription(description || existing?.description || "");
   const normalizedCategory = normalizeCategory(category || existing?.category || "General");
@@ -313,13 +336,14 @@ async function upsertListing({
               slug = $17,
               current_version = $18,
               review_notes = $19,
+              runtime_family = $20,
               reviewed_at = CASE WHEN $9 IN ('published', 'rejected', 'removed') THEN NOW() ELSE reviewed_at END,
               published_at = CASE
                 WHEN $9 = 'published' THEN COALESCE(published_at, NOW())
                 ELSE published_at
               END,
               updated_at = NOW()
-        WHERE id = $20
+        WHERE id = $21
       RETURNING *`,
       [
         snapshotId || null,
@@ -343,6 +367,7 @@ async function upsertListing({
         resolvedSlug,
         nextVersion,
         reviewNotes,
+        normalizedRuntimeFamily,
         existing.id,
       ],
     );
@@ -378,9 +403,10 @@ async function upsertListing({
        central_error,
        slug,
        current_version,
+       runtime_family,
        published_at
      )
-     VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18,
+     VALUES($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19,
        CASE WHEN $9 = 'published' THEN NOW() ELSE NULL END
      )
      RETURNING *`,
@@ -403,6 +429,7 @@ async function upsertListing({
       centralError !== undefined ? normalizeDescription(centralError) : null,
       resolvedSlug,
       initialVersion,
+      normalizedRuntimeFamily,
     ],
   );
 

--- a/backend-api/agentPayloads.ts
+++ b/backend-api/agentPayloads.ts
@@ -11,6 +11,7 @@ const { NORA_INTEGRATIONS_SKILL_FILE } = require("../agent-runtime/lib/integrati
 const {
   normalizeBackendName,
   normalizeExecutionTargetId,
+  normalizeRuntimeFamilyName,
 } = require("../agent-runtime/lib/backendCatalog");
 const { buildAgentRuntimeFields, parseSandboxProfile } = require("./agentRuntimeFields");
 
@@ -972,8 +973,14 @@ function extractTemplateDefaultsFromSnapshot(snapshot) {
     normalizedExecutionTargetId || normalizeExecutionTargetId(requestedBackend) || backend;
   const requestedSandbox = defaults.sandbox_profile ?? defaults.sandboxProfile ?? defaults.sandbox;
   const sandbox = parseSandboxProfile(requestedSandbox) || "standard";
+  // Unknown or absent families collapse to the platform default ("openclaw")
+  // so templates captured before runtime_family existed keep installing.
+  const runtimeFamily = normalizeRuntimeFamilyName(
+    defaults.runtime_family ?? defaults.runtimeFamily,
+  );
 
   return {
+    runtimeFamily,
     backend,
     executionTargetId,
     sandbox,

--- a/backend-api/db_schema.sql
+++ b/backend-api/db_schema.sql
@@ -398,6 +398,7 @@ CREATE TABLE IF NOT EXISTS agent_hub_listings (
   downloads INTEGER DEFAULT 0,
   built_in BOOLEAN DEFAULT false,
   source_type TEXT DEFAULT 'platform',
+  runtime_family TEXT NOT NULL DEFAULT 'openclaw',
   status TEXT DEFAULT 'published',
   visibility TEXT DEFAULT 'public',
   share_target TEXT DEFAULT 'internal',

--- a/backend-api/routes/agentHub.ts
+++ b/backend-api/routes/agentHub.ts
@@ -255,6 +255,7 @@ function buildSnapshotConfigFromAgent(agent, templatePayload) {
   return {
     kind: "community-template",
     defaults: {
+      runtime_family: agent.runtime_family || "openclaw",
       backend,
       sandbox: runtimeFields.sandbox_profile,
       vcpu: agent.vcpu || 2,
@@ -599,6 +600,7 @@ router.post(
       category: listingCategory,
       builtIn: false,
       sourceType: agentHubStore.LISTING_SOURCE_COMMUNITY,
+      runtimeFamily: agent.runtime_family || "openclaw",
       status: agentHubStore.LISTING_STATUS_PUBLISHED,
       visibility: agentHubStore.LISTING_VISIBILITY_PUBLIC,
       shareTarget,

--- a/backend-api/server.ts
+++ b/backend-api/server.ts
@@ -2378,6 +2378,8 @@ async function migrateDB(database = db, env = process.env) {
        added_by_user_id UUID REFERENCES users(id) ON DELETE SET NULL,
        created_at TIMESTAMPTZ DEFAULT NOW()
      )`,
+    `DO $$ BEGIN ALTER TABLE agent_hub_listings ADD COLUMN runtime_family TEXT NOT NULL DEFAULT 'openclaw'; EXCEPTION WHEN duplicate_column THEN NULL; END $$`,
+    `UPDATE agent_hub_listings SET runtime_family = 'openclaw' WHERE runtime_family IS NULL`,
   ];
 
   return runVersionedMigrations(database, migrations, {

--- a/infra/helm/nora/files/db_schema.sql
+++ b/infra/helm/nora/files/db_schema.sql
@@ -398,6 +398,7 @@ CREATE TABLE IF NOT EXISTS agent_hub_listings (
   downloads INTEGER DEFAULT 0,
   built_in BOOLEAN DEFAULT false,
   source_type TEXT DEFAULT 'platform',
+  runtime_family TEXT NOT NULL DEFAULT 'openclaw',
   status TEXT DEFAULT 'published',
   visibility TEXT DEFAULT 'public',
   share_target TEXT DEFAULT 'internal',


### PR DESCRIPTION
PR 6 of the Hermes Skills epic — first of three Agent Hub PRs. **Inert plumbing only**: no share/install behavior changes.

- `agent_hub_listings.runtime_family` (TEXT NOT NULL DEFAULT 'openclaw') in both schema files; boot migration **appended at the versioned array's end** (per the #320 lesson — the array is positional+checksummed).
- `agentHubStore` normalizes (known families only), persists, and serializes the field on every listing read.
- Share-time snapshot defaults now record the publishing agent's family (`buildSnapshotConfigFromAgent`), and `extractTemplateDefaultsFromSnapshot` surfaces `runtimeFamily` with an openclaw fallback for all pre-existing snapshots.
- This implements the redundant-carrier design (listing column authoritative → snapshot defaults → payload metadata) that C3's install resolution will consume; C2 adds the Hermes publish path + /share guard.

Tests: new agentHubRuntimeFamily suite + agentPayloads back-compat cases (33 targeted); full backend suite green (the two suites that mock worker node_modules by path verified separately — worktree symlink artifact, not code); typecheck + prettier clean; schema files byte-identical.