### PR TITLE
fix(deps): make the postcss override follow the direct dependency

### DIFF
--- a/admin-dashboard/package.json
+++ b/admin-dashboard/package.json
@@ -23,7 +23,7 @@
     "tailwindcss": "^4.2.2"
   },
   "overrides": {
-    "postcss": "^8.5.23",
+    "postcss": "$postcss",
     "sharp": "^0.35.3"
   },
   "devDependencies": {

--- a/frontend-dashboard/package.json
+++ b/frontend-dashboard/package.json
@@ -30,7 +30,7 @@
     "tailwindcss": "^4.2.2"
   },
   "overrides": {
-    "postcss": "^8.5.23",
+    "postcss": "$postcss",
     "sharp": "^0.35.3"
   },
   "devDependencies": {

--- a/frontend-marketing/package.json
+++ b/frontend-marketing/package.json
@@ -25,7 +25,7 @@
     "tailwindcss": "^4.2.2"
   },
   "overrides": {
-    "postcss": "^8.5.23",
+    "postcss": "$postcss",
     "sharp": "$sharp"
   },
   "devDependencies": {


### PR DESCRIPTION
Every Dependabot run has been ending in failure. The updater log gives the reason — nine times over:

```
| postcss | dependency_file_not_resolvable |
|   "message": "Override for postcss@8.5.26 conflicts with direct dependency." |
```

## Cause

All three frontends declare `postcss` **twice** — once as a direct dependency and again in `overrides`, both pinned to the literal `"^8.5.23"`:

```json
"dependencies": { "postcss": "^8.5.23" },
"overrides":    { "postcss": "^8.5.23" }
```

npm rejects that the moment the two can disagree. So any attempt to move postcss off 8.5.23 fails to resolve — and takes the whole updater run down with it.

## Fix

npm's answer is the `"$name"` self-reference, which makes the override track whatever the direct dependency resolves to. **The repo already uses this pattern** — `frontend-marketing` overrides sharp as `"$sharp"` for exactly this reason.

`sharp` needs no change: it's a direct dependency only in frontend-marketing (which already self-references). In the other two it's purely transitive, so a literal range there is correct.

## Verification

Reproduced the failing case directly:

| | before | after |
|---|---|---|
| `npm install --package-lock-only postcss@8.5.26` | could not resolve | succeeds, lock resolves **8.5.26** |

On master the change is inert — postcss still resolves to 8.5.23 in all three lockfiles, **no lockfile churn** (3 one-line changes total), and all three typechecks pass.

## Bonus confirmation

The same updater job definition confirms the ignore rules from #377 / #378 / #392 are live:

```json
"ignore-conditions":[
  {"dependency-name":"@kubernetes/client-node","version-requirement":">=2"},
  {"dependency-name":"sanitize-html","version-requirement":">=2.17.6"},
  {"dependency-name":"typescript","version-requirement":">=7"}
]
```