### PR TITLE
feat(agent-hub): Hermes bundle install + materializer + hub UI unlock (C3)

### DIFF
--- a/admin-dashboard/pages/agent-hub/index.tsx
+++ b/admin-dashboard/pages/agent-hub/index.tsx
@@ -173,6 +173,9 @@ export default function AgentHubAdmin() {
                       Source
                     </th>
                     <th className="px-2 py-3 text-[11px] font-black uppercase tracking-[0.18em] text-slate-400">
+                      Family
+                    </th>
+                    <th className="px-2 py-3 text-[11px] font-black uppercase tracking-[0.18em] text-slate-400">
                       Status
                     </th>
                     <th className="px-2 py-3 text-[11px] font-black uppercase tracking-[0.18em] text-slate-400">
@@ -225,6 +228,11 @@ export default function AgentHubAdmin() {
                               </>
                             )}
                           </div>
+                        </td>
+                        <td className="px-2 py-4">
+                          <span className="inline-flex items-center rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-[10px] font-black uppercase tracking-widest text-slate-700">
+                            {item.runtime_family === "hermes" ? "Hermes" : "OpenClaw"}
+                          </span>
                         </td>
                         <td className="px-2 py-4">
                           <span

--- a/backend-api/__tests__/agentHubHermes.test.ts
+++ b/backend-api/__tests__/agentHubHermes.test.ts
@@ -16,6 +16,11 @@ const mockUpsertListing = jest.fn();
 const mockGetListing = jest.fn();
 const mockGetAgentHubSettings = jest.fn();
 const mockLogEvent = jest.fn();
