### PR TITLE
feat(agent-hub): Hermes publish path + /share family guard (C2)

### DIFF
--- a/backend-api/__tests__/agentHubHermes.test.ts
+++ b/backend-api/__tests__/agentHubHermes.test.ts
@@ -1,0 +1,599 @@
+// @ts-nocheck
+process.env.ENCRYPTION_KEY = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
+const mockDb = { query: jest.fn() };
+const mockRunContainerCommand = jest.fn();
+const mockIsRemoteDockerAgent = jest.fn();
+const mockAssertRemoteHostAgentUse = jest.fn();
+const mockToPublicRemoteHostAuthorizationError = jest.fn();
+const mockAssertRemoteHostExecutionTargetAvailable = jest.fn();
+const mockRuntimeAuthHeaders = jest.fn();
+const mockBuildHermesTemplatePayloadFromAgent = jest.fn();
+const mockBuildHermesBundleMetadata = jest.fn();
+const mockCreateSnapshot = jest.fn();
+const mockGetSnapshot = jest.fn();
+const mockUpsertListing = jest.fn();
+const mockGetListing = jest.fn();
+const mockGetAgentHubSettings = jest.fn();
+const mockLogEvent = jest.fn();
+
+jest.mock("../db", () => mockDb);
+jest.mock("../authSync", () => ({
+  runContainerCommand: mockRunContainerCommand,
+}));
+jest.mock("../containerManager", () => ({
+  restart: jest.fn(),
+  isKubernetesAgent: jest.fn(),
+  updateEnv: jest.fn(),
+  persistLifecycleRuntimeAddress: jest.fn(),
+}));
+jest.mock("../healthChecks", () => ({
+  waitForAgentReadiness: jest.fn(),
+}));
+jest.mock("../remoteHosts", () => ({
+  isRemoteDockerAgent: (...args) => mockIsRemoteDockerAgent(...args),
+  assertRemoteHostAgentUse: (...args) => mockAssertRemoteHostAgentUse(...args),
+  toPublicRemoteHostAuthorizationError: (...args) =>
+    mockToPublicRemoteHostAuthorizationError(...args),
+  assertRemoteHostExecutionTargetAvailable: (...args) =>
+    mockAssertRemoteHostExecutionTargetAvailable(...args),
+}));
+jest.mock("../runtimeAuth", () => ({
+  runtimeAuthHeaders: mockRuntimeAuthHeaders,
+}));
+jest.mock("../hermesTemplateExport", () => ({
+  buildHermesTemplatePayloadFromAgent: mockBuildHermesTemplatePayloadFromAgent,
+  buildHermesBundleMetadata: mockBuildHermesBundleMetadata,
+}));
+jest.mock("../redisQueue", () => ({
+  addDeploymentJob: jest.fn(),
+}));
+jest.mock("../billing", () => ({
+  IS_PAAS: false,
+  SELFHOSTED_LIMITS: { max_vcpu: 8, max_ram_mb: 16384, max_disk_gb: 200 },
+  enforceLimits: jest.fn(),
+}));
+jest.mock("../agentHubStore", () => ({
+  LISTING_SOURCE_PLATFORM: "platform",
+  LISTING_SOURCE_COMMUNITY: "community",
+  LISTING_STATUS_PUBLISHED: "published",
+  LISTING_VISIBILITY_PUBLIC: "public",
+  LISTING_SHARE_TARGET_INTERNAL: "internal",
+  LISTING_SHARE_TARGET_COMMUNITY: "community",
+  LISTING_SHARE_TARGET_BOTH: "both",
+  LISTING_LOCAL_VISIBILITY_OWNER: "owner",
+  LISTING_LOCAL_VISIBILITY_INTERNAL: "internal",
+  CENTRAL_SHARE_STATUS_NOT_SHARED: "not_shared",
+  CENTRAL_SHARE_STATUS_QUEUED: "queued",
+  CENTRAL_SHARE_STATUS_SUBMITTED: "submitted",
+  CENTRAL_SHARE_STATUS_FAILED: "failed",
+  getListing: (...args) => mockGetListing(...args),
+  upsertListing: (...args) => mockUpsertListing(...args),
+  updateCentralShareStatus: jest.fn(),
+  listAgentHubLocalListings: jest.fn(),
+  listUserListings: jest.fn(),
+  listCommunityCatalog: jest.fn(),
+  recordInstall: jest.fn(),
+  recordDownload: jest.fn(),
+  createReport: jest.fn(),
+}));
+jest.mock("../agentHubApiKeys", () => ({
+  listApiKeys: jest.fn(),
+  createApiKey: jest.fn(),
+  revokeApiKey: jest.fn(),
+}));
+jest.mock("../agentHubRemote", () => ({
+  fetchCatalog: jest.fn(),
+  fetchListing: jest.fn(),
+  submitListing: jest.fn(),
+}));
+jest.mock("../platformSettings", () => ({
+  getAgentHubSettings: (...args) => mockGetAgentHubSettings(...args),
+  getAgentHubSourceApiKey: jest.fn(),
+}));
+jest.mock("../snapshots", () => ({
+  createSnapshot: (...args) => mockCreateSnapshot(...args),
+  getSnapshot: (...args) => mockGetSnapshot(...args),
+  updateSnapshot: jest.fn(),
+}));
+jest.mock("../scheduler", () => ({
+  selectNode: jest.fn(),
+}));
+jest.mock("../monitoring", () => ({
+  logEvent: (...args) => mockLogEvent(...args),
+}));
+jest.mock("../kubernetesClusters", () => ({
+  assertKubernetesExecutionTargetAvailable: jest.fn(),
+}));
+jest.mock("../middleware/auth", () => ({
+  requireSession: (req, _res, next) => {
+    req.user = { id: "user-1", email: "user@example.com" };
+    next();
+  },
+}));
+jest.mock("../middleware/errorHandler", () => ({
+  asyncHandler: (fn) => (req, res, next) => Promise.resolve(fn(req, res, next)).catch(next),
+}));
+jest.mock("../auditLog", () => ({
+  buildAgentContext: jest.fn(() => ({})),
+  buildAuditMetadata: jest.fn(() => ({})),
+  buildListingContext: jest.fn(() => ({})),
+  buildReportContext: jest.fn(() => ({})),
+  createMutationFailureAuditMiddleware: () => (_req, _res, next) => next(),
+}));
+
+const express = require("express");
+const request = require("supertest");
+const router = require("../routes/agentHub");
+const { summarizeTemplatePayload } = require("../agentPayloads");
+// The route tests above exercise the mocked export module; the capture unit
+// tests below need the real implementation with the same mocked transports.
+const hermesTemplateExport = jest.requireActual("../hermesTemplateExport");
+
+const ORIGINAL_ENABLED_RUNTIME_FAMILIES = process.env.ENABLED_RUNTIME_FAMILIES;
+
+function encode(content) {
+  return Buffer.from(content, "utf8").toString("base64");
+}
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  app.use((error, _req, res, _next) => {
+    res.status(error.statusCode || 500).json({ error: error.message });
+  });
+  return app;
+}
+
+function hermesAgentRow(overrides = {}) {
+  return {
+    id: "agent-h1",
+    user_id: "user-1",
+    name: "Hermes Helper",
+    status: "running",
+    container_id: "container-1",
+    runtime_family: "hermes",
+    backend_type: "docker",
+    deploy_target: "docker",
+    execution_target_id: "docker",
+    sandbox_type: "standard",
+    sandbox_profile: "standard",
+    runtime_host: null,
+    vcpu: 2,
+    ram_mb: 2048,
+    disk_gb: 20,
+    image: "nousresearch/hermes-agent:latest",
+    hermes_skills: [
+      {
+        source: "hermes-hub",
+        ref: "official/security/1password",
+        name: "1password",
+        installMode: "cli",
+        installedAt: "2026-07-01T00:00:00.000Z",
+      },
+    ],
+    template_payload: null,
+    ...overrides,
+  };
+}
+
+function openclawAgentRow(overrides = {}) {
+  return {
+    id: "agent-o1",
+    user_id: "user-1",
+    name: "OpenClaw Buddy",
+    status: "stopped",
+    container_id: null,
+    runtime_family: "openclaw",
+    backend_type: "docker",
+    deploy_target: "docker",
+    execution_target_id: "docker",
+    sandbox_type: "standard",
+    sandbox_profile: "standard",
+    runtime_host: null,
+    vcpu: 2,
+    ram_mb: 2048,
+    disk_gb: 20,
+    image: "openclaw:latest",
+    template_payload: {
+      files: [{ path: "CUSTOM.md", contentBase64: encode("stored template") }],
+    },
+    ...overrides,
+  };
+}
+
+function hermesCapturePayload(files = null) {
+  return {
+    version: 1,
+    files: files || [{ path: "notes.md", contentBase64: encode("# Notes"), mode: 0o644 }],
+    memoryFiles: [],
+    wiring: { channels: [], integrations: [] },
+    metadata: {
+      runtimeFamily: "hermes",
+      source: "hermes-live-capture",
+      capturedAt: "2026-07-30T00:00:00.000Z",
+    },
+  };
+}
+
+const HERMES_BUNDLE_METADATA = Object.freeze({
+  runtimeFamily: "hermes",
+  hermesSkills: [
+    {
+      source: "hermes-hub",
+      ref: "official/security/1password",
+      name: "1password",
+      installMode: "cli",
+      installedAt: "2026-07-01T00:00:00.000Z",
+    },
+  ],
+  hermesModelConfig: { provider: "nous", defaultModel: "hermes-4-405b", baseUrl: "" },
+});
+
+function primeAgentQuery(agent) {
+  mockDb.query.mockImplementation(async (sql) => {
+    if (String(sql).includes("FROM agents WHERE id = $1 AND user_id = $2")) {
+      return { rows: agent ? [agent] : [] };
+    }
+    return { rows: [] };
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.ENABLED_RUNTIME_FAMILIES = "openclaw,hermes";
+  mockIsRemoteDockerAgent.mockImplementation((agent) =>
+    [agent?.deploy_target, agent?.backend_type, agent?.execution_target_id].some((value) =>
+      String(value || "")
+        .toLowerCase()
+        .startsWith("remote"),
+    ),
+  );
+  mockToPublicRemoteHostAuthorizationError.mockImplementation((error) => error);
+  mockAssertRemoteHostAgentUse.mockResolvedValue({ id: "shared-host" });
+  mockRuntimeAuthHeaders.mockResolvedValue({});
+  mockGetAgentHubSettings.mockResolvedValue({ defaultShareTarget: "internal" });
+  mockCreateSnapshot.mockResolvedValue({
+    id: "snapshot-1",
+    name: "Snapshot",
+    kind: "community-template",
+    template_key: null,
+  });
+  mockUpsertListing.mockResolvedValue({
+    id: "listing-1",
+    name: "Listing",
+    central_share_status: "not_shared",
+  });
+  mockGetListing.mockResolvedValue({
+    id: "listing-1",
+    name: "Listing",
+    central_share_status: "not_shared",
+  });
+  mockLogEvent.mockResolvedValue(undefined);
+});
+
+afterAll(() => {
+  if (ORIGINAL_ENABLED_RUNTIME_FAMILIES === undefined) {
+    delete process.env.ENABLED_RUNTIME_FAMILIES;
+  } else {
+    process.env.ENABLED_RUNTIME_FAMILIES = ORIGINAL_ENABLED_RUNTIME_FAMILIES;
+  }
+});
+
+describe("POST /share runtime-family guard", () => {
+  it("rejects sharing an agent whose family is not enabled on this instance", async () => {
+    process.env.ENABLED_RUNTIME_FAMILIES = "openclaw";
+    primeAgentQuery(hermesAgentRow());
+
+    const res = await request(buildApp()).post("/share").send({ agentId: "agent-h1" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/not enabled/i);
+    expect(mockBuildHermesTemplatePayloadFromAgent).not.toHaveBeenCalled();
+    expect(mockCreateSnapshot).not.toHaveBeenCalled();
+  });
+
+  it("rejects sharing an agent with an unknown runtime family", async () => {
+    primeAgentQuery(hermesAgentRow({ runtime_family: "quantumclaw" }));
+
+    const res = await request(buildApp()).post("/share").send({ agentId: "agent-h1" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/cannot be published/i);
+    expect(mockBuildHermesTemplatePayloadFromAgent).not.toHaveBeenCalled();
+    expect(mockCreateSnapshot).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["stopped status", { status: "stopped" }],
+    ["missing container id", { container_id: null }],
+  ])("returns 409 for a Hermes agent with %s", async (_label, overrides) => {
+    primeAgentQuery(hermesAgentRow(overrides));
+
+    const res = await request(buildApp()).post("/share").send({ agentId: "agent-h1" });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/live agent workspace/i);
+    expect(mockBuildHermesTemplatePayloadFromAgent).not.toHaveBeenCalled();
+    expect(mockCreateSnapshot).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /share hermes publish flow", () => {
+  it("captures the live workspace, merges bundle metadata, and persists the hermes family", async () => {
+    const agent = hermesAgentRow();
+    primeAgentQuery(agent);
+    mockBuildHermesTemplatePayloadFromAgent.mockResolvedValue(hermesCapturePayload());
+    mockBuildHermesBundleMetadata.mockResolvedValue({ ...HERMES_BUNDLE_METADATA });
+
+    const res = await request(buildApp())
+      .post("/share")
+      .send({ agentId: "agent-h1", name: "Hermes Bundle" });
+
+    expect(res.status).toBe(200);
+    expect(mockBuildHermesTemplatePayloadFromAgent).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "agent-h1" }),
+    );
+    expect(mockBuildHermesBundleMetadata).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "agent-h1" }),
+    );
+
+    const [, , , snapshotConfig] = mockCreateSnapshot.mock.calls[0];
+    expect(snapshotConfig.defaults.runtime_family).toBe("hermes");
+    expect(snapshotConfig.templatePayload.metadata).toEqual(
+      expect.objectContaining({
+        runtimeFamily: "hermes",
+        hermesSkills: HERMES_BUNDLE_METADATA.hermesSkills,
+        hermesModelConfig: HERMES_BUNDLE_METADATA.hermesModelConfig,
+      }),
+    );
+    // The captured workspace must ship as-is: no synthesized OpenClaw core files.
+    expect(snapshotConfig.templatePayload.files.map((entry) => entry.path)).toEqual(["notes.md"]);
+
+    expect(mockUpsertListing).toHaveBeenCalledWith(
+      expect.objectContaining({ runtimeFamily: "hermes" }),
+    );
+  });
+
+  it("keeps the secrets scan gating hermes shares", async () => {
+    primeAgentQuery(hermesAgentRow());
+    mockBuildHermesTemplatePayloadFromAgent.mockResolvedValue(
+      hermesCapturePayload([
+        {
+          path: "notes.md",
+          contentBase64: encode(`OPENAI_API_KEY=sk-${"A1b2C3d4E5".repeat(3)}`),
+          mode: 0o644,
+        },
+      ]),
+    );
+    mockBuildHermesBundleMetadata.mockResolvedValue({ ...HERMES_BUNDLE_METADATA });
+
+    const res = await request(buildApp()).post("/share").send({ agentId: "agent-h1" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/secrets/i);
+    expect(res.body.issues.length).toBeGreaterThan(0);
+    expect(mockCreateSnapshot).not.toHaveBeenCalled();
+    expect(mockUpsertListing).not.toHaveBeenCalled();
+  });
+
+  it("surfaces capture failures as a 409 without creating a listing", async () => {
+    primeAgentQuery(hermesAgentRow());
+    mockBuildHermesTemplatePayloadFromAgent.mockRejectedValue(
+      new Error("Container exec unavailable"),
+    );
+
+    const res = await request(buildApp()).post("/share").send({ agentId: "agent-h1" });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe("Container exec unavailable");
+    expect(mockCreateSnapshot).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /share openclaw publish flow (unchanged)", () => {
+  it("still publishes from the stored payload with synthesized core files", async () => {
+    primeAgentQuery(openclawAgentRow());
+
+    const res = await request(buildApp())
+      .post("/share")
+      .send({ agentId: "agent-o1", name: "OpenClaw Template" });
+
+    expect(res.status).toBe(200);
+    expect(mockBuildHermesTemplatePayloadFromAgent).not.toHaveBeenCalled();
+    expect(mockBuildHermesBundleMetadata).not.toHaveBeenCalled();
+
+    const [, , , snapshotConfig] = mockCreateSnapshot.mock.calls[0];
+    expect(snapshotConfig.defaults.runtime_family).toBe("openclaw");
+    const paths = snapshotConfig.templatePayload.files.map((entry) => entry.path);
+    expect(paths).toEqual(expect.arrayContaining(["CUSTOM.md", "AGENTS.md", "SOUL.md"]));
+
+    expect(mockUpsertListing).toHaveBeenCalledWith(
+      expect.objectContaining({ runtimeFamily: "openclaw" }),
+    );
+  });
+});
+
+describe("hermesTemplateExport workspace capture", () => {
+  function captureResult(payload) {
+    return {
+      exitCode: 0,
+      output: Buffer.from(JSON.stringify(payload), "utf8").toString("base64"),
+    };
+  }
+
+  function decodeHermesHelperScript(command) {
+    const match = String(command || "").match(/base64\.b64decode\("([^"]+)"\)\.decode\('utf-8'\)/);
+    if (!match) return "";
+    return Buffer.from(match[1], "base64").toString("utf8");
+  }
+
+  it("builds a capture command that walks the workspace with the documented exclusions", () => {
+    const command = hermesTemplateExport.buildHermesWorkspaceCaptureCommand();
+    const script = decodeHermesHelperScript(command);
+
+    expect(script).toContain('"/opt/data/workspace"');
+    expect(script).toContain('excluded_dir_names = {"integrations"}');
+    expect(script).toContain('excluded_file_names = {"NORA_INTEGRATIONS.md"}');
+    expect(script).toContain('name.startswith("integrations") and name.endswith(".json")');
+    expect(script).toContain('name.startswith(".")');
+    expect(script).toContain("max_file_bytes = 1048576");
+    expect(script).toContain("max_files = 200");
+  });
+
+  it("normalizes a live capture into a hermes payload without core-file synthesis", async () => {
+    mockRunContainerCommand.mockResolvedValue(
+      captureResult({
+        files: [
+          { path: "scripts/run.sh", contentBase64: encode("echo hi") },
+          { path: "notes.md", contentBase64: encode("# Notes") },
+        ],
+        truncated: false,
+        skippedFileCount: 0,
+        skippedFiles: [],
+      }),
+    );
+
+    const payload =
+      await hermesTemplateExport.buildHermesTemplatePayloadFromAgent(hermesAgentRow());
+
+    expect(mockRunContainerCommand).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "agent-h1" }),
+      expect.stringContaining("PY"),
+      { timeout: 120000 },
+    );
+    expect(payload.files.map((entry) => entry.path)).toEqual(["notes.md", "scripts/run.sh"]);
+    expect(payload.metadata).toEqual(
+      expect.objectContaining({ runtimeFamily: "hermes", source: "hermes-live-capture" }),
+    );
+    expect(payload.metadata.captureTruncated).toBeUndefined();
+
+    const summary = summarizeTemplatePayload(payload);
+    expect(summary.runtimeFamily).toBe("hermes");
+    expect(summary.requiredCoreCount).toBe(0);
+    expect(summary.presentRequiredCoreCount).toBe(0);
+    expect(summary.missingRequiredCoreFiles).toEqual([]);
+    expect(summary.coreFiles).toEqual([]);
+    expect(summary.files.map((file) => file.path)).toEqual(["notes.md", "scripts/run.sh"]);
+  });
+
+  it("flags truncated captures in metadata and warns", async () => {
+    const warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+    mockRunContainerCommand.mockResolvedValue(
+      captureResult({
+        files: [{ path: "notes.md", contentBase64: encode("# Notes") }],
+        truncated: true,
+        skippedFileCount: 2,
+        skippedFiles: ["big.bin", "video.mp4"],
+      }),
+    );
+
+    try {
+      const payload =
+        await hermesTemplateExport.buildHermesTemplatePayloadFromAgent(hermesAgentRow());
+
+      expect(payload.metadata.captureTruncated).toBe(true);
+      expect(payload.metadata.captureSkippedFileCount).toBe(2);
+      expect(payload.metadata.captureSkippedFiles).toEqual(["big.bin", "video.mp4"]);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("skipped content"));
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("rejects empty capture output", async () => {
+    mockRunContainerCommand.mockResolvedValue({ exitCode: 0, output: "  " });
+
+    await expect(
+      hermesTemplateExport.buildHermesTemplatePayloadFromAgent(hermesAgentRow()),
+    ).rejects.toThrow(/empty output/i);
+  });
+
+  it("rejects non-JSON capture output with a diagnostic error", async () => {
+    mockRunContainerCommand.mockResolvedValue({ exitCode: 0, output: "not-base64-json" });
+
+    await expect(
+      hermesTemplateExport.buildHermesTemplatePayloadFromAgent(hermesAgentRow()),
+    ).rejects.toThrow(/Unexpected Hermes workspace capture output/i);
+  });
+});
+
+describe("hermesTemplateExport bundle metadata", () => {
+  it("restricts model config to provider/defaultModel/baseUrl even when the row has keys", async () => {
+    mockDb.query.mockResolvedValue({
+      rows: [
+        {
+          model_config: JSON.stringify({
+            provider: "openrouter",
+            defaultModel: "hermes-4",
+            baseUrl: "https://openrouter.ai/api/v1",
+            apiKey: "sk-secret-camel-000000",
+            api_key: "sk-secret-snake-000000",
+          }),
+        },
+      ],
+    });
+
+    const metadata = await hermesTemplateExport.buildHermesBundleMetadata(hermesAgentRow());
+
+    expect(mockDb.query).toHaveBeenCalledWith(expect.stringContaining("hermes_runtime_state"), [
+      "agent-h1",
+    ]);
+    expect(metadata.runtimeFamily).toBe("hermes");
+    expect(metadata.hermesModelConfig).toEqual({
+      provider: "openrouter",
+      defaultModel: "hermes-4",
+      baseUrl: "https://openrouter.ai/api/v1",
+    });
+    expect(JSON.stringify(metadata)).not.toContain("sk-secret");
+  });
+
+  it("re-normalizes saved skills, dropping reserved and duplicate entries", async () => {
+    mockDb.query.mockResolvedValue({ rows: [] });
+
+    const metadata = await hermesTemplateExport.buildHermesBundleMetadata(
+      hermesAgentRow({
+        hermes_skills: [
+          {
+            source: "hermes-hub",
+            ref: "official/security/1password",
+            name: "1password",
+            installMode: "cli",
+            installedAt: "2026-07-01T00:00:00.000Z",
+          },
+          {
+            source: "hermes-hub",
+            ref: "official/security/1password",
+            name: "1password",
+            installMode: "cli",
+            installedAt: "2026-07-02T00:00:00.000Z",
+          },
+          { source: "hermes-hub", ref: "internal", name: "nora-integrations" },
+          { source: "hermes-hub", ref: "bad", name: "../escape" },
+        ],
+      }),
+    );
+
+    expect(metadata.hermesSkills).toEqual([
+      {
+        source: "hermes-hub",
+        ref: "official/security/1password",
+        name: "1password",
+        installMode: "cli",
+        installedAt: "2026-07-01T00:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("returns empty model config when no hermes_runtime_state row exists", async () => {
+    mockDb.query.mockResolvedValue({ rows: [] });
+
+    const metadata = await hermesTemplateExport.buildHermesBundleMetadata(
+      hermesAgentRow({ hermes_skills: [] }),
+    );
+
+    expect(metadata.hermesModelConfig).toEqual({ provider: "", defaultModel: "", baseUrl: "" });
+    expect(metadata.hermesSkills).toEqual([]);
+  });
+});

--- a/backend-api/__tests__/agentPayloads.test.ts
+++ b/backend-api/__tests__/agentPayloads.test.ts
@@ -16,8 +16,11 @@ jest.mock("../remoteHosts", () => ({
 
 const {
   buildTemplatePayloadFromAgent,
+  ensureCoreTemplateFiles,
   extractTemplateDefaultsFromSnapshot,
+  extractTemplatePayloadFromSnapshot,
   serializeAgent,
+  summarizeTemplatePayload,
 } = require("../agentPayloads");
 const { buildAgentHubTemplateUpdate } = require("../agentHubTemplateEdits");
 
@@ -224,6 +227,143 @@ describe("Agent Hub template runtime family", () => {
         },
       }),
     ).toEqual(expect.objectContaining({ runtimeFamily: "openclaw" }));
+  });
+});
+
+const OPENCLAW_REQUIRED_PATHS = [
+  "AGENTS.md",
+  "SOUL.md",
+  "TOOLS.md",
+  "IDENTITY.md",
+  "USER.md",
+  "HEARTBEAT.md",
+  "MEMORY.md",
+];
+
+describe("ensureCoreTemplateFiles family awareness", () => {
+  const hermesFiles = [
+    { path: "notes/plan.md", content: "# Plan" },
+    { path: "scripts/run.sh", content: "echo hi" },
+  ];
+
+  it("keeps synthesizing the seven required OpenClaw files by default", () => {
+    const payload = ensureCoreTemplateFiles({ files: [] }, { name: "Pinned Behavior" });
+
+    const paths = payload.files.map((entry) => entry.path);
+    expect(paths).toEqual(expect.arrayContaining(OPENCLAW_REQUIRED_PATHS));
+    expect(paths).not.toContain("BOOTSTRAP.md");
+  });
+
+  it("skips synthesis for an explicit non-OpenClaw runtime family", () => {
+    const payload = ensureCoreTemplateFiles({ files: hermesFiles }, { runtimeFamily: "hermes" });
+
+    expect(payload.files.map((entry) => entry.path)).toEqual(["notes/plan.md", "scripts/run.sh"]);
+  });
+
+  it("skips synthesis when the payload metadata carries runtimeFamily hermes", () => {
+    const payload = ensureCoreTemplateFiles({
+      files: hermesFiles,
+      metadata: { runtimeFamily: "hermes" },
+    });
+
+    expect(payload.files.map((entry) => entry.path)).toEqual(["notes/plan.md", "scripts/run.sh"]);
+    expect(payload.metadata).toEqual({ runtimeFamily: "hermes" });
+  });
+
+  it("collapses unknown carried families to OpenClaw synthesis", () => {
+    const payload = ensureCoreTemplateFiles({
+      files: [],
+      metadata: { runtimeFamily: "quantumclaw" },
+    });
+
+    expect(payload.files.map((entry) => entry.path)).toEqual(
+      expect.arrayContaining(OPENCLAW_REQUIRED_PATHS),
+    );
+  });
+
+  it("lets an explicit openclaw override beat a hermes metadata carrier", () => {
+    const payload = ensureCoreTemplateFiles(
+      { files: [], metadata: { runtimeFamily: "hermes" } },
+      { runtimeFamily: "openclaw" },
+    );
+
+    expect(payload.files.map((entry) => entry.path)).toEqual(
+      expect.arrayContaining(OPENCLAW_REQUIRED_PATHS),
+    );
+  });
+});
+
+describe("summarizeTemplatePayload family awareness", () => {
+  it("pins the OpenClaw summary contract: requiredCoreCount 7 and synthesized core files", () => {
+    const summary = summarizeTemplatePayload({ files: [] }, { context: { name: "Pinned" } });
+
+    expect(summary.runtimeFamily).toBe("openclaw");
+    expect(summary.requiredCoreCount).toBe(7);
+    expect(summary.presentRequiredCoreCount).toBe(7);
+    expect(summary.missingRequiredCoreFiles).toEqual([]);
+    expect(summary.coreFiles).toHaveLength(8);
+    expect(summary.fileCount).toBe(7);
+    expect(summary.extraFilesCount).toBe(0);
+    expect(summary.hasBootstrap).toBe(false);
+  });
+
+  it("reports zero core-file requirements for hermes payloads without fabricating files", () => {
+    const summary = summarizeTemplatePayload({
+      files: [{ path: "notes.md", content: "hello" }],
+      metadata: { runtimeFamily: "hermes" },
+    });
+
+    expect(summary.runtimeFamily).toBe("hermes");
+    expect(summary.requiredCoreCount).toBe(0);
+    expect(summary.presentRequiredCoreCount).toBe(0);
+    expect(summary.missingRequiredCoreFiles).toEqual([]);
+    expect(summary.coreFiles).toEqual([]);
+    expect(summary.fileCount).toBe(1);
+    expect(summary.extraFilesCount).toBe(1);
+    expect(summary.files.map((file) => file.path)).toEqual(["notes.md"]);
+    expect(summary.files[0].isCore).toBe(false);
+    expect(summary.files[0].requiredCore).toBe(false);
+  });
+
+  it("prefers the explicit runtimeFamily option over the metadata carrier", () => {
+    const summary = summarizeTemplatePayload(
+      { files: [], metadata: { runtimeFamily: "openclaw" } },
+      { runtimeFamily: "hermes" },
+    );
+
+    expect(summary.runtimeFamily).toBe("hermes");
+    expect(summary.requiredCoreCount).toBe(0);
+    expect(summary.fileCount).toBe(0);
+  });
+});
+
+describe("extractTemplatePayloadFromSnapshot family awareness", () => {
+  it("does not fabricate OpenClaw core files for hermes snapshots", () => {
+    const payload = extractTemplatePayloadFromSnapshot({
+      name: "Hermes Listing",
+      kind: "community-template",
+      config: {
+        defaults: { runtime_family: "hermes" },
+        templatePayload: { files: [{ path: "notes.md", content: "hi" }] },
+      },
+    });
+
+    expect(payload.files.map((entry) => entry.path)).toEqual(["notes.md"]);
+  });
+
+  it("keeps synthesizing core files for openclaw snapshots", () => {
+    const payload = extractTemplatePayloadFromSnapshot({
+      name: "OpenClaw Listing",
+      kind: "community-template",
+      config: {
+        defaults: { runtime_family: "openclaw" },
+        templatePayload: { files: [] },
+      },
+    });
+
+    expect(payload.files.map((entry) => entry.path)).toEqual(
+      expect.arrayContaining([...OPENCLAW_REQUIRED_PATHS, "BOOTSTRAP.md"]),
+    );
   });
 });
 

