### PR TITLE
test(e2e): fix the tab-switch race that reddened master

### DIFF
--- a/e2e/specs/admin-remote-hosts.spec.ts
+++ b/e2e/specs/admin-remote-hosts.spec.ts
@@ -382,8 +382,15 @@ test("self-hosted platform admin manages Remote Hosts without exposing stored se
       gatewayHost: "gateway.internal",
     });
 
+  // count() does not auto-wait. Guarding the click on it meant that if the tab
+  // bar had not rendered yet — the previous step awaits an API response, not the
+  // UI — the click was silently skipped and the assertions below ran against the
+  // Overview tab, where "SSH private key" exists only as a paragraph and no form
+  // field is present. That produced a confusing "element(s) not found" pointing
+  // at the field rather than at the missed tab switch. The tab is rendered
+  // unconditionally, so click() and let it auto-wait.
   const configTab = page.getByRole("button", { name: /host configuration|configuration/i });
-  if ((await configTab.count()) > 0) await configTab.first().click();
+  await configTab.first().click();
   await expect(page.getByLabel(/^SSH private key/i)).toHaveValue("");
   await expect(page.getByLabel(/^Key passphrase/i)).toHaveValue("");
   await expect(


### PR DESCRIPTION
`admin-remote-hosts.spec.ts` has been failing on master since #391 with `getByLabel(/^SSH private key/i) -> element(s) not found`.

## What was actually happening

I pulled the failure artifact instead of continuing to infer. The aria snapshot shows the page sitting on the **Overview** tab, where "SSH private key" appears only as a `paragraph` and no form field exists:

```yaml
- button "Overview"
- button "Configuration"
- button "Platform access"
- paragraph: SSH target
- paragraph: SSH private key      # <- a paragraph, not a field
```

The field was never missing. **The tab switch never happened.**

```js
const configTab = page.getByRole("button", { name: /...configuration/i });
if ((await configTab.count()) > 0) await configTab.first().click();
```

`count()` does not auto-wait. The preceding step awaits an API response, not the UI — so when the tab bar hadn't rendered yet, `count()` returned 0, the click was **silently skipped**, and every assertion below ran against the wrong tab. The error then pointed at the field rather than at the missed click, which is exactly what made this look like an accessible-name problem.

## The fix

The Configuration tab is rendered unconditionally, so the guard protected nothing. `click()` auto-waits, which is all this needed. It was also the **only** `count()`-guarded click in the entire e2e suite — an outlier, not a pattern.

## Why it surfaced now

The next/react bumps in #391 shifted render timing enough to lose a race that had been quietly winning. Nothing in that group was wrong.

## Correction on #395

#395 is a genuine accessibility fix — `Field`'s `<label>` wrapped the hint and the control, so a screen reader announced the whole hint as the field's *name*. That's worth keeping. But it was **not** the cause of this failure, and I shouldn't have concluded it was on the strength of a single green PR run. This is the actual fix.