### PR TITLE
fix(ci): grant pull-requests write to community-response workflow

### DIFF
--- a/.github/workflows/community-response.yml
+++ b/.github/workflows/community-response.yml
@@ -19,7 +19,7 @@ permissions:
   contents: read
   discussions: write
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 concurrency:
   group: community-response-${{ github.event_name == 'schedule' && 'audit' || github.run_id }}


### PR DESCRIPTION
## Summary

The Community Response workflow's `acknowledge` job fails with 403 ("Resource not accessible by integration") on every externally-opened pull request, and the scheduled `audit-response-deadlines` job has failed daily since 2026-08-20 on the same call — both while POSTing a comment to `/repos/.../issues/{n}/comments` for a PR thread (currently PR #336).

Root cause: commenting on a **pull request** through the issues API requires `pull-requests: write` on `GITHUB_TOKEN`; `issues: write` only covers actual issues (which is why issue and discussion acknowledgements kept working). The workflow declared `pull-requests: read`.

## Change

One line in `.github/workflows/community-response.yml`: `pull-requests: read` → `pull-requests: write`.

Safe with `pull_request_target`: the workflow checks out and runs the script from the default branch only, never from the fork.

## Validation

- Issue-triggered acknowledge runs succeed (issues: write present); all four recent PR-triggered runs 403 — matches the permission mapping.
- Failing call: `POST /repos/solomon2773/nora/issues/336/comments` → 403 in both the acknowledge job (run 31244767675) and the 2026-08-21 scheduled audit (run 32463530940).