### PR TITLE
feat(cli): add search, type, from, and to filter flags to nora monitoring events

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -45,6 +45,7 @@ nora agents rollback <id> <vid>  # restore a prior version
 
 nora monitoring metrics          # current metrics
 nora monitoring events --limit 50
+nora monitoring events --type agent_deleted --search backup --from 2026-08-01 --to 2026-08-20
 nora monitoring tail --interval 5000
 
 nora doctor                      # control-plane health check (needs an admin API key)

--- a/cli/src/commands/monitoring.js
+++ b/cli/src/commands/monitoring.js
@@ -7,7 +7,13 @@ async function metrics() {
 
 async function events(args, flags) {
   const limit = flags.limit ? Number(flags.limit) : 20;
-  const data = await api.get("/api/monitoring/events", { query: { limit } });
+  const query = { limit };
+  if (flags.search) query.search = flags.search;
+  if (flags.type) query.type = flags.type;
+  if (flags.from) query.from = flags.from;
+  if (flags.to) query.to = flags.to;
+
+  const data = await api.get("/api/monitoring/events", { query });
   const rows = Array.isArray(data) ? data : data.events || [];
   if (rows.length === 0) {
     console.log("(no events)");
@@ -45,7 +51,11 @@ module.exports = {
   describe: "Read monitoring metrics and the event stream",
   subcommands: {
     metrics: { run: metrics, describe: "Print current monitoring metrics" },
-    events: { run: events, describe: "Print recent events (--limit N)" },
+    events: {
+      run: events,
+      describe:
+        "Print recent events (--limit N, --search str, --type type, --from YYYY-MM-DD, --to YYYY-MM-DD)",
+    },
     tail: { run: tail, describe: "Stream new events (--interval ms, default 5000)" },
   },
 };

--- a/cli/src/monitoring.test.js
+++ b/cli/src/monitoring.test.js
@@ -1,0 +1,116 @@
+const test = require("node:test");
+const assert = require("node:assert");
+const api = require("./client");
+const monitoring = require("./commands/monitoring");
+
+test("monitoring events passes default limit of 20 when no flags provided", async () => {
+  const logs = [];
+  const originalLog = console.log;
+  const originalGet = api.get;
+
+  console.log = (msg) => logs.push(msg);
+  api.get = async (path, options) => {
+    assert.strictEqual(path, "/api/monitoring/events");
+    assert.deepStrictEqual(options, { query: { limit: 20 } });
+    return [
+      {
+        created_at: "2026-08-20T10:00:00Z",
+        type: "agent_started",
+        message: "Agent agent-1 started",
+      },
+    ];
+  };
+
+  try {
+    await monitoring.subcommands.events.run([], {});
+    assert.deepStrictEqual(logs, ["[2026-08-20T10:00:00Z] agent_started: Agent agent-1 started"]);
+  } finally {
+    console.log = originalLog;
+    api.get = originalGet;
+  }
+});
+
+test("monitoring events forwards search, type, from, to, and limit filter flags", async () => {
+  const logs = [];
+  const originalLog = console.log;
+  const originalGet = api.get;
+
+  console.log = (msg) => logs.push(msg);
+  api.get = async (path, options) => {
+    assert.strictEqual(path, "/api/monitoring/events");
+    assert.deepStrictEqual(options, {
+      query: {
+        limit: 10,
+        search: "backup failure",
+        type: "agent_deleted",
+        from: "2026-08-01",
+        to: "2026-08-20",
+      },
+    });
+    return [
+      {
+        created_at: "2026-08-15T12:00:00Z",
+        type: "agent_deleted",
+        message: "Agent agent-2 deleted after backup failure",
+      },
+    ];
+  };
+
+  try {
+    await monitoring.subcommands.events.run([], {
+      limit: 10,
+      search: "backup failure",
+      type: "agent_deleted",
+      from: "2026-08-01",
+      to: "2026-08-20",
+    });
+    assert.deepStrictEqual(logs, [
+      "[2026-08-15T12:00:00Z] agent_deleted: Agent agent-2 deleted after backup failure",
+    ]);
+  } finally {
+    console.log = originalLog;
+    api.get = originalGet;
+  }
+});
+
+test("monitoring events prints (no events) when response is empty", async () => {
+  const logs = [];
+  const originalLog = console.log;
+  const originalGet = api.get;
+
+  console.log = (msg) => logs.push(msg);
+  api.get = async () => [];
+
+  try {
+    await monitoring.subcommands.events.run([], { search: "nonexistent" });
+    assert.deepStrictEqual(logs, ["(no events)"]);
+  } finally {
+    console.log = originalLog;
+    api.get = originalGet;
+  }
+});
+
+test("monitoring events handles data.events wrapper structure", async () => {
+  const logs = [];
+  const originalLog = console.log;
+  const originalGet = api.get;
+
+  console.log = (msg) => logs.push(msg);
+  api.get = async () => ({
+    events: [
+      {
+        createdAt: "2026-08-20T11:00:00Z",
+        event_type: "agent_restarted",
+        message: "Restarted agent-3",
+      },
+    ],
+  });
+
+  try {
+    await monitoring.subcommands.events.run([], { type: "agent_restarted" });
+    assert.deepStrictEqual(logs, ["[2026-08-20T11:00:00Z] agent_restarted: Restarted agent-3"]);
+  } finally {
+    console.log = originalLog;
+    api.get = originalGet;
+  }
+});


### PR DESCRIPTION
Resolves #258

### Summary
Extends `nora monitoring events` to forward optional `--search`, `--type`, `--from`, and `--to` filters alongside existing `--limit` to `GET /api/monitoring/events`.

### Changes
- Updated `cli/src/commands/monitoring.js` to parse and forward `search`, `type`, `from`, `to`, and `limit` to the monitoring events endpoint.
- Updated `subcommands.events.describe` to document the new filter flags.
- Updated `cli/README.md` to document the new filter flags in CLI usage.
- Added comprehensive unit tests in `cli/src/monitoring.test.js` verifying default limit behavior, combined query forwarding, empty events handling, and data wrapping.

### Verification
Ran `cd cli && npm test`:
```text
✔ parses positional + flags with separated value (4.642771ms)
✔ parses --flag=value form (0.453834ms)
✔ treats lone --flag as boolean true (0.509078ms)
✔ --flag followed by another --flag treats first as boolean (0.25504ms)
✔ root help exposes the repository and a single support prompt (222.824961ms)
✔ --version prints only the package version (166.598806ms)
✔ monitoring events passes default limit of 20 when no flags provided (6.412262ms)
✔ monitoring events forwards search, type, from, to, and limit filter flags (0.72252ms)
✔ monitoring events prints (no events) when response is empty (0.752046ms)
✔ monitoring events handles data.events wrapper structure (0.72251ms)
✔ table with empty rows prints (none) (5.652181ms)
✔ table with rows formats output correctly (0.912908ms)
✔ workspaces list renders table output by default (6.005054ms)
✔ workspaces list --json outputs formatted JSON payload (0.662477ms)
ℹ tests 14
ℹ suites 0
ℹ pass 14
ℹ fail 0
```
Also verified with `npm run contributor:check -- cli` (lint, format check, secret scan, and test suite all passed).