### PR TITLE
chore(deps): tell Dependabot to hold sanitize-html at 2.17.5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,20 @@ updates:
       time: "07:00"
       timezone: Etc/UTC
     open-pull-requests-limit: 10
+    # sanitize-html 2.17.6+ depends on htmlparser2 v12, which is pure ESM with no
+    # CommonJS build. backend-api's Jest suite loads sanitize-html through
+    # agent-runtime's getSanitizeHtml(), and Jest's CJS sandbox cannot parse it —
+    # so any bump past 2.17.5 red-lines the suite. 2.17.5 already carries the
+    # GHSA-vccv-cmxp-4j9h fix, so holding here costs no security coverage.
+    #
+    # The exact "2.17.5" pin in package.json stops npm from drifting, but it does
+    # NOT stop Dependabot: a version update rewrites the manifest itself, and
+    # 2.17.5 -> 2.17.7 is a legitimate patch bump. This is the only place the
+    # constraint can be expressed. Lift both together once Jest can transform ESM
+    # dependencies, or once sanitize-html ships a CommonJS build again.
+    ignore:
+      - dependency-name: sanitize-html
+        versions: [">=2.17.6"]
     # Minor and patch updates land as one grouped PR per directory; majors stay
     # individual so a breaking bump is reviewed on its own.
     groups:


### PR DESCRIPTION
## Why

#351 (the `npm-minor-patch` group) bumped `sanitize-html` 2.17.5 → 2.17.7 and red-lined the backend-api suite with the same failure #347 just fixed:

```
SyntaxError: Cannot use import statement outside a module
  node_modules/htmlparser2/dist/index.js:1
```

2.17.6+ depends on `htmlparser2` v12 — pure ESM, no CommonJS build. backend-api's Jest suite reaches `sanitize-html` through agent-runtime's `getSanitizeHtml()`, and Jest's CJS sandbox can't parse it.

## The part worth noting

**The exact `"2.17.5"` pin from #347 was not enough.** It stops npm drifting on install, but it does not stop Dependabot: a version update *rewrites the manifest itself*, and 2.17.5 → 2.17.7 is a legitimate patch bump by semver.

`dependabot.yml` is the only place that constraint can be expressed. The pin and this ignore rule are both required — neither is sufficient alone, and that's now written down where the next person will look.

## No security cost

2.17.5 already carries the GHSA-vccv-cmxp-4j9h fix. Holding here loses no coverage.

Lift the pin and this rule **together** once Jest can transform ESM dependencies, or once sanitize-html ships a CommonJS build again.

## Next

Once this lands I'll `@dependabot recreate` #351 so the group PR regenerates without the sanitize-html bump.