### PR TITLE
chore(deps): hold TypeScript at 6 and ioredis at 5 until their blockers clear

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -46,6 +46,28 @@ updates:
     ignore:
       - dependency-name: sanitize-html
         versions: [">=2.17.6"]
+      # TypeScript 7 is blocked on two independent toolchain gaps, in different
+      # packages, so it cannot land anywhere useful yet:
+      #   - ts-jest caps its typescript peer at ">=4.3 <7" in every published
+      #     version including the latest (29.4.12), so `npm ci` in backend-api
+      #     fails ERESOLVE outright.
+      #   - Next.js 16 crashes during `next build` under TS 7 ("The id argument
+      #     must be of type string"), taking out all three dashboards.
+      # The five remaining packages would compile, but all nine share
+      # tsconfig.base.json — running two compiler majors against one shared
+      # config invites divergence for no benefit. Hold the whole monorepo on 6
+      # and lift this once ts-jest and Next.js both support 7.
+      - dependency-name: typescript
+        versions: [">=7"]
+      # ioredis 6 has to follow a bullmq major, not precede it. bullmq@5.76.4
+      # pins ioredis to an exact 5.10.1, so bumping our direct dependency does
+      # not upgrade anything — it installs a SECOND copy
+      # (bullmq/node_modules/ioredis@5.10.1 alongside ioredis@6.0.0), leaving
+      # two Redis client implementations in one process while BullMQ, far and
+      # away the heaviest Redis user here, stays on v5. Revisit together with
+      # bullmq 6.x.
+      - dependency-name: ioredis
+        versions: [">=6"]
     # Minor and patch updates land as one grouped PR per directory; majors stay
     # individual so a breaking bump is reviewed on its own.
     groups:


### PR DESCRIPTION
Dependabot's first run opened **27 PRs**. Twelve can't land. This records why, so it isn't rediscovered next week.

## TypeScript 7 — 9 PRs blocked

Two *independent* toolchain gaps, in different packages:

- **`ts-jest` caps its typescript peer at `">=4.3 <7"`** — in every published version, including the latest 29.4.12. So `npm ci` in backend-api fails ERESOLVE before anything compiles. That single conflict is what produced all **10** failing checks on #362.
- **Next.js 16 crashes during `next build`** under TS 7 (`The "id" argument must be of type string`), taking out all three dashboards.

Worth noting: **`tsc --noEmit` passes clean under TS 7.** Our types are fine — this is entirely about the surrounding toolchain.

The other five packages would compile, but all nine extend the same `tsconfig.base.json`. Running two compiler majors against one shared config invites divergence for no benefit, so the hold is monorepo-wide.

Blocked: #355 #359 #362 #363 #365 #368 #369 #372 #374

## ioredis 6 — 3 PRs blocked

`bullmq@5.76.4` pins ioredis to an **exact 5.10.1**, so bumping our direct dependency upgrades nothing. Verified locally — the resulting tree carries both:

```
node_modules/bullmq/node_modules/ioredis = 5.10.1
node_modules/ioredis                     = 6.0.0
```

Two Redis client implementations in one process, with BullMQ — far and away the heaviest Redis user here — still on v5. `bullmq` 6.2.0 exists and is the real upgrade; these bumps belong inside that change.

Blocked: #360 #373 #375

## Why ignore rules rather than just closing

Closing a Dependabot PR doesn't hold the line — it would simply propose the next patch version. The ignore rules are what make the decision stick, and they carry the reasoning inline for whoever lifts them.

## Lifting these

- **typescript**: once ts-jest and Next.js both support 7
- **ioredis**: together with the bullmq 6.x upgrade
- **sanitize-html** (already held): once Jest can transform ESM deps, or it ships CJS again