### PR TITLE
ci(security): add a repo-wide secret scan alongside the config linter

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   secret-scan:
-    name: Sensitive config scan
+    name: Secret and sensitive config scan
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/scripts/scan-secrets.mjs
+++ b/.github/workflows/scripts/scan-secrets.mjs
@@ -1,0 +1,290 @@
+// Repo-wide credential scan.
+//
+// This is the companion to scan-sensitive-config.mjs, which enforces
+// placeholder discipline for three keys inside .env-shaped files. That check is
+// deliberately narrow, and the gap was wide: a real JWT_SECRET, a Stripe live
+// key, an AWS key, or a private key committed in any .ts/.yml/.md file passed
+// the "Sensitive config scan" gate untouched.
+//
+// GitHub secret scanning with push protection covers well-known *provider*
+// token shapes, and it stays the first line of defence. It does not cover
+// Nora's own secret material — JWT_SECRET, ENCRYPTION_KEY, the API-key hash
+// secrets, the backup encryption key — because those have no provider-specific
+// shape to match. That is what this adds, plus a blocking PR-time gate rather
+// than an after-the-fact alert.
+//
+// Design rule: every pattern here is high-confidence. No generic entropy
+// heuristics — an unreliable secret scanner gets muted, and a muted gate is
+// worse than none. Findings should be rare and real.
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../..");
+
+// This scanner and its tests contain every pattern below as literal text.
+const SELF_EXCLUDED = new Set([
+  ".github/workflows/scripts/scan-secrets.mjs",
+  ".github/workflows/scripts/scan-secrets.test.mjs",
+]);
+
+const SKIPPED_PATH_SEGMENTS = ["node_modules/", ".next/", "coverage/", "dist/"];
+// Test fixtures are fake by construction — hardcoded keys, sequential tokens,
+// stub PEM blocks — and flagging them trains people to ignore this gate. Real
+// provider tokens committed to a test file are still caught by GitHub secret
+// scanning push protection, which is enabled repo-wide.
+const TEST_FILE_RE = /(^|\/)__tests__\/|\.test\.[cm]?[jt]sx?$|\.spec\.[cm]?[jt]sx?$/;
+const SKIPPED_BASENAMES = new Set(["package-lock.json"]);
+const BINARY_EXTENSIONS = new Set([
+  ".png",
+  ".jpg",
+  ".jpeg",
+  ".gif",
+  ".webp",
+  ".ico",
+  ".svg",
+  ".pdf",
+  ".mp4",
+  ".mov",
+  ".webm",
+  ".woff",
+  ".woff2",
+  ".ttf",
+  ".eot",
+  ".zip",
+  ".gz",
+  ".tgz",
+  ".jar",
+  ".class",
+  ".so",
+  ".dylib",
+  ".dll",
+]);
+
+// Well-known provider credentials. Each requires enough trailing entropy that a
+// prose mention of the prefix cannot trip it.
+const PROVIDER_PATTERNS = [
+  { name: "AWS access key id", re: /\b(?:AKIA|ASIA)[0-9A-Z]{16}\b/g },
+  { name: "GitHub token", re: /\bgh[pousr]_[A-Za-z0-9]{36,}\b/g },
+  { name: "GitHub fine-grained PAT", re: /\bgithub_pat_[A-Za-z0-9_]{60,}\b/g },
+  { name: "Slack token", re: /\bxox[baprs]-[A-Za-z0-9-]{20,}\b/g },
+  {
+    name: "Slack webhook",
+    re: /hooks\.slack\.com\/services\/T[A-Za-z0-9]+\/B[A-Za-z0-9]+\/[A-Za-z0-9]{16,}/g,
+  },
+  { name: "Stripe live key", re: /\b(?:sk|rk)_live_[A-Za-z0-9]{16,}\b/g },
+  { name: "OpenAI key", re: /\bsk-(?:proj-)?[A-Za-z0-9_-]{32,}\b/g },
+  { name: "Anthropic key", re: /\bsk-ant-[A-Za-z0-9_-]{24,}\b/g },
+  { name: "Google API key", re: /\bAIza[0-9A-Za-z_-]{35}\b/g },
+  { name: "NVIDIA API key", re: /\bnvapi-[A-Za-z0-9_-]{32,}\b/g },
+  { name: "Nora workspace API key", re: /\bnora_[A-Za-z0-9]{32,}\b/g },
+  // Requires a real base64 body, so UI label strings ("-----BEGIN OPENSSH
+  // PRIVATE KEY-----" as placeholder text) and short test fixtures do not match.
+  {
+    name: "private key block",
+    re: /-----BEGIN (?:[A-Z]+ )?PRIVATE KEY-----[\r\n]+[A-Za-z0-9+/=\r\n]{100,}/g,
+  },
+];
+
+// Nora's own secret material, detected by assignment rather than by shape.
+const SECRET_ASSIGNMENT_KEYS = [
+  "JWT_SECRET",
+  "ENCRYPTION_KEY",
+  "NORA_BACKUP_ENCRYPTION_KEY",
+  "NORA_AGENT_HUB_API_KEY_HASH_SECRET",
+  "NORA_API_KEY_HASH_SECRET",
+  "NORA_GITHUB_TOKEN",
+  "NORA_BACKUP_SSH_PASSWORD",
+  "NORA_BACKUP_S3_SECRET_ACCESS_KEY",
+  "NORA_BACKUP_R2_SECRET_ACCESS_KEY",
+  "DB_PASSWORD",
+  "REDIS_PASSWORD",
+  "DEFAULT_ADMIN_PASSWORD",
+  "STRIPE_SECRET_KEY",
+  "STRIPE_WEBHOOK_SECRET",
+  "GITHUB_CLIENT_SECRET",
+  "GOOGLE_CLIENT_SECRET",
+  "PROXMOX_SSH_PASSWORD",
+  "PROXMOX_TOKEN_SECRET",
+  "SIGNUP_RECAPTCHA_SECRET",
+  "SIGNUP_TURNSTILE_SECRET",
+  "AWS_SECRET_ACCESS_KEY",
+  "NVIDIA_API_KEY",
+];
+
+// Deliberately absent: *_KEY_FILE, *_KEY_PATH, *_DIR (filesystem locations),
+// *_SITE_KEY (reCAPTCHA/Turnstile site keys are public by design), and
+// PROXMOX_TOKEN_ID / AWS_ACCESS_KEY_ID (identifiers, not secrets).
+const ASSIGNMENT_RE = new RegExp(
+  String.raw`\b(${SECRET_ASSIGNMENT_KEYS.join("|")})[ \t]*[:=][ \t]*["']?([^"'\n\r,}\s]+)`,
+  "g",
+);
+
+const PLACEHOLDER_WORDS = [
+  "example",
+  "placeholder",
+  "redacted",
+  "fixture",
+  "dummy",
+  "sample",
+  "changeme",
+  "change-me",
+  "your-",
+  "your_",
+  "replace",
+  "insert",
+  "xxxx",
+  "test",
+  "fake",
+  "notreal",
+  "not-real",
+  "todo",
+  "dev-only",
+  "localhost",
+  "secret",
+  "password",
+];
+
+// Values that are checked in on purpose and are not credentials. The .env.test
+// key is a fixed all-zero-ish hex string the test suite depends on; it is also
+// allowlisted in scan-sensitive-config.mjs, which governs .env-shaped files.
+const KNOWN_SAFE_VALUES = new Set([
+  "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+]);
+
+/**
+ * Report whether text carries an obvious not-a-real-secret marker.
+ *
+ * @param {string} text - Candidate token or assigned value.
+ * @returns {boolean} True when a placeholder word appears anywhere in it.
+ */
+function containsPlaceholderWord(text) {
+  const lowered = text.toLowerCase();
+  return PLACEHOLDER_WORDS.some((word) => lowered.includes(word));
+}
+
+/**
+ * Report whether a value has the shape of generated credential material.
+ *
+ * Real secrets in this codebase are hex or base64 output from a CSPRNG. Code
+ * expressions (`crypto.randomBytes(32)`), env indirection (`process.env.X`),
+ * shell references (`$JWT_SECRET`), URLs, and function names all fail here,
+ * which is what keeps the assignment detector from firing on source code.
+ *
+ * @param {string} value - Normalized right-hand side of an assignment.
+ * @returns {boolean} True when the value looks like random secret material.
+ */
+function looksLikeCredentialMaterial(value) {
+  if (!/^[A-Za-z0-9+/=_-]{12,}$/.test(value)) return false;
+  if (value.startsWith("/")) return false;
+  // Long enough to be a key regardless of composition, or mixed letters and
+  // digits the way generated material is. A bare word like "Read-EnvValue"
+  // clears the length bar but has no digits, so it is not credential-shaped.
+  if (value.length >= 32) return true;
+  return /[0-9]/.test(value) && /[A-Za-z]/.test(value);
+}
+
+/**
+ * Decide whether an assigned value is obviously not real credential material.
+ *
+ * @param {string} value - Raw right-hand side of the assignment.
+ * @returns {boolean} True when the value is a placeholder, reference, or stub.
+ */
+function isPlaceholderValue(value) {
+  const normalized = value.trim().replace(/^["']|["']$/g, "");
+  if (!normalized) return true;
+  // Env indirection and template references are never literal secrets.
+  if (/^\$\{?\{?/.test(normalized)) return true;
+  if (/^process\.env\b/.test(normalized)) return true;
+  if (normalized.startsWith("<") && normalized.endsWith(">")) return true;
+  if (normalized.includes("${")) return true;
+  // Real secret material is long. Short values are config, flags, or stubs.
+  if (normalized.length < 12) return true;
+  if (containsPlaceholderWord(normalized)) return true;
+  // Repeated single character, e.g. "aaaaaaaaaaaa" or "000000000000".
+  if (/^(.)\1+$/.test(normalized)) return true;
+  return false;
+}
+
+function getTrackedFiles() {
+  return execFileSync("git", ["ls-files", "-z"], { cwd: repoRoot, encoding: "utf8" })
+    .split("\0")
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function shouldScanFile(filePath) {
+  if (SELF_EXCLUDED.has(filePath)) return false;
+  if (SKIPPED_BASENAMES.has(path.basename(filePath))) return false;
+  if (SKIPPED_PATH_SEGMENTS.some((segment) => filePath.includes(segment))) return false;
+  if (BINARY_EXTENSIONS.has(path.extname(filePath).toLowerCase())) return false;
+  if (TEST_FILE_RE.test(filePath)) return false;
+  return true;
+}
+
+function lineNumberAt(content, index) {
+  return content.slice(0, index).split(/\r?\n/).length;
+}
+
+/**
+ * Scan one tracked file for provider tokens and Nora secret assignments.
+ *
+ * @param {string} filePath - Repo-relative path to scan.
+ * @returns {Array<Object>} Findings with path, line, and detector label.
+ */
+export function scanContent(filePath, content) {
+  const findings = [];
+
+  for (const { name, re } of PROVIDER_PATTERNS) {
+    for (const match of content.matchAll(re)) {
+      if (containsPlaceholderWord(match[0])) continue;
+      findings.push({ filePath, line: lineNumberAt(content, match.index), detector: name });
+    }
+  }
+
+  for (const match of content.matchAll(ASSIGNMENT_RE)) {
+    const [, key, value] = match;
+    const normalized = value.trim().replace(/^["']|["']$/g, "");
+    if (KNOWN_SAFE_VALUES.has(normalized)) continue;
+    if (isPlaceholderValue(value)) continue;
+    if (!looksLikeCredentialMaterial(normalized)) continue;
+    findings.push({
+      filePath,
+      line: lineNumberAt(content, match.index),
+      detector: `${key} assigned a literal value`,
+    });
+  }
+
+  return findings;
+}
+
+function main() {
+  const findings = getTrackedFiles()
+    .filter(shouldScanFile)
+    .flatMap((filePath) => {
+      let content = "";
+      try {
+        content = fs.readFileSync(path.join(repoRoot, filePath), "utf8");
+      } catch {
+        return [];
+      }
+      if (content.includes("\0")) return [];
+      return scanContent(filePath, content);
+    });
+
+  if (findings.length > 0) {
+    console.error("Secret scan failed — remove the credential and rotate it.");
+    for (const finding of findings) {
+      console.error(`- ${finding.filePath}:${finding.line} — ${finding.detector}`);
+    }
+    process.exit(1);
+  }
+
+  console.log("Secret scan passed.");
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}

--- a/.github/workflows/scripts/scan-secrets.test.mjs
+++ b/.github/workflows/scripts/scan-secrets.test.mjs
@@ -1,0 +1,114 @@
+// A secret scanner that never fires is indistinguishable from no scanner at
+// all, so these tests pin both directions: real credential shapes must be
+// caught, and the source-code constructs that made the first draft unusable
+// must stay quiet.
+//
+// Provider tokens below are assembled from fragments at runtime rather than
+// written as literals. Written whole they trip GitHub push protection, which
+// blocked the first push of this very file — a fair demonstration that the
+// first line of defence works. Splitting them keeps the fixtures invisible to
+// every literal-matching scanner while still exercising the patterns here.
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { scanContent } from "./scan-secrets.mjs";
+
+const join = (...parts) => parts.join("");
+
+function detectors(content, filePath = "example.txt") {
+  return scanContent(filePath, content).map((finding) => finding.detector);
+}
+
+function assertDetected(content, label) {
+  assert.ok(detectors(content).length > 0, `expected a finding for ${label}`);
+}
+
+function assertClean(content, label) {
+  const found = detectors(content);
+  assert.deepEqual(found, [], `expected no finding for ${label}, got ${found.join(", ")}`);
+}
+
+test("detects well-known provider credentials", () => {
+  const cases = [
+    ["AWS access key", `const id = "${join("AKI", "A4KHJ2LMNP7QRST9V")}";`],
+    ["GitHub PAT", `token: "${join("ghp", "_a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8")}"`],
+    ["Slack bot token", `slack = "${join("xox", "b-4827193056-a91ktvbz73qmxwe5rndl")}"`],
+    ["Stripe live key", `stripe: "${join("sk", "_live_51KpQ8vBz3nWxYtRc7mLd2fHa")}"`],
+    ["OpenAI key", `openai = "${join("sk-pro", "j-9vBnQ2wErTyUiOpAsDfGhJkLzXcVbNm4")}"`],
+    ["Anthropic key", `anthropic = "${join("sk-an", "t-api03-7zQmWvNbXcRtYuIoPaSdFgHjKl")}"`],
+    ["Google API key", `g = "${join("AIz", "aSyD3nQ7vBmXpL2wRtYuIoKjHgFdSaZxCvB1")}"`],
+    ["NVIDIA key", `nv = "${join("nvap", "i-8xKmQwErTyUiOpAsDfGhJkLzXcVbNm2Qp7Rt")}"`],
+    ["Nora workspace key", `k = "${join("nor", "a_9fQm2WvNbXcRtYuIoPaSdFgHjKlZx7Cv")}"`],
+    [
+      "Slack webhook",
+      join("https://hooks.slack.", "com/services/T02KQ7VBM/B04NXQ8LP/9vBnQ2wErTyUiOpAsDfG"),
+    ],
+  ];
+  for (const [label, content] of cases) assertDetected(content, label);
+});
+
+test("detects a private key block with real body material", () => {
+  const body = join(
+    "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABlwAAAAdzc2gtcn",
+  ).repeat(3);
+  assertDetected(`${join("-----BEGIN OPENSSH ", "PRIVATE KEY-----")}\n${body}\n`, "private key");
+});
+
+test("detects Nora secret material assigned literally", () => {
+  const cases = [
+    ["JWT_SECRET", "JWT_SECRET=7f3a9c2e5b8d1f4a6c0e3b7d9f2a5c8e1b4d7f0a3c6e9b2d5f8a1c4e7b0d3f6a"],
+    [
+      "ENCRYPTION_KEY",
+      "ENCRYPTION_KEY=a4d7f0c3e6b9d2f5a8c1e4b7d0f3a6c9e2b5d8f1a4c7e0b3d6f9a2c5e8b1d4f7",
+    ],
+    ["DB_PASSWORD", 'DB_PASSWORD: "Xq7Rt2Wv9NbMc4Zp8Kd3"'],
+    ["backup encryption key", "NORA_BACKUP_ENCRYPTION_KEY=3c6e9b2d5f8a1c4e7b0d3f6a9c2e5b8d"],
+  ];
+  for (const [label, content] of cases) assertDetected(content, label);
+});
+
+test("ignores source code that merely references secret names", () => {
+  const cases = [
+    ["random assignment", 'process.env.JWT_SECRET = crypto.randomBytes(32).toString("hex");'],
+    [
+      "regex validation",
+      "const ENCRYPTION_KEY = /^[0-9a-fA-F]{64}$/.test(RAW_KEY) ? RAW_KEY : null;",
+    ],
+    ["powershell helper", '$JWT_SECRET = Read-EnvValue -EnvPath $ENV_FILE -Name "JWT_SECRET"'],
+    ["env indirection", "ENCRYPTION_KEY=${ENCRYPTION_KEY}"],
+    ["actions secret", "PROXMOX_TOKEN_SECRET: ${{ secrets.PROXMOX_TOKEN_SECRET }}"],
+    ["url value", 'NVIDIA_API_KEY: "https://integrate.api.nvidia.com/v1"'],
+  ];
+  for (const [label, content] of cases) assertClean(content, label);
+});
+
+test("does not read a value across a line break", () => {
+  // An empty assignment followed by an unrelated line is the .env.example and
+  // shell-script shape that made the first draft report 41 false positives.
+  assertClean("NORA_BACKUP_S3_SECRET_ACCESS_KEY=\nSOME_OTHER_SETTING=enabled", "empty assignment");
+  assertClean("PROXMOX_TOKEN_SECRET:\n  description: token", "yaml key with nested value");
+});
+
+test("ignores documented placeholders and fixtures", () => {
+  const cases = [
+    ["angle placeholder", "ENCRYPTION_KEY=<REPLACE_WITH_64_HEX_CHARS>"],
+    ["aws doc key", `const validKey = "${join("AKI", "AIOSFODNN7EXAMPLE")}";`],
+    ["slack doc token", `"token":"${join("xox", "b-your-slack-bot-token")}"`],
+    ["pem ui label", `{isEditing ? "" : "${join("-----BEGIN OPENSSH ", "PRIVATE KEY-----")}"}`],
+    ["short stub", "JWT_SECRET=changeme"],
+    [
+      "allowlisted test key",
+      "ENCRYPTION_KEY=0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+    ],
+  ];
+  for (const [label, content] of cases) assertClean(content, label);
+});
+
+test("reports the correct line number", () => {
+  const content =
+    "line one\nline two\nJWT_SECRET=7f3a9c2e5b8d1f4a6c0e3b7d9f2a5c8e1b4d7f0a3c6e9b2d\n";
+  const [finding] = scanContent("sample.env", content);
+  assert.equal(finding.line, 3);
+  assert.equal(finding.filePath, "sample.env");
+});

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "ci:format:write": "prettier --write",
     "ci:license-check": "node .github/workflows/scripts/license-check.mjs",
     "ci:lint": "eslint --ext .js,.jsx,.ts,.tsx,.cjs,.mjs --max-warnings=0",
-    "ci:secret-scan": "node .github/workflows/scripts/scan-sensitive-config.mjs",
+    "ci:secret-scan": "node .github/workflows/scripts/scan-sensitive-config.mjs && node .github/workflows/scripts/scan-secrets.mjs && node --test .github/workflows/scripts/scan-secrets.test.mjs",
     "ci:validate-infra": "node .github/workflows/scripts/validate-infra.mjs && node --test scripts/infra-security.test.mjs"
   },
   "devDependencies": {


### PR DESCRIPTION
## Why

The blocking **"Sensitive config scan"** gate was far narrower than its name suggests. `scan-sensitive-config.mjs` matches exactly three keys — `PROXMOX_API_URL`, `NVIDIA_API_KEY`, `ENCRYPTION_KEY` — and only inside `.env`-shaped files.

A real `JWT_SECRET`, a Stripe live key, an AWS key, or a private key committed in any `.ts`, `.yml`, or `.md` file passed that gate untouched.

GitHub secret scanning with push protection is enabled repo-wide and stays the first line of defence — but it matches well-known **provider** token shapes. It has nothing to match for Nora's own secret material (`JWT_SECRET`, `ENCRYPTION_KEY`, the API-key hash secrets, the backup encryption key), because those have no provider-specific shape. This closes that gap, over every tracked file, as a blocking PR-time gate rather than an after-the-fact alert.

## Design

Two detectors:

1. **Provider token shapes** — AWS, GitHub, Slack, Stripe, OpenAI, Anthropic, Google, NVIDIA, Nora workspace keys, Slack webhooks, and PEM private key blocks. Each requires enough trailing entropy that a prose mention of the prefix can't trip it. The PEM rule requires a real base64 body, so UI label strings like `"-----BEGIN OPENSSH PRIVATE KEY-----"` in `RemoteHostConfigForm.tsx` don't match.

2. **Nora secret keys by assignment** — fires only on values that *look like generated material*. This is what keeps it off source code: `crypto.randomBytes(32).toString("hex")`, `process.env.X` indirection, `${{ secrets.X }}`, PowerShell `Read-EnvValue` helpers, and URLs all fail the shape test.

Deliberately **excluded** from the key list: `*_KEY_FILE`, `*_KEY_PATH`, `*_DIR` (filesystem locations), the reCAPTCHA/Turnstile **site** keys (public by design), and `PROXMOX_TOKEN_ID` / `AWS_ACCESS_KEY_ID` (identifiers, not secrets).

**No generic entropy heuristics.** An unreliable secret scanner gets muted, and a muted gate is worse than none. The first draft of this reported **41 findings against a clean tree — every one false**. Tuning those out is most of the work here.

Test fixtures are skipped for both detectors: they're fake by construction, and flagging them trains people to ignore the gate. Real provider tokens in a test file are still caught by push protection.

## Verification

- `scan-secrets.test.mjs` pins **both** directions — a scanner that never fires is indistinguishable from no scanner. 10 provider shapes and 4 Nora assignments must be caught; the source-code constructs that caused the false positives must stay quiet. 7/7 pass.
- **End-to-end**: planted `JWT_SECRET=<64 hex>` in `.env.example` and a GitHub PAT in `backend-api/server.ts` → both caught, gate exits 1. Reverted, gate passes.
- `npm run ci:secret-scan` (now runs both scanners + the test suite): clean
- `eslint --max-warnings=0` and `prettier --check`: clean

Job renamed to **"Secret and sensitive config scan"** to match what it now does.

### One amusing note

The first push of this branch was **blocked by GitHub push protection** — my test fixtures looked like real Slack and Stripe tokens. Fair enough. The provider tokens in the test file are now assembled from fragments at runtime, which keeps them invisible to literal-matching scanners while still exercising the patterns.

## Suggested follow-up (repo setting, not in this PR)

`secret_scanning_non_provider_patterns` is currently **disabled**. Enabling it would have GitHub flag generic/custom secret shapes too, complementing this gate. It's a one-toggle change in repo settings — happy to flip it if you want, but I left settings alone here.