### PR TITLE
feat(backups): make backups restorable after their agent is deleted

### DIFF
--- a/backend-api/__tests__/accountBackups.test.ts
+++ b/backend-api/__tests__/accountBackups.test.ts
@@ -1,0 +1,81 @@
+// @ts-nocheck
+process.env.ENCRYPTION_KEY = "1".repeat(64);
+
+const mockDb = { query: jest.fn() };
+jest.mock("../db", () => mockDb);
+jest.mock("../billing", () => ({
+  IS_PAAS: false,
+  BILLING_ENABLED: false,
+  getSubscription: jest.fn(async () => ({ status: "active", managed_backups_enabled: true })),
+  getBackupUsage: jest.fn(async () => ({ count: 0, bytes: 0 })),
+}));
+
+const { deleteBackup, listUserBackups } = require("../backups");
+
+beforeEach(() => {
+  mockDb.query.mockReset();
+});
+
+// #338: managed backups could be created but not restored once their source
+// agent was deleted — the exact disaster-recovery case they exist for. Every
+// route was mounted under /agents and resolved the agent first, so the archive
+// and its row both survived while nothing routed to them.
+describe("account-scoped backup access (#338)", () => {
+  describe("listUserBackups", () => {
+    it("lists backups whose source agent has been deleted", async () => {
+      mockDb.query.mockResolvedValue({
+        rows: [
+          { id: "b-orphan", kind: "agent", status: "ready", agent_name: null, agent_exists: false },
+          { id: "b-live", kind: "agent", status: "ready", agent_name: "Live", agent_exists: true },
+        ],
+      });
+
+      const result = await listUserBackups("user-1");
+      const byId = Object.fromEntries(result.backups.map((b) => [b.id, b]));
+
+      expect(byId["b-orphan"]).toBeDefined();
+      expect(byId["b-orphan"].agent_exists).toBe(false);
+      expect(byId["b-live"].agent_exists).toBe(true);
+      expect(byId["b-live"].agent_name).toBe("Live");
+    });
+
+    it("scopes the query to the owner and never to an agent", async () => {
+      mockDb.query.mockResolvedValue({ rows: [] });
+      await listUserBackups("user-1");
+
+      const [sql, params] = mockDb.query.mock.calls[0];
+      expect(sql).toContain("b.user_id = $1");
+      // An inner join, or any agent_id predicate, would re-hide orphaned rows.
+      expect(sql).toContain("LEFT JOIN agents");
+      expect(sql).not.toMatch(/\bAND b\.agent_id\s*=/);
+      expect(params).toEqual(["user-1"]);
+    });
+  });
+
+  describe("backup lookup by id", () => {
+    // Exercised through deleteBackup's not-found path so the assertion stays on
+    // the lookup itself and never reaches storage.
+    async function captureLookupSql(args) {
+      mockDb.query.mockResolvedValue({ rows: [] });
+      await expect(deleteBackup(args)).rejects.toThrow("Backup not found");
+      return mockDb.query.mock.calls[0][0];
+    }
+
+    it("omits the agent constraint when no agent is supplied", async () => {
+      const sql = await captureLookupSql({ backupId: "b-1", userId: "user-1" });
+      expect(sql).toContain("user_id = $2");
+      // The agent_id predicate is what made a deleted agent hide its own backup.
+      expect(sql).not.toContain("agent_id");
+    });
+
+    it("still applies the agent constraint on the agent-scoped path", async () => {
+      const sql = await captureLookupSql({ backupId: "b-1", userId: "user-1", agentId: "a-1" });
+      expect(sql).toContain("agent_id = $3");
+    });
+
+    it("always scopes to the owner so a backup id alone is not enough", async () => {
+      const sql = await captureLookupSql({ backupId: "b-1", userId: "user-1" });
+      expect(sql).toContain("user_id");
+    });
+  });
+});

