### PR TITLE
test(infra): align community-response permission contract with PR commenting

### DIFF
--- a/scripts/infra-security.test.mjs
+++ b/scripts/infra-security.test.mjs
@@ -1626,7 +1626,7 @@ test("community response automation acknowledges and escalates every public thre
   }
   assert.match(workflow, /^ {2}discussions: write$/m);
   assert.match(workflow, /^ {2}issues: write$/m);
-  assert.match(workflow, /^ {2}pull-requests: read$/m);
+  assert.match(workflow, /^ {2}pull-requests: write$/m);
   assert.match(workflow, /ref: \$\{\{ github\.event\.repository\.default_branch \}\}/);
   assert.match(workflow, /persist-credentials: false/);
   assert.match(workflow, /community-response\.mjs acknowledge/);


### PR DESCRIPTION
Follow-up to #345, which granted `pull-requests: write` so the Community Response workflow can comment on pull request threads. The infra-security contract still asserted `pull-requests: read`, so `Infra validation` (and the `Security gate`) went red on master after the merge.

This updates the contract to match the corrected workflow. Verified locally: `node --test scripts/infra-security.test.mjs` — 31 pass, 0 fail.