### PR TITLE
ci(e2e): derive the Playwright runner image from the installed package

### DIFF
--- a/.github/workflows/ci-compose.yml
+++ b/.github/workflows/ci-compose.yml
@@ -238,8 +238,20 @@ jobs:
           cache-dependency-path: e2e/package-lock.json
       - run: npm ci
         working-directory: e2e
+      # The runner image ships browsers built for one exact Playwright version,
+      # so a hardcoded tag silently drifts the moment @playwright/test is bumped
+      # and every spec dies with "Executable doesn't exist at /ms-playwright/...".
+      # Deriving the tag from the installed package keeps them in lockstep.
+      - name: Resolve Playwright runner image
+        id: playwright-image
+        working-directory: e2e
+        run: |
+          set -euo pipefail
+          version="$(node -p "require('@playwright/test/package.json').version")"
+          echo "image=mcr.microsoft.com/playwright:v${version}-noble" >> "$GITHUB_OUTPUT"
+          echo "Using Playwright runner image for @playwright/test ${version}"
       - name: Pull Playwright runner image
-        run: docker pull mcr.microsoft.com/playwright:v1.59.1-noble
+        run: docker pull "${{ steps.playwright-image.outputs.image }}"
       - name: Start compose stack
         run: docker compose -f docker-compose.e2e.yml up -d --build
       - name: Wait for Nora stack
@@ -261,7 +273,7 @@ jobs:
             -e CI \
             -v "${{ github.workspace }}:/work" \
             -w /work/e2e \
-            mcr.microsoft.com/playwright:v1.59.1-noble \
+            "${{ steps.playwright-image.outputs.image }}" \
             npx playwright test
       - name: Capture compose diagnostics
         if: failure()


### PR DESCRIPTION
## The bug

The E2E job pulled `mcr.microsoft.com/playwright:v1.59.1-noble` from a **hardcoded tag in two places**, while `@playwright/test` came from `e2e/package.json`. Those drift apart the moment the package is bumped — and the runner image ships browsers built for one exact Playwright version, so the entire suite dies at launch:

```
browserType.launch: Executable doesn't exist at
  /ms-playwright/chromium_headless_shell-.../chrome-headless-shell
```

That's the single failing check on #391, which moves `@playwright/test` 1.59.1 → 1.62.1. It **looks** like a broken dependency bump, but it's a pinned image nobody remembered to move alongside it. Every future Playwright bump would have failed identically.

## The fix

The tag is now resolved from the installed package immediately after `npm ci`:

```yaml
- name: Resolve Playwright runner image
  id: playwright-image
  working-directory: e2e
  run: |
    version="$(node -p "require('@playwright/test/package.json').version")"
    echo "image=mcr.microsoft.com/playwright:v${version}-noble" >> "$GITHUB_OUTPUT"
```

Both the pull and the `docker run` use that output, so the image always matches the version the specs actually run against, and the two can't diverge again.

## Verification

Resolution tested locally against the real `e2e/node_modules`, and both tags confirmed to exist upstream via `docker manifest inspect`:

- `v1.59.1-noble` (current master) — exists
- `v1.62.1-noble` (what #391 needs) — exists

This PR's own E2E run exercises the resolution on the current version; #391 exercises it on the bumped one once rebased.