--- a/backend-api/__tests__/openapi.test.ts
+++ b/backend-api/__tests__/openapi.test.ts
@@ -65,6 +65,11 @@ const COMPLETE_ROUTERS = [
   { name: "integrations", router: () => require("../routes/integrations"), mount: "" },
   { name: "channels", router: () => require("../routes/channels"), mount: "/agents" },
   { name: "backups", router: () => require("../routes/backups"), mount: "/agents" },
+  {
+    name: "accountBackups",
+    router: () => require("../routes/accountBackups"),
+    mount: "/backups",
+  },
   { name: "agentHub", router: () => require("../routes/agentHub"), mount: "/agent-hub" },
   {
     name: "agentHubPublic",

--- a/backend-api/backups.ts
+++ b/backend-api/backups.ts
@@ -816,6 +816,46 @@ async function listAgentBackups(userId, agentId) {
   };
 }
 
+/**
+ * List every agent backup a user owns, including backups whose source agent has
+ * been deleted.
+ *
+ * listAgentBackups() resolves the agent first and 404s when it is gone, which
+ * made backups unreachable in exactly the disaster-recovery case the feature
+ * exists for (#338). This resolves by owner instead, and LEFT JOINs agents so
+ * callers can tell an orphaned backup from a live one rather than guessing.
+ *
+ * @param {string} userId - Backup owner.
+ * @returns {Promise<Object>} Owned agent backups, entitlement, and usage.
+ */
+async function listUserBackups(userId) {
+  const [rows, subscription, usage] = await Promise.all([
+    db.query(
+      `SELECT b.*, a.name AS agent_name, (a.id IS NOT NULL) AS agent_exists
+         FROM backups b
+         LEFT JOIN agents a ON a.id = b.agent_id AND a.user_id = b.user_id
+        WHERE b.user_id = $1
+          AND b.kind = 'agent'
+          AND b.status <> 'deleted'
+        ORDER BY b.created_at DESC`,
+      [userId],
+    ),
+    billing.getSubscription(userId),
+    billing.getBackupUsage(userId, {}),
+  ]);
+  return {
+    backups: rows.rows.map((row) => ({
+      ...serializeBackup(row),
+      agent_name: row.agent_name || null,
+      // Restoring an orphaned backup provisions a fresh agent; the UI needs to
+      // say so rather than implying it restores into something still running.
+      agent_exists: row.agent_exists === true,
+    })),
+    entitlement: subscription,
+    usage,
+  };
+}
+
 async function listAdminBackups() {
   const result = await db.query(
     `SELECT b.*, u.email AS owner_email, a.name AS agent_name
@@ -2243,6 +2283,7 @@ module.exports = {
   getBackupDownload,
   listAdminBackups,
   listAgentBackups,
+  listUserBackups,
   processDueSchedules,
   pruneExpiredBackups,
   runBackupJob,

--- a/backend-api/openapi/paths/backups.js
+++ b/backend-api/openapi/paths/backups.js
@@ -5,6 +5,15 @@
 const { agentParam, jsonBody, jsonResponse, pathParameter, successSchema } = require("../common");
 
 const backupParam = pathParameter("backupId", "Backup UUID.", "uuid");
+// Account-scoped operations resolve a backup by id and owner, so they carry no
+// agent parameter and no agent-role requirement — the source agent may be gone.
+const accountOperation = (summary, parameters = [backupParam]) => ({
+  tags: ["Backups"],
+  summary,
+  parameters,
+  "x-session-required": true,
+  responses: jsonResponse("Success"),
+});
 const sessionOperation = (summary, parameters = [agentParam]) => ({
   tags: ["Backups"],
   summary,
@@ -109,6 +118,58 @@ module.exports = {
       ]),
       description:
         "Operator routes only support copy restore. In-place restore is restricted to platform-admin backup routes.",
+      requestBody: jsonBody(
+        {
+          type: "object",
+          properties: { mode: { type: "string", enum: ["copy"], default: "copy" } },
+          additionalProperties: false,
+        },
+        false,
+      ),
+      responses: jsonResponse("Migration/deployment draft populated from the backup"),
+    },
+  },
+  // Account-scoped backup access. The agent-scoped routes above resolve the
+  // agent first and 404 once it is deleted, which made backups unreachable in
+  // exactly the disaster-recovery case they exist for (#338).
+  "/backups": {
+    get: {
+      ...accountOperation("List every managed backup the caller owns", []),
+      description:
+        "Includes backups whose source agent has been deleted; each entry reports agent_exists so callers can distinguish an orphaned backup from a live one.",
+      responses: jsonResponse("Owned agent backups, entitlement, and usage", {
+        type: "object",
+        required: ["backups", "entitlement", "usage"],
+        properties: {
+          backups: { type: "array", items: { $ref: "#/components/schemas/Backup" } },
+          entitlement: { type: "object", additionalProperties: true },
+          usage: { type: "object", additionalProperties: true },
+        },
+      }),
+    },
+  },
+  "/backups/{backupId}/download": {
+    get: {
+      ...accountOperation("Download a backup archive by backup id"),
+      responses: {
+        200: {
+          description: "Encrypted backup archive",
+          content: { "application/gzip": { schema: { type: "string", format: "binary" } } },
+        },
+      },
+    },
+  },
+  "/backups/{backupId}": {
+    delete: {
+      ...accountOperation("Delete a backup and its stored archive by backup id"),
+      responses: jsonResponse("Deletion result", successSchema),
+    },
+  },
+  "/backups/{backupId}/restore": {
+    post: {
+      ...accountOperation("Create a copy-restore deployment draft by backup id"),
+      description:
+        "Works after the source agent has been deleted: copy restore provisions a fresh agent from the archive. In-place restore still requires the original agent and remains on the agent-scoped route.",
       requestBody: jsonBody(
         {
           type: "object",

--- a/backend-api/routes/accountBackups.ts
+++ b/backend-api/routes/accountBackups.ts
@@ -1,0 +1,101 @@
+// @ts-nocheck
+const express = require("express");
+
+const {
+  createRestoreDraft,
+  deleteBackup,
+  getBackupDownload,
+  listUserBackups,
+} = require("../backups");
+const monitoring = require("../monitoring");
+const { createMutationFailureAuditMiddleware } = require("../auditLog");
+const { asyncHandler } = require("../middleware/errorHandler");
+const { requireSession } = require("../middleware/auth");
+
+// Account-scoped backup access, resolved by backup id rather than through an
+// agent.
+//
+// The agent-scoped router at /agents/:id/backups resolves the agent first and
+// 404s when it is gone, so a backup became unreachable the moment its source
+// agent was deleted — precisely the disaster-recovery case managed backups
+// exist for. The archive and its row both survived; nothing routed to them
+// (#338).
+//
+// The service layer already supported this: createRestoreDraft,
+// getBackupDownload and deleteBackup all take agentId = null and scope by
+// user_id, so ownership is enforced the same way here. Only the routing was
+// missing.
+const router = express.Router();
+
+// Same reasoning as the agent-scoped router: backup archives carry full agent
+// state and restore creates new runtime drafts, so a workspace API key must not
+// inherit its issuer's owner access.
+router.use(requireSession);
+router.use(createMutationFailureAuditMiddleware("backup"));
+
+router.get(
+  "/",
+  asyncHandler(async (req, res) => {
+    res.json(await listUserBackups(req.user.id));
+  }),
+);
+
+router.get(
+  "/:backupId/download",
+  asyncHandler(async (req, res) => {
+    const { buffer, filename } = await getBackupDownload({
+      backupId: req.params.backupId,
+      userId: req.user.id,
+    });
+    res.setHeader("Content-Type", "application/gzip");
+    res.setHeader("Content-Disposition", `attachment; filename="${filename}"`);
+    res.send(buffer);
+  }),
+);
+
+router.delete(
+  "/:backupId",
+  asyncHandler(async (req, res) => {
+    res.json(
+      await deleteBackup({
+        backupId: req.params.backupId,
+        userId: req.user.id,
+      }),
+    );
+  }),
+);
+
+router.post(
+  "/:backupId/restore",
+  asyncHandler(async (req, res) => {
+    // In-place restore needs a live agent to restore into, so it stays on the
+    // agent-scoped route. Copy restore provisions a fresh agent from the
+    // archive, which is what makes it work after the source agent is gone.
+    const mode = String(req.body?.mode || "copy")
+      .trim()
+      .toLowerCase();
+    if (mode !== "copy") {
+      return res.status(400).json({
+        error:
+          "Only copy restore is available here. In-place restore requires the original agent and is available on /agents/:id/backups/:backupId/restore.",
+      });
+    }
+
+    const result = await createRestoreDraft({
+      backupId: req.params.backupId,
+      userId: req.user.id,
+    });
+    await monitoring.logEvent(
+      "backup_restore_draft_created",
+      "Backup restore draft created from account-scoped route",
+      {
+        actor: { userId: req.user.id, email: req.user.email || null, role: req.user.role || null },
+        backup: { id: req.params.backupId },
+        restore: { mode: "copy", draftId: result.draft?.id || null },
+      },
+    );
+    res.json(result);
+  }),
+);
+
+module.exports = router;

--- a/backend-api/server.ts
+++ b/backend-api/server.ts
@@ -1238,6 +1238,9 @@ app.use(createGatewayRouter());
 // ─── Protected Routes ─────────────────────────────────────────────
 app.use("/agents", require("./routes/agents"));
 app.use("/agents", require("./routes/backups"));
+// Account-scoped backup access by backup id. The agent-scoped router above
+// cannot reach a backup once its source agent is deleted (#338).
+app.use("/backups", require("./routes/accountBackups"));
 app.use("/agents", require("./routes/agentFiles"));
 app.use("/agents", require("./routes/channels"));
 app.use("/agents", require("./routes/nemoclaw"));


### PR DESCRIPTION
Closes #338.

Managed backups could be **created** but not **restored once their source agent was gone** — the exact disaster-recovery case the feature exists for.

Every backup route was mounted under `/agents` and resolved the agent first, so deleting an agent 404'd its own backups:

```
GET  /agents/<id>/backups                 -> 404 Agent not found
POST /agents/<id>/backups/<bid>/restore   -> 404
```

The encrypted archive and the `backups` row both survived; nothing routed to them. Recovery meant reading the archive off the volume by hand, decrypting it, and using the migration-upload path — not a supported user path, and blocked in its own right by the draft-id bug in #339.

## The authorization layer was already fine — routing was the blocker

`createRestoreDraft`, `getBackupDownload` and `deleteBackup` all already accept `agentId = null`, and `loadBackup` only adds an agent predicate when one is passed, scoping by `user_id` either way.

So this adds the missing surface rather than reworking any authorization:

```
GET    /backups
GET    /backups/{backupId}/download
DELETE /backups/{backupId}
POST   /backups/{backupId}/restore
```

`listUserBackups` is the one new service function, because `listAgentBackups` resolves the agent first and can't serve an orphaned backup. It `LEFT JOIN`s agents and reports **`agent_exists`** so the UI can distinguish an orphaned backup from a live one instead of guessing — restoring an orphan provisions a *fresh* agent, and the interface should say so.

## Deliberate boundaries

**In-place restore stays agent-scoped.** It needs a live agent to restore into. Copy restore provisions a new agent from the archive, which is what makes it work after deletion. The new route rejects any other mode with a 400 pointing at the agent-scoped route.

**Session-only**, matching the agent-scoped router: backup archives carry full agent state, so a workspace API key must not inherit its issuer's owner access.

## Spec coverage

Registers the router with the OpenAPI drift test and documents all four operations. Without registration the new public surface would have been undocumented *and* unchecked — I verified the check actually bites by removing the restore path from the spec and watching the test fail on exactly `POST /backups/{backupId}/restore`.

backend-api 2340 pass.