--- a/backend-api/agentPayloads.ts
+++ b/backend-api/agentPayloads.ts
@@ -9,6 +9,7 @@ const remoteHosts = require("./remoteHosts");
 const { NORA_INTEGRATIONS_CONTEXT_FILE } = require("../agent-runtime/lib/runtimeBootstrap");
 const { NORA_INTEGRATIONS_SKILL_FILE } = require("../agent-runtime/lib/integrationTools");
 const {
+  DEFAULT_RUNTIME_FAMILY,
   normalizeBackendName,
   normalizeExecutionTargetId,
   normalizeRuntimeFamilyName,
@@ -167,6 +168,19 @@ function createEmptyTemplatePayload(metadata = {}) {
 
 // Core template files
 
+// Runtime-family resolution for core-file handling. An explicit caller-supplied
+// family wins, then the payload's own `metadata.runtimeFamily` carrier (which
+// survives federation through hubs that predate the runtime_family column),
+// then the platform default. Unknown values collapse to the default so payloads
+// captured before runtime families existed keep their OpenClaw behavior.
+function resolveTemplatePayloadRuntimeFamily(payload, explicitFamily = null) {
+  const requested = String(explicitFamily ?? "").trim();
+  if (requested) return normalizeRuntimeFamilyName(requested);
+  const carried = String(payload?.metadata?.runtimeFamily ?? "").trim();
+  if (carried) return normalizeRuntimeFamilyName(carried);
+  return DEFAULT_RUNTIME_FAMILY;
+}
+
 function buildCoreFileDefaultContent(filePath, context = {}) {
   const name = String(context.name || "OpenClaw Agent").trim() || "OpenClaw Agent";
   const description =
@@ -257,12 +271,21 @@ Track durable facts, preferences, operating constraints, and open loops here.`.t
  * Ensure a template payload contains Nora's required core OpenClaw files,
  * backfilling missing entries from aliases or generated defaults.
  *
+ * Core-file synthesis is an OpenClaw-only contract: payloads that resolve to a
+ * different runtime family (explicit `context.runtimeFamily`, or the payload's
+ * own `metadata.runtimeFamily` carrier) are normalized and returned unchanged
+ * so a Hermes workspace capture never gains fabricated OpenClaw markdown.
+ *
  * @param {Object} [rawPayload={}] - Template payload to validate and repair.
- * @param {Object} [context={}] - Template metadata used when generating default file content.
+ * @param {Object} [context={}] - Template metadata used when generating default
+ *   file content, plus an optional `runtimeFamily` override.
  * @returns {Object} Normalized payload that includes the required core files.
  */
 function ensureCoreTemplateFiles(rawPayload = {}, context = {}) {
   const payload = normalizeTemplatePayload(rawPayload);
+  if (resolveTemplatePayloadRuntimeFamily(payload, context.runtimeFamily) !== "openclaw") {
+    return payload;
+  }
   const fileByPath = new Map(payload.files.map((entry) => [entry.path, entry]));
   const includeBootstrap = context.includeBootstrap === true || fileByPath.has("BOOTSTRAP.md");
   const nextFiles = [...payload.files];
@@ -309,16 +332,31 @@ function ensureCoreTemplateFiles(rawPayload = {}, context = {}) {
  * Build a UI-friendly summary of a template payload, including core-file
  * presence, previews, and file counts.
  *
+ * The core-file sections are family-aware: an explicit `options.runtimeFamily`
+ * wins, then the payload's `metadata.runtimeFamily` carrier, defaulting to
+ * OpenClaw. Non-OpenClaw payloads report `requiredCoreCount: 0`, an empty
+ * `coreFiles` list, and never fabricate the OpenClaw markdown set.
+ *
  * @param {Object} [rawPayload={}] - Template payload to summarize.
- * @param {Object} [options={}] - Summary options such as whether to include full decoded content.
+ * @param {Object} [options={}] - Summary options such as whether to include
+ *   full decoded content and an optional `runtimeFamily` override.
  * @returns {Object} Summary object describing the payload and its files.
  */
 function summarizeTemplatePayload(rawPayload = {}, options = {}) {
   const includeContent = options.includeContent === true;
-  const payload = ensureCoreTemplateFiles(rawPayload, options.context || {});
+  const runtimeFamily = resolveTemplatePayloadRuntimeFamily(
+    decodeMaybeString(rawPayload),
+    options.runtimeFamily,
+  );
+  const payload = ensureCoreTemplateFiles(rawPayload, {
+    ...(options.context || {}),
+    runtimeFamily,
+  });
+  const coreFileSpecs = runtimeFamily === "openclaw" ? OPENCLAW_CORE_FILE_SPECS : [];
+  const requiredCorePaths = runtimeFamily === "openclaw" ? OPENCLAW_REQUIRED_CORE_PATHS : [];
   const fileByPath = new Map(payload.files.map((entry) => [entry.path, entry]));
   const files = payload.files.map((entry) => {
-    const spec = OPENCLAW_CORE_FILE_SPECS.find((candidate) => candidate.path === entry.path);
+    const spec = coreFileSpecs.find((candidate) => candidate.path === entry.path);
     const content = decodeContentBase64(entry.contentBase64);
     return {
       path: entry.path,
@@ -332,7 +370,7 @@ function summarizeTemplatePayload(rawPayload = {}, options = {}) {
     };
   });
 
-  const coreFiles = OPENCLAW_CORE_FILE_SPECS.map((spec) => {
+  const coreFiles = coreFileSpecs.map((spec) => {
     const entry = fileByPath.get(spec.path) || null;
     const content = entry ? decodeContentBase64(entry.contentBase64) : "";
     return {
@@ -347,22 +385,23 @@ function summarizeTemplatePayload(rawPayload = {}, options = {}) {
     };
   });
 
-  const missingRequiredCoreFiles = OPENCLAW_REQUIRED_CORE_PATHS.filter(
+  const missingRequiredCoreFiles = requiredCorePaths.filter(
     (filePath) => !fileByPath.has(filePath),
   );
 
   return {
     payload,
+    runtimeFamily,
     fileCount: payload.files.length,
     memoryFileCount: payload.memoryFiles.length,
     integrationCount: payload.wiring.integrations.length,
     channelCount: payload.wiring.channels.length,
-    requiredCoreCount: OPENCLAW_REQUIRED_CORE_PATHS.length,
-    presentRequiredCoreCount: OPENCLAW_REQUIRED_CORE_PATHS.length - missingRequiredCoreFiles.length,
+    requiredCoreCount: requiredCorePaths.length,
+    presentRequiredCoreCount: requiredCorePaths.length - missingRequiredCoreFiles.length,
     missingRequiredCoreFiles,
     hasBootstrap: fileByPath.has("BOOTSTRAP.md"),
     extraFilesCount: payload.files.filter(
-      (entry) => !OPENCLAW_CORE_FILE_SPECS.some((spec) => spec.path === entry.path),
+      (entry) => !coreFileSpecs.some((spec) => spec.path === entry.path),
     ).length,
     coreFiles,
     files,
@@ -930,11 +969,19 @@ async function materializeTemplateWiring(agentId, rawPayload = {}) {
 function extractTemplatePayloadFromSnapshot(snapshot, options = {}) {
   const config = decodeMaybeString(snapshot?.config);
   const builtIn = config?.builtIn === true || snapshot?.built_in === true;
+  const defaults = config?.defaults && typeof config.defaults === "object" ? config.defaults : {};
+  // Family resolution order for snapshots: stored snapshot defaults first, then
+  // the payload's own metadata.runtimeFamily carrier (inside
+  // ensureCoreTemplateFiles), then the OpenClaw default.
+  const defaultsRuntimeFamily = String(
+    defaults.runtime_family ?? defaults.runtimeFamily ?? "",
+  ).trim();
   return ensureCoreTemplateFiles(stripInternalTemplateMetadata(config.templatePayload || {}), {
     name: snapshot?.name || "OpenClaw Agent",
     description: snapshot?.description || "",
     templateKey: snapshot?.template_key || config?.templateKey || null,
     sourceType: builtIn ? "platform" : "community",
+    ...(defaultsRuntimeFamily ? { runtimeFamily: defaultsRuntimeFamily } : {}),
     includeBootstrap:
       options.includeBootstrap === true ||
       snapshot?.kind === "starter-template" ||

--- a/backend-api/hermesTemplateExport.ts
+++ b/backend-api/hermesTemplateExport.ts
@@ -1,0 +1,226 @@
+// @ts-nocheck
+const db = require("./db");
+const { runContainerCommand } = require("./authSync");
+const { buildHermesPythonCommand } = require("./hermesUi");
+const { normalizeTemplatePayload } = require("./agentPayloads");
+const {
+  normalizeSavedHermesSkillEntries,
+} = require("../agent-runtime/lib/hermesSkillsReconciliation");
+
+// Live-capture root and caps for Hermes Agent Hub bundles. The workspace tree
+// is the operator-authored surface of a Hermes agent (notes, docs, scripts);
+// caps keep a busy workspace from producing multi-hundred-megabyte bundles.
+const HERMES_TEMPLATE_WORKSPACE_ROOT = "/opt/data/workspace";
+const HERMES_TEMPLATE_MAX_FILE_BYTES = 1024 * 1024;
+const HERMES_TEMPLATE_MAX_FILES = 200;
+const HERMES_TEMPLATE_CAPTURE_TIMEOUT_MS = 120000;
+// Skipped-path lists in bundle metadata are informational; cap them so a
+// pathological workspace cannot bloat the listing snapshot itself.
+const HERMES_TEMPLATE_MAX_SKIPPED_PATHS = 50;
+
+function decodeMaybeJson(value, fallback = {}) {
+  if (!value) return fallback;
+  if (typeof value === "string") {
+    try {
+      return JSON.parse(value);
+    } catch {
+      return fallback;
+    }
+  }
+  return typeof value === "object" ? value : fallback;
+}
+
+function cleanConfigString(value) {
+  return typeof value === "string" ? value.trim() : "";
+}
+
+/**
+ * Build the in-container capture command for a Hermes agent's workspace.
+ *
+ * The Python walk excludes the Nora-generated integration artifacts (the
+ * `integrations/` directory, `integrations*.json` manifests, and
+ * `NORA_INTEGRATIONS.md` — the same set `hermesManifest` writes and the
+ * migration reader excludes), every dotfile/dot-directory (`.env`, `.nora`,
+ * caches), files above the per-file byte cap, and everything past the total
+ * file cap. The result is emitted as one base64-wrapped JSON line because exec
+ * streams can mangle raw JSON, and base64 survives them unchanged.
+ *
+ * @returns {string} Shell command that prints base64-encoded capture JSON.
+ */
+function buildHermesWorkspaceCaptureCommand() {
+  const script = `
+import base64
+import json
+import os
+
+root = ${JSON.stringify(HERMES_TEMPLATE_WORKSPACE_ROOT)}
+max_file_bytes = ${HERMES_TEMPLATE_MAX_FILE_BYTES}
+max_files = ${HERMES_TEMPLATE_MAX_FILES}
+max_skipped_paths = ${HERMES_TEMPLATE_MAX_SKIPPED_PATHS}
+excluded_dir_names = {"integrations"}
+excluded_file_names = {"NORA_INTEGRATIONS.md"}
+
+files = []
+skipped_files = []
+truncated = False
+
+for current_root, dir_names, file_names in os.walk(root):
+    # Prune excluded and dot-directories in place so os.walk never descends
+    # into them; sorting keeps the capture deterministic.
+    dir_names[:] = sorted(
+        name
+        for name in dir_names
+        if not name.startswith(".") and name not in excluded_dir_names
+    )
+    rel_root = os.path.relpath(current_root, root)
+    if rel_root == ".":
+        rel_root = ""
+    for name in sorted(file_names):
+        if name.startswith("."):
+            continue
+        if name in excluded_file_names:
+            continue
+        if name.startswith("integrations") and name.endswith(".json"):
+            continue
+        rel_path = rel_root + "/" + name if rel_root else name
+        abs_path = os.path.join(current_root, name)
+        if os.path.islink(abs_path) or not os.path.isfile(abs_path):
+            continue
+        try:
+            size = os.path.getsize(abs_path)
+        except OSError:
+            skipped_files.append(rel_path)
+            continue
+        if size > max_file_bytes:
+            skipped_files.append(rel_path)
+            continue
+        if len(files) >= max_files:
+            truncated = True
+            break
+        try:
+            with open(abs_path, "rb") as handle:
+                content = handle.read()
+        except OSError:
+            skipped_files.append(rel_path)
+            continue
+        files.append({
+            "path": rel_path,
+            "contentBase64": base64.b64encode(content).decode("ascii"),
+        })
+    if truncated:
+        break
+
+payload = {
+    "files": files,
+    "truncated": truncated,
+    "skippedFileCount": len(skipped_files),
+    "skippedFiles": skipped_files[:max_skipped_paths],
+}
+print(base64.b64encode(json.dumps(payload).encode("utf-8")).decode("ascii"))
+`;
+
+  return buildHermesPythonCommand(script);
+}
+
+function parseHermesCaptureOutput(output) {
+  const encoded = String(output || "").trim();
+  if (!encoded) {
+    throw new Error("Hermes workspace capture returned empty output");
+  }
+  try {
+    return JSON.parse(Buffer.from(encoded, "base64").toString("utf8"));
+  } catch (error) {
+    const nextError = new Error(
+      `Unexpected Hermes workspace capture output: ${encoded.slice(0, 200) || error.message}`,
+    );
+    nextError.cause = error;
+    throw nextError;
+  }
+}
+
+/**
+ * Capture a Hermes agent's live `/opt/data/workspace` tree as a normalized
+ * Agent Hub template payload.
+ *
+ * There is deliberately no stored-template fallback: Hermes agents do not keep
+ * a durable template_payload the way OpenClaw agents do, so the runtime must be
+ * reachable. Callers gate on running/warning status before invoking this.
+ *
+ * @param {Object} agent - Running Hermes agent row to capture.
+ * @returns {Promise<Object>} Normalized payload with `metadata.runtimeFamily`
+ *   set to "hermes" and capture truncation flags when limits were hit.
+ */
+async function buildHermesTemplatePayloadFromAgent(agent) {
+  const result = await runContainerCommand(agent, buildHermesWorkspaceCaptureCommand(), {
+    timeout: HERMES_TEMPLATE_CAPTURE_TIMEOUT_MS,
+  });
+  const captured = parseHermesCaptureOutput(result?.output);
+  const files = Array.isArray(captured?.files) ? captured.files : [];
+  const truncated = captured?.truncated === true;
+  const skippedFileCount = Number.parseInt(captured?.skippedFileCount, 10) || 0;
+  const skippedFiles = Array.isArray(captured?.skippedFiles)
+    ? captured.skippedFiles.map((entry) => String(entry || "")).filter(Boolean)
+    : [];
+
+  if (truncated || skippedFileCount > 0) {
+    console.warn(
+      `Hermes template capture for agent ${agent?.id || "unknown"} skipped content: ` +
+        `${skippedFileCount} oversized or unreadable file(s)` +
+        (truncated ? `; file list truncated at ${HERMES_TEMPLATE_MAX_FILES}` : ""),
+    );
+  }
+
+  return normalizeTemplatePayload({
+    files,
+    metadata: {
+      runtimeFamily: "hermes",
+      source: "hermes-live-capture",
+      capturedAt: new Date().toISOString(),
+      ...(truncated ? { captureTruncated: true } : {}),
+      ...(skippedFileCount > 0
+        ? { captureSkippedFileCount: skippedFileCount, captureSkippedFiles: skippedFiles }
+        : {}),
+    },
+  });
+}
+
+/**
+ * Build the Hermes-specific bundle metadata for an Agent Hub listing: the
+ * agent's saved skills (re-normalized through the shared reconciliation
+ * module) and its model selection restricted to non-secret fields.
+ *
+ * `hermes_runtime_state.model_config` is written through
+ * `normalizeHermesModelConfig` and should already be key-free, but this picker
+ * fails closed regardless: only `{provider, defaultModel, baseUrl}` ever cross
+ * the hub boundary — never API keys.
+ *
+ * @param {Object} agent - Hermes agent row (including `hermes_skills`).
+ * @param {Object} [dbClient=db] - Database client used to read model config.
+ * @returns {Promise<Object>} Metadata fields to merge into the bundle payload.
+ */
+async function buildHermesBundleMetadata(agent, dbClient = db) {
+  const result = await dbClient.query(
+    "SELECT model_config FROM hermes_runtime_state WHERE agent_id = $1 LIMIT 1",
+    [agent.id],
+  );
+  const rawModelConfig = decodeMaybeJson(result.rows[0]?.model_config, {});
+
+  return {
+    runtimeFamily: "hermes",
+    hermesSkills: normalizeSavedHermesSkillEntries(decodeMaybeJson(agent?.hermes_skills, [])),
+    hermesModelConfig: {
+      provider: cleanConfigString(rawModelConfig.provider),
+      defaultModel: cleanConfigString(rawModelConfig.defaultModel),
+      baseUrl: cleanConfigString(rawModelConfig.baseUrl),
+    },
+  };
+}
+
+module.exports = {
+  HERMES_TEMPLATE_MAX_FILES,
+  HERMES_TEMPLATE_MAX_FILE_BYTES,
+  HERMES_TEMPLATE_WORKSPACE_ROOT,
+  buildHermesBundleMetadata,
+  buildHermesTemplatePayloadFromAgent,
+  buildHermesWorkspaceCaptureCommand,
+};

--- a/backend-api/routes/admin.ts
+++ b/backend-api/routes/admin.ts
@@ -517,6 +517,7 @@ async function buildAdminListingDetail(listing, reports = [], options = {}) {
   const template = templatePayload
     ? summarizeTemplatePayload(templatePayload, {
         includeContent: options.includeContent === true,
+        runtimeFamily: listing?.runtime_family || null,
       })
     : null;
 

--- a/backend-api/routes/agentHub.ts
+++ b/backend-api/routes/agentHub.ts
@@ -29,10 +29,16 @@ const { getDefaultAgentImage } = require("../../agent-runtime/lib/agentImages");
 const {
   DEFAULT_RUNTIME_FAMILY,
   getDefaultBackend,
+  getEnabledRuntimeFamilies,
   getRuntimeSelectionStatus,
   isKnownBackend,
+  isKnownRuntimeFamily,
   normalizeBackendName,
 } = require("../../agent-runtime/lib/backendCatalog");
+const {
+  buildHermesBundleMetadata,
+  buildHermesTemplatePayloadFromAgent,
+} = require("../hermesTemplateExport");
 const { asyncHandler } = require("../middleware/errorHandler");
 const { requireSession } = require("../middleware/auth");
 const {
@@ -295,6 +301,7 @@ async function buildListingTemplateDetail(listing, options = {}) {
   const template = templatePayload
     ? summarizeTemplatePayload(templatePayload, {
         includeContent: options.includeContent === true,
+        runtimeFamily: listing?.runtime_family || null,
       })
     : null;
 
@@ -346,6 +353,15 @@ function buildRemoteTemplateDetail(remoteDetail, options = {}) {
   );
   const template = summarizeTemplatePayload(templatePayload, {
     includeContent: options.includeContent === true,
+    // Family resolution order for federated listings: listing field first,
+    // then remote defaults, then the payload metadata carrier (handled inside
+    // the summarizer) for hubs that predate runtime_family.
+    runtimeFamily:
+      remoteDetail.runtime_family ??
+      remoteDetail.runtimeFamily ??
+      remoteDetail.defaults?.runtime_family ??
+      remoteDetail.defaults?.runtimeFamily ??
+      null,
   });
   return {
     ...remoteDetail,
@@ -544,11 +560,49 @@ router.post(
       }
     }
 
+    // Server-side family guard. Publishing is a family-specific capture path,
+    // so an unknown or disabled family must fail closed instead of silently
+    // producing a broken bundle (the pre-runtime_family behavior for Hermes).
+    const runtimeFamily = String(agent.runtime_family || DEFAULT_RUNTIME_FAMILY)
+      .trim()
+      .toLowerCase();
+    if (!isKnownRuntimeFamily(runtimeFamily)) {
+      return res.status(400).json({
+        error: `Agents with runtime family "${runtimeFamily}" cannot be published to the Agent Hub.`,
+      });
+    }
+    if (!getEnabledRuntimeFamilies(process.env).includes(runtimeFamily)) {
+      return res.status(400).json({
+        error: `Runtime family "${runtimeFamily}" is not enabled on this Nora control plane. Enable it via ENABLED_RUNTIME_FAMILIES before publishing this agent.`,
+      });
+    }
+
     let templatePayload;
-    try {
-      templatePayload = await buildTemplatePayloadFromAgent(agent, "files_only");
-    } catch (error) {
-      return res.status(409).json({ error: error.message });
+    if (runtimeFamily === "hermes") {
+      // Hermes bundles are captured from the live /opt/data/workspace tree
+      // over container exec — there is no stored-template fallback, so the
+      // runtime must be up before a bundle can be built.
+      const capturable =
+        (agent.status === "running" || agent.status === "warning") && agent.container_id;
+      if (!capturable) {
+        return res.status(409).json({
+          error:
+            "Hermes templates are captured from the live agent workspace. Start the agent and retry once it is running.",
+        });
+      }
+      try {
+        templatePayload = await buildHermesTemplatePayloadFromAgent(agent);
+        const bundleMetadata = await buildHermesBundleMetadata(agent);
+        templatePayload.metadata = { ...templatePayload.metadata, ...bundleMetadata };
+      } catch (error) {
+        return res.status(409).json({ error: error.message });
+      }
+    } else {
+      try {
+        templatePayload = await buildTemplatePayloadFromAgent(agent, "files_only");
+      } catch (error) {
+        return res.status(409).json({ error: error.message });
+      }
     }
 
     const issues = scanTemplatePayloadForSecrets(templatePayload);
@@ -600,7 +654,7 @@ router.post(
       category: listingCategory,
       builtIn: false,
       sourceType: agentHubStore.LISTING_SOURCE_COMMUNITY,
-      runtimeFamily: agent.runtime_family || "openclaw",
+      runtimeFamily,
       status: agentHubStore.LISTING_STATUS_PUBLISHED,
       visibility: agentHubStore.LISTING_VISIBILITY_PUBLIC,
       shareTarget,

--- a/backend-api/routes/agentHubPublic.ts
+++ b/backend-api/routes/agentHubPublic.ts
@@ -51,7 +51,10 @@ function buildPublisher(listing = {}, sourceHubUrl = "") {
 
 function buildCatalogListing(listing, snapshot = null, templatePayload = null, options = {}) {
   const template = templatePayload
-    ? summarizeTemplatePayload(templatePayload, { includeContent: false })
+    ? summarizeTemplatePayload(templatePayload, {
+        includeContent: false,
+        runtimeFamily: listing?.runtime_family || null,
+      })
     : null;
   const publisher = buildPublisher(listing, options.sourceHubUrl || "");
 
@@ -122,7 +125,10 @@ async function buildCatalogDetail(listing, { includeContent = false, sourceHubUr
     ...summary,
     defaults: snapshot ? extractTemplateDefaultsFromSnapshot(snapshot) : {},
     templatePayload,
-    template: summarizeTemplatePayload(templatePayload, { includeContent: true }),
+    template: summarizeTemplatePayload(templatePayload, {
+      includeContent: true,
+      runtimeFamily: listing?.runtime_family || null,
+    }),
   };
 }
 

--- a/docs/concepts/agent-hub.mdx
+++ b/docs/concepts/agent-hub.mdx
@@ -8,13 +8,27 @@ Agent Hub is Nora's template marketplace. A **listing** captures everything need
 
 ## Listing types
 
-| Source type    | Where it lives                                       | Visibility                                 |
-| -------------- | ---------------------------------------------------- | ------------------------------------------ |
-| Built-in       | Seeded by Nora at startup                            | Visible to every workspace.                |
-| Workspace      | Published by an operator from one of their agents    | Visible to the publishing workspace.        |
-| Community      | Synced from the configured upstream Agent Hub source | Visible to every workspace once approved.   |
+| Source type | Where it lives                                       | Visibility                                |
+| ----------- | ---------------------------------------------------- | ----------------------------------------- |
+| Built-in    | Seeded by Nora at startup                            | Visible to every workspace.               |
+| Workspace   | Published by an operator from one of their agents    | Visible to the publishing workspace.      |
+| Community   | Synced from the configured upstream Agent Hub source | Visible to every workspace once approved. |
 
 Built-in templates ship with the platform. Workspace listings are private until you also share them outward. Community listings are pulled from the upstream catalog at `NORA_AGENT_HUB_URL` (default `https://nora.solomontsao.com`).
+
+## Publishing by runtime family
+
+Every listing records the `runtimeFamily` of the agent it was captured from (`openclaw` or `hermes`). Publishing is only accepted for families that are both supported and enabled on the instance (`ENABLED_RUNTIME_FAMILIES`); sharing an agent with an unknown or disabled family is rejected. The capture path differs per family:
+
+- **OpenClaw** — the snapshot is exported through the agent runtime, falling back to the agent's stored template when the runtime is unreachable. Nora guarantees the seven required core markdown files (`AGENTS.md`, `SOUL.md`, `TOOLS.md`, `IDENTITY.md`, `USER.md`, `HEARTBEAT.md`, `MEMORY.md`) are present, synthesizing sensible defaults for any that are missing.
+- **Hermes** — the snapshot is captured from the **live** agent's `/opt/data/workspace` tree over container exec, so the agent must be running when you publish. The capture excludes Nora-generated integration artifacts (the `integrations/` directory, `integrations*.json` manifests, and `NORA_INTEGRATIONS.md`), all dotfiles (for example `.env`), any file larger than 1 MB, and stops after 200 files — truncation is flagged in the bundle metadata. The bundle additionally records the agent's saved Hermes skills and its model selection (`provider`, `defaultModel`, `baseUrl` — never API keys). No OpenClaw core files are synthesized for Hermes bundles: the workspace ships exactly as captured.
+
+Publishing runs the same secret scan for every family — listings with detected credentials are rejected before a snapshot is created.
+
+<Note>
+  Hermes listings can currently be published and browsed; one-click install of Hermes bundles ships
+  with the Hermes Agent Hub install path.
+</Note>
 
 ## Sharing model
 
@@ -29,7 +43,11 @@ Each workspace listing has a `shareTarget`:
 Switching to `community` or `both` triggers a sync to the upstream hub. The upstream review state is mirrored back into `centralShareStatus` (`not_shared`, `queued`, `submitted`, `failed`). Reviewers in the upstream hub can request changes, and the listing's `centralError` surfaces the reason.
 
 <Note>
-  "Community" doesn't have to mean public. The upstream hub is whatever `NORA_AGENT_HUB_URL` points at — the default public catalog, or an Agent Hub you self-host for your own company. Point it at your own hub and `community`/`both` sharing becomes a private, org-internal catalog: every operator publishes to and installs from a shared company hub without anything leaving your infrastructure.
+  "Community" doesn't have to mean public. The upstream hub is whatever `NORA_AGENT_HUB_URL` points
+  at — the default public catalog, or an Agent Hub you self-host for your own company. Point it at
+  your own hub and `community`/`both` sharing becomes a private, org-internal catalog: every
+  operator publishes to and installs from a shared company hub without anything leaving your
+  infrastructure.
 </Note>
 
 ## Versions
@@ -50,15 +68,25 @@ Workspaces can report community listings for abuse or licensing concerns. Report
 
 ## Permissions
 
-| Capability                                        | Required role |
-| ------------------------------------------------- | ------------- |
-| Browse internal + community listings              | viewer        |
-| Install a listing into the workspace              | editor        |
-| Publish, edit, or unpublish a workspace's listing | admin         |
-| Manage the source-catalog API key                 | admin         |
+Agent Hub authorization is platform-level today, not workspace-role-based:
+
+| Capability                                      | Who can do it                               |
+| ----------------------------------------------- | ------------------------------------------- |
+| Browse internal + community listings            | Any signed-in user                          |
+| Install a listing                               | Any signed-in user (subject to plan limits) |
+| Publish, edit, or unpublish a listing           | The owner of the source agent (and listing) |
+| Moderate listings and manage Agent Hub settings | Platform admin                              |
 
 <Note>
-  Agent Hub source-catalog API keys are stored hashed (HMAC with `NORA_AGENT_HUB_API_KEY_HASH_SECRET`). Rotating the secret invalidates every issued key.
+  Workspace-scoped RBAC for Agent Hub (viewer/editor/admin roles gating browse, install, and publish
+  per workspace) is on the roadmap. Until it lands, any authenticated user on the instance can
+  browse and install listings, and only the direct owner of an agent can publish or edit its
+  listing.
+</Note>
+
+<Note>
+  Agent Hub source-catalog API keys are stored hashed (HMAC with
+  `NORA_AGENT_HUB_API_KEY_HASH_SECRET`). Rotating the secret invalidates every issued key.
 </Note>
 
 ## Related

--- a/docs/guides/agent-hub.mdx
+++ b/docs/guides/agent-hub.mdx
@@ -66,7 +66,8 @@ The fastest way to see the full flow is to install a built-in template and confi
     ![Install dialog — workspace + agent-name confirmation before materializing the listing](/images/guides/agent-hub/install-dialog.png)
 
     <Note>
-      Installing requires the `editor` role on the destination workspace.
+      Any signed-in user can install a listing today; workspace-scoped install roles are on the
+      roadmap. See [Permissions](#permissions).
     </Note>
 
   </Step>
@@ -135,12 +136,19 @@ The Agent Hub source-catalog API key authenticates Nora to the upstream hub. Man
 
 ## Permissions
 
-| Capability                       | Required role |
-| -------------------------------- | ------------- |
-| Browse listings                  | viewer        |
-| Install a listing                | editor        |
-| Publish, edit, unpublish listing | admin         |
-| Manage source-catalog API keys   | admin         |
+Agent Hub authorization is platform-level today, not workspace-role-based:
+
+| Capability                       | Who can do it                               |
+| -------------------------------- | ------------------------------------------- |
+| Browse listings                  | Any signed-in user                          |
+| Install a listing                | Any signed-in user (subject to plan limits) |
+| Publish, edit, unpublish listing | The owner of the source agent               |
+| Moderation and hub settings      | Platform admin                              |
+
+<Note>
+  Workspace-scoped RBAC for Agent Hub actions is on the roadmap; until it lands the roles above are
+  the actual enforcement.
+</Note>
 
 ## Troubleshooting
 


### PR DESCRIPTION
PR 7 of the Hermes Skills epic (follows #323). Publish side of Hermes hub bundles; install lands in C3 (final PR), so the frontend publish button stays hermes-hidden here.

- **`hermesTemplateExport.ts`**: live-workspace capture (`/opt/data/workspace` via in-container Python, TTY+base64 transport; integrations artifacts, dotfiles, >1MB files excluded; 200-file cap with truncation flags in metadata) + bundle metadata — `hermesSkills` re-normalized through the shared module, model config **restricted to `{provider, defaultModel, baseUrl}`** (asserted: keys present in the DB row never reach the bundle).
- **Family-aware `agentPayloads.ts`** (the delicate one): non-openclaw payloads get no core-file synthesis and `requiredCoreCount: 0`; resolution order explicit → `metadata.runtimeFamily` → openclaw; every `ensureCoreTemplateFiles`/`summarizeTemplatePayload` call site handled deliberately (listing column → snapshot defaults → metadata chain for federation reads). OpenClaw summaries are pinned unchanged by tests.
- **`/share` server-side guard**: unknown/disabled family → 400 — closing the pre-existing gap where sharing a Hermes agent silently produced a bogus OpenClaw-stub bundle; hermes shares require a running runtime (409 otherwise) and go through the unchanged secrets scan.
- **Docs**: per-family publishing + the agent-hub permission matrix now describes actual behavior (workspace RBAC noted as roadmap — fixes long-standing doc drift).

Validation: targeted 59/59; full backend suite 2306 green; typecheck/eslint/prettier clean.