### PR TITLE
fix(admin): make form fields announce their label, not label plus hint

### DIFF
--- a/admin-dashboard/components/remote-hosts/RemoteHostConfigForm.tsx
+++ b/admin-dashboard/components/remote-hosts/RemoteHostConfigForm.tsx
@@ -31,14 +31,28 @@ function Field({
   children: ReactNode;
   wide?: boolean;
 }) {
+  // The <label> deliberately wraps ONLY the label text. It used to wrap the hint
+  // and the control too, which made the control's accessible name the whole
+  // subtree — "SSH private key Secrets are encrypted at rest. Leave blank to
+  // preserve the encrypted value. A key is stored." rather than "SSH private
+  // key". That is a real a11y defect (a screen reader announces the entire hint
+  // as the field's name) and it made every getByLabel() lookup depend on hint
+  // wording. Keeping the name equal to the label is both correct and stable.
   return (
-    <label htmlFor={id} className={wide ? "md:col-span-2" : ""}>
-      <span className="block text-[11px] font-black uppercase tracking-[0.16em] text-slate-500">
+    <div className={wide ? "md:col-span-2" : ""}>
+      <label
+        htmlFor={id}
+        className="block text-[11px] font-black uppercase tracking-[0.16em] text-slate-500"
+      >
         {label}
-      </span>
-      {hint ? <span className="mt-1 block text-xs font-medium text-slate-500">{hint}</span> : null}
+      </label>
+      {hint ? (
+        <span id={`${id}-hint`} className="mt-1 block text-xs font-medium text-slate-500">
+          {hint}
+        </span>
+      ) : null}
       <span className="mt-2 block">{children}</span>
-    </label>
+    </div>
   );
 }
 


### PR DESCRIPTION
Fixes master, which went red on `admin-remote-hosts.spec.ts` after #391 merged:

```
getByLabel(/^SSH private key/i) -> element(s) not found
```

## Bisect

I isolated it rather than guessing. #394 pinned **only** `@playwright/test` back to 1.59.1, leaving next/react/lucide-react at the merged versions — and the suite went green. So it's the Playwright 1.59.1 → 1.62.1 bump in that group, not the UI bumps.

## But the defect is ours

The bump only *exposed* it. `Field`'s `<label>` wrapped the label text, the hint, **and** the control — so the control's accessible name was the entire subtree:

> "SSH private key Secrets are encrypted at rest. Leave blank to preserve the encrypted value. A key is stored."

instead of `"SSH private key"`.

That's a genuine accessibility bug — a screen reader announces the whole hint as the field's *name* — and it made every `getByLabel()` lookup in these forms depend on hint wording. Which is why a Playwright upgrade could break it at all.

## The fix

The `<label>` now wraps only the label text and associates the control via `htmlFor`, so the accessible name is exactly the label.

Verified against a faithful repro of the rendered markup under **both** versions:

```
- textbox "SSH private key"
getByLabel(/^SSH private key/i)              -> 1
getByLabel('SSH private key', {exact:true})  -> 1
```

(Before the fix, the same probe showed `textbox "SSH private key Secrets are encrypted at rest. …"`.)

## Scope

Deliberately limited to this component. The other three `Field` implementations in admin-dashboard take no `hint`, so their accessible name is already just the label — nothing to fix.

**This keeps the Playwright 1.62.1 bump** rather than pinning away from it. #394 was the bisect experiment and gets closed once this is green.