### PR TITLE
fix(migrations): stop the draft preview erasing its own id

### DIFF
--- a/backend-api/__tests__/agentMigrationsBackend.test.ts
+++ b/backend-api/__tests__/agentMigrationsBackend.test.ts
@@ -23,6 +23,8 @@ jest.mock("dockerode", () =>
 
 const {
   __test,
+  buildDraftPreview,
+  createMigrationDraft,
   buildHermesSeedArchive,
   buildLiveMigrationManifest,
   buildMigrationManifestFromAgent,
@@ -492,4 +494,53 @@ it("safely stops a direct Docker Hermes source when exec termination is unconfir
   expect(captureError).toMatchObject({ code: "DOCKER_EXEC_COMPLETION_UNCONFIRMED" });
   expect(captureError).not.toHaveProperty("cleanupError");
   expect(stop).toHaveBeenCalledWith({ t: 10 });
+});
+
+// #339: every draft response came back with id: null even though Postgres held
+// a real UUID. The preview set id: row.id and then spread buildDraftPreview(),
+// which re-set id from a manifest field nothing ever populates — so the spread
+// silently erased the only handle callers had on the draft. The dashboard gates
+// migrate-deploy on migrationDraft?.id, so restored drafts were undeployable.
+describe("migration draft identity (#339)", () => {
+  it("returns the persisted row id rather than null", async () => {
+    mockDb.query.mockReset().mockResolvedValue({
+      rows: [
+        {
+          id: "11111111-2222-3333-4444-555555555555",
+          created_at: "2026-08-24T00:00:00.000Z",
+          expires_at: "2026-08-25T00:00:00.000Z",
+          status: "ready",
+        },
+      ],
+    });
+
+    const draft = await createMigrationDraft({
+      userId: "user-1",
+      manifest: { name: "Imported Agent", runtimeFamily: "openclaw" },
+    });
+
+    expect(draft.preview.id).toBe("11111111-2222-3333-4444-555555555555");
+    expect(draft.preview.createdAt).toBe("2026-08-24T00:00:00.000Z");
+    expect(draft.preview.expiresAt).toBe("2026-08-25T00:00:00.000Z");
+  });
+
+  it("keeps the row id even when the manifest carries a conflicting one", async () => {
+    mockDb.query.mockReset().mockResolvedValue({
+      rows: [{ id: "row-id-wins", created_at: null, expires_at: null }],
+    });
+
+    const draft = await createMigrationDraft({
+      userId: "user-1",
+      manifest: { id: "manifest-id-loses", name: "Imported Agent" },
+    });
+
+    expect(draft.preview.id).toBe("row-id-wins");
+  });
+
+  it("does not let the preview builder contribute an id at all", () => {
+    // The builder owning an `id` key is what made the spread destructive.
+    expect(buildDraftPreview({ id: "from-manifest", name: "Imported Agent" })).not.toHaveProperty(
+      "id",
+    );
+  });
 });

--- a/backend-api/agentMigrations.ts
+++ b/backend-api/agentMigrations.ts
@@ -198,7 +198,9 @@ function buildDraftPreview(manifest = {}) {
     : [];
 
   return {
-    id: manifest.id || null,
+    // Deliberately no `id` here. A draft's identity is the persisted row id,
+    // and nothing ever sets manifest.id — it was always null, so spreading this
+    // over a caller's real id silently erased it (#339).
     name: manifest.name || "Imported Agent",
     runtimeFamily:
       String(manifest.runtimeFamily || "")
@@ -1388,10 +1390,12 @@ async function createMigrationDraft({
     ...row,
     manifest: normalizedManifest,
     preview: {
+      // Spread first, then the row-derived fields, so the persisted identity
+      // always wins no matter what the preview builder grows later.
+      ...buildDraftPreview(normalizedManifest),
       id: row.id,
       createdAt: row.created_at,
       expiresAt: row.expires_at,
-      ...buildDraftPreview(normalizedManifest),
     },
   };
 }
@@ -1468,10 +1472,10 @@ async function getOwnedMigrationDraft(draftId, userId) {
     ...row,
     manifest,
     preview: {
+      ...buildDraftPreview(manifest),
       id: row.id,
       createdAt: row.created_at,
       expiresAt: row.expires_at,
-      ...buildDraftPreview(manifest),
     },
   };
 }


### PR DESCRIPTION
Closes #339.

Every migration/restore draft came back as `id: null` even though Postgres held a real UUID with `status: 'ready'`.

That id is the **only** handle on a draft — the draft routes return just `draft.preview` and there's no list endpoint. So a persisted draft was undeployable through the API, and the dashboard's migrate-deploy stays permanently disabled because it gates on `migrationDraft?.id`. Recovering a draft meant reading its id straight out of Postgres.

## Cause

Both draft paths built the preview as:

```js
preview: {
  id: row.id,                              // real UUID
  ...buildDraftPreview(manifest),          // re-sets id: manifest.id || null
}
```

Spread order meant the `null` landed last and overwrote the real id.

## Fixed at both levels, not just reordered

**The builder no longer contributes an `id`.** Nothing populates `manifest.id` — line 201 was its only reference anywhere in the file — so the field was always `null` and existed purely to clobber real ones. A draft's identity is the persisted row id.

**Both call sites spread first and set row-derived fields last**, so `row.id`, `created_at` and `expires_at` win regardless of what the builder grows later. Reordering alone would have left the same trap armed for the next field someone adds.

## Tests

Three regression tests: the row id survives; it still wins if a manifest ever *does* carry a conflicting id; and the builder exposes no `id` key at all. All three **fail against the pre-fix module** (`3 failed, 37 passed`) and pass after.

Worth noting the existing route tests couldn't have caught this — they mock `createMigrationDraft` wholesale, so the real preview construction was never exercised.

backend-api 2337 pass.