+const mockAddDeploymentJob = jest.fn();
+const mockEnforceLimits = jest.fn();
+const mockFetchListing = jest.fn();
+const mockRecordInstall = jest.fn();
+const mockSelectNode = jest.fn();
 
 jest.mock("../db", () => mockDb);
 jest.mock("../authSync", () => ({
@@ -46,12 +51,12 @@ jest.mock("../hermesTemplateExport", () => ({
   buildHermesBundleMetadata: mockBuildHermesBundleMetadata,
 }));
 jest.mock("../redisQueue", () => ({
-  addDeploymentJob: jest.fn(),
+  addDeploymentJob: (...args) => mockAddDeploymentJob(...args),
 }));
 jest.mock("../billing", () => ({
   IS_PAAS: false,
   SELFHOSTED_LIMITS: { max_vcpu: 8, max_ram_mb: 16384, max_disk_gb: 200 },
-  enforceLimits: jest.fn(),
+  enforceLimits: (...args) => mockEnforceLimits(...args),
 }));
 jest.mock("../agentHubStore", () => ({
   LISTING_SOURCE_PLATFORM: "platform",
@@ -73,7 +78,7 @@ jest.mock("../agentHubStore", () => ({
   listAgentHubLocalListings: jest.fn(),
   listUserListings: jest.fn(),
   listCommunityCatalog: jest.fn(),
-  recordInstall: jest.fn(),
+  recordInstall: (...args) => mockRecordInstall(...args),
   recordDownload: jest.fn(),
   createReport: jest.fn(),
 }));
@@ -84,7 +89,7 @@ jest.mock("../agentHubApiKeys", () => ({
 }));
 jest.mock("../agentHubRemote", () => ({
   fetchCatalog: jest.fn(),
-  fetchListing: jest.fn(),
+  fetchListing: (...args) => mockFetchListing(...args),
   submitListing: jest.fn(),
 }));
 jest.mock("../platformSettings", () => ({
@@ -97,7 +102,7 @@ jest.mock("../snapshots", () => ({
   updateSnapshot: jest.fn(),
 }));
 jest.mock("../scheduler", () => ({
-  selectNode: jest.fn(),
+  selectNode: (...args) => mockSelectNode(...args),
 }));
 jest.mock("../monitoring", () => ({
   logEvent: (...args) => mockLogEvent(...args),
@@ -271,6 +276,10 @@ beforeEach(() => {
     central_share_status: "not_shared",
   });
   mockLogEvent.mockResolvedValue(undefined);
+  mockEnforceLimits.mockResolvedValue({ allowed: true, subscription: { plan: "selfhosted" } });
+  mockAddDeploymentJob.mockResolvedValue(undefined);
+  mockRecordInstall.mockResolvedValue(undefined);
+  mockSelectNode.mockResolvedValue(null);
 });
 
 afterAll(() => {
@@ -595,5 +604,366 @@ describe("hermesTemplateExport bundle metadata", () => {
 
     expect(metadata.hermesModelConfig).toEqual({ provider: "", defaultModel: "", baseUrl: "" });
     expect(metadata.hermesSkills).toEqual([]);
+  });
+});
+
+// ── /install ────────────────────────────────────────────────────
+
+function hermesBundlePayload({ files = null, metadata = {} } = {}) {
+  return {
+    version: 1,
+    files: files || [{ path: "notes.md", contentBase64: encode("# Notes"), mode: 0o644 }],
+    memoryFiles: [],
+    wiring: { channels: [], integrations: [] },
+    metadata: { runtimeFamily: "hermes", ...metadata },
+  };
+}
+
+function hermesListingRow(overrides = {}) {
+  return {
+    id: "listing-h1",
+    name: "Hermes Bundle",
+    snapshot_id: "snapshot-h1",
+    status: "published",
+    source_type: "community",
+    local_visibility: "internal",
+    owner_user_id: "user-2",
+    runtime_family: "hermes",
+    ...overrides,
+  };
+}
+
+function snapshotRow({ defaults = {}, templatePayload = {} } = {}) {
+  return {
+    id: "snapshot-h1",
+    name: "Hermes Bundle",
+    kind: "community-template",
+    template_key: null,
+    config: {
+      kind: "community-template",
+      defaults: {
+        backend: "docker",
+        sandbox: "standard",
+        vcpu: 2,
+        ram_mb: 2048,
+        disk_gb: 20,
+        image: null,
+        ...defaults,
+      },
+      templatePayload,
+    },
+  };
+}
+
+function primeInstallQueries() {
+  const insertedAgent = {
+    id: "agent-new-1",
+    user_id: "user-1",
+    status: "queued",
+  };
+  mockDb.query.mockImplementation(async (sql, params) => {
+    const text = String(sql);
+    if (text.includes("INSERT INTO agents")) {
+      return {
+        rows: [
+          {
+            ...insertedAgent,
+            name: params[1],
+            runtime_family: params[12],
+            deploy_target: params[13],
+            execution_target_id: params[14],
+            sandbox_profile: params[15],
+          },
+        ],
+      };
+    }
+    return { rows: [] };
+  });
+}
+
+function findQueryCall(matcher) {
+  return mockDb.query.mock.calls.find(([sql]) => String(sql).includes(matcher)) || null;
+}
+
+describe("POST /install runtime-family resolution", () => {
+  it("resolves the family from the listing column and persists a hermes agent", async () => {
+    primeInstallQueries();
+    mockGetListing.mockResolvedValue(hermesListingRow());
+    mockGetSnapshot.mockResolvedValue(
+      snapshotRow({
+        defaults: { runtime_family: "hermes" },
+        templatePayload: hermesBundlePayload(),
+      }),
+    );
+
+    const res = await request(buildApp())
+      .post("/install")
+      .send({ listingId: "listing-h1", name: "My Hermes Agent" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.runtime_family).toBe("hermes");
+    const [, params] = findQueryCall("INSERT INTO agents");
+    expect(params[12]).toBe("hermes");
+    expect(mockRecordInstall).toHaveBeenCalledWith("listing-h1");
+    expect(mockAddDeploymentJob).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "agent-new-1", backend: "docker", sandbox: "standard" }),
+    );
+  });
+
+  it("resolves the family from snapshot defaults when the listing column is absent", async () => {
+    primeInstallQueries();
+    mockGetListing.mockResolvedValue(hermesListingRow({ runtime_family: null }));
+    mockGetSnapshot.mockResolvedValue(
+      snapshotRow({
+        defaults: { runtime_family: "hermes" },
+        templatePayload: hermesBundlePayload({ metadata: { runtimeFamily: undefined } }),
+      }),
+    );
+
+    const res = await request(buildApp())
+      .post("/install")
+      .send({ listingId: "listing-h1", name: "Defaults Hermes" });
+
+    expect(res.status).toBe(200);
+    const [, params] = findQueryCall("INSERT INTO agents");
+    expect(params[12]).toBe("hermes");
+  });
+
+  it("resolves a remote listing's family from the payload metadata carrier alone", async () => {
+    primeInstallQueries();
+    mockFetchListing.mockResolvedValue({
+      id: "hub:remote-1",
+      remote_id: "remote-1",
+      name: "Remote Hermes",
+      templatePayload: hermesBundlePayload(),
+      defaults: {},
+    });
+
+    const res = await request(buildApp())
+      .post("/install")
+      .send({ listingId: "hub:remote-1", name: "Metadata Hermes" });
+
+    expect(res.status).toBe(200);
+    const [, params] = findQueryCall("INSERT INTO agents");
+    expect(params[12]).toBe("hermes");
+    expect(mockRecordInstall).not.toHaveBeenCalled();
+  });
+
+  it("defaults a remote listing with no family carriers to openclaw", async () => {
+    primeInstallQueries();
+    mockFetchListing.mockResolvedValue({
+      id: "hub:remote-2",
+      remote_id: "remote-2",
+      name: "Legacy Remote",
+      templatePayload: {
+        version: 1,
+        files: [{ path: "CUSTOM.md", contentBase64: encode("stored") }],
+        memoryFiles: [],
+        wiring: { channels: [], integrations: [] },
+        metadata: {},
+      },
+      defaults: {},
+    });
+
+    const res = await request(buildApp())
+      .post("/install")
+      .send({ listingId: "hub:remote-2", name: "Legacy Agent" });
+
+    expect(res.status).toBe(200);
+    const [, params] = findQueryCall("INSERT INTO agents");
+    expect(params[12]).toBe("openclaw");
+  });
+
+  it.each([
+    ["a mismatched family", "openclaw"],
+    ["an unknown family", "quantumclaw"],
+  ])("rejects a request carrying %s with 400", async (_label, requestedFamily) => {
+    primeInstallQueries();
+    mockGetListing.mockResolvedValue(hermesListingRow());
+    mockGetSnapshot.mockResolvedValue(
+      snapshotRow({
+        defaults: { runtime_family: "hermes" },
+        templatePayload: hermesBundlePayload(),
+      }),
+    );
+
+    const res = await request(buildApp())
+      .post("/install")
+      .send({ listingId: "listing-h1", name: "Mismatch", runtime_family: requestedFamily });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/targets the "hermes" runtime family/i);
+    expect(findQueryCall("INSERT INTO agents")).toBeNull();
+    expect(mockAddDeploymentJob).not.toHaveBeenCalled();
+  });
+
+  it("rejects installing a listing whose family is not enabled on this instance", async () => {
+    process.env.ENABLED_RUNTIME_FAMILIES = "openclaw";
+    primeInstallQueries();
+    mockGetListing.mockResolvedValue(hermesListingRow());
+    mockGetSnapshot.mockResolvedValue(
+      snapshotRow({
+        defaults: { runtime_family: "hermes" },
+        templatePayload: hermesBundlePayload(),
+      }),
+    );
+
+    const res = await request(buildApp())
+      .post("/install")
+      .send({ listingId: "listing-h1", name: "Disabled Hermes" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/not enabled/i);
+    expect(findQueryCall("INSERT INTO agents")).toBeNull();
+    expect(mockAddDeploymentJob).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /install hermes bundle persistence", () => {
+  it("persists normalized bundle skills and seeds hermes_runtime_state.model_config", async () => {
+    primeInstallQueries();
+    mockGetListing.mockResolvedValue(hermesListingRow());
+    mockGetSnapshot.mockResolvedValue(
+      snapshotRow({
+        defaults: { runtime_family: "hermes" },
+        templatePayload: hermesBundlePayload({
+          metadata: {
+            hermesSkills: [
+              {
+                source: "hermes-bundle",
+                ref: "official/security/1password",
+                name: "1password",
+                installMode: "cli",
+                installedAt: "2026-07-01T00:00:00.000Z",
+              },
+              {
+                source: "hermes-bundle",
+                ref: "",
+                name: "pdf-tools",
+                installMode: "files",
+                installedAt: "2026-07-01T00:00:00.000Z",
+              },
+              { source: "hermes-hub", ref: "", name: "refless-cli", installMode: "cli" },
+              { source: "hermes-hub", ref: "internal", name: "nora-integrations" },
+            ],
+            hermesModelConfig: {
+              provider: "nous",
+              defaultModel: "hermes-4-405b",
+              baseUrl: "",
+            },
+          },
+        }),
+      }),
+    );
+
+    const res = await request(buildApp())
+      .post("/install")
+      .send({ listingId: "listing-h1", name: "Bundle Agent", runtime_family: "hermes" });
+
+    expect(res.status).toBe(200);
+
+    const [, agentParams] = findQueryCall("INSERT INTO agents");
+    const persistedSkills = JSON.parse(agentParams[11]);
+    expect(persistedSkills.map((entry) => entry.name)).toEqual(["1password", "pdf-tools"]);
+    expect(persistedSkills[1].installMode).toBe("files");
+
+    const stateCall = findQueryCall("hermes_runtime_state");
+    expect(stateCall).not.toBeNull();
+    expect(stateCall[1][0]).toBe("agent-new-1");
+    expect(JSON.parse(stateCall[1][1])).toEqual({
+      provider: "nous",
+      defaultModel: "hermes-4-405b",
+      baseUrl: "",
+    });
+
+    expect(findQueryCall("INSERT INTO deployments")).not.toBeNull();
+    expect(mockAddDeploymentJob).toHaveBeenCalledTimes(1);
+  });
+
+  it("caps persisted bundle skills at 20 entries", async () => {
+    primeInstallQueries();
+    mockGetListing.mockResolvedValue(hermesListingRow());
+    mockGetSnapshot.mockResolvedValue(
+      snapshotRow({
+        defaults: { runtime_family: "hermes" },
+        templatePayload: hermesBundlePayload({
+          metadata: {
+            hermesSkills: Array.from({ length: 25 }, (_, index) => ({
+              source: "hermes-bundle",
+              ref: `official/tools/skill-${index}`,
+              name: `skill-${index}`,
+              installMode: "cli",
+              installedAt: "2026-07-01T00:00:00.000Z",
+            })),
+          },
+        }),
+      }),
+    );
+
+    const res = await request(buildApp())
+      .post("/install")
+      .send({ listingId: "listing-h1", name: "Capped Agent" });
+
+    expect(res.status).toBe(200);
+    const [, agentParams] = findQueryCall("INSERT INTO agents");
+    expect(JSON.parse(agentParams[11])).toHaveLength(20);
+  });
+
+  it("skips the runtime-state seed when the bundle has no meaningful model config", async () => {
+    primeInstallQueries();
+    mockGetListing.mockResolvedValue(hermesListingRow());
+    mockGetSnapshot.mockResolvedValue(
+      snapshotRow({
+        defaults: { runtime_family: "hermes" },
+        templatePayload: hermesBundlePayload({
+          metadata: { hermesModelConfig: { provider: "", defaultModel: "", baseUrl: "" } },
+        }),
+      }),
+    );
+
+    const res = await request(buildApp())
+      .post("/install")
+      .send({ listingId: "listing-h1", name: "No Model Agent" });
+
+    expect(res.status).toBe(200);
+    expect(findQueryCall("hermes_runtime_state")).toBeNull();
+  });
+});
+
+describe("POST /install openclaw flow (unchanged)", () => {
+  it("still installs openclaw listings with synthesized core files and no hermes state", async () => {
+    primeInstallQueries();
+    mockGetListing.mockResolvedValue(
+      hermesListingRow({
+        id: "listing-o1",
+        name: "OpenClaw Template",
+        runtime_family: "openclaw",
+      }),
+    );
+    mockGetSnapshot.mockResolvedValue(
+      snapshotRow({
+        defaults: { runtime_family: "openclaw" },
+        templatePayload: {
+          version: 1,
+          files: [{ path: "CUSTOM.md", contentBase64: encode("stored template") }],
+          memoryFiles: [],
+          wiring: { channels: [], integrations: [] },
+          metadata: {},
+        },
+      }),
+    );
+
+    const res = await request(buildApp())
+      .post("/install")
+      .send({ listingId: "listing-o1", name: "OpenClaw Install", runtime_family: "openclaw" });
+
+    expect(res.status).toBe(200);
+    const [, params] = findQueryCall("INSERT INTO agents");
+    expect(params[12]).toBe("openclaw");
+    expect(JSON.parse(params[11])).toEqual([]);
+    const payloadPaths = JSON.parse(params[10]).files.map((entry) => entry.path);
+    expect(payloadPaths).toEqual(expect.arrayContaining(["CUSTOM.md", "AGENTS.md", "SOUL.md"]));
+    expect(findQueryCall("hermes_runtime_state")).toBeNull();
+    expect(mockAddDeploymentJob).toHaveBeenCalledTimes(1);
   });
 });

--- a/backend-api/__tests__/provisionerProviderSelection.test.ts
+++ b/backend-api/__tests__/provisionerProviderSelection.test.ts
@@ -139,6 +139,7 @@ const {
   resolveCanonicalDeploymentOwnerUserId,
   runProvisionerExecCommand,
   seedHermesArchiveForDeployment,
+  materializeHermesTemplatePayload,
 } = require("../../workers/provisioner/worker");
 const { DASHBOARD_PORT_PURPOSE, GATEWAY_PORT_PURPOSE } = require("../portAllocations");
 
@@ -414,6 +415,188 @@ describe("provisioner Hermes restore seeding", () => {
     ).resolves.toEqual({ seeded: false, reason: "archive-empty" });
 
     expect(buildSeedArchive).not.toHaveBeenCalled();
+  });
+});
+
+describe("provisioner Hermes template-bundle materialization", () => {
+  function encodeContent(content) {
+    return Buffer.from(content, "utf8").toString("base64");
+  }
+
+  function bundlePayload(files) {
+    return {
+      version: 1,
+      files,
+      memoryFiles: [],
+      wiring: { channels: [], integrations: [] },
+      metadata: { runtimeFamily: "hermes" },
+    };
+  }
+
+  function buildExecuteMock({ markerPresent = false } = {}) {
+    return jest.fn(async (_provisioner, _containerId, command) => {
+      if (String(command).startsWith("if [ -f ")) {
+        return { output: markerPresent ? "NORA_TEMPLATE_APPLIED" : "NORA_TEMPLATE_ABSENT" };
+      }
+      return { output: "" };
+    });
+  }
+
+  it("skips entirely when the migration seed already restored the workspace", async () => {
+    const execute = buildExecuteMock();
+
+    await expect(
+      materializeHermesTemplatePayload({
+        agentId: "agent-h1",
+        provisioner: {},
+        containerId: "hermes-container",
+        templatePayload: bundlePayload([{ path: "notes.md", contentBase64: encodeContent("n") }]),
+        migrationSeeded: true,
+        execute,
+      }),
+    ).resolves.toEqual({ applied: false, reason: "migration-seed" });
+
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("skips without exec calls when the payload carries no files", async () => {
+    const execute = buildExecuteMock();
+
+    await expect(
+      materializeHermesTemplatePayload({
+        agentId: "agent-h1",
+        provisioner: {},
+        containerId: "hermes-container",
+        templatePayload: bundlePayload([]),
+        execute,
+      }),
+    ).resolves.toEqual({ applied: false, reason: "no-files" });
+
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it("skips after the marker probe when a previous materialization is recorded", async () => {
+    const execute = buildExecuteMock({ markerPresent: true });
+
+    await expect(
+      materializeHermesTemplatePayload({
+        agentId: "agent-h1",
+        provisioner: {},
+        containerId: "hermes-container",
+        templatePayload: bundlePayload([{ path: "notes.md", contentBase64: encodeContent("n") }]),
+        execute,
+      }),
+    ).resolves.toEqual({ applied: false, reason: "marker-present" });
+
+    expect(execute).toHaveBeenCalledTimes(1);
+    expect(String(execute.mock.calls[0][2])).toContain("/opt/data/.nora/template-applied");
+  });
+
+  it("maps workspace and .hermes-skills paths, repairs ownership, and writes the marker last", async () => {
+    const execute = buildExecuteMock();
+
+    const result = await materializeHermesTemplatePayload({
+      agentId: "agent-h1",
+      provisioner: {},
+      containerId: "hermes-container",
+      templatePayload: bundlePayload([
+        { path: "notes.md", contentBase64: encodeContent("# Notes"), mode: 0o644 },
+        { path: "scripts/run.sh", contentBase64: encodeContent("echo hi"), mode: 0o755 },
+        {
+          path: ".hermes-skills/pdf-tools/SKILL.md",
+          contentBase64: encodeContent("---\nname: pdf-tools\n---"),
+          mode: 0o644,
+        },
+      ]),
+      execute,
+    });
+
+    expect(result).toEqual({ applied: true, reason: null, fileCount: 3 });
+
+    const commands = execute.mock.calls.map((call) => String(call[2]));
+    // probe, one write batch, ownership repair, marker write
+    expect(commands).toHaveLength(4);
+    expect(commands[1]).toContain("'/opt/data/workspace/notes.md'");
+    expect(commands[1]).toContain("'/opt/data/workspace/scripts/run.sh'");
+    expect(commands[1]).toContain("chmod 0755 '/opt/data/workspace/scripts/run.sh'");
+    expect(commands[1]).toContain("'/opt/data/skills/pdf-tools/SKILL.md'");
+    expect(commands[1]).not.toContain(".hermes-skills");
+    expect(commands[2]).toContain("chown -R hermes:hermes '/opt/data/workspace'");
+    expect(commands[2]).toContain("chown -R hermes:hermes '/opt/data/skills'");
+    expect(commands[3]).toContain("mkdir -p '/opt/data/.nora'");
+    expect(commands[3]).toContain("'/opt/data/.nora/template-applied'");
+    // The marker write must come after every file write and the chown.
+    expect(commands[3]).not.toContain("base64 -d");
+  });
+
+  it("only repairs ownership on roots that were actually written", async () => {
+    const execute = buildExecuteMock();
+
+    await materializeHermesTemplatePayload({
+      agentId: "agent-h1",
+      provisioner: {},
+      containerId: "hermes-container",
+      templatePayload: bundlePayload([
+        { path: "notes.md", contentBase64: encodeContent("# Notes") },
+      ]),
+      execute,
+    });
+
+    const chownCommand = String(execute.mock.calls[2][2]);
+    expect(chownCommand).toContain("'/opt/data/workspace'");
+    expect(chownCommand).not.toContain("'/opt/data/skills'");
+  });
+
+  it.each([
+    ["an absolute path", "/etc/passwd"],
+    ["a dot-dot traversal", "../escape.md"],
+    ["a nested dot-dot traversal", "docs/../../escape.md"],
+    ["an empty path", ""],
+    ["an unsafe character", "notes;rm.md"],
+    ["a reserved skill directory", ".hermes-skills/nora-integrations/SKILL.md"],
+    ["a skills prefix without a file", ".hermes-skills/pdf-tools"],
+  ])("rejects %s without writing anything", async (_label, unsafePath) => {
+    const execute = buildExecuteMock();
+
+    await expect(
+      materializeHermesTemplatePayload({
+        agentId: "agent-h1",
+        provisioner: {},
+        containerId: "hermes-container",
+        templatePayload: bundlePayload([
+          { path: "notes.md", contentBase64: encodeContent("safe") },
+          { path: unsafePath, contentBase64: encodeContent("unsafe") },
+        ]),
+        execute,
+      }),
+    ).rejects.toThrow(/unsafe file path/i);
+
+    // Only the marker probe ran — no partial writes, no marker.
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it("splits large payloads into multiple size-bounded write batches", async () => {
+    const execute = buildExecuteMock();
+    const bigContent = encodeContent("x".repeat(400 * 1024));
+
+    await materializeHermesTemplatePayload({
+      agentId: "agent-h1",
+      provisioner: {},
+      containerId: "hermes-container",
+      templatePayload: bundlePayload([
+        { path: "one.bin", contentBase64: bigContent },
+        { path: "two.bin", contentBase64: bigContent },
+        { path: "three.bin", contentBase64: bigContent },
+      ]),
+      execute,
+    });
+
+    const commands = execute.mock.calls.map((call) => String(call[2]));
+    // probe + 3 single-file batches (each exceeds the batch budget) + chown + marker
+    expect(commands).toHaveLength(6);
+    expect(commands[1]).toContain("'/opt/data/workspace/one.bin'");
+    expect(commands[2]).toContain("'/opt/data/workspace/two.bin'");
+    expect(commands[3]).toContain("'/opt/data/workspace/three.bin'");
   });
 });
 

--- a/backend-api/agentPayloads.ts
+++ b/backend-api/agentPayloads.ts
@@ -1057,6 +1057,7 @@ module.exports = {
   materializeTemplateWiring,
   normalizeTemplatePayload,
   resolveContainerName,
+  resolveTemplatePayloadRuntimeFamily,
   sanitizeAgentName,
   serializeAgent,
   stripInternalTemplateMetadata,

--- a/backend-api/routes/agentHub.ts
+++ b/backend-api/routes/agentHub.ts
@@ -19,7 +19,9 @@ const {
   extractTemplateDefaultsFromSnapshot,
   extractTemplatePayloadFromSnapshot,
   materializeTemplateWiring,
+  normalizeTemplatePayload,
   resolveContainerName,
+  resolveTemplatePayloadRuntimeFamily,
   sanitizeAgentName,
   serializeAgent,
   stripInternalTemplateMetadata,
@@ -34,11 +36,16 @@ const {
   isKnownBackend,
   isKnownRuntimeFamily,
   normalizeBackendName,
+  normalizeRuntimeFamilyName,
 } = require("../../agent-runtime/lib/backendCatalog");
 const {
   buildHermesBundleMetadata,
   buildHermesTemplatePayloadFromAgent,
 } = require("../hermesTemplateExport");
+const {
+  normalizeSavedHermesSkillEntries,
+} = require("../../agent-runtime/lib/hermesSkillsReconciliation");
+const { replacePersistedHermesState } = require("../hermesUi");
 const { asyncHandler } = require("../middleware/errorHandler");
 const { requireSession } = require("../middleware/auth");
 const {
@@ -159,12 +166,60 @@ function resolveRequestedDeployTarget({
   return getDefaultBackend(process.env);
 }
 
-function normalizeRequestedRuntimeFamily(value) {
-  const normalized = String(value || "")
-    .trim()
-    .toLowerCase();
-  if (!normalized) return null;
-  return normalized === DEFAULT_RUNTIME_FAMILY ? DEFAULT_RUNTIME_FAMILY : null;
+// Keep in sync with MAX_HERMES_SKILLS_PER_DEPLOY in routes/agents.ts: an
+// installed bundle must not seed more saved skills than a deploy may request.
+const MAX_HERMES_SKILLS_PER_INSTALL = 20;
+
+/**
+ * Resolve the runtime family of a listing being installed, in the redundant
+ * carrier order the bundle format defines: the listing's own `runtime_family`
+ * field (authoritative, always present on local rows), then the snapshot or
+ * remote `defaults` block, then the template payload's `metadata.runtimeFamily`
+ * carrier (survives federation through hubs that predate runtime_family),
+ * defaulting to OpenClaw.
+ *
+ * @param {Object} listing - Local or remote listing row/detail.
+ * @param {Object} defaults - Raw defaults block attached to the listing.
+ * @param {Object} templatePayload - Template payload being installed.
+ * @returns {string} Known runtime family name.
+ */
+function resolveListingRuntimeFamily(listing, defaults, templatePayload) {
+  const carriers = [
+    listing?.runtime_family ?? listing?.runtimeFamily,
+    defaults?.runtime_family ?? defaults?.runtimeFamily,
+  ];
+  for (const carrier of carriers) {
+    const candidate = String(carrier ?? "").trim();
+    if (candidate) return normalizeRuntimeFamilyName(candidate);
+  }
+  return resolveTemplatePayloadRuntimeFamily(normalizeTemplatePayload(templatePayload));
+}
+
+/**
+ * Extract the saved-skill entries a Hermes bundle should seed onto the
+ * installed agent. Entries are re-normalized through the shared reconciliation
+ * module (reserved and malformed names dropped, `installMode` preserved) and
+ * only entries the runtime can actually restore are kept: CLI installs need a
+ * ref, files-mode skills rematerialize from the template payload.
+ *
+ * @param {Object} templatePayload - Normalized bundle payload.
+ * @returns {Array<Object>} Saved-skill entries for `agents.hermes_skills`.
+ */
+function extractHermesBundleSkills(templatePayload) {
+  return normalizeSavedHermesSkillEntries(templatePayload?.metadata?.hermesSkills)
+    .filter((entry) => entry.ref || entry.installMode === "files")
+    .slice(0, MAX_HERMES_SKILLS_PER_INSTALL);
+}
+
+function extractHermesBundleModelConfig(templatePayload) {
+  const rawConfig = templatePayload?.metadata?.hermesModelConfig;
+  if (!rawConfig || typeof rawConfig !== "object") return null;
+  const modelConfig = {
+    provider: String(rawConfig.provider || "").trim(),
+    defaultModel: String(rawConfig.defaultModel || "").trim(),
+    baseUrl: String(rawConfig.baseUrl || "").trim(),
+  };
+  return Object.values(modelConfig).some(Boolean) ? modelConfig : null;
 }
 
 function assertRuntimeSelectionAvailable(runtimeFields) {
@@ -351,17 +406,18 @@ function buildRemoteTemplateDetail(remoteDetail, options = {}) {
   const templatePayload = stripInternalTemplateMetadata(
     remoteDetail.templatePayload || remoteDetail.template_payload || {},
   );
+  // Family resolution order for federated listings: listing field first, then
+  // remote defaults, then the payload metadata carrier for hubs that predate
+  // runtime_family. The resolved value is surfaced as `runtime_family` so the
+  // install route and the UI treat remote details like local listing rows.
+  const runtimeFamily = resolveListingRuntimeFamily(
+    remoteDetail,
+    remoteDetail.defaults,
+    templatePayload,
+  );
   const template = summarizeTemplatePayload(templatePayload, {
     includeContent: options.includeContent === true,
-    // Family resolution order for federated listings: listing field first,
-    // then remote defaults, then the payload metadata carrier (handled inside
-    // the summarizer) for hubs that predate runtime_family.
-    runtimeFamily:
-      remoteDetail.runtime_family ??
-      remoteDetail.runtimeFamily ??
-      remoteDetail.defaults?.runtime_family ??
-      remoteDetail.defaults?.runtimeFamily ??
-      null,
+    runtimeFamily,
   });
   return {
     ...remoteDetail,
@@ -371,6 +427,7 @@ function buildRemoteTemplateDetail(remoteDetail, options = {}) {
     remote: true,
     source_type: "community",
     status: "published",
+    runtime_family: runtimeFamily,
     defaults: remoteDetail.defaults || {},
     snapshot: remoteDetail.snapshot || null,
     template:
@@ -411,6 +468,7 @@ function buildCentralSubmissionPayload(listing, snapshot, templatePayload) {
       sourceType: listing.source_type,
       ownerName: listing.owner_name || listing.owner_email || "Nora user",
       version: listing.current_version || 1,
+      runtimeFamily: listing.runtime_family || DEFAULT_RUNTIME_FAMILY,
     },
     snapshot: {
       id: snapshot.id,
@@ -756,22 +814,39 @@ router.post(
     }
     res.locals.auditContext = buildListingContext(listing);
 
-    const name = sanitizeAgentName(requestedName, snap.name || listing.name || "OpenClaw-Agent");
+    // Decision-6 family resolution: listing column -> snapshot/remote defaults
+    // -> payload metadata carrier -> OpenClaw. The remote branch already
+    // resolved this into `listing.runtime_family` via buildRemoteTemplateDetail;
+    // the local branch reads the listing row column directly.
+    const listingFamily = resolveListingRuntimeFamily(listing, defaults, templatePayload);
+    const requestBody = req.body || {};
+    const requestedFamilyRaw = requestBody.runtime_family ?? requestBody.runtimeFamily;
+    if (requestedFamilyRaw != null && String(requestedFamilyRaw).trim()) {
+      const requestedFamily = String(requestedFamilyRaw).trim().toLowerCase();
+      if (!isKnownRuntimeFamily(requestedFamily) || requestedFamily !== listingFamily) {
+        return res.status(400).json({
+          error: `This template targets the "${listingFamily}" runtime family and cannot be installed with runtime_family "${requestedFamily}".`,
+        });
+      }
+    }
+    if (!getEnabledRuntimeFamilies(process.env).includes(listingFamily)) {
+      return res.status(400).json({
+        error: `Runtime family "${listingFamily}" is not enabled on this Nora control plane. Enable it via ENABLED_RUNTIME_FAMILIES before installing this template.`,
+      });
+    }
+
+    const name = sanitizeAgentName(
+      requestedName,
+      snap.name || listing.name || (listingFamily === "hermes" ? "Hermes-Agent" : "OpenClaw-Agent"),
+    );
     if (name.length > 100) {
       return res.status(400).json({ error: "Agent name must be 100 characters or less" });
     }
 
-    const requestBody = req.body || {};
-    const runtimeFamily = normalizeRequestedRuntimeFamily(requestBody.runtime_family);
-    if (requestBody.runtime_family != null && runtimeFamily == null) {
-      return res.status(400).json({
-        error: `Unsupported runtime_family. Nora currently supports only "${DEFAULT_RUNTIME_FAMILY}".`,
-      });
-    }
     const runtimeFields = resolveRequestedRuntimeFields({
       request: {
         ...requestBody,
-        runtime_family: runtimeFamily || DEFAULT_RUNTIME_FAMILY,
+        runtime_family: listingFamily,
       },
       fallback: {
         backend_type: defaults.backend || null,
@@ -802,12 +877,17 @@ router.post(
       runtimeSelection: runtimeFields,
     });
 
+    // Hermes bundles seed the agent's saved skills at install time; the deploy
+    // worker's reconcile/rematerialize pass then restores them on first boot.
+    const hermesSkills =
+      listingFamily === "hermes" ? extractHermesBundleSkills(templatePayload) : [];
+
     const result = await db.query(
       `INSERT INTO agents(
          user_id, name, status, node, backend_type, sandbox_type, vcpu, ram_mb, disk_gb,
-         container_name, image, template_payload, runtime_family, deploy_target,
+         container_name, image, template_payload, hermes_skills, runtime_family, deploy_target,
          execution_target_id, sandbox_profile
-       ) VALUES($1, $2, 'queued', $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
+       ) VALUES($1, $2, 'queued', $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::jsonb, $13, $14, $15, $16)
        RETURNING *`,
       [
         req.user.id,
@@ -821,6 +901,7 @@ router.post(
         containerName,
         image,
         JSON.stringify(templatePayload),
+        JSON.stringify(hermesSkills),
         runtimeFields.runtime_family,
         runtimeFields.deploy_target,
         runtimeFields.execution_target_id,
@@ -828,6 +909,17 @@ router.post(
       ],
     );
     const agent = result.rows[0];
+
+    // Seed the bundle's model selection (never keys) as durable Hermes state so
+    // the deploy worker's persisted-state replay applies it on first boot.
+    const hermesModelConfig =
+      listingFamily === "hermes" ? extractHermesBundleModelConfig(templatePayload) : null;
+    if (hermesModelConfig) {
+      await replacePersistedHermesState(agent.id, {
+        modelConfig: hermesModelConfig,
+        channels: [],
+      });
+    }
 
     await materializeTemplateWiring(agent.id, templatePayload);
     await db.query("INSERT INTO deployments(agent_id, status) VALUES($1, 'queued')", [agent.id]);

--- a/backend-api/routes/agentHubPublic.ts
+++ b/backend-api/routes/agentHubPublic.ts
@@ -7,9 +7,15 @@ const { scanTemplatePayloadForSecrets } = require("../agentHubSafety");
 const {
   extractTemplateDefaultsFromSnapshot,
   extractTemplatePayloadFromSnapshot,
+  normalizeTemplatePayload,
+  resolveTemplatePayloadRuntimeFamily,
   stripInternalTemplateMetadata,
   summarizeTemplatePayload,
 } = require("../agentPayloads");
+const {
+  DEFAULT_RUNTIME_FAMILY,
+  normalizeRuntimeFamilyName,
+} = require("../../agent-runtime/lib/backendCatalog");
 
 const router = express.Router();
 
@@ -25,6 +31,22 @@ function normalizeDescription(value, fallback = "", maxLength = 1200) {
 
 function normalizeCategory(value) {
   return normalizeText(value, "General", 60) || "General";
+}
+
+// Decision-6 family resolution for inbound submissions: explicit listing field
+// first, then the submission's defaults block, then the template payload's
+// metadata carrier (how bundles survive federation through hubs that predate
+// runtime_family), defaulting to OpenClaw.
+function resolveSubmittedRuntimeFamily(listingPayload, defaults, templatePayload) {
+  const carriers = [
+    listingPayload?.runtimeFamily ?? listingPayload?.runtime_family,
+    defaults?.runtime_family ?? defaults?.runtimeFamily,
+  ];
+  for (const carrier of carriers) {
+    const candidate = String(carrier ?? "").trim();
+    if (candidate) return normalizeRuntimeFamilyName(candidate);
+  }
+  return resolveTemplatePayloadRuntimeFamily(normalizeTemplatePayload(templatePayload));
 }
 
 function requestBaseUrl(req) {
@@ -67,6 +89,7 @@ function buildCatalogListing(listing, snapshot = null, templatePayload = null, o
     price: listing.price || "Free",
     source_type: "community",
     status: listing.status,
+    runtime_family: listing.runtime_family || DEFAULT_RUNTIME_FAMILY,
     ownerName: publisher.displayName,
     publisher,
     current_version: listing.current_version || 1,
@@ -192,6 +215,11 @@ router.post("/submissions", requireAgentHubApiKey, async (req, res, next) => {
     const name = normalizeText(listingPayload.name, "Community Template", 100);
     const description = normalizeDescription(listingPayload.description);
     const category = normalizeCategory(listingPayload.category);
+    const runtimeFamily = resolveSubmittedRuntimeFamily(
+      listingPayload,
+      payload.defaults,
+      templatePayload,
+    );
     const snapshot = await snapshots.createSnapshot(
       null,
       name,
@@ -216,6 +244,7 @@ router.post("/submissions", requireAgentHubApiKey, async (req, res, next) => {
       category,
       builtIn: false,
       sourceType: agentHubStore.LISTING_SOURCE_COMMUNITY,
+      runtimeFamily,
       status: agentHubStore.LISTING_STATUS_PENDING_REVIEW,
       visibility: agentHubStore.LISTING_VISIBILITY_PUBLIC,
       shareTarget: agentHubStore.LISTING_SHARE_TARGET_COMMUNITY,

--- a/docs/concepts/agent-hub.mdx
+++ b/docs/concepts/agent-hub.mdx
@@ -25,10 +25,14 @@ Every listing records the `runtimeFamily` of the agent it was captured from (`op
 
 Publishing runs the same secret scan for every family — listings with detected credentials are rejected before a snapshot is created.
 
-<Note>
-  Hermes listings can currently be published and browsed; one-click install of Hermes bundles ships
-  with the Hermes Agent Hub install path.
-</Note>
+## Installing by runtime family
+
+The catalog shows each listing's family as a badge, and a family filter appears whenever the catalog contains both OpenClaw and Hermes listings. Installing resolves the listing's family server-side — listing field first, then the snapshot's stored defaults, then the template payload's `metadata.runtimeFamily` carrier (which survives federation through hubs that predate the family field), defaulting to `openclaw`. A request that names a different family is rejected, as is installing a listing whose family is not enabled on the instance. The install dialog constrains the deploy target and sandbox pickers to the targets enabled for the listing's family.
+
+- **OpenClaw** — the template files (including the guaranteed core markdown set) are stored on the new agent and written into the workspace by the normal deploy bootstrap.
+- **Hermes** — after the runtime is created, the deploy worker writes the bundle's files into the new agent over container exec: workspace files land under `/opt/data/workspace`, and files-mode skill directories captured under the reserved `.hermes-skills/<name>/` prefix land under `/opt/data/skills`. A marker file (`/opt/data/.nora/template-applied`) records the materialization, so redeploys whose `/opt/data` survived (Kubernetes PVCs, named volumes) never clobber files the agent has since edited; on Docker targets where `/opt/data` is rebuilt, the marker disappears with it and the bundle is re-materialized. The bundle's saved skills are seeded into the agent and reinstalled by the skills reconciler on boot, and its model selection (`provider`, `defaultModel`, `baseUrl` — keys are never bundled) is applied as the new agent's Hermes model config. Connect an LLM provider and any integrations after install, exactly as for a manually deployed Hermes agent.
+
+If an installed agent was created from a migration draft, the migration's restored workspace wins and the bundle files are skipped for that deployment.
 
 ## Sharing model
 

--- a/docs/guides/agent-hub.mdx
+++ b/docs/guides/agent-hub.mdx
@@ -52,16 +52,19 @@ The fastest way to see the full flow is to install a built-in template and confi
 
 <Steps>
   <Step title="Open Agent Hub">
-    From the dashboard, open **Agent Hub** in the workspace navigation. The catalog shows three filters: **Internal** (your workspace's listings), **Community** (synced from the upstream hub), and **Built-in** (platform-seeded templates).
+    From the dashboard, open **Agent Hub** in the workspace navigation. The catalog shows three filters: **Internal** (your workspace's listings), **Community** (synced from the upstream hub), and **Built-in** (platform-seeded templates). Every card carries a runtime-family badge (**OpenClaw** or **Hermes**), and a family filter row appears whenever the catalog contains both families.
   </Step>
 
 <Step title="Select a listing">
   Click any listing to open its detail page. You'll see the runtime family, deploy target, sandbox
-  profile, default image, and any bootstrap files or integrations the template wires up.
+  profile, default image, and any bootstrap files or integrations the template wires up. OpenClaw
+  listings show their core markdown set; Hermes listings show the captured workspace files instead.
 </Step>
 
   <Step title="Click Install">
-    Choose the workspace (defaults to the current one) and an agent name. Nora materializes the latest version of the listing into a new agent in `queued` status. The deployment job runs the same path as a manual deploy.
+    Choose the workspace (defaults to the current one) and an agent name. The deploy target and sandbox pickers only offer targets enabled for the listing's runtime family. Nora materializes the latest version of the listing into a new agent in `queued` status. The deployment job runs the same path as a manual deploy.
+
+    For a Hermes listing, the deploy worker writes the bundle into the new runtime after it is created: workspace files under `/opt/data/workspace`, bundled skill directories under `/opt/data/skills`, guarded by a `/opt/data/.nora/template-applied` marker so redeploys with surviving storage never overwrite files the agent has edited. The bundle's saved skills are reinstalled by the skills reconciler on boot, and its captured model selection (provider, model, base URL — never API keys) becomes the new agent's model config.
 
     ![Install dialog — workspace + agent-name confirmation before materializing the listing](/images/guides/agent-hub/install-dialog.png)
 

--- a/frontend-dashboard/lib/runtime.test.ts
+++ b/frontend-dashboard/lib/runtime.test.ts
@@ -3,7 +3,10 @@ import test from "node:test";
 
 import {
   activeExecutionTargetFromConfig,
+  listingRuntimeFamily,
   mergeRemoteHostsIntoConfig,
+  runtimeFamilyFilterOptions,
+  runtimeSupportsAgentHubSharing,
   visibleSandboxOptionsFromTarget,
 } from "./runtime";
 
@@ -158,5 +161,39 @@ test("unavailable or view-only remote hosts do not become deploy targets", () =>
   assert.equal(
     mergeRemoteHostsIntoConfig(backendConfig, [{ ...connectedHost, canDeploy: false }]),
     backendConfig,
+  );
+});
+
+test("runtimeSupportsAgentHubSharing includes both openclaw and hermes", () => {
+  assert.equal(runtimeSupportsAgentHubSharing("openclaw"), true);
+  assert.equal(runtimeSupportsAgentHubSharing("hermes"), true);
+  assert.equal(runtimeSupportsAgentHubSharing({ runtime_family: "hermes" }), true);
+  assert.equal(runtimeSupportsAgentHubSharing({}), true);
+  assert.equal(runtimeSupportsAgentHubSharing("quantumclaw"), false);
+});
+
+test("listingRuntimeFamily resolves the listing field, template summary, then openclaw", () => {
+  assert.equal(listingRuntimeFamily({ runtime_family: "hermes" }), "hermes");
+  assert.equal(listingRuntimeFamily({ runtimeFamily: "hermes" }), "hermes");
+  assert.equal(listingRuntimeFamily({ template: { runtimeFamily: "hermes" } }), "hermes");
+  assert.equal(
+    listingRuntimeFamily({ runtime_family: "openclaw", template: { runtimeFamily: "hermes" } }),
+    "openclaw",
+  );
+  assert.equal(listingRuntimeFamily({ runtime_family: "unknown-family" }), "openclaw");
+  assert.equal(listingRuntimeFamily({}), "openclaw");
+  assert.equal(listingRuntimeFamily(null), "openclaw");
+});
+
+test("runtimeFamilyFilterOptions only offers a filter when families are mixed", () => {
+  assert.deepEqual(runtimeFamilyFilterOptions([]), []);
+  assert.deepEqual(runtimeFamilyFilterOptions([{ runtime_family: "openclaw" }, {}]), []);
+  assert.deepEqual(
+    runtimeFamilyFilterOptions([{ runtime_family: "hermes" }, { runtime_family: "hermes" }]),
+    [],
+  );
+  assert.deepEqual(
+    runtimeFamilyFilterOptions([{ runtime_family: "hermes" }, { runtime_family: "openclaw" }, {}]),
+    ["openclaw", "hermes"],
   );
 });

--- a/frontend-dashboard/lib/runtime.ts
+++ b/frontend-dashboard/lib/runtime.ts
@@ -522,5 +522,26 @@ export function runtimeSupportsAgentHubSharing(agentOrRuntimeFamily = {}) {
     typeof agentOrRuntimeFamily === "string"
       ? normalizeRuntimeFamily(agentOrRuntimeFamily)
       : resolveAgentRuntimeFamily(agentOrRuntimeFamily);
-  return runtimeFamily !== "hermes";
+  return runtimeFamily === "openclaw" || runtimeFamily === "hermes";
+}
+
+// Runtime family of an Agent Hub listing/detail. Mirrors the backend's
+// resolution order: the listing's runtime_family field first, then the
+// template summary's resolved family (covers remote details from hubs that
+// predate runtime_family), defaulting to OpenClaw.
+export function listingRuntimeFamily(listing: any = {}) {
+  return (
+    normalizeRuntimeFamily(listing?.runtime_family ?? listing?.runtimeFamily) ||
+    normalizeRuntimeFamily(listing?.template?.runtimeFamily) ||
+    "openclaw"
+  );
+}
+
+// Family filter options for a listing collection, in canonical family order.
+// Empty when every listing shares one family — a single-family catalog has
+// nothing to filter, so callers hide the chip row entirely.
+export function runtimeFamilyFilterOptions(listings: any[] = []) {
+  const present = new Set((Array.isArray(listings) ? listings : []).map(listingRuntimeFamily));
+  const families = Object.keys(RUNTIME_FAMILY_LABELS).filter((family) => present.has(family));
+  return families.length > 1 ? families : [];
 }

--- a/frontend-dashboard/pages/agent-hub/[id].tsx
+++ b/frontend-dashboard/pages/agent-hub/[id].tsx
@@ -26,9 +26,10 @@ import { useToast } from "../../components/Toast";
 import {
   activeExecutionTargetFromConfig,
   activeSandboxOptionFromTarget,
+  formatRuntimeFamilyLabel,
+  listingRuntimeFamily,
   resolveAgentExecutionTarget,
   resolveAgentSandboxProfile,
-  runtimeFamilyFromConfig,
 } from "../../lib/runtime";
 
 const REPORT_REASONS = [
@@ -221,7 +222,9 @@ export default function AgentHubTemplateDetail() {
         body: JSON.stringify({
           listingId: detail.id,
           name: trimmedName,
-          runtime_family: runtimeFamilyFromConfig(backendConfig)?.id || "openclaw",
+          // The listing's own family, not the instance default — the backend
+          // rejects a mismatch between the request and the listing.
+          runtime_family: listingRuntimeFamily(detail),
           deploy_target: installExecutionTarget,
           execution_target_id: installExecutionTarget,
           sandbox_profile: installSandboxProfile || "standard",
@@ -386,8 +389,12 @@ export default function AgentHubTemplateDetail() {
   const isPreset = detail?.source_type === "platform";
   const statusClass =
     STATUS_STYLES[detail?.status] || "bg-slate-100 text-slate-700 border-slate-200";
+  const listingFamily = listingRuntimeFamily(detail);
+  const isHermesListing = listingFamily === "hermes";
+  const listingFamilyLabel = formatRuntimeFamilyLabel(listingFamily);
   const installActiveExecutionTarget = activeExecutionTargetFromConfig(
     backendConfig,
+    listingFamily,
     installExecutionTarget,
   );
   const installActiveSandboxOption = activeSandboxOptionFromTarget(
@@ -455,6 +462,9 @@ export default function AgentHubTemplateDetail() {
                     >
                       {String(detail.status || "unknown").replace(/_/g, " ")}
                     </span>
+                    <span className="inline-flex rounded-full border border-blue-500/30 bg-blue-500/10 px-3 py-1 text-[10px] font-black uppercase tracking-[0.18em] text-blue-300">
+                      {listingFamilyLabel}
+                    </span>
                   </div>
 
                   <h1 className="mt-5 text-4xl font-black tracking-tight text-white sm:text-5xl">
@@ -488,8 +498,12 @@ export default function AgentHubTemplateDetail() {
                   />
                   <HeroMetric
                     icon={Layers3}
-                    label="Core Files"
-                    value={`${detail.template?.presentRequiredCoreCount || 0}/${detail.template?.requiredCoreCount || 7}`}
+                    label={isHermesListing ? "Runtime" : "Core Files"}
+                    value={
+                      isHermesListing
+                        ? listingFamilyLabel
+                        : `${detail.template?.presentRequiredCoreCount || 0}/${detail.template?.requiredCoreCount || 7}`
+                    }
                   />
                   <HeroMetric
                     icon={FileText}
@@ -509,10 +523,14 @@ export default function AgentHubTemplateDetail() {
                         Template Summary
                       </p>
                       <h2 className="mt-2 text-2xl font-black tracking-tight text-slate-950">
-                        OpenClaw core files included
+                        {isHermesListing
+                          ? "Workspace files included"
+                          : "OpenClaw core files included"}
                       </h2>
                       <p className="mt-2 text-sm font-medium leading-relaxed text-slate-500">
-                        Inspect the markdown files that will be installed into the agent template.
+                        {isHermesListing
+                          ? "Inspect the workspace files captured from the published Hermes agent. They are written into the new agent's workspace on first deploy."
+                          : "Inspect the markdown files that will be installed into the agent template."}{" "}
                         This view does not change download counts.
                       </p>
                     </div>
@@ -538,7 +556,7 @@ export default function AgentHubTemplateDetail() {
                   <div className="flex flex-col gap-6 lg:grid lg:grid-cols-[260px_minmax(0,1fr)]">
                     <div className="space-y-2">
                       <p className="text-[11px] font-black uppercase tracking-[0.18em] text-slate-400">
-                        Core Files
+                        {isHermesListing ? "Workspace Files" : "Core Files"}
                       </p>
                       {coreFiles.map((file) => (
                         <button
@@ -558,9 +576,11 @@ export default function AgentHubTemplateDetail() {
 
                       {extraFiles.length > 0 ? (
                         <>
-                          <p className="pt-3 text-[11px] font-black uppercase tracking-[0.18em] text-slate-400">
-                            Additional Files
-                          </p>
+                          {!isHermesListing && (
+                            <p className="pt-3 text-[11px] font-black uppercase tracking-[0.18em] text-slate-400">
+                              Additional Files
+                            </p>
+                          )}
                           {extraFiles.map((file) => (
                             <button
                               key={file.path}
@@ -618,8 +638,10 @@ export default function AgentHubTemplateDetail() {
                         </h2>
                         <p className="mt-2 max-w-3xl text-sm font-medium leading-relaxed text-slate-500">
                           Editing a shared listing updates the internal template immediately and
-                          refreshes community sync when that target is enabled. Core files stay
-                          pinned to the OpenClaw filenames, and extra files can be added or removed.
+                          refreshes community sync when that target is enabled.{" "}
+                          {isHermesListing
+                            ? "Workspace files can be edited, added, or removed."
+                            : "Core files stay pinned to the OpenClaw filenames, and extra files can be added or removed."}
                         </p>
                       </div>
 
@@ -860,6 +882,7 @@ export default function AgentHubTemplateDetail() {
                       label="Status"
                       value={String(detail.status || "unknown").replace(/_/g, " ")}
                     />
+                    <MetadataRow label="Runtime Family" value={listingFamilyLabel} />
                     <MetadataRow label="Category" value={detail.category || "General"} />
                     <MetadataRow label="Price" value={detail.price || "Free"} />
                     <MetadataRow label="Owner" value={publisherName(detail)} />
@@ -893,6 +916,7 @@ export default function AgentHubTemplateDetail() {
           loading={installing}
           backendConfig={backendConfig}
           viewerRole={currentUser?.role || "user"}
+          runtimeFamily={listingFamily}
           executionTarget={installExecutionTarget}
           sandboxProfile={installSandboxProfile}
           onExecutionTargetChange={setInstallExecutionTarget}
@@ -1023,6 +1047,7 @@ function InstallTemplateDialog({
   loading,
   backendConfig,
   viewerRole,
+  runtimeFamily,
   executionTarget,
   sandboxProfile,
   onExecutionTargetChange,
@@ -1034,6 +1059,7 @@ function InstallTemplateDialog({
   open,
 }) {
   if (!open || !item) return null;
+  const isHermesTemplate = runtimeFamily === "hermes";
 
   return (
     <div
@@ -1053,8 +1079,11 @@ function InstallTemplateDialog({
               Install Template
             </h3>
             <p className="mt-1 text-sm leading-relaxed text-slate-500">
-              {item.name} will be turned into a new queued agent in your fleet, including the
-              OpenClaw core markdown files shown on this page.
+              {item.name} will be turned into a new queued agent in your fleet, including the{" "}
+              {isHermesTemplate
+                ? "Hermes workspace files, bundled skills, and model selection shown on this page"
+                : "OpenClaw core markdown files shown on this page"}
+              .
             </p>
           </div>
           <button
@@ -1092,6 +1121,7 @@ function InstallTemplateDialog({
           <RuntimePathFields
             backendConfig={backendConfig}
             viewerRole={viewerRole}
+            runtimeFamily={runtimeFamily}
             executionTarget={executionTarget}
             sandboxProfile={sandboxProfile}
             onExecutionTargetChange={onExecutionTargetChange}

--- a/frontend-dashboard/pages/agent-hub/index.tsx
+++ b/frontend-dashboard/pages/agent-hub/index.tsx
@@ -21,6 +21,11 @@ import {
 import Layout from "../../components/layout/Layout";
 import { fetchWithAuth } from "../../lib/api";
 import { useToast } from "../../components/Toast";
+import {
+  formatRuntimeFamilyLabel,
+  listingRuntimeFamily,
+  runtimeFamilyFilterOptions,
+} from "../../lib/runtime";
 
 const AGENT_HUB_TABS = [
   { id: "presets", label: "Platform Presets" },
@@ -103,6 +108,7 @@ export default function AgentHub() {
   const [loading, setLoading] = useState(true);
   const [activeTab, setActiveTab] = useState("presets");
   const [category, setCategory] = useState("All");
+  const [familyFilter, setFamilyFilter] = useState("all");
   const [selectedItem, setSelectedItem] = useState(null);
   const [installName, setInstallName] = useState("");
   const [installingId, setInstallingId] = useState("");
@@ -169,6 +175,7 @@ export default function AgentHub() {
   function selectTab(nextTab) {
     setActiveTab(nextTab);
     setCategory("All");
+    setFamilyFilter("all");
     router.replace(
       {
         pathname: router.pathname,
@@ -187,8 +194,15 @@ export default function AgentHub() {
     "All",
     ...Array.from(new Set(scopedItems.map((item) => item.category).filter(Boolean))),
   ];
+  const familyOptions = runtimeFamilyFilterOptions(scopedItems);
+  const familyFilteredItems =
+    familyFilter === "all"
+      ? scopedItems
+      : scopedItems.filter((item) => listingRuntimeFamily(item) === familyFilter);
   const filteredItems =
-    category === "All" ? scopedItems : scopedItems.filter((item) => item.category === category);
+    category === "All"
+      ? familyFilteredItems
+      : familyFilteredItems.filter((item) => item.category === category);
 
   async function installAgent() {
     if (!selectedItem) return;
@@ -291,8 +305,8 @@ export default function AgentHub() {
             </h1>
             <p className="text-slate-400 font-medium text-lg leading-relaxed">
               Platform starter packs and internal shares stay separated from the hosted community
-              catalog. Inspect each template before installing, including the OpenClaw core files
-              that will ship with it.
+              catalog. Inspect each template before installing, including the OpenClaw core files or
+              Hermes workspace files that will ship with it.
             </p>
           </div>
         </header>
@@ -363,6 +377,25 @@ export default function AgentHub() {
                 : communityHub.error
                   ? `Community sync failed from ${communityHub.url || "the configured hub"}: ${communityHub.error}`
                   : `Community catalog synced from ${communityHub.url || "the configured hub"}. ${formatSyncCadence(communityHub)}`}
+            </div>
+          )}
+
+          {familyOptions.length > 0 && (
+            <div className="flex items-center gap-2 overflow-x-auto pb-1">
+              {["all", ...familyOptions].map((family) => (
+                <button
+                  key={family}
+                  onClick={() => setFamilyFilter(family)}
+                  className={clsx(
+                    "px-4 py-2 rounded-xl text-xs font-black uppercase tracking-[0.14em] transition-all whitespace-nowrap ring-1",
+                    familyFilter === family
+                      ? "bg-blue-600 text-white ring-blue-500/50"
+                      : "bg-white text-slate-500 hover:text-slate-900 hover:bg-slate-50 ring-slate-200",
+                  )}
+                >
+                  {family === "all" ? "All Runtimes" : formatRuntimeFamilyLabel(family)}
+                </button>
+              ))}
             </div>
           )}
 
@@ -475,6 +508,7 @@ function AgentHubCard({
   reporting,
 }) {
   const isPreset = item.source_type === "platform";
+  const familyLabel = formatRuntimeFamilyLabel(listingRuntimeFamily(item));
 
   return (
     <div className="group bg-white border border-slate-200 rounded-[2.3rem] shadow-sm hover:shadow-2xl hover:shadow-blue-500/10 hover:border-blue-500/20 transition-all duration-500 overflow-hidden flex flex-col p-1">
@@ -494,16 +528,21 @@ function AgentHubCard({
               <Users size={30} strokeWidth={2.4} />
             )}
           </div>
-          <span
-            className={clsx(
-              "px-3 py-1 rounded-full text-[10px] font-black uppercase tracking-widest border",
-              isPreset
-                ? "bg-slate-100 text-slate-700 border-slate-200"
-                : "bg-emerald-50 text-emerald-700 border-emerald-200",
-            )}
-          >
-            {isPreset ? "Preset" : item.remote ? "Community" : "Shared"}
-          </span>
+          <div className="flex flex-col items-end gap-2">
+            <span
+              className={clsx(
+                "px-3 py-1 rounded-full text-[10px] font-black uppercase tracking-widest border",
+                isPreset
+                  ? "bg-slate-100 text-slate-700 border-slate-200"
+                  : "bg-emerald-50 text-emerald-700 border-emerald-200",
+              )}
+            >
+              {isPreset ? "Preset" : item.remote ? "Community" : "Shared"}
+            </span>
+            <span className="px-3 py-1 rounded-full text-[10px] font-black uppercase tracking-widest border bg-blue-50/70 text-blue-700 border-blue-100">
+              {familyLabel}
+            </span>
+          </div>
         </div>
 
         <div className="space-y-2">
@@ -532,8 +571,12 @@ function AgentHubCard({
         <div className="grid grid-cols-2 gap-3">
           <TemplateInfoPill
             icon={Layers3}
-            label="Core Files"
-            value={`${item.template?.presentRequiredCoreCount || 0}/${item.template?.requiredCoreCount || 7}`}
+            label={familyLabel === "Hermes" ? "Bundle" : "Core Files"}
+            value={
+              familyLabel === "Hermes"
+                ? "Workspace files"
+                : `${item.template?.presentRequiredCoreCount || 0}/${item.template?.requiredCoreCount || 7}`
+            }
           />
           <TemplateInfoPill
             icon={FileText}
@@ -616,6 +659,7 @@ function AgentHubCard({
 
 function MyListingCard({ item, onDownload, downloading }) {
   const statusClass = STATUS_STYLES[item.status] || "bg-slate-100 text-slate-700 border-slate-200";
+  const familyLabel = formatRuntimeFamilyLabel(listingRuntimeFamily(item));
 
   return (
     <div className="bg-white border border-slate-200 rounded-[2.3rem] shadow-sm overflow-hidden flex flex-col p-6 gap-5">
@@ -630,6 +674,9 @@ function MyListingCard({ item, onDownload, downloading }) {
               )}
             >
               {String(item.status || "unknown").replace(/_/g, " ")}
+            </span>
+            <span className="px-3 py-1 rounded-full text-[10px] font-black uppercase tracking-widest border bg-blue-50/70 text-blue-700 border-blue-100">
+              {familyLabel}
             </span>
           </div>
           <p className="mt-2 text-sm text-slate-500 leading-relaxed">
@@ -675,10 +722,12 @@ function MyListingCard({ item, onDownload, downloading }) {
         </div>
         <div>
           <p className="text-[10px] font-black uppercase tracking-[0.16em] text-slate-400">
-            Core Files
+            {familyLabel === "Hermes" ? "Bundle" : "Core Files"}
           </p>
           <p className="mt-1 font-semibold text-slate-900">
-            {item.template?.presentRequiredCoreCount || 0}/{item.template?.requiredCoreCount || 7}
+            {familyLabel === "Hermes"
+              ? "Workspace files"
+              : `${item.template?.presentRequiredCoreCount || 0}/${item.template?.requiredCoreCount || 7}`}
           </p>
         </div>
         <div>

--- a/workers/provisioner/worker.ts
+++ b/workers/provisioner/worker.ts
@@ -117,6 +117,7 @@ const {
   computeOrphanedInstalledHermesSkills,
   installedEntriesFromHermesLockData,
   isReservedHermesSkillName,
+  isValidHermesSkillName,
   normalizeSavedHermesSkillEntry,
   removeSavedHermesSkillEntry,
 } = require("../../agent-runtime/lib/hermesSkillsReconciliation");
@@ -1155,6 +1156,211 @@ async function seedHermesArchiveForDeployment({
   // enters the normal provisioning cleanup path instead of finalizing runtime.
   await authorize(provisioner);
   return { seeded: true, reason: null };
+}
+
+// ── Hermes template-bundle materialization ──────────────────────
+// Agent Hub Hermes bundles ship workspace files (and files-mode skill
+// directories under the reserved `.hermes-skills/<name>/` prefix) in the
+// agent's stored template payload. They are written into the runtime after
+// creation via exec — NOT the Docker-only seed-archive path above, so the
+// same materializer works on k8s and remote targets. A marker file skips
+// re-materialization on redeploys whose /opt/data survived (k8s PVCs,
+// post-#301 named volumes), so agent-edited files are never clobbered.
+const HERMES_TEMPLATE_WORKSPACE_DIR = "/opt/data/workspace";
+const HERMES_TEMPLATE_MARKER_DIR = "/opt/data/.nora";
+const HERMES_TEMPLATE_APPLIED_MARKER = `${HERMES_TEMPLATE_MARKER_DIR}/template-applied`;
+const HERMES_TEMPLATE_SKILLS_PREFIX = ".hermes-skills/";
+const HERMES_TEMPLATE_MARKER_PRESENT_TOKEN = "NORA_TEMPLATE_APPLIED";
+const HERMES_TEMPLATE_MARKER_ABSENT_TOKEN = "NORA_TEMPLATE_ABSENT";
+// Base64 payload budget per exec batch; each write command carries its file
+// inline, so this bounds individual command sizes across exec transports.
+const HERMES_TEMPLATE_WRITE_BATCH_BYTES = 512 * 1024;
+
+// Local variant of hermesManifest.writeBase64FileCommand (same
+// mkdir/base64/chmod idiom). Deliberately replicated rather than imported:
+// the manifest helper is not exported and takes UTF-8 text it re-encodes,
+// while bundle entries already carry base64 that must survive byte-for-byte
+// for binary workspace files.
+function buildHermesTemplateFileWriteCommand(filePath, contentBase64, mode = "0644") {
+  const quotedPath = shellSingleQuote(filePath);
+  const quotedDir = shellSingleQuote(filePath.split("/").slice(0, -1).join("/") || "/");
+  return [
+    `mkdir -p ${quotedDir}`,
+    `printf '%s' ${shellSingleQuote(String(contentBase64 || ""))} | base64 -d > ${quotedPath}`,
+    `chmod ${mode} ${quotedPath}`,
+  ].join(" && ");
+}
+
+// Single validation + mapping choke point for bundle file paths — they are
+// interpolated into shell commands, so this mirrors the containment rules in
+// runtimeBootstrap/agentPayloads (relative only, no dot/dot-dot segments,
+// conservative charset). `.hermes-skills/<name>/<rest>` maps into the hub
+// skills tree with the skill-name charset + reserved-name rules enforced;
+// everything else lands under the workspace root. Returns null on rejection.
+function resolveHermesTemplateFilePath(rawPath) {
+  const normalized = String(rawPath || "")
+    .trim()
+    .replace(/\\/g, "/");
+  if (!normalized || normalized.startsWith("/") || !/^[A-Za-z0-9._/-]+$/.test(normalized)) {
+    return null;
+  }
+  const segments = normalized.split("/").filter(Boolean);
+  if (segments.length === 0 || segments.some((segment) => segment === "." || segment === "..")) {
+    return null;
+  }
+  if (normalized.startsWith(HERMES_TEMPLATE_SKILLS_PREFIX)) {
+    const [skillName, ...rest] = segments.slice(1);
+    if (
+      !skillName ||
+      rest.length === 0 ||
+      !isValidHermesSkillName(skillName) ||
+      isReservedHermesSkillName(skillName)
+    ) {
+      return null;
+    }
+    return `${HERMES_SKILLS_DIR}/${[skillName, ...rest].join("/")}`;
+  }
+  return `${HERMES_TEMPLATE_WORKSPACE_DIR}/${segments.join("/")}`;
+}
+
+function formatHermesTemplateFileMode(mode) {
+  if (!Number.isInteger(mode) || mode <= 0 || mode > 0o7777) return "0644";
+  return mode.toString(8).padStart(4, "0");
+}
+
+/**
+ * Write an installed Agent Hub bundle's files into a freshly created Hermes
+ * runtime. Skipped when a migration seed already restored the workspace
+ * (migration wins over the bundle), when the payload has no files, or when the
+ * marker file reports a previous materialization (surviving /opt/data). Files
+ * are written in size-bounded exec batches, ownership is repaired for the
+ * runtime user on every root that was touched, and the marker is written last
+ * so a failed partial write is retried on the next deploy instead of sealed.
+ *
+ * @param {object} options.templatePayload Stored agent template payload.
+ * @param {boolean} [options.migrationSeeded] Whether the migration seed archive
+ *   restored this runtime's workspace during the same deployment.
+ * @param {Function} [options.execute] Exec runner override for tests.
+ * @returns {Promise<{applied: boolean, reason: string|null, fileCount?: number}>}
+ */
+async function materializeHermesTemplatePayload({
+  agentId,
+  provisioner,
+  containerId,
+  templatePayload,
+  migrationSeeded = false,
+  logPrefix = "[hermes-template]",
+  execute = runProvisionerExecCommand,
+} = {}) {
+  if (migrationSeeded) {
+    console.log(
+      `${logPrefix} agent=${agentId} Skipping template bundle; migration seed was applied`,
+    );
+    return { applied: false, reason: "migration-seed" };
+  }
+
+  const files = Array.isArray(templatePayload?.files) ? templatePayload.files : [];
+  if (files.length === 0) {
+    return { applied: false, reason: "no-files" };
+  }
+
+  const markerProbe =
+    `if [ -f ${JSON.stringify(HERMES_TEMPLATE_APPLIED_MARKER)} ]; ` +
+    `then printf '${HERMES_TEMPLATE_MARKER_PRESENT_TOKEN}'; ` +
+    `else printf '${HERMES_TEMPLATE_MARKER_ABSENT_TOKEN}'; fi`;
+  const { output } = await execute(provisioner, containerId, markerProbe, {
+    tty: true,
+    timeout: 30000,
+    agentId,
+  });
+  if (String(output || "").includes(HERMES_TEMPLATE_MARKER_PRESENT_TOKEN)) {
+    console.log(
+      `${logPrefix} agent=${agentId} Template bundle already materialized (marker present); skipping`,
+    );
+    return { applied: false, reason: "marker-present" };
+  }
+
+  // Validate and map every path before writing anything: a bundle with one
+  // unsafe path must fail whole rather than apply partially.
+  const writes = [];
+  let touchedWorkspace = false;
+  let touchedSkills = false;
+  for (const entry of files) {
+    const targetPath = resolveHermesTemplateFilePath(entry?.path);
+    if (!targetPath) {
+      throw new Error(
+        `Hermes template bundle contains an unsafe file path: ${String(entry?.path || "(empty)").slice(0, 200)}`,
+      );
+    }
+    if (targetPath.startsWith(`${HERMES_SKILLS_DIR}/`)) {
+      touchedSkills = true;
+    } else {
+      touchedWorkspace = true;
+    }
+    writes.push({
+      contentBase64: String(entry?.contentBase64 || ""),
+      command: buildHermesTemplateFileWriteCommand(
+        targetPath,
+        entry?.contentBase64,
+        formatHermesTemplateFileMode(entry?.mode),
+      ),
+    });
+  }
+
+  const batches = [];
+  let currentBatch = [];
+  let currentBatchBytes = 0;
+  for (const write of writes) {
+    if (
+      currentBatch.length > 0 &&
+      currentBatchBytes + write.contentBase64.length > HERMES_TEMPLATE_WRITE_BATCH_BYTES
+    ) {
+      batches.push(currentBatch);
+      currentBatch = [];
+      currentBatchBytes = 0;
+    }
+    currentBatch.push(write.command);
+    currentBatchBytes += write.contentBase64.length;
+  }
+  if (currentBatch.length > 0) batches.push(currentBatch);
+
+  for (const batch of batches) {
+    await execute(provisioner, containerId, ["set -eu", ...batch].join("\n"), {
+      timeout: 120000,
+      agentId,
+    });
+  }
+
+  const ownershipRoots = [
+    ...(touchedWorkspace ? [HERMES_TEMPLATE_WORKSPACE_DIR] : []),
+    ...(touchedSkills ? [HERMES_SKILLS_DIR] : []),
+  ];
+  await execute(
+    provisioner,
+    containerId,
+    ownershipRoots
+      .map((root) => `chown -R hermes:hermes ${shellSingleQuote(root)} 2>/dev/null || true`)
+      .join("\n"),
+    { timeout: 60000, agentId },
+  );
+
+  // Marker written last: a failure anywhere above leaves the marker absent so
+  // the next deploy retries the full materialization.
+  await execute(
+    provisioner,
+    containerId,
+    [
+      "set -eu",
+      `mkdir -p ${shellSingleQuote(HERMES_TEMPLATE_MARKER_DIR)}`,
+      `date -u +%Y-%m-%dT%H:%M:%SZ > ${shellSingleQuote(HERMES_TEMPLATE_APPLIED_MARKER)}`,
+    ].join("\n"),
+    { timeout: 30000, agentId },
+  );
+
+  console.log(
+    `${logPrefix} agent=${agentId} Materialized ${writes.length} template bundle file(s)`,
+  );
+  return { applied: true, reason: null, fileCount: writes.length };
 }
 
 function buildHermesPythonCommand(script) {
@@ -4555,11 +4761,31 @@ const worker = new Worker(
             channels: [],
           }));
 
-          await seedHermesArchiveForDeployment({
+          const hermesSeed = await seedHermesArchiveForDeployment({
             agentId: id,
             provisioner,
             containerId,
           });
+
+          // A migration seed wins over an Agent Hub bundle: when the attached
+          // manifest restored a workspace, the bundle's files must not clobber
+          // it. Bundle failures are non-fatal — the marker stays absent and the
+          // next deploy retries; skills replay separately via reconciliation.
+          try {
+            await materializeHermesTemplatePayload({
+              agentId: id,
+              provisioner,
+              containerId,
+              templatePayload,
+              migrationSeeded: hermesSeed?.seeded === true,
+            });
+          } catch (e) {
+            throwIfRemoteAuthorizationFailure(e);
+            console.warn(
+              `[provisioner] Failed to materialize Hermes template bundle for agent ${id}:`,
+              e.message,
+            );
+          }
 
           if (
             hasMeaningfulHermesModelConfig(persistedHermesState?.modelConfig) ||
@@ -5287,6 +5513,7 @@ module.exports = {
   runRuntimeCommand,
   runProvisionerExecCommand,
   seedHermesArchiveForDeployment,
+  materializeHermesTemplatePayload,
   toUnrecoverableRuntimeSelectionError,
   readInstalledHermesSkills,
   installHermesSkill,


### PR DESCRIPTION
PR 8 of 8 — completes the Hermes Skills epic. Hub listings now install as Hermes agents end-to-end, and the hub UI speaks both runtime families.

- **/install family resolution** (listing column → snapshot defaults → payload metadata → openclaw): request mismatch and disabled families → 400; family-aware name/image resolution; hermes installs persist the bundle's `hermes_skills` (normalized, capped) and seed `hermes_runtime_state.model_config` for the worker's existing replay — no new worker model logic.
- **Worker `materializeHermesTemplatePayload`**: post-ready, base64-native batched writes with a single path-containment choke point (`.hermes-skills/<name>/` → `/opt/data/skills`, everything else → the workspace; reserved names refused); `/opt/data/.nora/template-applied` marker guard so PVC/volume redeploys never clobber agent-modified files; migration seed takes precedence; marker written last so partial failures retry next deploy.
- **Federation**: `runtime_family` round-trips through outbound submissions, inbound `/submissions`, and the public catalog, with `metadata.runtimeFamily` as the older-hub carrier.
- **Frontend unlock**: publish enabled for Hermes agents, family badges + filter chips in the hub, family badge/metadata on detail, install targets scoped to the listing's family, family-conditional file inspector (fixes the misleading "0/7 core files" a Hermes listing would have shown), admin moderation gains a Family column.

Validation: full backend suite **2330 green** (+ new install-matrix and materializer suites, 87 targeted), worker + both frontends typecheck clean, eslint/prettier clean.

With this merged, the whole epic (#318–#324 + this) is shipped: skills browse/install/reconcile, Skills tab, deploy-time selection, instance Skills Library, and Agent Hub Hermes bundles publish + install.